### PR TITLE
SCTP Actors: unblacklist SCTP kernel modules on upgrade if needed

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/sctpchecks/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sctpchecks/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.models import SCTPConfig, RpmTransactionTasks
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+class SCTPChecks(Actor):
+    """
+    Parses collected SCTP information and take necessary actions.
+
+    The only action performed by this actor is to request the installation of the
+    kernel-modules-extra rpm package, based on if SCTP is being used or not which
+    is collected on SCTPConfig message. If yes, it then produces a RpmTransactionTasks
+    requesting to install the package.
+    """
+    name = 'sctp_checks'
+    consumes = (SCTPConfig,)
+    produces = (RpmTransactionTasks, )
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        for sctpconfig in self.consume(SCTPConfig):
+            if sctpconfig.wanted:
+                self.produce(RpmTransactionTasks(to_install=['kernel-modules-extra']))
+                break

--- a/repos/system_upgrade/el7toel8/actors/sctpconfigread/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sctpconfigread/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.sctplib import is_sctp_wanted
+from leapp.models import ActiveKernelModulesFacts, SCTPConfig
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class SCTPConfigRead(Actor):
+    """
+    Determines whether or not the SCTP kernel module might be wanted.
+
+    This actor determines whether or not the SCTP is currently used by this machine or has been quite
+    recently used (1 month timeframe). In case it has been used it will issue a SCTPConfig message that
+    defines the decision whether or not the SCTP module should be removed from the module blacklist on RHEL8.
+    """
+    name = 'sctp_read_status'
+    consumes = (ActiveKernelModulesFacts,)
+    produces = (SCTPConfig,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        self.produce(SCTPConfig(wanted=is_sctp_wanted()))

--- a/repos/system_upgrade/el7toel8/actors/sctpconfigread/libraries/sctpdlm.py
+++ b/repos/system_upgrade/el7toel8/actors/sctpconfigread/libraries/sctpdlm.py
@@ -1,0 +1,64 @@
+#
+# Functions for probing SCTP usage by DLM
+#
+import re
+
+from six.moves.configparser import SafeConfigParser
+
+from leapp.libraries.stdlib import api
+
+
+def check_dlm_cfgfile():
+    """Parse DLM config file"""
+    fname = "/etc/dlm/dlm.conf"
+
+    try:
+        with open(fname, 'r') as fp:
+            cfgs = '[dlm]\n' + fp.read()
+    except (OSError, IOError):
+        return False
+
+    cfg = SafeConfigParser()
+    try:
+        cfg.read_string(cfgs)
+    except AttributeError:
+        # Python2 ConfigParser doesn't have cfg.read_string
+        from cStringIO import StringIO
+        cfg.readfp(StringIO(cfgs))
+
+    if not cfg.has_option('dlm', 'protocol'):
+        return False
+
+    proto = cfg.get('dlm', 'protocol').lower()
+    return proto in ['sctp', 'detect', '1', '2']
+
+
+def check_dlm_sysconfig():
+    """Parse /etc/sysconfig/dlm"""
+    regex = re.compile('^[^#]*DLM_CONTROLD_OPTS.*=.*(?:--protocol|-r)[ =]*([^"\' ]+).*', re.IGNORECASE)
+
+    try:
+        with open('/etc/sysconfig/dlm', 'r') as fp:
+            lines = fp.readlines()
+    except (OSError, IOError):
+        return False
+
+    for line in lines:
+        if regex.match(line):
+            proto = regex.sub('\\1', line).lower().strip()
+            if proto in ['sctp', 'detect']:
+                return True
+
+    return False
+
+
+def is_dlm_using_sctp():
+    if check_dlm_cfgfile():
+        api.current_logger().info('DLM is configured to use SCTP on dlm.conf.')
+        return True
+
+    if check_dlm_sysconfig():
+        api.current_logger().info('DLM is configured to use SCTP on sysconfig.')
+        return True
+
+    return False

--- a/repos/system_upgrade/el7toel8/actors/sctpconfigread/libraries/sctplib.py
+++ b/repos/system_upgrade/el7toel8/actors/sctpconfigread/libraries/sctplib.py
@@ -1,0 +1,107 @@
+#
+# Helper functions
+#
+
+from os.path import isfile
+from subprocess import CalledProcessError
+
+from leapp.libraries.actor import sctpdlm
+from leapp.libraries.stdlib import api, call
+from leapp.models import ActiveKernelModulesFacts
+
+
+def anyfile(files):
+    """
+    Determines if any of the given paths exist and are a file.
+    
+    :return: True if any of the given paths exists and it is a file.
+    :rtype: bool
+    """
+    for f in files:
+        try:
+            if isfile(f):
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def is_module_loaded(module):
+    """
+    Determines if the given kernel module has been reported in the ActiveKernelModuleFacts as loaded.
+
+    :return: True if the module has been found in the ActiveKernelModuleFacts.
+    :rtype: bool
+    """    
+    for fact in api.consume(ActiveKernelModulesFacts):
+        for active_module in fact.kernel_modules:
+            if active_module.filename == module:
+                return True
+    return False
+
+
+def is_sctp_used():
+    """
+    Logic function that decides whether SCTP is being used on this machine.
+
+    :return: True if SCTP usage was detected.
+    :rtype: bool
+    """
+
+    # If anything is using SCTP, be it for listening on new connections or
+    # connecting somewhere else, the module will be loaded. Thus, no need to
+    # also probe on sockets.
+    if is_module_loaded('sctp'):
+        return True
+
+    # Basic files from lksctp-tools. This check is enough and checking RPM
+    # database is an overkill here and this allows for checking for
+    # manually installed ones, which is possible.
+    lksctp_files = ['/usr/lib64/libsctp.so.1',
+                    '/usr/lib/libsctp.so.1',
+                    '/usr/bin/sctp_test']
+    if anyfile(lksctp_files):
+        api.current_logger().debug('At least one of lksctp files is present.')
+        return True
+
+    if sctpdlm.is_dlm_using_sctp():
+        return True
+
+    return False
+
+
+def was_sctp_used():
+    """
+    Determines whether SCTP has been used in the path month, by checking the journalctl.
+
+    :return: True if SCTP usage has been found.
+    :rtype: bool
+    """
+    try:
+        call(['check_syslog_for_sctp.sh'])
+    except CalledProcessError:
+        api.current_logger().debug('Nothing regarding SCTP was found on journal.')
+        return False
+    api.current_logger().debug('Found logs regarding SCTP on journal.')
+    return True
+
+
+
+def is_sctp_wanted():
+    """
+    Decision making funtion that decides based on the current or past usage of SCTP, the SCTP module is wanted
+    on the new system.
+
+    :return: True if SCTP seems to be in use or has been recently used.
+    :rtype: bool
+    """
+    if is_sctp_used():
+        api.current_logger().info('SCTP is being used.')
+        return True
+
+    if was_sctp_used():
+        api.current_logger().info('SCTP was used.')
+        return True
+
+    api.current_logger().info('SCTP is not being used and neither wanted.')
+    return False

--- a/repos/system_upgrade/el7toel8/actors/sctpconfigread/tools/check_syslog_for_sctp.sh
+++ b/repos/system_upgrade/el7toel8/actors/sctpconfigread/tools/check_syslog_for_sctp.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/bin/journalctl --system -S '1 month ago' | /usr/bin/grep -q -m1 -w sctp

--- a/repos/system_upgrade/el7toel8/actors/sctpconfigupdate/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sctpconfigupdate/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import sctpupdate
+from leapp.models import SCTPConfig
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class SCTPConfigUpdate(Actor):
+    """
+    Updates the kernel module blacklist for SCTP.
+
+    If the SCTP module is wanted on RHEL8 the modprobe configuration gets updated to remove SCTP from the black listed
+    kernel modules.
+    """
+    name = 'sctp_config_update'
+    description = 'This actor updates SCTP configuration for RHEL8.'
+    consumes = (SCTPConfig,)
+    produces = ()
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        sctpupdate.perform_update()

--- a/repos/system_upgrade/el7toel8/actors/sctpconfigupdate/libraries/sctpupdate.py
+++ b/repos/system_upgrade/el7toel8/actors/sctpconfigupdate/libraries/sctpupdate.py
@@ -1,0 +1,22 @@
+from leapp.libraries.stdlib import api, call
+from leapp.models import SCTPConfig
+
+
+def enable_sctp():
+    """
+    Enables the SCTP module by removing it from being black listed.
+    """
+
+    api.current_logger().info('Enabling SCTP.')
+    call(['/usr/bin/sed', '-i', 's/^\s*blacklist.*sctp/#&/',
+          '/etc/modprobe.d/sctp_diag-blacklist.conf',
+          '/etc/modprobe.d/sctp-blacklist.conf'])
+    api.current_logger().info('Enabled SCTP.')
+
+
+def perform_update():
+    for sctpconfig in api.consume(SCTPConfig):
+        api.current_logger().info('Consuming sctp={}'.format(sctpconfig.wanted))
+        if sctpconfig.wanted:
+            enable_sctp()
+            break

--- a/repos/system_upgrade/el7toel8/models/sctpconfigmodel.py
+++ b/repos/system_upgrade/el7toel8/models/sctpconfigmodel.py
@@ -1,0 +1,6 @@
+from leapp.models import Model, fields
+from leapp.topics import SCTPConfigTopic
+
+class SCTPConfig(Model):
+    topic = SCTPConfigTopic
+    wanted = fields.Boolean(default=False)

--- a/repos/system_upgrade/el7toel8/topics/sctpconfigtopic.py
+++ b/repos/system_upgrade/el7toel8/topics/sctpconfigtopic.py
@@ -1,0 +1,4 @@
+from leapp.topics import Topic
+
+class SCTPConfigTopic(Topic):
+    name = 'sctp_config_topic'


### PR DESCRIPTION
Some modules can be autoloaded by user-triggered actions, including
SCTP stack. To enhance system security, we will disable that for some
modules, including SCTP.

These Actors are responsible for identifying that SCTP is being used
on the system being upgraded and then re-enable it automatically.