### PR TITLE
Make "baseurl" field optional and add "metalink" field

### DIFF
--- a/repos/system_upgrade/el7toel8/models/systemfacts.py
+++ b/repos/system_upgrade/el7toel8/models/systemfacts.py
@@ -23,7 +23,9 @@ class RepositoryData(Model):
     topic = SystemInfoTopic
 
     name = fields.String()
-    baseurl = fields.String()
+    baseurl = fields.Nullable(fields.String())
+    metalink = fields.Nullable(fields.String())
+    mirrorlist = fields.Nullable(fields.String())
     enabled = fields.Boolean(default=True)
     additional_fields = fields.Nullable(fields.String())
 


### PR DESCRIPTION
Currently "baseurl" field is mandatory and when we parse the field
commented we try to add it to "additional_fields" string  as "#baseurl"
and thus omitting the wanted value.

We also add "metalink" field which now ends in "additional_fields"
string too.

Without this patch we fails here:

```python  
File "/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py", line 205, in get_repositories
    yield Repositories(file=repo, data=_parse(repo))
  File "/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py", line 27, in inner
    return list(f(*args, **kwargs))
  File "/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py", line 198, in _parse
    yield RepositoryData(**prepared)
  File "/usr/lib/python2.7/site-packages/leapp/models/__init__.py", line 86, in __init__
    getattr(defined_fields[field], init_method)(kwargs, field, self)
  File "/usr/lib/python2.7/site-packages/leapp/models/fields/__init__.py", line 110, in from_initialization
    self._validate_model_value(value=source_value, name=name)
  File "/usr/lib/python2.7/site-packages/leapp/models/fields/__init__.py", line 166, in _validate_model_value
    super(BuiltinField, self)._validate_model_value(value, name)
  File "/usr/lib/python2.7/site-packages/leapp/models/fields/__init__.py", line 62, in _validate_model_value
    raise ModelViolationError('The value of "{name}" field is None, but this is not allowed'.format(name=name))
ModelViolationError: The value of "baseurl" field is None, but this is not allowed
```