### PR TITLE
Add metapackage for dependencies

### DIFF
--- a/packaging/leapp-el7toel8-deps.spec
+++ b/packaging/leapp-el7toel8-deps.spec
@@ -1,0 +1,61 @@
+%global  lrdname  leapp-repository-deps-el8
+%global  ldname   leapp-deps-el8
+
+Name:       leapp-el7toel8-deps
+Version:    5.0.0
+Release:    1%{?dist}
+Summary:    Dependencies for *leapp* packages
+BuildArch:  noarch
+
+License:    AGPLv3+
+URL:        https://leapp-to.github.io
+
+%description
+%{summary}
+
+##################################################
+# DEPS FOR LEAPP REPOSITORY ON RHEL 8
+##################################################
+%package -n %{lrdname}
+Summary:    Meta-package with system dependencies for leapp repository
+Provides:   leapp-repository-dependencies = 1
+Obsoletes:  leapp-repository-deps
+
+Requires:   dnf >= 4
+
+%description -n %{lrdname}
+%{summary}
+
+##################################################
+# DEPS FOR LEAPP FRAMEWORK ON RHEL 8
+##################################################
+%package -n %{ldname}
+Summary:    Meta-package with system dependencies for leapp framework
+Provides:   leapp-framework-dependencies = 1
+Obsoletes:  leapp-deps
+
+Requires:   python2-six
+Requires:   python2-setuptools
+Requires:   findutils
+
+%description -n %{ldname}
+%{summary}
+
+%prep
+
+%build
+
+%install
+
+# do not create main packages
+#%files
+
+%files -n %{lrdname}
+# no files here
+
+%files -n %{ldname}
+# no files here
+
+%changelog
+* Tue Jan 22 2019 Petr Stodulka <pstodulk@redhat.com> - %{version}-%{release}
+- Initial rpm

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -12,12 +12,13 @@ URL:        https://leapp-to.github.io
 Source0:    https://github.com/oamg/leapp-repository/archive/leapp-repository-%{version}.tar.gz
 Source1:    leapp-repository-initrd.tar.gz
 Source2:    leapp-repository-data.tar.gz
+Source3:    deps-pkgs.tar.gz
 BuildArch:  noarch
-Requires:   dnf >= 4
 Requires:   %{name}-data = %{version}-%{release}
-%if 0%{?fedora} || 0%{?rhel} > 7
-Requires:   systemd-container
-%endif
+
+# IMPORTANT: everytime the requirements are changed, increment number by one
+# - same for Provides in deps subpackage
+Requires:   leapp-repository-dependencies = 1
 
 %description
 Repositories for leapp
@@ -26,16 +27,41 @@ Repositories for leapp
 %package data
 License: Red Hat Enterprise Agreement
 Summary: Package evolution data for leapp
-Requires: %{name} = %{version}-%{release}
+Requires:   %{name} = %{version}-%{release}
 
 %description data
 Package evolution data for leapp.
 
+# This metapackage should contain all RPM dependencies exluding deps on *leapp*
+# RPMs. This metapackage will be automatically replaced during the upgrade
+# to satisfy dependencies with RPMs from target system.
+%package deps
+Summary:    Meta-package with system dependencies of %{name} package
+
+# IMPORTANT: everytime the requirements are changed, increment number by one
+# - same for Requires in main package
+Provides:  leapp-repository-dependencies = 1
+##################################################
+# Real requirements for the leapp-repository HERE
+##################################################
+Requires:   dnf >= 4
+%if 0%{?rhel} && 0%{?rhel} == 7
+# Required to gather system facts about SELinux
+Requires:   libselinux-python
+%else ## RHEL 8 dependencies ##
+# Requires:   systemd-container
+%endif
+##################################################
+# end requirement
+##################################################
+%description deps
+%{summary}
 
 %prep
 %autosetup -n %{name}-%{version}
 %setup -q  -n %{name}-%{version} -D -T -a 1
 %setup -q  -n %{name}-%{version} -D -T -a 2
+%setup -q  -n %{name}-%{version} -D -T -a 3
 
 
 %build
@@ -44,6 +70,7 @@ make build
 cp -a leapp-repository-initrd*/vmlinuz-upgrade.x86_64       repos/system_upgrade/el7toel8/files/
 cp -a leapp-repository-initrd*/initramfs-upgrade.x86_64.img repos/system_upgrade/el7toel8/files/
 cp -a leapp-pes-data*/packaging/sources/pes-events.json     repos/system_upgrade/el7toel8/actors/peseventsscanner/files/
+cp -a leapp*deps*rpm repos/system_upgrade/el7toel8/files/bundled-rpms/
 
 
 %install
@@ -87,6 +114,8 @@ done;
 %files data
 %{repositorydir}/system_upgrade/el7toel8/actors/peseventsscanner/files/pes-events.json
 
+%files deps
+# no files here
 
 %changelog
 * Fri Jan 11 2019 Michal Reznik <mreznik@redhat.com> - %{version}-%{release}


### PR DESCRIPTION
    Currently we are not able to use python dependencies correctly to
    ensure the RPM will not be removed during the upgrade of the system.
    As a workround, put all such system dependencies into the
    leapp-repository-deps metapackage which is supposed to be replaced
    later (another commit(s)) during the upgrade transaction by the
    another metapackage containing dependencies satisfying dependencies
    of target (RHEL 8) system.
    
    To reflect way of the leapp framework how this should be resolved,
    the leapp-repository rpm should create dependency on specific
    capability:
      leapp-repository-dependencies
    
    which has to be provided by such meta package. Any time the
    dependencies are changed, the capability number has to be incremented
    by one. Such change has to be reflected by both (for RHEL7 and RHEL8)
    metapackages.


    Handle leapp & leapp-repository dependencies during upgrade
    
    Add new SPEC file for RHEL 8 metapackes that handle dependencies of
    leapp and leapp-repository packages. These replace original
    metapackages produced on RHEL 7 system.
    
    The Makefile has been modified to build those packages during
    processing of the `source` target and create new source consumed
    and required by original SPEC file. Such packages are bundled inside
    the leapp-repository RPM and they are installed automatically
    during the IPU.
    
    For the building of RHEL 8 metapackages has to be used separate
    rpm repository, otherwise packages are viewable by DNF inside
    repository and do cause installation issue of leapp and
    leapp-repository packages as these metapackages cannot be installed
    on RHEL 7 system.

