### PR TITLE
Add actors for transferring SELinux customizations

### DIFF
--- a/packaging/leapp-el7toel8-deps.spec
+++ b/packaging/leapp-el7toel8-deps.spec
@@ -18,13 +18,15 @@ URL:        https://oamg.github.io/leapp/
 ##################################################
 %package -n %{lrdname}
 Summary:    Meta-package with system dependencies for leapp repository
-Provides:   leapp-repository-dependencies = 4
+Provides:   leapp-repository-dependencies = 5
 Obsoletes:  leapp-repository-deps
 
 Requires:   dnf >= 4
 Requires:   pciutils
 Requires:   python3
 Requires:   python3-pyudev
+# required by SELinux actors
+Requires:   policycoreutils-python-utils
 
 %description -n %{lrdname}
 %{summary}

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -29,7 +29,7 @@ BuildRequires:  python-devel
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage
-Requires:       leapp-repository-dependencies = 4
+Requires:       leapp-repository-dependencies = 5
 
 # That's temporary to ensure the obsoleted subpackage is not installed
 # and will be removed when the current version of leapp-repository is installed
@@ -56,7 +56,7 @@ Summary:    Meta-package with system dependencies of %{name} package
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Requires in main package
-Provides:  leapp-repository-dependencies = 4
+Provides:  leapp-repository-dependencies = 5
 ##################################################
 # Real requirements for the leapp-repository HERE
 ##################################################
@@ -66,6 +66,8 @@ Requires:   pciutils
 # Required to gather system facts about SELinux
 Requires:   libselinux-python
 Requires:   python-pyudev
+# required by SELinux actors
+Requires:   policycoreutils-python
 %else ## RHEL 8 dependencies ##
 # Requires:   systemd-container
 %endif

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/Makefile
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/Makefile
@@ -1,0 +1,2 @@
+install-deps:
+	yum install -y policycoreutils policycoreutils-python

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/actor.py
@@ -1,0 +1,104 @@
+from leapp.actors import Actor
+from leapp.models import SELinuxModules, SELinuxCustom, CheckResult
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+from leapp.libraries.stdlib import call
+import subprocess
+import os
+from shutil import rmtree
+
+WORKING_DIRECTORY = '/tmp/selinux/'
+
+class SELinuxApplyCustom(Actor):
+    name = 'selinuxapplycustom'
+    description = 'No description has been provided for the selinuxapplycustom actor.'
+    consumes = (SELinuxCustom, SELinuxModules, )
+    produces = (CheckResult, )
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag, )
+
+    def process(self):
+        # cil module files need to be extracted to disk in order to be installed
+        try:
+            # clear working directory
+            rmtree(WORKING_DIRECTORY)
+        except OSError:
+            #expected
+            pass
+        try:
+            os.mkdir(WORKING_DIRECTORY)
+        except OSError:
+            self.log.info("Failed to access working directory! Aborting.")
+            return
+
+        # import custom SElinux modules
+        for semodules in self.consume(SELinuxModules):
+            self.log.info("Processing custom SELinux policy modules. Count: " +
+                str(len(semodules.modules))
+            )
+            for module in semodules.modules:
+                cil_filename = WORKING_DIRECTORY + module.name + ".cil"
+                self.log.info("Installing " + module.name
+                 + " on priority " + str(module.priority) + ".")
+                if module.removed:
+                    self.log.info("The following lines where removed because of incompatibility: ")
+                    self.log.info('\n'.join(module.removed))
+                # write module content to disk
+                try:
+                    with open(cil_filename, 'w') as file:
+                        file.write(module.content)
+                except OSError as e:
+                    self.log.info("Error writing " + cil_filename + " :" + e.strerror)
+                    continue
+
+                try:
+                    semanage = call([
+                        'semodule',
+                        '-X',
+                        str(module.priority),
+                        '-i',
+                        cil_filename]
+                    )
+                except subprocess.CalledProcessError as e:
+                    self.log.info("Error installing module: " + e.strerror)
+                    pass
+                try:
+                    os.remove(cil_filename)
+                except OSError:
+                    self.log.info("Error removing module file")
+        # import SELinux customizations collected by "semanage export"
+        for custom in self.consume(SELinuxCustom):
+            self.log.info('Importing SELinux customizations collected by "semanage export".')
+            semanage_filename = WORKING_DIRECTORY + "semanage"
+            # save SELinux customizations to disk
+            try:
+                with open(semanage_filename, 'w') as file:
+                    file.write('\n'.join(custom.commands))
+            except OSError as e:
+                self.log.info("Error writing SELinux customizations:" + e.strerror)
+            # import customizations
+            try:
+                call(['semanage', 'import', '-f', semanage_filename])
+            except subprocess.CalledProcessError:
+                continue
+            # clean-up
+            try:
+                os.remove(semanage_filename)
+            except OSError:
+                continue
+
+        # clean-up
+        try:
+            os.rmdir("/tmp/selinux")
+        except OSError:
+            pass
+
+        self.log.info("SElinux customizations reapplied successfully.")
+        self.produce(
+           CheckResult(
+               severity='Info',
+               result='Pass',
+               summary='SElinux customizations reapplied successfully.',
+               details='SELinux modules with non-standard priority and other custom settings where reapplied after the upgrade.',
+               solutions=None
+        ))
+
+

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/actor.py
@@ -41,7 +41,8 @@ class SELinuxApplyCustom(Actor):
                 cil_filename = os.path.join(WORKING_DIRECTORY, "%s.cil" % module.name)
                 self.log.info("Installing module %s on priority %d.", module.name, module.priority)
                 if module.removed:
-                    self.log.info("The following lines where removed because of incompatibility: \n%s", '\n'.join(module.removed))
+                    self.log.info("The following lines where removed because of incompatibility: \n%s",
+                                  '\n'.join(module.removed))
                 # write module content to disk
                 try:
                     with open(cil_filename, 'w') as cil_file:
@@ -62,14 +63,14 @@ class SELinuxApplyCustom(Actor):
                     self.log.info("Error installing module: %s", str(e))
                     # TODO - save the failed module to /etc/selinux ?
                     # currently it is still left in the old policy store
-                    pass
                 try:
                     os.remove(cil_filename)
                 except OSError as e:
                     self.log.info("Error removing module file: %s", str(e))
         # import SELinux customizations collected by "semanage export"
         for custom in self.consume(SELinuxCustom):
-            self.log.info('Importing the following SELinux customizations collected by "semanage export": \n%s', '\n'.join(custom.commands))
+            self.log.info('Importing the following SELinux customizations collected by "semanage export": \n%s',
+                          '\n'.join(custom.commands))
             semanage_filename = os.path.join(WORKING_DIRECTORY, "semanage")
             # save SELinux customizations to disk
             try:
@@ -103,5 +104,3 @@ class SELinuxApplyCustom(Actor):
 
         # TODO - summarize all changes after LEAPP team rewrites reporting
         # from leapp.reporting import Report
-
-

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/actor.py
@@ -9,6 +9,7 @@ from leapp.libraries.stdlib import run, CalledProcessError
 
 WORKING_DIRECTORY = '/tmp/selinux/'
 
+
 class SELinuxApplyCustom(Actor):
     '''
     Re-apply SELinux customizations from RHEL-7 installation
@@ -52,13 +53,13 @@ class SELinuxApplyCustom(Actor):
                     continue
 
                 try:
-                    run([
-                        'semodule',
-                        '-X',
-                        str(module.priority),
-                        '-i',
-                        cil_filename]
-                    )
+                    run(['semodule',
+                         '-X',
+                         str(module.priority),
+                         '-i',
+                         cil_filename
+                         ]
+                        )
                 except CalledProcessError as e:
                     self.log.info("Error installing module: %s", str(e))
                     # TODO - save the failed module to /etc/selinux ?

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/actor.py
@@ -1,88 +1,93 @@
-from leapp.actors import Actor
-from leapp.models import SELinuxModules, SELinuxCustom, CheckResult
-from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
-from leapp.libraries.stdlib import call
-import subprocess
 import os
 from shutil import rmtree
+
+from leapp.actors import Actor
+from leapp.models import SELinuxModules, SELinuxCustom, SELinuxRequestRPMs
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+from leapp.libraries.stdlib import run, CalledProcessError
+
 
 WORKING_DIRECTORY = '/tmp/selinux/'
 
 class SELinuxApplyCustom(Actor):
+    '''
+    Re-apply SELinux customizations from RHEL-7 installation
+
+    Re-apply SELinux policy customizations (custom policy modules and changes
+    introduced by semanage). Any changes (due to incompatiblity with RHEL-8
+    SELinux policy) are reported to user.
+    '''
     name = 'selinuxapplycustom'
-    description = 'No description has been provided for the selinuxapplycustom actor.'
-    consumes = (SELinuxCustom, SELinuxModules, )
-    produces = (CheckResult, )
-    tags = (ApplicationsPhaseTag, IPUWorkflowTag, )
+    consumes = (SELinuxCustom, SELinuxModules)
+    produces = ()
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
 
     def process(self):
         # cil module files need to be extracted to disk in order to be installed
-        try:
-            # clear working directory
-            rmtree(WORKING_DIRECTORY)
-        except OSError:
-            #expected
-            pass
+
+        # clear working directory
+        rmtree(WORKING_DIRECTORY, ignore_errors=True)
+
         try:
             os.mkdir(WORKING_DIRECTORY)
         except OSError:
-            self.log.info("Failed to access working directory! Aborting.")
+            self.log.info("Failed to create working directory! Aborting.")
             return
 
         # import custom SElinux modules
         for semodules in self.consume(SELinuxModules):
-            self.log.info("Processing custom SELinux policy modules. Count: " +
-                str(len(semodules.modules))
-            )
+            self.log.info("Processing custom SELinux policy modules. Count: %d.", len(semodules.modules))
             for module in semodules.modules:
-                cil_filename = WORKING_DIRECTORY + module.name + ".cil"
-                self.log.info("Installing " + module.name
-                 + " on priority " + str(module.priority) + ".")
+                cil_filename = os.path.join(WORKING_DIRECTORY, "%s.cil" % module.name)
+                self.log.info("Installing module %s on priority %d.", module.name, module.priority)
                 if module.removed:
-                    self.log.info("The following lines where removed because of incompatibility: ")
-                    self.log.info('\n'.join(module.removed))
+                    self.log.info("The following lines where removed because of incompatibility: \n%s", '\n'.join(module.removed))
                 # write module content to disk
                 try:
-                    with open(cil_filename, 'w') as file:
-                        file.write(module.content)
+                    with open(cil_filename, 'w') as cil_file:
+                        cil_file.write(module.content)
                 except OSError as e:
-                    self.log.info("Error writing " + cil_filename + " :" + e.strerror)
+                    self.log.info("Error writing %s : %s", cil_filename, str(e))
                     continue
 
                 try:
-                    semanage = call([
+                    run([
                         'semodule',
                         '-X',
                         str(module.priority),
                         '-i',
                         cil_filename]
                     )
-                except subprocess.CalledProcessError as e:
-                    self.log.info("Error installing module: " + e.strerror)
+                except CalledProcessError as e:
+                    self.log.info("Error installing module: %s", str(e))
+                    # TODO - save the failed module to /etc/selinux ?
+                    # currently it is still left in the old policy store
                     pass
                 try:
                     os.remove(cil_filename)
-                except OSError:
-                    self.log.info("Error removing module file")
+                except OSError as e:
+                    self.log.info("Error removing module file: %s", str(e))
         # import SELinux customizations collected by "semanage export"
         for custom in self.consume(SELinuxCustom):
-            self.log.info('Importing SELinux customizations collected by "semanage export".')
-            semanage_filename = WORKING_DIRECTORY + "semanage"
+            self.log.info('Importing the following SELinux customizations collected by "semanage export": \n%s', '\n'.join(custom.commands))
+            semanage_filename = os.path.join(WORKING_DIRECTORY, "semanage")
             # save SELinux customizations to disk
             try:
-                with open(semanage_filename, 'w') as file:
-                    file.write('\n'.join(custom.commands))
+                with open(semanage_filename, 'w') as s_file:
+                    s_file.write('\n'.join(custom.commands))
             except OSError as e:
-                self.log.info("Error writing SELinux customizations:" + e.strerror)
+                self.log.info("Error writing SELinux customizations: %s", str(e))
             # import customizations
             try:
-                call(['semanage', 'import', '-f', semanage_filename])
-            except subprocess.CalledProcessError:
+                run(['semanage', 'import', '-f', semanage_filename])
+            except CalledProcessError as e:
+                self.log.info("Failed to import SELinux customizations: %s", str(e))
                 continue
             # clean-up
             try:
                 os.remove(semanage_filename)
-            except OSError:
+            except OSError as e:
+                self.log.info("Failed to remove temporary file %s: %s", semanage_filename, str(e))
                 continue
 
         # clean-up
@@ -91,14 +96,12 @@ class SELinuxApplyCustom(Actor):
         except OSError:
             pass
 
-        self.log.info("SElinux customizations reapplied successfully.")
-        self.produce(
-           CheckResult(
-               severity='Info',
-               result='Pass',
-               summary='SElinux customizations reapplied successfully.',
-               details='SELinux modules with non-standard priority and other custom settings where reapplied after the upgrade.',
-               solutions=None
-        ))
+        # TODO - Verify that all RPM packages reqested by selinux actors are installed
+        self.log.info("Verifying selinux-related RPMs requested before upgrade.")
+        for rpms in self.consume(SELinuxRequestRPMs):
+            self.log.info("To keep: %s \n To install: %s", ", ".join(rpms.to_keep), ", ".join(rpms.to_install))
+
+        # TODO - summarize all changes after LEAPP team rewrites reporting
+        # from leapp.reporting import Report
 
 

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/tests/component_test.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from leapp.snactor.fixture import current_actor_context
 from leapp.models import SELinuxModule, SELinuxModules, SELinuxCustom, SELinuxFacts, SELinuxRequestRPMs
 from leapp.libraries.stdlib import api, run, CalledProcessError
@@ -15,16 +17,18 @@ test_modules = [
 ]
 
 semanage_commands = [
-['fcontext', '-t', 'ganesha_var_run_t', "'/ganesha(/.*)?'"],
-['fcontext', '-t', 'httpd_sys_content_t', "'/web(/.*)?'"],
-['port', '-t', 'http_port_t', '-p', 'udp', '81']
+    ['fcontext', '-t', 'ganesha_var_run_t', "'/ganesha(/.*)?'"],
+    ['fcontext', '-t', 'httpd_sys_content_t', "'/web(/.*)?'"],
+    ['port', '-t', 'http_port_t', '-p', 'udp', '81']
 ]
+
 
 def findModuleSemodule(semodule_lfull, name, priority):
     for line in semodule_lfull:
         if name in line and priority in line:
             return line
     return None
+
 
 def findSemanageRule(rules, rule):
     for r in rules:
@@ -35,11 +39,13 @@ def findSemanageRule(rules, rule):
             return r
     return None
 
+
+@pytest.mark.skip(reason='Test disabled because it would modify the system')
 def test_SELinuxApplyCustom(current_actor_context):
 
     semodule_list = [SELinuxModule(name=module, priority=int(prio),
                                    content="(allow domain proc_type (file (getattr open read)))", removed=[])
-                                   for (prio, module) in test_modules]
+                     for (prio, module) in test_modules]
 
     commands = [" ".join([c[0], "-a"] + c[1:]) for c in semanage_commands[1:]]
     semanage_removed = [" ".join([semanage_commands[0][0], "-a"] + semanage_commands[0][1:])]
@@ -68,7 +74,10 @@ def test_SELinuxApplyCustom(current_actor_context):
     for command in semanage_commands[1:-1]:
         assert findSemanageRule(semanage_export, command)
 
-def teardown():
+
+# Test disabled because it's setup and teardown would modify the system
+# Remove "_" before re-activation
+def teardown_():
     for priority, module in test_modules:
         try:
             run(["semodule", "-X", priority, "-r", module])

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/tests/component_test.py
@@ -1,0 +1,91 @@
+import os
+
+from leapp.snactor.fixture import current_actor_context
+from leapp.models import SELinuxModule, SELinuxModules, SELinuxCustom, SELinuxFacts, SELinuxRequestRPMs
+from leapp.libraries.stdlib import api, run, CalledProcessError
+from leapp.reporting import Report
+
+test_modules = [
+    ["400", "mock1"],
+    ["99", "mock1"],
+    ["200", "mock1"],
+    ["400", "mock2"],
+    ["999", "mock3"],
+    ["400", "permissive_abrt_t"]
+]
+
+semanage_commands = [
+['fcontext', '-t', 'ganesha_var_run_t', "'/ganesha(/.*)?'"],
+['fcontext', '-t', 'httpd_sys_content_t', "'/web(/.*)?'"],
+['port', '-t', 'http_port_t', '-p', 'udp', '81']
+]
+
+def findModuleSemodule(semodule_lfull, name, priority):
+    for line in semodule_lfull:
+        if name in line and priority in line:
+            return line
+    return None
+
+def findSemanageRule(rules, rule):
+    for r in rules:
+        for word in rule:
+            if word not in r:
+                break
+        else:
+            return r
+    return None
+
+def test_SELinuxApplyCustom(current_actor_context):
+
+    semodule_list = [SELinuxModule(name=module, priority=int(prio),
+                                   content="(allow domain proc_type (file (getattr open read)))", removed=[])
+                                   for (prio, module) in test_modules]
+
+    commands = [" ".join([c[0], "-a"] + c[1:]) for c in semanage_commands[1:]]
+    semanage_removed = [" ".join([semanage_commands[0][0], "-a"] + semanage_commands[0][1:])]
+
+    current_actor_context.feed(SELinuxModules(modules=semodule_list))
+    current_actor_context.feed(SELinuxCustom(commands=commands, removed=semanage_removed))
+    current_actor_context.run()
+
+    # check if all given modules and local customizations where removed
+    semodule_lfull = []
+    semanage_export = []
+    try:
+        semodule = run(["semodule", "-lfull"], split=True)
+        semodule_lfull = semodule.get("stdout", "")
+        semanage = run(["semanage", "export"], split=True)
+        semanage_export = semanage.get("stdout", "")
+    except CalledProcessError as e:
+        api.current_logger().warning("Error listing selinux customizations: %s", str(e.stderr))
+        assert False
+
+    # check that all modules installed during test setup where reported
+    for priority, name in test_modules:
+        if priority != "100" and priority != "200":
+            assert findModuleSemodule(semodule_lfull, name, priority)
+    # check that all valid commands where reintroduced to the system
+    for command in semanage_commands[1:-1]:
+        assert findSemanageRule(semanage_export, command)
+
+def teardown():
+    for priority, module in test_modules:
+        try:
+            run(["semodule", "-X", priority, "-r", module])
+        except CalledProcessError as e:
+            # expected if the test fails
+            api.current_logger().warning("Error removing selinux modules after testing: %s", str(e.stderr))
+
+    for command in semanage_commands[1:]:
+        try:
+            run(["semanage", command[0], "-d"] + [x.strip('"\'') for x in command[1:]])
+        except CalledProcessError as e:
+            # expected if the test fails
+            api.current_logger().warning("Error removing selinux customizations after testing: %s", str(e.stderr))
+            continue
+
+    try:
+        run(["semanage", semanage_commands[0][0], "-d"] + semanage_commands[0][1:])
+    except CalledProcessError:
+        # expected
+        pass

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/tests/component_test.py
@@ -31,11 +31,11 @@ def _run_cmd(cmd, logmsg="", split=True):
             api.current_logger().warning("%s: %s", logmsg, str(e.stderr))
 
 
-def findModuleSemodule(semodule_lfull, name, priority):
+def find_module_semodule(semodule_lfull, name, priority):
     return next((line for line in semodule_lfull if (name in line and priority in line)), None)
 
 
-def findSemanageRule(rules, rule):
+def find_semanage_rule(rules, rule):
     return next((r for r in rules if all(word in r for word in rule)), None)
 
 
@@ -79,7 +79,7 @@ def test_SELinuxApplyCustom(current_actor_context, destructive_selinux_teardown)
     # check that all reported modules where introduced to the system
     for priority, name in TEST_MODULES:
         if priority != "100" and priority != "200":
-            assert findModuleSemodule(semodule_lfull, name, priority)
+            assert find_module_semodule(semodule_lfull, name, priority)
     # check that all valid commands where introduced to the system
     for command in SEMANAGE_COMMANDS[1:-1]:
-        assert findSemanageRule(semanage_export, command)
+        assert find_semanage_rule(semanage_export, command)

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/Makefile
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/Makefile
@@ -1,0 +1,2 @@
+install-deps:
+	yum install -y policycoreutils policycoreutils-python

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
@@ -1,20 +1,11 @@
-import os
-import re
-from shutil import rmtree
-
 from leapp.actors import Actor
 from leapp.models import SELinuxModules, SELinuxModule, SELinuxCustom, SELinuxFacts, SELinuxRequestRPMs, RpmTransactionTasks
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import run, CalledProcessError
+from leapp.libraries.actor import library
+
 
 WORKING_DIRECTORY = '/tmp/selinux/'
-
-# types and attributes that where removed between RHEL 7 and 8
-REMOVED_TYPES_=["base_typeattr_15","direct_run_init","gpgdomain","httpd_exec_scripts","httpd_user_script_exec_type","ibendport_type","ibpkey_type","pcmcia_typeattr_2","pcmcia_typeattr_3","pcmcia_typeattr_4","pcmcia_typeattr_5","pcmcia_typeattr_6","pcmcia_typeattr_7","sandbox_caps_domain","sandbox_typeattr_2","sandbox_typeattr_3","sandbox_typeattr_4","server_ptynode","systemctl_domain","user_home_content_type","userhelper_type","cgdcbxd_exec_t","cgdcbxd_t","cgdcbxd_unit_file_t","cgdcbxd_var_run_t","ganesha_use_fusefs","ganesha_exec_t","ganesha_t","ganesha_tmp_t","ganesha_unit_file_t","ganesha_var_log_t","ganesha_var_run_t","ganesha_use_fusefs"]
-
-# types, attributes and boolean contained in container-selinux
-CONTAINER_TYPES=["container_connect_any","container_runtime_t","container_runtime_exec_t","spc_t","container_auth_t","container_auth_exec_t","spc_var_run_t","container_var_lib_t","container_home_t","container_config_t","container_lock_t","container_log_t","container_runtime_tmp_t","container_runtime_tmpfs_t","container_var_run_t","container_plugin_var_run_t","container_unit_file_t","container_devpts_t","container_share_t","container_port_t","container_build_t","container_logreader_t","docker_log_t","docker_tmpfs_t","docker_share_t","docker_t","docker_lock_t","docker_home_t","docker_exec_t","docker_unit_file_t","docker_devpts_t","docker_config_t","docker_tmp_t","docker_auth_exec_t","docker_plugin_var_run_t","docker_port_t","docker_auth_t","docker_var_run_t","docker_var_lib_t","container_domain","container_net_domain"]
-
 
 class SELinuxContentScanner(Actor):
     '''
@@ -36,7 +27,7 @@ class SELinuxContentScanner(Actor):
             if not fact.enabled:
                 return
 
-        (semodule_list, rpms_to_keep, rpms_to_install) = self.getSELinuxModules()
+        (semodule_list, rpms_to_keep, rpms_to_install) = library.getSELinuxModules()
 
         self.produce(SELinuxModules(modules=semodule_list))
         self.produce(
@@ -54,23 +45,7 @@ class SELinuxContentScanner(Actor):
             )
         )
 
-        semanage_removed = []
-        semanage_valid = []
-        try:
-            # Collect SELinux customizations and select the ones that
-            # can be reapplied after the upgrade
-            semanage = run(['semanage', 'export'], split=True)
-            for line in semanage.get("stdout", []):
-                for setype in REMOVED_TYPES_:
-                    if setype in line:
-                        semanage_removed.append(line)
-                        break
-                else:
-                    semanage_valid.append(line)
-
-        except CalledProcessError as e:
-            self.log.info("Failed to export SELinux customizations: %s", str(e))
-            return
+        (semanage_valid, semanage_removed) = library.getSELinuxCustomizations()
 
         self.produce(
             SELinuxCustom(
@@ -78,141 +53,3 @@ class SELinuxContentScanner(Actor):
                 removed=semanage_removed
             )
         )
-
-    def checkModule(self, name):
-        '''
-        Check if given module contains one of removed types.
-
-        If so, comment out corresponding lines and return them.
-        The function expects a text file "$name" containing cil policy
-        to be present in the current directory.
-        '''
-        try:
-            removed = run(['grep', '-w', '-E', "|".join(REMOVED_TYPES_), name], split=True)
-            run(['sed', '-i', '/%s/s/^/;/g' % '\|'.join(REMOVED_TYPES_), name])
-            return removed.get("stdout", [])
-        except CalledProcessError:
-            return []
-
-
-    def listSELinuxModules(self):
-        '''
-        Produce list of SELinux policy modules
-
-        Returns list of tuples (name,priority)
-        '''
-        try:
-            semodule = run(['semodule', '-lfull'], split=True)
-        except CalledProcessError:
-            return []
-
-        modules = []
-        for module in semodule.get("stdout", []):
-            # Matching line such as "100 zebra             pp "
-            # "<priority> <module name>    <module type - pp/cil> "
-            m = re.match(r'([0-9]+)\s+([\w-]+)\s+([\w-]+)\s*\Z', module)
-            if not m:
-                #invalid output of "semodule -lfull"
-                self.log.info('Invalid output of "semodule -lfull": %s', module)
-                continue
-            modules.append((m.group(2), m.group(1)))
-
-        return modules
-
-
-    def getSELinuxModules(self):
-        '''
-        Read all custom SELinux policy modules from the system
-
-        Returns 3-tuple (modules, retain_rpms, install_rpms)
-        where "modules" is a list of "SELinuxModule" objects,
-        "retain_rpms" is a list of RPMs that should be retained 
-        during the upgrade and "install_rpms" is a list of RPMs
-        that should be installed during the upgrade
-
-        '''
-
-        modules = self.listSELinuxModules()
-        semodule_list = []
-        # list of rpms containing policy modules to be installed on RHEL 8
-        retain_rpms = []
-        install_rpms = []
-
-        # modules need to be extracted into cil files
-        # cd to /tmp/selinux and save working directory so that we can return there
-
-        # clear working directory
-        rmtree(WORKING_DIRECTORY, ignore_errors=True)
-
-        try:
-            wd = os.getcwd()
-            os.mkdir(WORKING_DIRECTORY)
-            os.chdir(WORKING_DIRECTORY)
-        except OSError:
-            self.log.info("Failed to access working directory! Aborting.")
-            return ([],[],[])
-
-        for (name, priority) in modules:
-            if priority == "200":
-                # Module on priority 200 was installed by an RPM
-                # Request $name-selinux to be installed on RHEL8
-                retain_rpms.append(name + "-selinux")
-                continue
-            if priority == "100":
-                # module from selinux-policy-* package - skipping
-                continue
-            # extract custom module and save it to SELinuxModule object
-            try:
-                run(['semodule', '-c', '-X', priority, '-E', name])
-                # check if the module contains invalid types and remove them if so
-                removed = self.checkModule(name + ".cil")
-
-                # get content of the module
-                try:
-                    with open(name + ".cil", 'r') as cil_file:
-                        module_content = cil_file.read()
-                except OSError as e:
-                    self.log.info("Error reading %s.cil : %s", name, str(e))
-                    continue
-
-                semodule_list.append(SELinuxModule(
-                    name=name,
-                    priority=int(priority),
-                    content=module_content,
-                    removed=removed
-                    )
-                )
-            except CalledProcessError:
-                self.log.info("Module %s could not be extracted!", name)
-                continue
-            # rename the cil module file so that it does not clash
-            # with the same module on different priority
-            try:
-                os.rename(name + ".cil",  "%s_%s" % (name, priority))
-            except OSError:
-                # TODO leapp.libraries.stdlib.api.current_logger()
-                # and move the method to a library
-                self.log.info("Failed to rename module file.")
-        # this is necessary for check if container-selinux needs to be installed
-        try:
-            run(['semanage', 'export', '-f', 'semanage'])
-        except CalledProcessError:
-            pass
-        # Check if modules contain any type, attribute, or boolean contained in container-selinux and install it if so
-        # This is necessary since container policy module is part of selinux-policy-targeted in RHEL 7 (but not in RHEL 8)
-        try:
-            semodule = run(['grep', '-w', '-r', '-E', "|".join(CONTAINER_TYPES)], split=False)
-            # Request "container-selinux" to be installed since container types where used in local customizations
-            # and container-selinux policy was removed from selinux-policy-* packages
-            install_rpms.append("container-selinux")
-        except CalledProcessError:
-            # expected, ignore exception
-            pass
-
-        try:
-            os.chdir(wd)
-        except OSError:
-            pass
-        rmtree(WORKING_DIRECTORY, ignore_errors=True)
-
-        return (semodule_list, retain_rpms, install_rpms)

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
@@ -1,0 +1,176 @@
+from leapp.actors import Actor
+from leapp.models import SELinuxModules, SELinuxModule, SELinuxCustom, SystemFacts
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+from leapp.libraries.stdlib import call
+import subprocess
+import re
+import os
+from shutil import rmtree
+
+WORKING_DIRECTORY = '/tmp/selinux/'
+
+# types and attributes that where removed between RHEL 7 and 8
+REMOVED_TYPES_=["base_typeattr_15","direct_run_init","gpgdomain","httpd_exec_scripts","httpd_user_script_exec_type","ibendport_type","ibpkey_type","pcmcia_typeattr_2","pcmcia_typeattr_3","pcmcia_typeattr_4","pcmcia_typeattr_5","pcmcia_typeattr_6","pcmcia_typeattr_7","sandbox_caps_domain","sandbox_typeattr_2","sandbox_typeattr_3","sandbox_typeattr_4","server_ptynode","systemctl_domain","user_home_content_type","userhelper_type","cgdcbxd_exec_t","cgdcbxd_t","cgdcbxd_unit_file_t","cgdcbxd_var_run_t","ganesha_use_fusefs","ganesha_exec_t","ganesha_t","ganesha_tmp_t","ganesha_unit_file_t","ganesha_var_log_t","ganesha_var_run_t","ganesha_use_fusefs"]
+# to be used with grep
+REMOVED_TYPES="|".join(REMOVED_TYPES_)
+# to be used with sed
+SED_COMMAND='/' + '\|'.join(REMOVED_TYPES_) + '/s/^/;/g'
+
+# types, attributes and boolean contained in container-selinux
+CONTAINER_TYPES="|".join(["container_connect_any","container_runtime_t","container_runtime_exec_t","spc_t","container_auth_t","container_auth_exec_t","spc_var_run_t","container_var_lib_t","container_home_t","container_config_t","container_lock_t","container_log_t","container_runtime_tmp_t","container_runtime_tmpfs_t","container_var_run_t","container_plugin_var_run_t","container_unit_file_t","container_devpts_t","container_share_t","container_port_t","container_build_t","container_logreader_t","docker_log_t","docker_tmpfs_t","docker_share_t","docker_t","docker_lock_t","docker_home_t","docker_exec_t","docker_unit_file_t","docker_devpts_t","docker_config_t","docker_tmp_t","docker_auth_exec_t","docker_plugin_var_run_t","docker_port_t","docker_auth_t","docker_var_run_t","docker_var_lib_t","container_domain","container_net_domain"])
+
+
+class SELinuxContentScanner(Actor):
+    name = 'selinuxcontentscanner'
+    description = 'No description has been provided for the selinuxcontentscanner actor.'
+    consumes = (SystemFacts, )
+    produces = (SELinuxModules, SELinuxCustom, )
+    tags = (FactsPhaseTag, IPUWorkflowTag, )
+
+    def process(self):
+        # exit if SELinux is disabled
+        for fact in self.consume(SystemFacts):
+            if fact.selinux.enabled is False:
+                return
+
+        semodule_list = self.getSELinuxModules()
+
+        self.produce(SELinuxModules(modules=semodule_list))
+
+        semanage_removed = []
+        semanage_valid = []
+        try:
+            # Collect SELinux customizations and select the ones that
+            # can be reapplied after the upgrade
+            semanage = call(['semanage', 'export'], split=True)
+            for line in semanage:
+                for setype in REMOVED_TYPES_:
+                    if setype in line:
+                        semanage_removed.append(line)
+                        break
+                else:
+                    semanage_valid.append(line)
+
+        except subprocess.CalledProcessError:
+            return
+
+        self.produce(
+            SELinuxCustom(
+                commands=semanage_valid,
+                removed=semanage_removed
+            )
+        )
+
+        #cmd = [ 'semanage', 'export' ]
+        #stdout = call(cmd, split=False)
+        #semodules = SELinuxModules(
+        #    modules=[SELinuxModule(
+        #        name="nn",
+        #        priority=1,
+        #        content=stdout
+        #)],)
+        #self.produce(semodules)
+
+
+
+    def checkModule(self, name):
+        """ Check if module contains one of removed types.
+            If so, comment out corresponding lines and return them.
+        """
+        try:
+            removed = call(['grep', '-w', '-E', REMOVED_TYPES, name], split=True)
+            call(['sed', '-i', SED_COMMAND, name])
+            return removed
+        except subprocess.CalledProcessError:
+            return []
+
+    def parseSemodule(self, modules_str):
+        """Parse list of modules into list of tuples (name,priority)"""
+        modules = []
+        for module in modules_str:
+            # Matching line such as "100 zebra             pp "
+            # "<priority> <module name>    <module type - pp/cil> "
+            m = re.match('([0-9]+)\s+(\w+)\s+(\w+)\s*\Z', module)
+            if not m:
+                #invalid output of "semodule -lfull"
+                break
+            modules.append((m.group(2), m.group(1)))
+
+        return modules
+
+    def getSELinuxModules(self):
+        try:
+            semodule = call(['semodule', '-lfull'], split=True)
+        except subprocess.CalledProcessError:
+            return
+
+        modules = self.parseSemodule(semodule)
+        semodule_list = []
+
+        # modules need to be extracted into cil files
+        # cd to /tmp/selinux and save working directory so that we can return there
+        try:
+            # clear working directory
+            rmtree(WORKING_DIRECTORY)
+        except OSError:
+            #expected
+            pass
+        try:
+            wd = os.getcwd()
+            os.mkdir(WORKING_DIRECTORY)
+            os.chdir(WORKING_DIRECTORY)
+        except OSError:
+            self.log.info("Failed to access working directory! Aborting.")
+            return []
+
+        for (name, priority) in modules:
+            if priority == "200":
+                #TODO - request "name-selinux" to be installed
+                continue
+            if priority == "100":
+                #module from selinux-policy-* package - skipping
+                continue
+            # extract custom module and save it to SELinuxModule object
+            try:
+                call(['semodule', '-c', '-X', priority, '-E', name])
+                # check if the module contains invalid types and remove them if so
+                removed = self.checkModule(name + ".cil")
+                # get content of the module
+                module_content = call(['cat', name + ".cil"], split=False)
+
+                semodule_list.append(SELinuxModule(
+                    name=name,
+                    priority=int(priority),
+                    content=module_content,
+                    removed=removed
+                    )
+                )
+            except subprocess.CalledProcessError:
+                continue
+            # rename the cil module file so that it does not clash
+            # with the same module on different priority
+            try:
+                os.rename(name + ".cil", name + "_" + str(priority))
+            except OSError:
+                self.log.info("Failed to rename module file.")
+        # this is necessary for check if container-selinux needs to be installed
+        try:
+            call(['semanage', 'export', '-f', 'semanage'])
+        except subprocess.CalledProcessError:
+            pass
+        # Check if modules contain any type, attribute, or boolean contained in container-selinux and install it if so
+        # This is necessary since container policy module is part of selinux-policy-targeted in RHEL 7 (but not in RHEL 8)
+        try:
+            semodule = call(['grep', '-w', '-r', '-E', CONTAINER_TYPES], split=False)
+            #TODO - request "container-selinux" to be installed
+        except subprocess.CalledProcessError:
+            # expected, ignore exception
+            pass
+
+        try:
+            rmtree(WORKING_DIRECTORY)
+            os.chdir(wd)
+        except OSError:
+            pass
+
+        return semodule_list

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
@@ -24,7 +24,7 @@ class SELinuxContentScanner(Actor):
             if not fact.enabled:
                 return
 
-        (semodule_list, rpms_to_keep, rpms_to_install) = library.getSELinuxModules()
+        (semodule_list, rpms_to_keep, rpms_to_install) = library.get_selinux_modules()
 
         self.produce(SELinuxModules(modules=semodule_list))
         self.produce(
@@ -42,7 +42,7 @@ class SELinuxContentScanner(Actor):
             )
         )
 
-        (semanage_valid, semanage_removed) = library.getSELinuxCustomizations()
+        (semanage_valid, semanage_removed) = library.get_selinux_customizations()
 
         self.produce(
             SELinuxCustom(

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
@@ -1,11 +1,9 @@
 from leapp.actors import Actor
-from leapp.models import SELinuxModules, SELinuxModule, SELinuxCustom, SELinuxFacts, SELinuxRequestRPMs, RpmTransactionTasks
+from leapp.models import SELinuxModules, SELinuxCustom, SELinuxFacts, SELinuxRequestRPMs, RpmTransactionTasks
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import run, CalledProcessError
 from leapp.libraries.actor import library
 
-
-WORKING_DIRECTORY = '/tmp/selinux/'
 
 class SELinuxContentScanner(Actor):
     '''
@@ -32,16 +30,16 @@ class SELinuxContentScanner(Actor):
         self.produce(SELinuxModules(modules=semodule_list))
         self.produce(
             RpmTransactionTasks(
-                to_install = rpms_to_install,
+                to_install=rpms_to_install,
                 # possibly not necessary - dnf should not remove RPMs (that exist in both RHEL 7 and 8) durign update
-                to_keep = rpms_to_keep
+                to_keep=rpms_to_keep
             )
         )
         # this is produced so that we can later verify that the RPMs are present after upgrade
         self.produce(
             SELinuxRequestRPMs(
-                to_install = rpms_to_install,
-                to_keep = rpms_to_keep
+                to_install=rpms_to_install,
+                to_keep=rpms_to_keep
             )
         )
 

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
@@ -1,7 +1,6 @@
 from leapp.actors import Actor
 from leapp.models import SELinuxModules, SELinuxCustom, SELinuxFacts, SELinuxRequestRPMs, RpmTransactionTasks
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
-from leapp.libraries.stdlib import run, CalledProcessError
 from leapp.libraries.actor import library
 
 

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/libraries/library.py
@@ -1,0 +1,179 @@
+import os
+import re
+from shutil import rmtree
+from leapp.libraries.stdlib import api, run, CalledProcessError
+
+# types and attributes that where removed between RHEL 7 and 8
+REMOVED_TYPES_=["base_typeattr_15","direct_run_init","gpgdomain","httpd_exec_scripts","httpd_user_script_exec_type","ibendport_type","ibpkey_type","pcmcia_typeattr_2","pcmcia_typeattr_3","pcmcia_typeattr_4","pcmcia_typeattr_5","pcmcia_typeattr_6","pcmcia_typeattr_7","sandbox_caps_domain","sandbox_typeattr_2","sandbox_typeattr_3","sandbox_typeattr_4","server_ptynode","systemctl_domain","user_home_content_type","userhelper_type","cgdcbxd_exec_t","cgdcbxd_t","cgdcbxd_unit_file_t","cgdcbxd_var_run_t","ganesha_use_fusefs","ganesha_exec_t","ganesha_t","ganesha_tmp_t","ganesha_unit_file_t","ganesha_var_log_t","ganesha_var_run_t","ganesha_use_fusefs"]
+
+# types, attributes and boolean contained in container-selinux
+CONTAINER_TYPES=["container_connect_any","container_runtime_t","container_runtime_exec_t","spc_t","container_auth_t","container_auth_exec_t","spc_var_run_t","container_var_lib_t","container_home_t","container_config_t","container_lock_t","container_log_t","container_runtime_tmp_t","container_runtime_tmpfs_t","container_var_run_t","container_plugin_var_run_t","container_unit_file_t","container_devpts_t","container_share_t","container_port_t","container_build_t","container_logreader_t","docker_log_t","docker_tmpfs_t","docker_share_t","docker_t","docker_lock_t","docker_home_t","docker_exec_t","docker_unit_file_t","docker_devpts_t","docker_config_t","docker_tmp_t","docker_auth_exec_t","docker_plugin_var_run_t","docker_port_t","docker_auth_t","docker_var_run_t","docker_var_lib_t","container_domain","container_net_domain"]
+
+
+def checkModule(name):
+    '''
+    Check if given module contains one of removed types.
+
+    If so, comment out corresponding lines and return them.
+    The function expects a text file "$name" containing cil policy
+    to be present in the current directory.
+    '''
+    try:
+        removed = run(['grep', '-w', '-E', "|".join(REMOVED_TYPES_), name], split=True)
+        run(['sed', '-i', '/%s/s/^/;/g' % '\|'.join(REMOVED_TYPES_), name])
+        return removed.get("stdout", [])
+    except CalledProcessError:
+        return []
+
+
+def listSELinuxModules():
+    '''
+    Produce list of SELinux policy modules
+
+    Returns list of tuples (name,priority)
+    '''
+    try:
+        semodule = run(['semodule', '-lfull'], split=True)
+    except CalledProcessError:
+        return []
+
+    modules = []
+    for module in semodule.get("stdout", []):
+        # Matching line such as "100 zebra             pp "
+        # "<priority> <module name>    <module type - pp/cil> "
+        m = re.match(r'([0-9]+)\s+([\w-]+)\s+([\w-]+)\s*\Z', module)
+        if not m:
+            #invalid output of "semodule -lfull"
+            api.current_logger().info('Invalid output of "semodule -lfull": %s', module)
+            continue
+        modules.append((m.group(2), m.group(1)))
+
+    return modules
+
+
+def getSELinuxModules():
+    '''
+    Read all custom SELinux policy modules from the system
+
+    Returns 3-tuple (modules, retain_rpms, install_rpms)
+    where "modules" is a list of "SELinuxModule" objects,
+    "retain_rpms" is a list of RPMs that should be retained 
+    during the upgrade and "install_rpms" is a list of RPMs
+    that should be installed during the upgrade
+
+    '''
+
+    modules = listSELinuxModules()
+    semodule_list = []
+    # list of rpms containing policy modules to be installed on RHEL 8
+    retain_rpms = []
+    install_rpms = []
+
+    # modules need to be extracted into cil files
+    # cd to /tmp/selinux and save working directory so that we can return there
+
+    # clear working directory
+    rmtree(WORKING_DIRECTORY, ignore_errors=True)
+
+    try:
+        wd = os.getcwd()
+        os.mkdir(WORKING_DIRECTORY)
+        os.chdir(WORKING_DIRECTORY)
+    except OSError:
+        api.current_logger().info("Failed to access working directory! Aborting.")
+        return ([],[],[])
+
+    for (name, priority) in modules:
+        if priority == "200":
+            # Module on priority 200 was installed by an RPM
+            # Request $name-selinux to be installed on RHEL8
+            retain_rpms.append(name + "-selinux")
+            continue
+        if priority == "100":
+            # module from selinux-policy-* package - skipping
+            continue
+        # extract custom module and save it to SELinuxModule object
+        try:
+            run(['semodule', '-c', '-X', priority, '-E', name])
+            # check if the module contains invalid types and remove them if so
+            removed = checkModule(name + ".cil")
+
+            # get content of the module
+            try:
+                with open(name + ".cil", 'r') as cil_file:
+                    module_content = cil_file.read()
+            except OSError as e:
+                api.current_logger().info("Error reading %s.cil : %s", name, str(e))
+                continue
+
+            semodule_list.append(SELinuxModule(
+                name=name,
+                priority=int(priority),
+                content=module_content,
+                removed=removed
+                )
+            )
+        except CalledProcessError:
+            api.current_logger().info("Module %s could not be extracted!", name)
+            continue
+        # rename the cil module file so that it does not clash
+        # with the same module on different priority
+        try:
+            os.rename(name + ".cil",  "%s_%s" % (name, priority))
+        except OSError:
+            # TODO leapp.libraries.stdlib.api.current_logger()
+            # and move the method to a library
+            api.current_logger().info("Failed to rename module file.")
+    # this is necessary for check if container-selinux needs to be installed
+    try:
+        run(['semanage', 'export', '-f', 'semanage'])
+    except CalledProcessError:
+        pass
+    # Check if modules contain any type, attribute, or boolean contained in container-selinux and install it if so
+    # This is necessary since container policy module is part of selinux-policy-targeted in RHEL 7 (but not in RHEL 8)
+    try:
+        semodule = run(['grep', '-w', '-r', '-E', "|".join(CONTAINER_TYPES)], split=False)
+        # Request "container-selinux" to be installed since container types where used in local customizations
+        # and container-selinux policy was removed from selinux-policy-* packages
+        install_rpms.append("container-selinux")
+    except CalledProcessError:
+        # expected, ignore exception
+        pass
+
+    try:
+        os.chdir(wd)
+    except OSError:
+        pass
+    rmtree(WORKING_DIRECTORY, ignore_errors=True)
+
+    return (semodule_list, retain_rpms, install_rpms)
+
+def getSELinuxCustomizations():
+    '''
+    Extract local SELinux customizations introduced by semanage command
+
+    Returns tuple (semanage_valid, semanage_removed)
+    where "semanage_valid" is a list of semanage commands
+    which should be safe to re-apply on RHEL 8 system
+    and "semanage_removed" is a list of commands that
+    will no longer be valid after system upgrade
+    '''
+
+    semanage_removed = []
+    semanage_valid = []
+    try:
+        # Collect SELinux customizations and select the ones that
+        # can be reapplied after the upgrade
+        semanage = run(['semanage', 'export'], split=True)
+        for line in semanage.get("stdout", []):
+            for setype in REMOVED_TYPES_:
+                if setype in line:
+                    semanage_removed.append(line)
+                    break
+            else:
+                semanage_valid.append(line)
+
+    except CalledProcessError as e:
+        api.current_logger().info("Failed to export SELinux customizations: %s", str(e))
+    
+    return (semanage_valid, semanage_removed)

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/libraries/library.py
@@ -30,7 +30,7 @@ CONTAINER_TYPES = ["container_connect_any", "container_runtime_t", "container_ru
 WORKING_DIRECTORY = '/tmp/selinux/'
 
 
-def checkModule(name):
+def check_module(name):
     '''
     Check if given module contains one of removed types and comment out corresponding lines.
 
@@ -48,7 +48,7 @@ def checkModule(name):
         return []
 
 
-def listSELinuxModules():
+def list_selinux_modules():
     '''
     Produce list of SELinux policy modules
 
@@ -74,7 +74,7 @@ def listSELinuxModules():
     return modules
 
 
-def getSELinuxModules():
+def get_selinux_modules():
     '''
     Read all custom SELinux policy modules from the system
 
@@ -86,7 +86,7 @@ def getSELinuxModules():
 
     '''
 
-    modules = listSELinuxModules()
+    modules = list_selinux_modules()
     semodule_list = []
     # list of rpms containing policy modules to be installed on RHEL 8
     retain_rpms = []
@@ -120,7 +120,7 @@ def getSELinuxModules():
         try:
             run(['semodule', '-c', '-X', priority, '-E', name])
             # check if the module contains invalid types and remove them if so
-            removed = checkModule(module_file)
+            removed = check_module(module_file)
 
             # get content of the module
             try:
@@ -171,7 +171,7 @@ def getSELinuxModules():
     return (semodule_list, list(set(retain_rpms)), list(set(install_rpms)))
 
 
-def getSELinuxCustomizations():
+def get_selinux_customizations():
     '''
     Extract local SELinux customizations introduced by semanage command
 

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/libraries/library.py
@@ -1,6 +1,7 @@
 import os
 import re
 from shutil import rmtree
+
 from leapp.libraries.stdlib import api, run, CalledProcessError
 from leapp.models import SELinuxModule
 
@@ -27,6 +28,7 @@ CONTAINER_TYPES = ["container_connect_any", "container_runtime_t", "container_ru
                    "docker_var_lib_t", "container_domain", "container_net_domain"]
 
 WORKING_DIRECTORY = '/tmp/selinux/'
+
 
 def checkModule(name):
     '''
@@ -61,7 +63,7 @@ def listSELinuxModules():
         # "<priority> <module name>    <module type - pp/cil> "
         m = re.match(r'([0-9]+)\s+([\w-]+)\s+([\w-]+)\s*\Z', module)
         if not m:
-            #invalid output of "semodule -lfull"
+            # invalid output of "semodule -lfull"
             api.current_logger().info('Invalid output of "semodule -lfull": %s', module)
             continue
         modules.append((m.group(2), m.group(1)))
@@ -165,6 +167,7 @@ def getSELinuxModules():
     rmtree(WORKING_DIRECTORY, ignore_errors=True)
 
     return (semodule_list, retain_rpms, install_rpms)
+
 
 def getSELinuxCustomizations():
     '''

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/component_test.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from leapp.snactor.fixture import current_actor_context
 from leapp.models import SELinuxModule, SELinuxModules, SELinuxCustom, SELinuxFacts, SELinuxRequestRPMs
 from leapp.libraries.stdlib import api, run, CalledProcessError
@@ -14,15 +16,18 @@ test_modules = [
 ]
 
 semanage_commands = [
-['fcontext', '-t', 'httpd_sys_content_t', '"/web(/.*)?"'],
-['fcontext', '-t', 'ganesha_var_run_t', '"/ganesha(/.*)?"'],
-['port', '-t', 'http_port_t', '-p', 'udp', '81'],
-['permissive', 'abrt_t']
+    ['fcontext', '-t', 'httpd_sys_content_t', '"/web(/.*)?"'],
+    ['fcontext', '-t', 'ganesha_var_run_t', '"/ganesha(/.*)?"'],
+    ['port', '-t', 'http_port_t', '-p', 'udp', '81'],
+    ['permissive', 'abrt_t']
 ]
 
 testmoduledir = os.path.join(os.getcwd(), "tests/mock_modules/")
 
-def setup():
+
+# Test disabled because it's setup and teardown would modify the system
+# Remove "_" before re-activation
+def setup_():
     for priority, module in test_modules:
         try:
             semodule = run(["semodule", "-X", priority, "-i", os.path.join(testmoduledir, module + ".cil")])
@@ -39,11 +44,13 @@ def setup():
             api.current_logger().warning("Error applying selinux customizations %s", str(e.stderr))
             continue
 
+
 def findModule(selinuxmodules, name, priority):
     for module in selinuxmodules.modules:
         if module.name == name and module.priority == int(priority):
             return module
     return None
+
 
 def findSemanageRule(rules, rule):
     for r in rules:
@@ -54,6 +61,8 @@ def findSemanageRule(rules, rule):
             return r
     return None
 
+
+@pytest.mark.skip(reason="Test disabled because it's setup and teardown would modify the system")
 def test_SELinuxContentScanner(current_actor_context):
 
     expected_data = {'policy': 'targeted',
@@ -89,7 +98,9 @@ def test_SELinuxContentScanner(current_actor_context):
     assert findSemanageRule(custom.commands, semanage_commands[2])
 
 
-def teardown():
+# Test disabled because it's setup and teardown would modify the system
+# Remove "_" before re-activation
+def teardown_():
     for command in semanage_commands[:-1]:
         try:
             run(["semanage", command[0], "-d"] + command[1:])

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/component_test.py
@@ -57,12 +57,12 @@ def destructive_selinux_env():
                  "Error removing selinux module {} after testing".format(module))
 
 
-def findModule(selinuxmodules, name, priority):
+def find_module(selinuxmodules, name, priority):
     return next((module for module in selinuxmodules.modules
                 if (module.name == name and module.priority == int(priority))), None)
 
 
-def findSemanageRule(rules, rule):
+def find_semanage_rule(rules, rule):
     return next((r for r in rules if all(word in r for word in rule)), None)
 
 
@@ -85,7 +85,7 @@ def test_SELinuxContentScanner(current_actor_context, destructive_selinux_env):
     # check that all modules installed during test setup where reported
     for priority, name in TEST_MODULES:
         if priority != "100" and priority != "200":
-            assert findModule(modules, name, priority)
+            assert find_module(modules, name, priority)
 
     rpms = current_actor_context.consume(SELinuxRequestRPMs)[0]
     assert rpms
@@ -97,7 +97,7 @@ def test_SELinuxContentScanner(current_actor_context, destructive_selinux_env):
     custom = current_actor_context.consume(SELinuxCustom)[0]
     assert custom
     # the second command contains removed type and should be discarded
-    assert findSemanageRule(custom.removed, SEMANAGE_COMMANDS[1])
+    assert find_semanage_rule(custom.removed, SEMANAGE_COMMANDS[1])
     # the rest of the commands should be reported (except for the last which will show up in modules)
-    assert findSemanageRule(custom.commands, SEMANAGE_COMMANDS[0])
-    assert findSemanageRule(custom.commands, SEMANAGE_COMMANDS[2])
+    assert find_semanage_rule(custom.commands, SEMANAGE_COMMANDS[0])
+    assert find_semanage_rule(custom.commands, SEMANAGE_COMMANDS[2])

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/component_test.py
@@ -1,0 +1,105 @@
+import os
+
+from leapp.snactor.fixture import current_actor_context
+from leapp.models import SELinuxModule, SELinuxModules, SELinuxCustom, SELinuxFacts, SELinuxRequestRPMs
+from leapp.libraries.stdlib import api, run, CalledProcessError
+from leapp.reporting import Report
+
+test_modules = [
+    ["400", "mock1"],
+    ["99", "mock1"],
+    ["200", "mock1"],
+    ["400", "mock2"],
+    ["999", "mock3"]
+]
+
+semanage_commands = [
+['fcontext', '-t', 'httpd_sys_content_t', '"/web(/.*)?"'],
+['fcontext', '-t', 'ganesha_var_run_t', '"/ganesha(/.*)?"'],
+['port', '-t', 'http_port_t', '-p', 'udp', '81'],
+['permissive', 'abrt_t']
+]
+
+testmoduledir = os.path.join(os.getcwd(), "tests/mock_modules/")
+
+def setup():
+    for priority, module in test_modules:
+        try:
+            semodule = run(["semodule", "-X", priority, "-i", os.path.join(testmoduledir, module + ".cil")])
+        except CalledProcessError as e:
+            api.current_logger().warning("Error installing mock module: %s", e.stderr)
+            api.current_logger().warning("Error installing mock module: %s, %s", str(e.stderr),
+                                         semodule.get("stderr", "fuck"))
+            continue
+
+    for command in semanage_commands:
+        try:
+            run(["semanage", command[0], "-a"] + command[1:])
+        except CalledProcessError as e:
+            api.current_logger().warning("Error applying selinux customizations %s", str(e.stderr))
+            continue
+
+def findModule(selinuxmodules, name, priority):
+    for module in selinuxmodules.modules:
+        if module.name == name and module.priority == int(priority):
+            return module
+    return None
+
+def findSemanageRule(rules, rule):
+    for r in rules:
+        for word in rule:
+            if word not in r:
+                break
+        else:
+            return r
+    return None
+
+def test_SELinuxContentScanner(current_actor_context):
+
+    expected_data = {'policy': 'targeted',
+                     'mls_enabled': True,
+                     'enabled': True,
+                     'runtime_mode': 'enforcing',
+                     'static_mode': 'enforcing'}
+
+    current_actor_context.feed(SELinuxFacts(**expected_data))
+    current_actor_context.run()
+
+    modules = current_actor_context.consume(SELinuxModules)[0]
+    api.current_logger().warning("Modules: %s", str(modules))
+    assert modules
+    # check that all modules installed during test setup where reported
+    for priority, name in test_modules:
+        if priority != "100" and priority != "200":
+            assert findModule(modules, name, priority)
+
+    rpms = current_actor_context.consume(SELinuxRequestRPMs)[0]
+    assert rpms
+    # modules with priority 200 should only originate in "<module_name>-selinux" rpms
+    assert "mock1-selinux" in rpms.to_keep
+    # mock1 contains container related type
+    assert "container-selinux" in rpms.to_install
+
+    custom = current_actor_context.consume(SELinuxCustom)[0]
+    assert custom
+    # the second command contains removed type and should be discarded
+    assert findSemanageRule(custom.removed, semanage_commands[1])
+    # the rest of the commands should be reported (except for the last which will show up in modules)
+    assert findSemanageRule(custom.commands, semanage_commands[0])
+    assert findSemanageRule(custom.commands, semanage_commands[2])
+
+
+def teardown():
+    for command in semanage_commands[:-1]:
+        try:
+            run(["semanage", command[0], "-d"] + command[1:])
+        except CalledProcessError as e:
+            api.current_logger().warning("Error removing selinux customizations after testing: %s", str(e.stderr))
+            continue
+
+    for priority, module in reversed(test_modules + [["400", "permissive_abrt_t"]]):
+        try:
+            run(["semodule", "-X", priority, "-r", module])
+        except CalledProcessError as e:
+            api.current_logger().warning("Error removing selinux modules after testing: %s", str(e.stderr))
+            continue

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/component_test.py
@@ -30,11 +30,9 @@ testmoduledir = os.path.join(os.getcwd(), "tests/mock_modules/")
 def setup_():
     for priority, module in test_modules:
         try:
-            semodule = run(["semodule", "-X", priority, "-i", os.path.join(testmoduledir, module + ".cil")])
+            run(["semodule", "-X", priority, "-i", os.path.join(testmoduledir, module + ".cil")])
         except CalledProcessError as e:
-            api.current_logger().warning("Error installing mock module: %s", e.stderr)
-            api.current_logger().warning("Error installing mock module: %s, %s", str(e.stderr),
-                                         semodule.get("stderr", "fuck"))
+            api.current_logger().warning("Error installing mock module: %s", str(e.stderr))
             continue
 
     for command in semanage_commands:

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/mock_modules/mock1.cil
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/mock_modules/mock1.cil
@@ -1,0 +1,4 @@
+(type mock_type_t)
+(typeattributeset domain (mock_type_t))
+(allow mock_type_t proc_type (file (getattr open read)))
+(allow mock_type_t container_var_run_t (file (getattr open read)))

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/mock_modules/mock2.cil
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/mock_modules/mock2.cil
@@ -1,0 +1,4 @@
+(type mock_type2_t)
+(typeattributeset direct_run_init (mock_type2_t))
+(allow mock_type_t file_type (file (getattr open read)))
+(allow mock_type_t ganesha_exec_t (file (getattr open read)))

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/mock_modules/mock3.cil
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/mock_modules/mock3.cil
@@ -1,0 +1,3 @@
+(type mock_type3_t)
+(typeattributeset domain (mock_type3_t))
+(allow mock_type_t file_type (file (getattr open read)))

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/unit_test.py
@@ -1,0 +1,67 @@
+from leapp.libraries.stdlib import run, CalledProcessError
+from leapp.libraries.actor import library
+
+class run_mocked(object):
+    def __init__(self):
+        self.args = []
+        self.called = 0
+
+    def __call__(self, args, split=True):
+        self.called += 1
+        self.args = args
+
+        if self.args == ['semodule', '-lfull']:
+            stdout = ["400 permissive_abrt_t cil",
+                     "400   zebra       cil",
+                     "300 zebra       cil",
+                     "100 vpn               pp  ",
+                     "099 zebra             cil     ",
+                     "100   minissdpd         pp"]
+
+        elif self.args == ['semanage', 'export']:
+            stdout = ["boolean -D",
+                     "login -D",
+                     "interface -D",
+                     "user -D",
+                     "port -D",
+                     "node -D",
+                     "fcontext -D",
+                     "module -D",
+                     "boolean -m -1 cron_can_relabel",
+                     "port -a -t http_port_t -p udp 81",
+                     "fcontext -a -f a -t httpd_sys_content_t '/web(/.*)?'",
+                     "fcontext -a -f a -t ganesha_var_run_t '/ganesha(/.*)?'"]
+
+        return {'stdout': stdout}
+
+class run_mocked_fail(object):
+    def __init__(self):
+        self.called = 0
+
+    def __call__(self, args, split=True):
+        raise CalledProcessError(self, 1, "Mock error ;)")
+
+
+def test_listSELinuxModules(monkeypatch):
+    monkeypatch.setattr(library, "run", run_mocked())
+
+    assert library.listSELinuxModules() == [("permissive_abrt_t", "400"),
+                                            ("zebra", "400"),
+                                            ("zebra", "300"),
+                                            ("vpn", "100"),
+                                            ("zebra", "099"),
+                                            ("minissdpd", "100")]
+
+    monkeypatch.setattr(library, "run", run_mocked_fail())
+
+    assert library.listSELinuxModules() == []
+
+def test_getSELinuxCustomizations(monkeypatch):
+    monkeypatch.setattr(library, "run", run_mocked())
+
+    (semanage_valid, semanage_removed) = library.getSELinuxCustomizations()
+
+    assert len(semanage_valid) == 11
+    assert semanage_valid[0] == "boolean -D"
+    assert semanage_valid[10] == "fcontext -a -f a -t httpd_sys_content_t '/web(/.*)?'"
+    assert semanage_removed == ["fcontext -a -f a -t ganesha_var_run_t '/ganesha(/.*)?'"]

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/unit_test.py
@@ -1,6 +1,7 @@
 from leapp.libraries.stdlib import run, CalledProcessError
 from leapp.libraries.actor import library
 
+
 class run_mocked(object):
     def __init__(self):
         self.args = []
@@ -12,27 +13,28 @@ class run_mocked(object):
 
         if self.args == ['semodule', '-lfull']:
             stdout = ["400 permissive_abrt_t cil",
-                     "400   zebra       cil",
-                     "300 zebra       cil",
-                     "100 vpn               pp  ",
-                     "099 zebra             cil     ",
-                     "100   minissdpd         pp"]
+                      "400   zebra       cil",
+                      "300 zebra       cil",
+                      "100 vpn               pp  ",
+                      "099 zebra             cil     ",
+                      "100   minissdpd         pp"]
 
         elif self.args == ['semanage', 'export']:
             stdout = ["boolean -D",
-                     "login -D",
-                     "interface -D",
-                     "user -D",
-                     "port -D",
-                     "node -D",
-                     "fcontext -D",
-                     "module -D",
-                     "boolean -m -1 cron_can_relabel",
-                     "port -a -t http_port_t -p udp 81",
-                     "fcontext -a -f a -t httpd_sys_content_t '/web(/.*)?'",
-                     "fcontext -a -f a -t ganesha_var_run_t '/ganesha(/.*)?'"]
+                      "login -D",
+                      "interface -D",
+                      "user -D",
+                      "port -D",
+                      "node -D",
+                      "fcontext -D",
+                      "module -D",
+                      "boolean -m -1 cron_can_relabel",
+                      "port -a -t http_port_t -p udp 81",
+                      "fcontext -a -f a -t httpd_sys_content_t '/web(/.*)?'",
+                      "fcontext -a -f a -t ganesha_var_run_t '/ganesha(/.*)?'"]
 
         return {'stdout': stdout}
+
 
 class run_mocked_fail(object):
     def __init__(self):
@@ -55,6 +57,7 @@ def test_listSELinuxModules(monkeypatch):
     monkeypatch.setattr(library, "run", run_mocked_fail())
 
     assert library.listSELinuxModules() == []
+
 
 def test_getSELinuxCustomizations(monkeypatch):
     monkeypatch.setattr(library, "run", run_mocked())

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/unit_test.py
@@ -44,25 +44,25 @@ class run_mocked_fail(object):
         raise CalledProcessError(self, 1, "Mock error ;)")
 
 
-def test_listSELinuxModules(monkeypatch):
+def test_list_selinux_modules(monkeypatch):
     monkeypatch.setattr(library, "run", run_mocked())
 
-    assert library.listSELinuxModules() == [("permissive_abrt_t", "400"),
-                                            ("zebra", "400"),
-                                            ("zebra", "300"),
-                                            ("vpn", "100"),
-                                            ("zebra", "099"),
-                                            ("minissdpd", "100")]
+    assert library.list_selinux_modules() == [("permissive_abrt_t", "400"),
+                                              ("zebra", "400"),
+                                              ("zebra", "300"),
+                                              ("vpn", "100"),
+                                              ("zebra", "099"),
+                                              ("minissdpd", "100")]
 
     monkeypatch.setattr(library, "run", run_mocked_fail())
 
-    assert library.listSELinuxModules() == []
+    assert library.list_selinux_modules() == []
 
 
-def test_getSELinuxCustomizations(monkeypatch):
+def test_get_selinux_customizations(monkeypatch):
     monkeypatch.setattr(library, "run", run_mocked())
 
-    (semanage_valid, semanage_removed) = library.getSELinuxCustomizations()
+    (semanage_valid, semanage_removed) = library.get_selinux_customizations()
 
     assert len(semanage_valid) == 11
     assert semanage_valid[0] == "boolean -D"

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/Makefile
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/Makefile
@@ -1,0 +1,2 @@
+install-deps:
+	yum install -y policycoreutils policycoreutils-python

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
@@ -2,6 +2,7 @@ from leapp.actors import Actor
 from leapp.models import SELinuxModules, SELinuxCustom
 from leapp.tags import PreparationPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import run, CalledProcessError
+from leapp.libraries.actor import library
 
 class SELinuxPrepare(Actor):
     '''
@@ -19,32 +20,5 @@ class SELinuxPrepare(Actor):
     tags = (PreparationPhaseTag, IPUWorkflowTag)
 
     def process(self):
-        # remove SELinux customizations done by semanage -- to be reintroduced after the upgrade
-        self.log.info('Removing SELinux customizations introduced by semanage.')
-
-        semanage_options = ["login","user","port","interface","module","node","fcontext","boolean","ibpkey","ibendport"]
-        # permissive domains are handled by porting modules (permissive -a adds new cil module with priority 400)
-        for option in semanage_options:
-            try:
-                run(['semanage', option, '-D'])
-            except CalledProcessError:
-                continue
-
-        # remove custom SElinux modules - to be reinstalled after the upgrade
-        for semodules in self.consume(SELinuxModules):
-            self.log.info("Removing custom SELinux policy modules. Count: %d", len(semodules.modules))
-            for module in semodules.modules:
-                self.log.info("Removing %s on priority %d.", module.name, module.priority)
-                try:
-                    run([
-                        'semodule',
-                        '-X',
-                        str(module.priority),
-                        '-r',
-                        module.name]
-                    )
-                except CalledProcessError as e:
-                    self.log.info("Failed to remove module %s on priority %d: %s", module.name, module.priority, str(e))
-                    continue
-
-        self.log.info("SElinux customizations removed successfully.")
+        library.removeSemanageCustomizations()
+        library.removeCustomModules()

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
@@ -1,0 +1,49 @@
+from leapp.actors import Actor
+from leapp.models import SELinuxModules, SELinuxCustom, CheckResult
+from leapp.tags import PreparationPhaseTag, IPUWorkflowTag
+from leapp.libraries.stdlib import call
+import subprocess
+
+class SELinuxPrepare(Actor):
+    name = 'selinuxprepare'
+    description = 'No description has been provided for the selinuxprepare actor.'
+    consumes = (SELinuxCustom, SELinuxModules, )
+    produces = (CheckResult, )
+    tags = (PreparationPhaseTag, IPUWorkflowTag, )
+
+    def process(self):
+        # remove custom SElinux modules - to be reinstalled after the upgrade
+        for semodules in self.consume(SELinuxModules):
+            self.log.info("Removing custom SELinux policy modules. Count: " +
+                str(len(semodules.modules))
+            )
+            for module in semodules.modules:
+                self.log.info("Removing " + module.name
+                 + " on priority " + str(module.priority) + ".")
+
+                try:
+                    semanage = call([
+                        'semodule',
+                        '-X',
+                        str(module.priority),
+                        '-r',
+                        module.name]
+                    )
+                except subprocess.CalledProcessError:
+                    self.log.info("Failed to remove " + module.name
+                        + " on priority " + str(module.priority) + ".")
+                    continue
+
+        # remove SELinux customizations done by semanage -- to be reintroduced after the upgrade
+        self.log.info('Removing SELinux customizations introduced by semanage.')
+
+        semanage_options = ["login","user","port","interface","module","node","fcontext","boolean","permissive","dontaudit","ibpkey","ibendport"]
+        for option in semanage_options:
+            try:
+                call(['semanage', option, '-D'])
+            except subprocess.CalledProcessError:
+                continue
+
+        self.log.info("SElinux customizations removed successfully.")
+
+

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
@@ -14,7 +14,6 @@ class SELinuxPrepare(Actor):
     '''
 
     name = 'selinuxprepare'
-    # TODO change description to doc string - first line is summary, followed by more in-depth description
     consumes = (SELinuxCustom, SELinuxModules)
     produces = ()
     tags = (PreparationPhaseTag, IPUWorkflowTag)

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
@@ -1,8 +1,8 @@
 from leapp.actors import Actor
 from leapp.models import SELinuxModules, SELinuxCustom
 from leapp.tags import PreparationPhaseTag, IPUWorkflowTag
-from leapp.libraries.stdlib import run, CalledProcessError
 from leapp.libraries.actor import library
+
 
 class SELinuxPrepare(Actor):
     '''

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
@@ -19,5 +19,5 @@ class SELinuxPrepare(Actor):
     tags = (PreparationPhaseTag, IPUWorkflowTag)
 
     def process(self):
-        library.removeSemanageCustomizations()
-        library.removeCustomModules()
+        library.remove_semanage_customizations()
+        library.remove_custom_modules()

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
@@ -1,49 +1,50 @@
 from leapp.actors import Actor
-from leapp.models import SELinuxModules, SELinuxCustom, CheckResult
+from leapp.models import SELinuxModules, SELinuxCustom
 from leapp.tags import PreparationPhaseTag, IPUWorkflowTag
-from leapp.libraries.stdlib import call
-import subprocess
+from leapp.libraries.stdlib import run, CalledProcessError
 
 class SELinuxPrepare(Actor):
+    '''
+    Remove selinux policy customizations before updating selinux-policy* packages
+
+    RHEL-7 policy customizations could cause policy package upgrade to fail and therefore
+    need to be removed. Customizations introduced by semanage are removed first,
+    followed by custom policy modules gathered by SELinuxContentScanner.
+    '''
+
     name = 'selinuxprepare'
-    description = 'No description has been provided for the selinuxprepare actor.'
-    consumes = (SELinuxCustom, SELinuxModules, )
-    produces = (CheckResult, )
-    tags = (PreparationPhaseTag, IPUWorkflowTag, )
+    # TODO change description to doc string - first line is summary, followed by more in-depth description
+    consumes = (SELinuxCustom, SELinuxModules)
+    produces = ()
+    tags = (PreparationPhaseTag, IPUWorkflowTag)
 
     def process(self):
+        # remove SELinux customizations done by semanage -- to be reintroduced after the upgrade
+        self.log.info('Removing SELinux customizations introduced by semanage.')
+
+        semanage_options = ["login","user","port","interface","module","node","fcontext","boolean","ibpkey","ibendport"]
+        # permissive domains are handled by porting modules (permissive -a adds new cil module with priority 400)
+        for option in semanage_options:
+            try:
+                run(['semanage', option, '-D'])
+            except CalledProcessError:
+                continue
+
         # remove custom SElinux modules - to be reinstalled after the upgrade
         for semodules in self.consume(SELinuxModules):
-            self.log.info("Removing custom SELinux policy modules. Count: " +
-                str(len(semodules.modules))
-            )
+            self.log.info("Removing custom SELinux policy modules. Count: %d", len(semodules.modules))
             for module in semodules.modules:
-                self.log.info("Removing " + module.name
-                 + " on priority " + str(module.priority) + ".")
-
+                self.log.info("Removing %s on priority %d.", module.name, module.priority)
                 try:
-                    semanage = call([
+                    run([
                         'semodule',
                         '-X',
                         str(module.priority),
                         '-r',
                         module.name]
                     )
-                except subprocess.CalledProcessError:
-                    self.log.info("Failed to remove " + module.name
-                        + " on priority " + str(module.priority) + ".")
+                except CalledProcessError as e:
+                    self.log.info("Failed to remove module %s on priority %d: %s", module.name, module.priority, str(e))
                     continue
 
-        # remove SELinux customizations done by semanage -- to be reintroduced after the upgrade
-        self.log.info('Removing SELinux customizations introduced by semanage.')
-
-        semanage_options = ["login","user","port","interface","module","node","fcontext","boolean","permissive","dontaudit","ibpkey","ibendport"]
-        for option in semanage_options:
-            try:
-                call(['semanage', option, '-D'])
-            except subprocess.CalledProcessError:
-                continue
-
         self.log.info("SElinux customizations removed successfully.")
-
-

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/libraries/library.py
@@ -2,7 +2,7 @@ from leapp.libraries.stdlib import api, run, CalledProcessError
 from leapp.models import SELinuxModules
 
 
-def removeSemanageCustomizations():
+def remove_semanage_customizations():
     # remove SELinux customizations done by semanage -- to be reintroduced after the upgrade
     api.current_logger().info('Removing SELinux customizations introduced by semanage.')
 
@@ -16,7 +16,7 @@ def removeSemanageCustomizations():
             continue
 
 
-def removeCustomModules():
+def remove_custom_modules():
     # remove custom SElinux modules - to be reinstalled after the upgrade
     for semodules in api.consume(SELinuxModules):
         api.current_logger().info("Removing custom SELinux policy modules. Count: %d", len(semodules.modules))

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/libraries/library.py
@@ -24,12 +24,11 @@ def removeCustomModules():
             api.current_logger().info("Removing %s on priority %d.", module.name, module.priority)
             try:
                 run(['semodule',
-                     '-X',
-                     str(module.priority),
-                     '-r',
-                     module.name]
+                     '-X', str(module.priority),
+                     '-r', module.name
+                     ]
                     )
             except CalledProcessError as e:
-                api.current_logger().info("Failed to remove module %s on priority %d: %s",
-                                          module.name, module.priority, str(e))
+                api.current_logger().warning("Failed to remove module %s on priority %d: %s",
+                                             module.name, module.priority, str(e.stderr))
                 continue

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/libraries/library.py
@@ -1,0 +1,34 @@
+from leapp.libraries.stdlib import api, run, CalledProcessError
+from leapp.models import SELinuxModules, SELinuxCustom
+
+def removeSemanageCustomizations():
+    # remove SELinux customizations done by semanage -- to be reintroduced after the upgrade
+    api.current_logger().info('Removing SELinux customizations introduced by semanage.')
+
+    semanage_options = ["login", "user", "port", "interface", "module", "node",
+                        "fcontext", "boolean", "ibpkey", "ibendport"]
+    # permissive domains are handled by porting modules (permissive -a adds new cil module with priority 400)
+    for option in semanage_options:
+        try:
+            run(['semanage', option, '-D'])
+        except CalledProcessError:
+            continue
+
+def removeCustomModules():
+    # remove custom SElinux modules - to be reinstalled after the upgrade
+    for semodules in api.consume(SELinuxModules):
+        api.current_logger().info("Removing custom SELinux policy modules. Count: %d", len(semodules.modules))
+        for module in semodules.modules:
+            api.current_logger().info("Removing %s on priority %d.", module.name, module.priority)
+            try:
+                run([
+                    'semodule',
+                    '-X',
+                    str(module.priority),
+                    '-r',
+                    module.name]
+                )
+            except CalledProcessError as e:
+                api.current_logger().info("Failed to remove module %s on priority %d: %s",
+                                          module.name, module.priority, str(e))
+                continue

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/libraries/library.py
@@ -1,5 +1,6 @@
 from leapp.libraries.stdlib import api, run, CalledProcessError
-from leapp.models import SELinuxModules, SELinuxCustom
+from leapp.models import SELinuxModules
+
 
 def removeSemanageCustomizations():
     # remove SELinux customizations done by semanage -- to be reintroduced after the upgrade
@@ -14,6 +15,7 @@ def removeSemanageCustomizations():
         except CalledProcessError:
             continue
 
+
 def removeCustomModules():
     # remove custom SElinux modules - to be reinstalled after the upgrade
     for semodules in api.consume(SELinuxModules):
@@ -21,13 +23,12 @@ def removeCustomModules():
         for module in semodules.modules:
             api.current_logger().info("Removing %s on priority %d.", module.name, module.priority)
             try:
-                run([
-                    'semodule',
-                    '-X',
-                    str(module.priority),
-                    '-r',
-                    module.name]
-                )
+                run(['semodule',
+                     '-X',
+                     str(module.priority),
+                     '-r',
+                     module.name]
+                    )
             except CalledProcessError as e:
                 api.current_logger().info("Failed to remove module %s on priority %d: %s",
                                           module.name, module.priority, str(e))

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/component_test.py
@@ -1,9 +1,13 @@
 import os
 
+import pytest
+
 from leapp.snactor.fixture import current_actor_context
 from leapp.models import SELinuxModule, SELinuxModules, SELinuxCustom
 from leapp.libraries.stdlib import api, run, CalledProcessError
 from leapp.reporting import Report
+
+enabled = False
 
 test_modules = [
     ["400", "mock1"],
@@ -14,40 +18,46 @@ test_modules = [
 ]
 
 semanage_commands = [
-['fcontext', '-t', 'httpd_sys_content_t', '"/web(/.*)?"'],
-['fcontext', '-t', 'ganesha_var_run_t', '"/ganesha(/.*)?"'],
-['port', '-t', 'http_port_t', '-p', 'udp', '81'],
-['permissive', 'abrt_t']
+    ['fcontext', '-t', 'httpd_sys_content_t', '"/web(/.*)?"'],
+    ['fcontext', '-t', 'ganesha_var_run_t', '"/ganesha(/.*)?"'],
+    ['port', '-t', 'http_port_t', '-p', 'udp', '81'],
+    ['permissive', 'abrt_t']
 ]
 
 # save value of semodule -lfull for comparison
 semodule_lfull = ""
 semanage_export = ""
-try:
-    semodule = run(["semodule", "-lfull"], split=False)
-    semodule_lfull = semodule.get("stdout", "")
-    semanage = run(["semanage", "export"], split=False)
-    semanage_export = semanage.get("stdout", "")
-except CalledProcessError as e:
-    api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
+
+if enabled:
+    try:
+        semodule = run(["semodule", "-lfull"], split=False)
+        semodule_lfull = semodule.get("stdout", "")
+        semanage = run(["semanage", "export"], split=False)
+        semanage_export = semanage.get("stdout", "")
+    except CalledProcessError as e:
+        api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
 
 testmoduledir = os.path.join(os.getcwd(), "tests/mock_modules/")
 
+
 def setup():
-    for priority, module in test_modules:
-        try:
-            run(["semodule", "-X", priority, "-i", os.path.join(testmoduledir, module + ".cil")])
-        except CalledProcessError as e:
-            api.current_logger().warning("Error installing mock module: %s", str(e.stderr))
-            continue
+    if enabled:
+        for priority, module in test_modules:
+            try:
+                run(["semodule", "-X", priority, "-i", os.path.join(testmoduledir, module + ".cil")])
+            except CalledProcessError as e:
+                api.current_logger().warning("Error installing mock module: %s", str(e.stderr))
+                continue
 
-    for command in semanage_commands:
-        try:
-            run(["semanage", command[0], "-a"] + command[1:])
-        except CalledProcessError as e:
-            api.current_logger().warning("Error applying selinux customizations %s", str(e.stderr))
-            continue
+        for command in semanage_commands:
+            try:
+                run(["semanage", command[0], "-a"] + command[1:])
+            except CalledProcessError as e:
+                api.current_logger().warning("Error applying selinux customizations %s", str(e.stderr))
+                continue
 
+
+@pytest.mark.skip(reason='Test disabled because it would modify the system')
 def test_SELinuxPrepare(current_actor_context):
     try:
         semodule = run(["semodule", "-lfull"], split=False)
@@ -58,7 +68,7 @@ def test_SELinuxPrepare(current_actor_context):
         api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
 
     semodule_list = [SELinuxModule(name=module, priority=int(prio), content="", removed=[])
-                                    for (prio, module) in test_modules + [["400", "permissive_abrt_t"]]]
+                     for (prio, module) in test_modules + [["400", "permissive_abrt_t"]]]
 
     current_actor_context.feed(SELinuxModules(modules=semodule_list))
     current_actor_context.run()
@@ -73,17 +83,19 @@ def test_SELinuxPrepare(current_actor_context):
         api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
         assert False
 
-def teardown():
-    for priority, module in test_modules + [["400", "permissive_abrt_t"]]:
-        try:
-            run(["semodule", "-X", priority, "-r", module])
-        except CalledProcessError:
-            #expected -- should be removed by the actor
-            pass
 
-    for command in semanage_commands:
-        try:
-            run(["semanage", command[0], "-d"] + command[1:])
-        except CalledProcessError:
-            #expected -- should be removed by the actor
-            continue
+def teardown():
+    if enabled:
+        for priority, module in test_modules + [["400", "permissive_abrt_t"]]:
+            try:
+                run(["semodule", "-X", priority, "-r", module])
+            except CalledProcessError:
+                # expected -- should be removed by the actor
+                pass
+
+        for command in semanage_commands:
+            try:
+                run(["semanage", command[0], "-d"] + command[1:])
+            except CalledProcessError:
+                # expected -- should be removed by the actor
+                continue

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/component_test.py
@@ -1,0 +1,89 @@
+import os
+
+from leapp.snactor.fixture import current_actor_context
+from leapp.models import SELinuxModule, SELinuxModules, SELinuxCustom
+from leapp.libraries.stdlib import api, run, CalledProcessError
+from leapp.reporting import Report
+
+test_modules = [
+    ["400", "mock1"],
+    ["99", "mock1"],
+    ["300", "mock1"],
+    ["400", "mock2"],
+    ["999", "mock3"]
+]
+
+semanage_commands = [
+['fcontext', '-t', 'httpd_sys_content_t', '"/web(/.*)?"'],
+['fcontext', '-t', 'ganesha_var_run_t', '"/ganesha(/.*)?"'],
+['port', '-t', 'http_port_t', '-p', 'udp', '81'],
+['permissive', 'abrt_t']
+]
+
+# save value of semodule -lfull for comparison
+semodule_lfull = ""
+semanage_export = ""
+try:
+    semodule = run(["semodule", "-lfull"], split=False)
+    semodule_lfull = semodule.get("stdout", "")
+    semanage = run(["semanage", "export"], split=False)
+    semanage_export = semanage.get("stdout", "")
+except CalledProcessError as e:
+    api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
+
+testmoduledir = os.path.join(os.getcwd(), "tests/mock_modules/")
+
+def setup():
+    for priority, module in test_modules:
+        try:
+            run(["semodule", "-X", priority, "-i", os.path.join(testmoduledir, module + ".cil")])
+        except CalledProcessError as e:
+            api.current_logger().warning("Error installing mock module: %s", str(e.stderr))
+            continue
+
+    for command in semanage_commands:
+        try:
+            run(["semanage", command[0], "-a"] + command[1:])
+        except CalledProcessError as e:
+            api.current_logger().warning("Error applying selinux customizations %s", str(e.stderr))
+            continue
+
+def test_SELinuxPrepare(current_actor_context):
+    try:
+        semodule = run(["semodule", "-lfull"], split=False)
+        api.current_logger().info("Before test:" + semodule.get("stdout", ""))
+        semanage = run(["semanage", "export"], split=False)
+        api.current_logger().info("Before test:" + semanage.get("stdout", ""))
+    except CalledProcessError as e:
+        api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
+
+    semodule_list = [SELinuxModule(name=module, priority=int(prio), content="", removed=[])
+                                    for (prio, module) in test_modules + [["400", "permissive_abrt_t"]]]
+
+    current_actor_context.feed(SELinuxModules(modules=semodule_list))
+    current_actor_context.run()
+
+    # check if all given modules and local customizations where removed
+    try:
+        semodule = run(["semodule", "-lfull"], split=False)
+        assert semodule_lfull == semodule.get("stdout", "")
+        semanage = run(["semanage", "export"], split=False)
+        assert semanage_export == semanage.get("stdout", "")
+    except CalledProcessError as e:
+        api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
+        assert False
+
+def teardown():
+    for priority, module in test_modules + [["400", "permissive_abrt_t"]]:
+        try:
+            run(["semodule", "-X", priority, "-r", module])
+        except CalledProcessError:
+            #expected -- should be removed by the actor
+            pass
+
+    for command in semanage_commands:
+        try:
+            run(["semanage", command[0], "-d"] + command[1:])
+        except CalledProcessError:
+            #expected -- should be removed by the actor
+            continue

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/component_test.py
@@ -68,7 +68,7 @@ def test_SELinuxPrepare(current_actor_context):
         api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
 
     semodule_list = [SELinuxModule(name=module, priority=int(prio), content="", removed=[])
-                     for (prio, module) in test_modules + [["400", "permissive_abrt_t"]]]
+                     for (prio, module) in test_modules.reverse() + [["400", "permissive_abrt_t"]]]
 
     current_actor_context.feed(SELinuxModules(modules=semodule_list))
     current_actor_context.run()

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/component_test.py
@@ -7,9 +7,8 @@ from leapp.models import SELinuxModule, SELinuxModules, SELinuxCustom
 from leapp.libraries.stdlib import api, run, CalledProcessError
 from leapp.reporting import Report
 
-enabled = False
 
-test_modules = [
+TEST_MODULES = [
     ["400", "mock1"],
     ["99", "mock1"],
     ["300", "mock1"],
@@ -17,85 +16,77 @@ test_modules = [
     ["999", "mock3"]
 ]
 
-semanage_commands = [
+SEMANAGE_COMMANDS = [
     ['fcontext', '-t', 'httpd_sys_content_t', '"/web(/.*)?"'],
     ['fcontext', '-t', 'ganesha_var_run_t', '"/ganesha(/.*)?"'],
     ['port', '-t', 'http_port_t', '-p', 'udp', '81'],
     ['permissive', 'abrt_t']
 ]
 
-# save value of semodule -lfull for comparison
-semodule_lfull = ""
-semanage_export = ""
+testmoduledir = "tests/mock_modules/"
 
-if enabled:
+
+def _run_cmd(cmd, split=False, logmsg=""):
     try:
-        semodule = run(["semodule", "-lfull"], split=False)
-        semodule_lfull = semodule.get("stdout", "")
-        semanage = run(["semanage", "export"], split=False)
-        semanage_export = semanage.get("stdout", "")
+        return run(cmd, split=split).get("stdout", "")
     except CalledProcessError as e:
-        api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
+        # XXX FIXME not sure logging in tests makes sense
+        api.current_logger().warning("%s: %s", logmsg, str(e.stderr))
 
-testmoduledir = os.path.join(os.getcwd(), "tests/mock_modules/")
+
+SEMODULE_LFULL_INITIAL = _run_cmd(["semodule", "-lfull"], logmsg="Error listing SELinux customizations")
+SEMANAGE_EXPORT_INITIAL = _run_cmd(["semanage", "export"], logmsg="Error listing SELinux customizations")
 
 
 def setup():
-    if enabled:
-        for priority, module in test_modules:
-            try:
-                run(["semodule", "-X", priority, "-i", os.path.join(testmoduledir, module + ".cil")])
-            except CalledProcessError as e:
-                api.current_logger().warning("Error installing mock module: %s", str(e.stderr))
-                continue
+    # NOTE(ivasilev) Maybe there is a more elegant way to conditionally run setup/teardown
+    enabled = os.environ.get("DESTRUCTIVE_TESTING", False)
+    if not enabled:
+        return
 
-        for command in semanage_commands:
-            try:
-                run(["semanage", command[0], "-a"] + command[1:])
-            except CalledProcessError as e:
-                api.current_logger().warning("Error applying selinux customizations %s", str(e.stderr))
-                continue
+    for priority, module in TEST_MODULES:
+        tests_dir = os.path.join(os.getenv('PYTEST_CURRENT_TEST').rsplit(os.path.sep, 2)[0], testmoduledir)
+        _run_cmd(["semodule", "-X", priority, "-i", os.path.join(tests_dir, module + ".cil")],
+                 logmsg="Error installing mock module")
+
+    for command in SEMANAGE_COMMANDS:
+        _run_cmd(["semanage", command[0], "-a"] + command[1:], logmsg="Error applying selinux customizations")
 
 
-@pytest.mark.skip(reason='Test disabled because it would modify the system')
+@pytest.mark.skipif(not os.environ.get("DESTRUCTIVE_TESTING", False),
+                    reason='Test disabled by default because it would modify the system')
 def test_SELinuxPrepare(current_actor_context):
-    try:
-        semodule = run(["semodule", "-lfull"], split=False)
-        api.current_logger().info("Before test:" + semodule.get("stdout", ""))
-        semanage = run(["semanage", "export"], split=False)
-        api.current_logger().info("Before test:" + semanage.get("stdout", ""))
-    except CalledProcessError as e:
-        api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
+    for cmd in (["semodule", "-lfull"], ["semanage", "export"]):
+        res = _run_cmd(cmd)
+        api.current_logger().info("Before test:%s", res)
 
+    # XXX FIXME test_modules.reverse() returns None and changes underlying list which should not happen
+    # to global vars. Removing that reversing as it is broken anyway
     semodule_list = [SELinuxModule(name=module, priority=int(prio), content="", removed=[])
-                     for (prio, module) in test_modules.reverse() + [["400", "permissive_abrt_t"]]]
+                     for (prio, module) in TEST_MODULES + [["400", "permissive_abrt_t"]]]
 
     current_actor_context.feed(SELinuxModules(modules=semodule_list))
     current_actor_context.run()
 
     # check if all given modules and local customizations where removed
-    try:
-        semodule = run(["semodule", "-lfull"], split=False)
-        assert semodule_lfull == semodule.get("stdout", "")
-        semanage = run(["semanage", "export"], split=False)
-        assert semanage_export == semanage.get("stdout", "")
-    except CalledProcessError as e:
-        api.current_logger().warning("Error listing SELinux customizations: %s", str(e.stderr))
-        assert False
+    semodule_res = _run_cmd(["semodule", "-lfull"])
+    assert SEMODULE_LFULL_INITIAL == semodule_res
+    semanage_res = _run_cmd(["semanage", "export"])
+    assert SEMANAGE_EXPORT_INITIAL == semanage_res
 
 
 def teardown():
-    if enabled:
-        for priority, module in test_modules + [["400", "permissive_abrt_t"]]:
-            try:
-                run(["semodule", "-X", priority, "-r", module])
-            except CalledProcessError:
-                # expected -- should be removed by the actor
-                pass
+    # NOTE(ivasilev) Maybe there is a more elegant way to conditionally run setup/teardown
+    enabled = os.environ.get("DESTRUCTIVE_TESTING", False)
+    if not enabled:
+        return
 
-        for command in semanage_commands:
-            try:
-                run(["semanage", command[0], "-d"] + command[1:])
-            except CalledProcessError:
-                # expected -- should be removed by the actor
-                continue
+    for priority, module in TEST_MODULES + [["400", "permissive_abrt_t"]]:
+        # failure is expected -- should be removed by the actor
+        # XXX FIXME if failure is 100% expected - use assertRaises
+        _run_cmd(["semodule", "-X", priority, "-r", module])
+
+    for command in SEMANAGE_COMMANDS:
+        # failure is expected -- should be removed by the actor
+        # XXX FIXME if failure is 100% expected - use assertRaises
+        _run_cmd(["semanage", command[0], "-d"] + command[1:])

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/mock_modules/mock1.cil
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/mock_modules/mock1.cil
@@ -1,0 +1,4 @@
+(type mock_type_t)
+(typeattributeset domain (mock_type_t))
+(allow mock_type_t proc_type (file (getattr open read)))
+(allow mock_type_t container_var_run_t (file (getattr open read)))

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/mock_modules/mock2.cil
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/mock_modules/mock2.cil
@@ -1,0 +1,4 @@
+(type mock_type2_t)
+(typeattributeset direct_run_init (mock_type2_t))
+(allow mock_type_t file_type (file (getattr open read)))
+(allow mock_type_t ganesha_exec_t (file (getattr open read)))

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/mock_modules/mock3.cil
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/mock_modules/mock3.cil
@@ -1,0 +1,3 @@
+(type mock_type3_t)
+(typeattributeset domain (mock_type3_t))
+(allow mock_type_t file_type (file (getattr open read)))

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/unit_test.py
@@ -1,0 +1,47 @@
+from leapp.libraries.stdlib import run, CalledProcessError
+from leapp.libraries.actor import library
+from leapp.libraries.stdlib import api
+from leapp.models import SELinuxModules, SELinuxModule
+
+class run_mocked(object):
+    def __init__(self):
+        self.args = []
+        self.called = 0
+        self.removed_modules = set()
+        self.non_semodule_calls = 0
+
+    def __call__(self, args, split=True):
+        self.called += 1
+        self.args = args
+
+        if self.args[0] == 'semodule':
+            stdout = ["libsemanage.semanage_direct_remove_key: Removing last dummy module " +
+                      "(no other dummy module exists at another priority)."]
+            self.removed_modules.add(self.args[-1])
+        else:
+            self.non_semodule_calls += 1
+
+        return {'stdout': stdout}
+
+def test_removeCustomModules(monkeypatch):
+    mock_modules = {"a": 99,
+                    "b": 300,
+                    "c": 400,
+                    "abrt":190}
+
+    def consume_SELinuxModules_mocked(*models):
+
+        semodule_list = [SELinuxModule(name=k, priority=mock_modules[k], content="", removed=[])
+                                    for k in mock_modules]
+
+        yield SELinuxModules(modules=semodule_list)
+
+
+    monkeypatch.setattr(api, "consume", consume_SELinuxModules_mocked)
+    monkeypatch.setattr(library, "run", run_mocked())
+
+    library.removeCustomModules()
+    assert library.run.called == len(mock_modules)
+    assert library.run.non_semodule_calls == 0
+    # verify that removeCustomModules tried to remove all given modules
+    assert (set(mock_modules) - library.run.removed_modules) == set()

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/unit_test.py
@@ -25,7 +25,7 @@ class run_mocked(object):
         return {'stdout': stdout}
 
 
-def test_removeCustomModules(monkeypatch):
+def test_remove_custom_modules(monkeypatch):
     mock_modules = {"a": 99,
                     "b": 300,
                     "c": 400,
@@ -40,8 +40,8 @@ def test_removeCustomModules(monkeypatch):
     monkeypatch.setattr(api, "consume", consume_SELinuxModules_mocked)
     monkeypatch.setattr(library, "run", run_mocked())
 
-    library.removeCustomModules()
+    library.remove_custom_modules()
     assert library.run.called == len(mock_modules)
     assert library.run.non_semodule_calls == 0
-    # verify that removeCustomModules tried to remove all given modules
+    # verify that remove_custom_modules tried to remove all given modules
     assert (set(mock_modules) - library.run.removed_modules) == set()

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/unit_test.py
@@ -3,6 +3,7 @@ from leapp.libraries.actor import library
 from leapp.libraries.stdlib import api
 from leapp.models import SELinuxModules, SELinuxModule
 
+
 class run_mocked(object):
     def __init__(self):
         self.args = []
@@ -23,19 +24,18 @@ class run_mocked(object):
 
         return {'stdout': stdout}
 
+
 def test_removeCustomModules(monkeypatch):
     mock_modules = {"a": 99,
                     "b": 300,
                     "c": 400,
-                    "abrt":190}
+                    "abrt": 190}
 
     def consume_SELinuxModules_mocked(*models):
 
         semodule_list = [SELinuxModule(name=k, priority=mock_modules[k], content="", removed=[])
-                                    for k in mock_modules]
-
+                         for k in mock_modules]
         yield SELinuxModules(modules=semodule_list)
-
 
     monkeypatch.setattr(api, "consume", consume_SELinuxModules_mocked)
     monkeypatch.setattr(library, "run", run_mocked())

--- a/repos/system_upgrade/el7toel8/models/selinux.py
+++ b/repos/system_upgrade/el7toel8/models/selinux.py
@@ -1,0 +1,23 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+class SELinuxModule(Model):
+    """SELinux module in cil including priority"""
+    topic = SystemInfoTopic
+    name = fields.String()
+    priority = fields.Integer()
+    content = fields.String()
+    # lines removed due to content invalid on RHEL 8
+    removed = fields.List(fields.String())
+
+class SELinuxModules(Model):
+    """List of custom selinux modules (priority != 100,200)"""
+    topic = SystemInfoTopic
+    modules = fields.List(fields.Model(SELinuxModule))
+
+class SELinuxCustom(Model):
+    """SELinux customizations returned by semanage export"""
+    topic = SystemInfoTopic
+    commands = fields.List(fields.String())
+    removed = fields.List(fields.String())
+

--- a/repos/system_upgrade/el7toel8/models/selinux.py
+++ b/repos/system_upgrade/el7toel8/models/selinux.py
@@ -26,7 +26,7 @@ class SELinuxRequestRPMs(Model):
     SELinux related RPM packages that need to be present after upgrade
 
     Listed packages provide types that where used in policy
-    customizations (to_install), or the corresponding policy 
+    customizations (to_install), or the corresponding policy
     was installed on RHEL-7 installation with priority 200
     (to_keep).
     """

--- a/repos/system_upgrade/el7toel8/models/selinux.py
+++ b/repos/system_upgrade/el7toel8/models/selinux.py
@@ -1,6 +1,7 @@
 from leapp.models import Model, fields
 from leapp.topics import SystemInfoTopic, TransactionTopic
 
+
 class SELinuxModule(Model):
     """SELinux module in cil including priority"""
     topic = SystemInfoTopic
@@ -10,16 +11,19 @@ class SELinuxModule(Model):
     # lines removed due to content invalid on RHEL 8
     removed = fields.List(fields.String())
 
+
 class SELinuxModules(Model):
     """List of custom selinux modules (priority != 100,200)"""
     topic = SystemInfoTopic
     modules = fields.List(fields.Model(SELinuxModule))
+
 
 class SELinuxCustom(Model):
     """SELinux customizations returned by semanage export"""
     topic = SystemInfoTopic
     commands = fields.List(fields.String())
     removed = fields.List(fields.String())
+
 
 class SELinuxRequestRPMs(Model):
     """

--- a/repos/system_upgrade/el7toel8/models/selinux.py
+++ b/repos/system_upgrade/el7toel8/models/selinux.py
@@ -1,5 +1,5 @@
 from leapp.models import Model, fields
-from leapp.topics import SystemInfoTopic
+from leapp.topics import SystemInfoTopic, TransactionTopic
 
 class SELinuxModule(Model):
     """SELinux module in cil including priority"""
@@ -21,3 +21,15 @@ class SELinuxCustom(Model):
     commands = fields.List(fields.String())
     removed = fields.List(fields.String())
 
+class SELinuxRequestRPMs(Model):
+    """
+    SELinux related RPM packages that need to be present after upgrade
+
+    Listed packages provide types that where used in policy
+    customizations (to_install), or the corresponding policy 
+    was installed on RHEL-7 installation with priority 200
+    (to_keep).
+    """
+    topic = TransactionTopic
+    to_keep = fields.List(fields.String(), default=[])
+    to_install = fields.List(fields.String(), default=[])


### PR DESCRIPTION
Edit by pstodulk (as nothing was here):

Add actors to scan system for custom SELinux rules and transfer these to RHEL 8 when possible. The process looks like this:
  - get all custom rules during the scan phase
  - remove all custom rules during the preparation phase (inside initrd before rpm transaction]
  - try to reapply custom rules and inform about those that cannot be reapplied 