### PR TITLE
Fix mls enabled query

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
@@ -222,7 +222,7 @@ def get_selinux_status():
         return
 
     outdata = dict({'enabled': selinux.is_selinux_enabled() == 1})
-    outdata['mls_enabled'] = selinux.is_selinux_mls_enabled == 1
+    outdata['mls_enabled'] = selinux.is_selinux_mls_enabled() == 1
 
     try:
         outdata['runtime_mode'] = "enforcing" if selinux.security_getenforce() == 1 else "permissive"


### PR DESCRIPTION
During recent touches, the previous refactoring of SELinux functionality the mls enabled query  is_selinux_mls_enabled was not called.