### PR TITLE
Make sure /boot is mounted before removing boot entry

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/libraries/library.py
@@ -1,9 +1,19 @@
+from subprocess import CalledProcessError
+
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.stdlib import api, call
 from leapp.models import BootContent
 
 
 def remove_boot_entry():
+    # we need to make sure /boot is mounted before trying to remove the boot entry
+    try:
+        call([
+            '/bin/mount', '/boot'
+        ])
+    except CalledProcessError:
+        # /boot has been most likely already mounted
+        pass
     kernel_filepath = get_upgrade_kernel_filepath()
     call([
         '/usr/sbin/grubby',

--- a/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/tests/unit_test.py
@@ -21,7 +21,8 @@ def test_remove_boot_entry(monkeypatch):
 
     library.remove_boot_entry()
 
-    assert library.call.args == [['/usr/sbin/grubby', '--remove-kernel=/abc'], ['/bin/mount', '-a']]
+    assert library.call.args == [['/bin/mount', '/boot'],
+                                 ['/usr/sbin/grubby', '--remove-kernel=/abc'], ['/bin/mount', '-a']]
 
 
 def test_get_upgrade_kernel_filepath(monkeypatch):


### PR DESCRIPTION
We need to make sure /boot is mounted before trying to remove the boot entry.