### PR TITLE
Add ntp migration actors

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkntp/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/actor.py
@@ -5,8 +5,11 @@ from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
 class CheckNtp(Actor):
+    """
+    Check if ntp and/or ntpdate configuration needs to be migrated.
+    """
+
     name = 'check_ntp'
-    description = 'Check if ntp and/or ntpdate configuration needs to be migrated.'
     consumes = (InstalledRedHatSignedRPM,)
     produces = (Report, NtpMigrationDecision)
     tags = (ChecksPhaseTag, IPUWorkflowTag)

--- a/repos/system_upgrade/el7toel8/actors/checkntp/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/actor.py
@@ -3,6 +3,7 @@ from leapp.libraries.actor.library import check_ntp
 from leapp.models import Report, InstalledRedHatSignedRPM, NtpMigrationDecision
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
+
 class CheckNtp(Actor):
     name = 'check_ntp'
     description = 'Check if ntp and/or ntpdate configuration needs to be migrated.'
@@ -16,6 +17,6 @@ class CheckNtp(Actor):
         signed_rpms = self.consume(InstalledRedHatSignedRPM)
         for rpm_pkgs in signed_rpms:
             for pkg in rpm_pkgs.items:
-	        installed_packages.add(pkg.name)
+                installed_packages.add(pkg.name)
 
         self.produce(check_ntp(installed_packages))

--- a/repos/system_upgrade/el7toel8/actors/checkntp/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.library import check_ntp
+from leapp.models import Report, InstalledRedHatSignedRPM, NtpMigrationDecision
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+class CheckNtp(Actor):
+    name = 'check_ntp'
+    description = 'Check if ntp and/or ntpdate configuration needs to be migrated.'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (Report, NtpMigrationDecision)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        installed_packages = set()
+
+        signed_rpms = self.consume(InstalledRedHatSignedRPM)
+        for rpm_pkgs in signed_rpms:
+            for pkg in rpm_pkgs.items:
+	        installed_packages.add(pkg.name)
+
+        self.produce(check_ntp(installed_packages))

--- a/repos/system_upgrade/el7toel8/actors/checkntp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/libraries/library.py
@@ -1,11 +1,10 @@
 import base64
 import io
 import os
-from subprocess import CalledProcessError
 import tarfile
 
 from leapp.libraries.common import reporting
-from leapp.libraries.stdlib import api, run
+from leapp.libraries.stdlib import CalledProcessError, api, run
 from leapp.models import NtpMigrationDecision
 
 

--- a/repos/system_upgrade/el7toel8/actors/checkntp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/libraries/library.py
@@ -1,0 +1,65 @@
+from leapp.libraries.common import reporting
+from leapp.libraries.stdlib import api, run
+from leapp.models import NtpMigrationDecision
+
+from subprocess import CalledProcessError
+
+import base64, io, os, tarfile
+
+# Check if a service is active and enabled
+def check_service(name):
+    for state in ['active', 'enabled']:
+        try:
+            run(['systemctl', 'is-{}'.format(state), name])
+            api.current_logger().debug('{} is {}'.format(name, state))
+        except CalledProcessError:
+            api.current_logger().debug('{} is not {}'.format(name, state))
+            return False
+
+    return True
+
+# Check if a file exists
+def is_file(name):
+    return os.path.isfile(name)
+
+# Get a base64-encoded gzipped tarball of specified files
+def get_tgz64(filenames):
+    stream = io.BytesIO()
+    tar = tarfile.open(fileobj=stream, mode='w:gz')
+    for filename in filenames:
+        if os.path.isfile(filename):
+            tar.add(filename)
+    tar.close()
+
+    return base64.b64encode(stream.getvalue())
+
+# Check services from the ntp packages for migration
+def check_ntp(installed_packages):
+    service_data = [('ntpd', 'ntp', '/etc/ntp.conf'),
+                    ('ntpdate', 'ntpdate', '/etc/ntp/step-tickers'),
+                    ('ntp-wait', 'ntp-perl', None)]
+
+    migrate_services = []
+    migrate_configs = []
+    for service, package, main_config in service_data:
+        if package in installed_packages and \
+                check_service('{}.service'.format(service)) and \
+                (not main_config or is_file(main_config)):
+            migrate_services.append(service)
+            if main_config:
+                migrate_configs.append(service)
+
+    if len(migrate_configs):
+        reporting.report_generic(
+             title='{} configuration will be migrated'.format(' and '.join(migrate_configs)),
+             summary='{} service(s) detected to be enabled and active'.format(', '.join(migrate_services)),
+             severity='low')
+        # Save configuration files that will be renamed in the upgrade
+        config_tgz64 = get_tgz64(['/etc/ntp.conf', '/etc/ntp/keys',
+                                  '/etc/ntp/crypto/pw', '/etc/ntp/step-tickers'])
+    else:
+        api.current_logger().info('ntpd/ntpdate configuration will not be migrated')
+        migrate_services = []
+        config_tgz64 = ''
+
+    return NtpMigrationDecision(migrate_services=migrate_services, config_tgz64=config_tgz64)

--- a/repos/system_upgrade/el7toel8/actors/checkntp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/libraries/library.py
@@ -1,10 +1,13 @@
+import base64
+import io
+import os
+from subprocess import CalledProcessError
+import tarfile
+
 from leapp.libraries.common import reporting
 from leapp.libraries.stdlib import api, run
 from leapp.models import NtpMigrationDecision
 
-from subprocess import CalledProcessError
-
-import base64, io, os, tarfile
 
 # Check if a service is active and enabled
 def check_service(name):
@@ -18,9 +21,11 @@ def check_service(name):
 
     return True
 
+
 # Check if a file exists
 def is_file(name):
     return os.path.isfile(name)
+
 
 # Get a base64-encoded gzipped tarball of specified files
 def get_tgz64(filenames):
@@ -32,6 +37,7 @@ def get_tgz64(filenames):
     tar.close()
 
     return base64.b64encode(stream.getvalue())
+
 
 # Check services from the ntp packages for migration
 def check_ntp(installed_packages):

--- a/repos/system_upgrade/el7toel8/actors/checkntp/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/tests/unit_test.py
@@ -1,0 +1,68 @@
+from leapp.libraries.actor import library
+from leapp.libraries.common import reporting
+
+import base64, io, os, re, tarfile, tempfile
+
+class report_generic_mocked(object):
+    def __init__(self):
+        self.called = 0
+
+    def __call__(self, **report_fields):
+        self.called += 1
+        self.report_fields = report_fields
+
+
+def test_nomigration(monkeypatch):
+    monkeypatch.setattr(reporting, 'report_generic', report_generic_mocked())
+    monkeypatch.setattr(library, 'check_service', lambda _: False)
+    monkeypatch.setattr(library, 'is_file', lambda _: False)
+    monkeypatch.setattr(library, 'get_tgz64', lambda _: '')
+
+    library.check_ntp(set(['chrony', 'linuxptp', 'xterm']))
+
+    assert reporting.report_generic.called == 0
+
+
+def test_migration(monkeypatch):
+    for packages, services, migrate in [
+                (['ntp'], ['ntpd'], ['ntpd']),
+                (['ntp', 'ntpdate'], ['ntpd'], ['ntpd']),
+                (['ntpdate'], ['ntpdate'], ['ntpdate']),
+                (['ntp', 'ntpdate'], ['ntpdate'], ['ntpdate']),
+                (['ntp', 'ntpdate'], ['ntpd', 'ntpdate'], ['ntpd', 'ntpdate']),
+                (['ntp', 'ntpdate', 'ntp-perl'], ['ntpd', 'ntpdate'], ['ntpd', 'ntpdate']),
+                (['ntp', 'ntpdate'], ['ntpd', 'ntpdate', 'ntp-wait'], ['ntpd', 'ntpdate']),
+                (['ntp', 'ntpdate', 'ntp-perl'], ['ntpd', 'ntpdate', 'ntp-wait'], ['ntpd', 'ntpdate', 'ntp-wait']),
+            ]:
+        monkeypatch.setattr(reporting, 'report_generic', report_generic_mocked())
+        monkeypatch.setattr(library, 'check_service',
+                                     lambda service: service[:-8] in services)
+        monkeypatch.setattr(library, 'is_file', lambda _: True)
+        monkeypatch.setattr(library, 'get_tgz64', lambda _: '')
+
+        decision = library.check_ntp(set(packages))
+
+        assert reporting.report_generic.called == 1
+        assert 'configuration will be migrated' in \
+                reporting.report_generic.report_fields['title']
+        for service in ['ntpd', 'ntpdate']:
+            migrated = re.search(r'\b{}\b'.format(service),
+                                 reporting.report_generic.report_fields['title']) is not None
+            assert migrated == (service in migrate)
+
+        assert decision.migrate_services == migrate
+
+
+def test_tgz64(monkeypatch):
+    f, name = tempfile.mkstemp()
+    os.close(f)
+    tgz64 = library.get_tgz64([name])
+
+    stream = io.BytesIO(base64.b64decode(tgz64))
+    tar = tarfile.open(fileobj=stream, mode='r:gz')
+    names = tar.getnames()
+
+    tar.close()
+    os.unlink(name)
+
+    assert names == [name.lstrip('/')]

--- a/repos/system_upgrade/el7toel8/actors/checkntp/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/tests/unit_test.py
@@ -1,7 +1,13 @@
+import base64
+import io
+import os
+import re
+import tarfile
+import tempfile
+
 from leapp.libraries.actor import library
 from leapp.libraries.common import reporting
 
-import base64, io, os, re, tarfile, tempfile
 
 class report_generic_mocked(object):
     def __init__(self):
@@ -43,8 +49,7 @@ def test_migration(monkeypatch):
         decision = library.check_ntp(set(packages))
 
         assert reporting.report_generic.called == 1
-        assert 'configuration will be migrated' in \
-                reporting.report_generic.report_fields['title']
+        assert 'configuration will be migrated' in reporting.report_generic.report_fields['title']
         for service in ['ntpd', 'ntpdate']:
             migrated = re.search(r'\b{}\b'.format(service),
                                  reporting.report_generic.report_fields['title']) is not None

--- a/repos/system_upgrade/el7toel8/actors/migratentp/Makefile
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/Makefile
@@ -1,0 +1,2 @@
+install-deps:
+	yum install -y python-ipaddress

--- a/repos/system_upgrade/el7toel8/actors/migratentp/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/actor.py
@@ -5,8 +5,11 @@ from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
 
 
 class MigrateNtp(Actor):
+    """
+    Migrate ntp and/or ntpdate configuration to chrony.
+    """
+
     name = 'migrate_ntp'
-    description = 'Migrate ntp and/or ntpdate configuration to chrony.'
     consumes = (NtpMigrationDecision,)
     produces = (Report,)
     tags = (ApplicationsPhaseTag, IPUWorkflowTag)

--- a/repos/system_upgrade/el7toel8/actors/migratentp/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/actor.py
@@ -1,0 +1,15 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.library import migrate_ntp
+from leapp.models import Report, NtpMigrationDecision
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+class MigrateNtp(Actor):
+    name = 'migrate_ntp'
+    description = 'Migrate ntp and/or ntpdate configuration to chrony.'
+    consumes = (NtpMigrationDecision,)
+    produces = (Report,)
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        for decision in self.consume(NtpMigrationDecision):
+            migrate_ntp(decision.migrate_services, decision.config_tgz64)

--- a/repos/system_upgrade/el7toel8/actors/migratentp/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/actor.py
@@ -3,6 +3,7 @@ from leapp.libraries.actor.library import migrate_ntp
 from leapp.models import Report, NtpMigrationDecision
 from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
 
+
 class MigrateNtp(Actor):
     name = 'migrate_ntp'
     description = 'Migrate ntp and/or ntpdate configuration to chrony.'

--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
@@ -1,10 +1,12 @@
+import base64
+import io
+from subprocess import CalledProcessError
+import tarfile
+
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import reporting
-from leapp.libraries.stdlib import api, run
+from leapp.libraries.stdlib import run
 
-from subprocess import CalledProcessError
-
-import base64, io, tarfile
 
 def extract_tgz64(s):
     stream = io.BytesIO(base64.b64decode(s))
@@ -12,15 +14,18 @@ def extract_tgz64(s):
     tar.extractall()
     tar.close()
 
+
 def enable_service(name):
     try:
         run(['systemctl', 'enable', '{}.service'.format(name)])
     except CalledProcessError:
         raise StopActorExecutionError('Could not enable {} service'.format(name))
 
+
 def write_file(name, content):
     with open(name, 'w') as f:
-        f.write(content);
+        f.write(content)
+
 
 def ntp2chrony(root, ntp_conf, step_tickers):
     from leapp.libraries.actor import ntp2chrony
@@ -36,11 +41,12 @@ def ntp2chrony(root, ntp_conf, step_tickers):
     # the default ntp.conf
     return set(ntp_configuration.ignored_lines) - set(['disable monitor'])
 
+
 def migrate_ntp(migrate_services, config_tgz64):
     # Map of ntp->chrony services and flag if using configuration
-    service_map = { 'ntpd': ('chronyd', True),
-                    'ntpdate': ('chronyd', True),
-                    'ntp-wait': ('chrony-wait', False) }
+    service_map = {'ntpd': ('chronyd', True),
+                   'ntpdate': ('chronyd', True),
+                   'ntp-wait': ('chrony-wait', False)}
 
     # Minimal secure ntp.conf with no sources to migrate ntpdate only
     no_sources_directives = (

--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
@@ -1,0 +1,86 @@
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import reporting
+from leapp.libraries.stdlib import api, run
+
+from subprocess import CalledProcessError
+
+import base64, io, tarfile
+
+def extract_tgz64(s):
+    stream = io.BytesIO(base64.b64decode(s))
+    tar = tarfile.open(fileobj=stream, mode='r:gz')
+    tar.extractall()
+    tar.close()
+
+def enable_service(name):
+    try:
+        run(['systemctl', 'enable', '{}.service'.format(name)])
+    except CalledProcessError:
+        raise StopActorExecutionError('Could not enable {} service'.format(name))
+
+def write_file(name, content):
+    with open(name, 'w') as f:
+        f.write(content);
+
+def ntp2chrony(root, ntp_conf, step_tickers):
+    from leapp.libraries.actor import ntp2chrony
+
+    try:
+        ntp_configuration = ntp2chrony.NtpConfiguration(root, ntp_conf, step_tickers)
+        ntp_configuration.write_chrony_configuration('/etc/chrony.conf', '/etc/chrony.keys',
+                                                     False, True)
+    except Exception as e:
+        raise StopActorExecutionError('ntp2chrony failed: {}'.format(e))
+
+    # Return ignored lines from ntp.conf, except 'disable monitor' from
+    # the default ntp.conf
+    return set(ntp_configuration.ignored_lines) - set(['disable monitor'])
+
+def migrate_ntp(migrate_services, config_tgz64):
+    # Map of ntp->chrony services and flag if using configuration
+    service_map = { 'ntpd': ('chronyd', True),
+                    'ntpdate': ('chronyd', True),
+                    'ntp-wait': ('chrony-wait', False) }
+
+    # Minimal secure ntp.conf with no sources to migrate ntpdate only
+    no_sources_directives = (
+            '# This file was created to migrate ntpdate configuration to chrony\n'
+            '# without ntp configuration (ntpd service was disabled)\n'
+            'driftfile /var/lib/ntp/drift\n'
+            'restrict default ignore nomodify notrap nopeer noquery\n')
+
+    if len(migrate_services) == 0:
+        # Nothing to migrate
+        return
+
+    migrate_configs = []
+    for service in migrate_services:
+        if service not in service_map:
+            raise StopActorExecutionError('Unknown service {}'.format(service))
+        enable_service(service_map[service][0])
+        if service_map[service][1]:
+            migrate_configs.append(service)
+
+    # Unpack archive with configuration files
+    extract_tgz64(config_tgz64)
+
+    if 'ntpd' in migrate_configs:
+        ntp_conf = '/etc/ntp.conf'
+    else:
+        ntp_conf = '/etc/ntp.conf.nosources'
+        write_file(ntp_conf, no_sources_directives)
+
+    step_tickers = '/etc/ntp/step-tickers' if 'ntpdate' in migrate_configs else ''
+
+    ignored_lines = ntp2chrony('/', ntp_conf, step_tickers)
+
+    if len(ignored_lines) == 0:
+        reporting.report_generic(
+                title='{} configuration migrated to chrony'.format(' and '.join(migrate_configs)),
+                summary='ntp2chrony executed successfully',
+                severity='low')
+    else:
+        reporting.report_generic(
+                title='{} configuration partially migrated to chrony'.format(' and '.join(migrate_configs)),
+                summary='Some lines in /etc/ntp.conf were ignored in migration (check /etc/chrony.conf)',
+                severity='medium')

--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
@@ -1,11 +1,10 @@
 import base64
 import io
-from subprocess import CalledProcessError
 import tarfile
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import reporting
-from leapp.libraries.stdlib import run
+from leapp.libraries.stdlib import CalledProcessError, run
 
 
 def extract_tgz64(s):

--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/ntp2chrony.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/ntp2chrony.py
@@ -1,0 +1,671 @@
+#!/usr/bin/python
+#
+# Convert ntp configuration to chrony
+#
+# Copyright (C) 2018-2019  Miroslav Lichvar <mlichvar@redhat.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+import argparse
+import ipaddress
+import logging
+import os
+import os.path
+import re
+import subprocess
+import sys
+
+# python2 compatibility hacks
+if sys.version_info[0] < 3:
+    from io import open
+    reload(sys)
+    sys.setdefaultencoding("utf-8")
+
+class NtpConfiguration(object):
+    def __init__(self, root_dir, ntp_conf, step_tickers):
+        self.root_dir = root_dir if root_dir != "/" else ""
+        self.ntp_conf_path = ntp_conf
+        self.step_tickers_path = step_tickers
+
+        # Read and write files using an 8-bit transparent encoding
+        self.file_encoding = "latin-1"
+        self.enabled_services = set()
+        self.step_tickers = []
+        self.time_sources = []
+        self.fudges = {}
+        self.restrictions = {
+                # Built-in defaults
+                ipaddress.ip_network(u"0.0.0.0/0"): set(),
+                ipaddress.ip_network(u"::/0"): set(),
+        }
+        self.keyfile = ""
+        self.keys = []
+        self.trusted_keys = []
+        self.driftfile = ""
+        self.statistics = []
+        self.leapfile = ""
+        self.tos_options = {}
+        self.ignored_directives = set()
+        self.ignored_lines = []
+
+        #self.detect_enabled_services()
+        self.parse_step_tickers()
+        self.parse_ntp_conf()
+
+    def detect_enabled_services(self):
+        for service in ["ntpdate", "ntpd", "ntp-wait"]:
+            if os.path.islink("{}/etc/systemd/system/multi-user.target.wants/{}.service"
+                    .format(self.root_dir, service)):
+                self.enabled_services.add(service)
+        logging.info("Enabled services found in /etc/systemd/system: %s",
+                     " ".join(self.enabled_services))
+
+    def parse_step_tickers(self):
+        if not self.step_tickers_path:
+            return
+
+        path = os.path.join(self.root_dir, self.step_tickers_path)
+        if not os.path.isfile(path):
+            logging.info("Missing %s", path)
+            return
+
+        with open(path, encoding=self.file_encoding) as f:
+            for line in f:
+                line = line[:line.find('#')]
+
+                words = line.split()
+
+                if not words:
+                    continue
+
+                self.step_tickers.extend(words)
+
+    def parse_ntp_conf(self, path=None):
+        if path is None:
+            path = os.path.join(self.root_dir, self.ntp_conf_path)
+
+        with open(path, encoding=self.file_encoding) as f:
+            logging.info("Reading %s", path)
+
+            for line in f:
+                line = line[:line.find('#')]
+
+                words = line.split()
+
+                if not words:
+                    continue
+
+                if not self.parse_directive(words):
+                    self.ignored_lines.append(line)
+
+    def parse_directive(self, words):
+        name = words.pop(0)
+        if name.startswith("logconfig"):
+            name = "logconfig"
+
+        if words:
+            if name in ["server", "peer", "pool"]:
+                return self.parse_source(name, words)
+            elif name == "fudge":
+                return self.parse_fudge(words)
+            elif name == "restrict":
+                return self.parse_restrict(words)
+            elif name == "tos":
+                return self.parse_tos(words)
+            elif name == "includefile":
+                return self.parse_includefile(words)
+            elif name == "keys":
+                return self.parse_keys(words)
+            elif name == "trustedkey":
+                return self.parse_trustedkey(words)
+            elif name == "driftfile":
+                self.driftfile = words[0]
+            elif name == "statistics":
+                self.statistics = words
+            elif name == "leapfile":
+                self.leapfile = words[0]
+            else:
+                self.ignored_directives.add(name)
+                return False
+        else:
+            self.ignored_directives.add(name)
+            return False
+
+        return True
+
+    def parse_source(self, source_type, words):
+        ipv4_only = False
+        ipv6_only = False
+        source = {
+                "type": source_type,
+                "options": []
+        }
+
+        if words[0] == "-4":
+            ipv4_only = True
+            words.pop(0)
+        elif words[0] == "-6":
+            ipv6_only = True
+            words.pop(0)
+
+        if not words:
+            return False
+
+        source["address"] = words.pop(0)
+
+        # Check if -4/-6 corresponds to the address and ignore hostnames
+        if ipv4_only or ipv6_only:
+            try:
+                version = ipaddress.ip_address(source["address"]).version
+                if (ipv4_only and version != 4) or (ipv6_only and version != 6):
+                    return False
+            except ValueError:
+                return False
+
+        if source["address"].startswith("127.127."):
+            if not source["address"].startswith("127.127.1."):
+                # Ignore non-LOCAL refclocks
+                return False
+
+        while words:
+            if len(words) >= 2 and words[0] in ["minpoll", "maxpoll", "version", "key"]:
+                source["options"].append((words[0], words[1]))
+                words = words[2:]
+            elif words[0] in ["burst", "iburst", "noselect", "prefer", "true", "xleave"]:
+                source["options"].append((words[0],))
+                words.pop(0)
+            else:
+                return False
+
+        self.time_sources.append(source)
+        return True
+
+    def parse_fudge(self, words):
+        address = words.pop(0)
+        options = {}
+
+        while words:
+            if len(words) >= 2 and words[0] in ["stratum"]:
+                if not words[1].isdigit():
+                    return False
+                options[words[0]] = int(words[1])
+                words = words[2:]
+            elif len(words) >= 2:
+                words = words[2:]
+            else:
+                return False
+
+        self.fudges[address] = options
+        return True
+
+    def parse_restrict(self, words):
+        ipv4_only = False
+        ipv6_only = False
+        flags = set()
+        mask = ""
+
+        if words[0] == "-4":
+            ipv4_only = True
+            words.pop(0)
+        elif words[0] == "-6":
+            ipv6_only = True
+            words.pop(0)
+
+        if not words:
+            return False
+
+        address = words.pop(0)
+
+        while words:
+            if len(words) >= 2 and words[0] == "mask":
+                mask = words[1]
+                words = words[2:]
+            else:
+                if words[0] not in ["kod", "nomodify", "notrap", "nopeer", "noquery",
+                                    "limited", "ignore", "noserve"]:
+                    return False
+                flags.add(words[0])
+                words.pop(0)
+
+        # Convert to IP network(s), ignoring restrictions with hostnames
+        networks = []
+        if address == "default" and not mask:
+            if not ipv6_only:
+                networks.append(ipaddress.ip_network(u"0.0.0.0/0"))
+            if not ipv4_only:
+                networks.append(ipaddress.ip_network(u"::/0"))
+        else:
+            try:
+                if mask:
+                    networks.append(ipaddress.ip_network(u"{}/{}".format(address, mask)))
+                else:
+                    networks.append(ipaddress.ip_network(address))
+            except ValueError:
+                return False
+
+            if (ipv4_only and networks[-1].version != 4) or \
+                    (ipv6_only and networks[-1].version != 6):
+                return False
+
+        for network in networks:
+            self.restrictions[network] = flags
+
+        return True
+
+    def parse_tos(self, words):
+        options = {}
+        while words:
+            if len(words) >= 2 and words[0] in ["minsane", "orphan"]:
+                if not words[1].isdigit():
+                    return False
+                options[words[0]] = int(words[1])
+                words = words[2:]
+            elif len(words) >= 2 and words[0] in ["maxdist"]:
+                # Check if it is a float value
+                if not words[1].replace('.', '', 1).isdigit():
+                    return False
+                options[words[0]] = float(words[1])
+                words = words[2:]
+            else:
+                return False
+
+        self.tos_options.update(options)
+
+        return True
+
+    def parse_includefile(self, words):
+        path = os.path.join(self.root_dir, words[0])
+        if not os.path.isfile(path):
+            return False
+
+        self.parse_ntp_conf(path)
+        return True
+
+    def parse_keys(self, words):
+        keyfile = words[0]
+        path = os.path.join(self.root_dir, keyfile)
+        if not os.path.isfile(path):
+            logging.info("Missing %s", path)
+            return False
+
+        with open(path, encoding=self.file_encoding) as f:
+            logging.info("Reading %s", path)
+            keys = []
+            for line in f:
+                words = line.split()
+                if len(words) < 3 or not words[0].isdigit():
+                    continue
+                keys.append((int(words[0]), words[1], words[2]))
+
+            self.keyfile = keyfile
+            self.keys = keys
+
+        return True
+
+    def parse_trustedkey(self, words):
+        key_ranges = []
+        for word in words:
+            if word.isdigit():
+                key_ranges.append((int(word), int(word)))
+            elif re.match("^[0-9]+-[0-9]+$", word):
+                first, last = word.split("-")
+                key_ranges.append((int(first), int(last)))
+            else:
+                return False
+
+        self.trusted_keys = key_ranges
+        return True
+
+    def write_chrony_configuration(self, chrony_conf_path, chrony_keys_path,
+                                   dry_run=False, backup=False):
+        chrony_conf = self.get_chrony_conf(chrony_keys_path)
+        logging.debug("Generated %s:\n%s", chrony_conf_path, chrony_conf)
+
+        if not dry_run:
+            self.write_file(chrony_conf_path, 0o644, chrony_conf, backup)
+
+        chrony_keys = self.get_chrony_keys()
+        if chrony_keys:
+            logging.debug("Generated %s:\n%s", chrony_keys_path, chrony_keys)
+
+        if not dry_run:
+            self.write_file(chrony_keys_path, 0o640, chrony_keys, backup)
+
+    def get_processed_time_sources(self):
+        # Convert {0,1,2,3}.*pool.ntp.org servers to 2.*pool.ntp.org pools
+
+        # Make shallow copies of all sources (only type will be modified)
+        time_sources = [s.copy() for s in self.time_sources]
+
+        pools = {}
+        for source in time_sources:
+            if source["type"] != "server":
+                continue
+            m = re.match("^([0123])(\\.\\w+)?\\.pool\\.ntp\\.org$", source["address"])
+            if m is None:
+                continue
+            number = m.group(1)
+            zone = m.group(2)
+            if zone not in pools:
+                pools[zone] = []
+            pools[zone].append((int(number), source))
+
+        remove_servers = set()
+        for zone, pool in pools.items():
+            # sort and skip all pools not in [0, 3] range
+            pool.sort()
+            if [number for number, source in pool] != [0, 1, 2, 3]:
+                # only exact group of 4 servers can be converted, nothing to do here
+                continue
+            # verify that parameters are the same for all servers in the pool
+            if not all([p[1]["options"] == pool[0][1]["options"] for p in pool]):
+                break
+            remove_servers.update([pool[i][1]["address"] for i in [0, 1, 3]])
+            pool[2][1]["type"] = "pool"
+
+        processed_sources = []
+        for source in time_sources:
+            if source["type"] == "server" and source["address"] in remove_servers:
+                continue
+            processed_sources.append(source)
+        return processed_sources
+
+    def get_chrony_conf_sources(self):
+        conf = ""
+
+        if self.step_tickers:
+            conf += "# Specify NTP servers used for initial correction.\n"
+            conf += "initstepslew 0.1 {}\n".format(" ".join(self.step_tickers))
+            conf += "\n"
+
+        conf += "# Specify time sources.\n"
+
+        for source in self.get_processed_time_sources():
+            address = source["address"]
+            if address.startswith("127.127."):
+                if address.startswith("127.127.1."):
+                    continue
+                # No other refclocks are expected from the parser
+                assert False
+            else:
+                conf += "{} {}".format(source["type"], address)
+                for option in source["options"]:
+                    if option[0] in ["minpoll", "maxpoll", "version", "key",
+                                     "iburst", "noselect", "prefer", "xleave"]:
+                        conf += " {}".format(" ".join(option))
+                    elif option[0] == "burst":
+                        conf += " presend 6"
+                    elif option[0] == "true":
+                        conf += " trust"
+                    else:
+                        # No other options are expected from the parser
+                        assert False
+                conf += "\n"
+        conf += "\n"
+
+        return conf
+
+    def get_chrony_conf_allows(self):
+        allowed_networks = filter(lambda n: "ignore" not in self.restrictions[n] and
+                                    "noserve" not in self.restrictions[n],
+                                  self.restrictions.keys())
+
+        conf = ""
+        for network in sorted(allowed_networks, key=lambda n: (n.version, n)):
+            if network.num_addresses > 1:
+                conf += "allow {}\n".format(network)
+            else:
+                conf += "allow {}\n".format(network.network_address)
+
+        if conf:
+            conf = "# Allow NTP client access.\n" + conf
+            conf += "\n"
+
+        return conf
+
+    def get_chrony_conf_cmdallows(self):
+        allowed_networks = filter(lambda n: "ignore" not in self.restrictions[n] and
+                                    "noquery" not in self.restrictions[n] and
+                                    n != ipaddress.ip_network(u"127.0.0.1/32") and
+                                    n != ipaddress.ip_network(u"::1/128"),
+                                  self.restrictions.keys())
+
+        ip_versions = set()
+        conf = ""
+        for network in sorted(allowed_networks, key=lambda n: (n.version, n)):
+            ip_versions.add(network.version)
+            if network.num_addresses > 1:
+                conf += "cmdallow {}\n".format(network)
+            else:
+                conf += "cmdallow {}\n".format(network.network_address)
+
+        if conf:
+            conf = "# Allow remote monitoring.\n" + conf
+            if 4 in ip_versions:
+                conf += "bindcmdaddress 0.0.0.0\n"
+            if 6 in ip_versions:
+                conf += "bindcmdaddress ::\n"
+            conf += "\n"
+
+        return conf
+
+    def get_chrony_conf(self, chrony_keys_path):
+        local_stratum = 0
+        maxdistance = 0.0
+        minsources = 1
+        orphan_stratum = 0
+        logs = []
+
+        for source in self.time_sources:
+            address = source["address"]
+            if address.startswith("127.127.1."):
+                if address in self.fudges and "stratum" in self.fudges[address]:
+                    local_stratum = self.fudges[address]["stratum"]
+                else:
+                    local_stratum = 5
+
+        if "maxdist" in self.tos_options:
+            maxdistance = self.tos_options["maxdist"]
+        if "minsane" in self.tos_options:
+            minsources = self.tos_options["minsane"]
+        if "orphan" in self.tos_options:
+            orphan_stratum = self.tos_options["orphan"]
+
+        if "clockstats" in self.statistics:
+            logs.append("refclocks");
+        if "loopstats" in self.statistics:
+            logs.append("tracking")
+        if "peerstats" in self.statistics:
+            logs.append("statistics");
+        if "rawstats" in self.statistics:
+            logs.append("measurements")
+
+        conf = "# This file was converted from {}{}.\n".format(
+                    self.ntp_conf_path,
+                    " and " + self.step_tickers_path if self.step_tickers_path else "")
+        conf += "\n"
+
+        if self.ignored_lines:
+            conf += "# The following directives were ignored in the conversion:\n"
+
+            for line in self.ignored_lines:
+                # Remove sensitive information
+                line = re.sub(r"\s+pw\s+\S+", " pw XXX", line.rstrip())
+                conf += "# " + line + "\n"
+            conf += "\n"
+
+        conf += self.get_chrony_conf_sources()
+
+        conf += "# Record the rate at which the system clock gains/losses time.\n"
+        if not self.driftfile:
+            conf += "#"
+        conf += "driftfile /var/lib/chrony/drift\n"
+        conf += "\n"
+
+        conf += "# Allow the system clock to be stepped in the first three updates\n"
+        conf += "# if its offset is larger than 1 second.\n"
+        conf += "makestep 1.0 3\n"
+        conf += "\n"
+
+        conf += "# Enable kernel synchronization of the real-time clock (RTC).\n"
+        conf += "rtcsync\n"
+        conf += "\n"
+
+        conf += "# Enable hardware timestamping on all interfaces that support it.\n"
+        conf += "#hwtimestamp *\n"
+        conf += "\n"
+
+        if maxdistance > 0.0:
+            conf += "# Specify the maximum distance of sources to be selectable.\n"
+            conf += "maxdistance {}\n".format(maxdistance)
+            conf += "\n"
+
+        conf += "# Increase the minimum number of selectable sources required to adjust\n"
+        conf += "# the system clock.\n"
+        if minsources > 1:
+            conf += "minsources {}\n".format(minsources)
+        else:
+            conf += "#minsources 2\n"
+        conf += "\n"
+
+        conf += self.get_chrony_conf_allows()
+
+        conf += self.get_chrony_conf_cmdallows()
+
+        conf += "# Serve time even if not synchronized to a time source.\n"
+        if orphan_stratum > 0 and orphan_stratum < 16:
+            conf += "local stratum {} orphan\n".format(orphan_stratum)
+        elif local_stratum > 0 and local_stratum < 16:
+            conf += "local stratum {}\n".format(local_stratum)
+        else:
+            conf += "#local stratum 10\n"
+        conf += "\n"
+
+        conf += "# Specify file containing keys for NTP authentication.\n"
+        conf += "keyfile {}\n".format(chrony_keys_path)
+        conf += "\n"
+
+        conf += "# Get TAI-UTC offset and leap seconds from the system tz database.\n"
+        conf += "leapsectz right/UTC\n"
+        conf += "\n"
+
+        conf += "# Specify directory for log files.\n"
+        conf += "logdir /var/log/chrony\n"
+        conf += "\n"
+
+        conf += "# Select which information is logged.\n"
+        if logs:
+            conf += "log {}\n".format(" ".join(logs))
+        else:
+            conf += "#log measurements statistics tracking\n"
+
+        return conf
+
+    def get_chrony_keys(self):
+        if not self.keyfile:
+            return ""
+
+        keys = "# This file was converted from {}.\n".format(self.keyfile)
+        keys += "\n"
+
+        for key in self.keys:
+            key_id = key[0]
+            key_type = key[1]
+            password = key[2]
+
+            if key_type in ["m", "M"]:
+                key_type = "MD5"
+            elif key_type not in ["MD5", "SHA1", "SHA256", "SHA384", "SHA512"]:
+                continue
+
+            prefix = "ASCII" if len(password) <= 20 else "HEX"
+
+            for first, last in self.trusted_keys:
+                if first <= key_id <= last:
+                    trusted = True
+                    break
+            else:
+                trusted = False
+
+            # Disable keys that were not marked as trusted
+            if not trusted:
+                keys += "#"
+
+            keys += "{} {} {}:{}\n".format(key_id, key_type, prefix, password)
+
+        return keys
+
+    def write_file(self, path, mode, content, backup):
+        path = self.root_dir + path
+        if backup and os.path.isfile(path):
+            os.rename(path, path + ".old")
+
+        with open(os.open(path, os.O_CREAT | os.O_WRONLY | os.O_EXCL, mode), "w",
+                  encoding=self.file_encoding) as f:
+            logging.info("Writing %s", path)
+            f.write(u"" + content)
+
+        # Fix SELinux context if restorecon is installed
+        try:
+            subprocess.call(["restorecon", path])
+        except OSError:
+            pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert ntp configuration to chrony.")
+    parser.add_argument("-r", "--root", dest="roots", default=["/"], nargs="+",
+                        metavar="DIR", help="specify root directory (default /)")
+    parser.add_argument("--ntp-conf", action="store", default="/etc/ntp.conf",
+                        metavar="FILE", help="specify ntp config (default /etc/ntp.conf)")
+    parser.add_argument("--step-tickers", action="store", default="",
+                        metavar="FILE", help="specify ntpdate step-tickers config (no default)")
+    parser.add_argument("--chrony-conf", action="store", default="/etc/chrony.conf",
+                        metavar="FILE", help="specify chrony config (default /etc/chrony.conf)")
+    parser.add_argument("--chrony-keys", action="store", default="/etc/chrony.keys",
+                        metavar="FILE", help="specify chrony keyfile (default /etc/chrony.keys)")
+    parser.add_argument("-b", "--backup", action="store_true", help="backup existing configs before writing")
+    parser.add_argument("-L", "--ignored-lines", action="store_true", help="print ignored lines")
+    parser.add_argument("-D", "--ignored-directives", action="store_true",
+                        help="print names of ignored directives")
+    parser.add_argument("-n", "--dry-run", action="store_true", help="don't make any changes")
+    parser.add_argument("-v", "--verbose", action="count", default=0, help="increase verbosity")
+
+    args = parser.parse_args()
+
+    logging.basicConfig(format="%(message)s",
+                        level=[logging.ERROR, logging.INFO, logging.DEBUG][min(args.verbose, 2)])
+
+    for root in args.roots:
+        conf = NtpConfiguration(root, args.ntp_conf, args.step_tickers)
+
+        if args.ignored_lines:
+            for line in conf.ignored_lines:
+                print(line)
+
+        if args.ignored_directives:
+            for directive in conf.ignored_directives:
+                print(directive)
+
+        conf.write_chrony_configuration(args.chrony_conf, args.chrony_keys, args.dry_run, args.backup)
+
+if __name__ == "__main__":
+    main()

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/1_chrony.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/1_chrony.conf
@@ -1,0 +1,47 @@
+# This file was converted from tests/data/ntpconfs/1_ntp.conf.
+
+# Specify time sources.
+server ntpserver
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access.
+allow 0.0.0.0/0
+allow 127.0.0.1
+allow ::/0
+
+# Allow remote monitoring.
+cmdallow 0.0.0.0/0
+cmdallow ::/0
+bindcmdaddress 0.0.0.0
+bindcmdaddress ::
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+keyfile tests/data/chronyconfs/1_chrony.keys
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/2_chrony.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/2_chrony.conf
@@ -1,0 +1,46 @@
+# This file was converted from tests/data/ntpconfs/2_ntp.conf.
+
+# Specify time sources.
+server 0.rhel.pool.ntp.org
+server 1.rhel.pool.ntp.org
+server 2.rhel.pool.ntp.org
+server 172.18.242.69 prefer
+server 172.18.242.71 prefer
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access.
+allow 0.0.0.0/0
+allow 127.0.0.1
+allow ::/0
+allow ::1
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+keyfile tests/data/chronyconfs/2_chrony.keys
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/2_chrony.keys
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/2_chrony.keys
@@ -1,0 +1,3 @@
+#42 MD5 HEX:SorryForInconvenience
+#22 MD5 ASCII:Catch
+#2702 MD5 HEX:LavenderRose

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/3_chrony.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/3_chrony.conf
@@ -1,0 +1,49 @@
+# This file was converted from tests/data/ntpconfs/3_ntp.conf.
+
+# Specify time sources.
+server 0.rhel.pool.ntp.org
+server 1.rhel.pool.ntp.org
+server 2.rhel.pool.ntp.org
+server 0.rhel.pool.ntp.org
+server 1.rhel.pool.ntp.org
+server 2.rhel.pool.ntp.org
+server 172.18.242.69 prefer
+server 172.18.242.71 prefer
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access.
+allow 0.0.0.0/0
+allow 127.0.0.1
+allow ::/0
+allow ::1
+
+# Serve time even if not synchronized to a time source.
+local stratum 10
+
+# Specify file containing keys for NTP authentication.
+keyfile tests/data/chronyconfs/3_chrony.keys
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/3_chrony.keys
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/3_chrony.keys
@@ -1,0 +1,1 @@
+42 MD5 HEX:MarvinTheDepressiveAndroid

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/4_chrony.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/4_chrony.conf
@@ -1,0 +1,49 @@
+# This file was converted from tests/data/ntpconfs/4_ntp.conf.
+
+# Specify time sources.
+pool 2.pool.ntp.org
+pool 2.rhel.pool.ntp.org
+server 42.rhel.pool.ntp.org
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access.
+allow 0.0.0.0/0
+allow 127.0.0.1
+allow ::/0
+
+# Allow remote monitoring.
+cmdallow 0.0.0.0/0
+cmdallow ::/0
+bindcmdaddress 0.0.0.0
+bindcmdaddress ::
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+keyfile tests/data/chronyconfs/4_chrony.keys
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/5_chrony.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/5_chrony.conf
@@ -1,0 +1,48 @@
+# This file was converted from tests/data/ntpconfs/5_ntp.conf.
+
+# Specify time sources.
+pool 2.pool.ntp.org
+peer 0.pool.ntp.org
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access.
+allow 0.0.0.0/0
+allow 127.0.0.1
+allow ::/0
+
+# Allow remote monitoring.
+cmdallow 0.0.0.0/0
+cmdallow ::/0
+bindcmdaddress 0.0.0.0
+bindcmdaddress ::
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+keyfile tests/data/chronyconfs/5_chrony.keys
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/6_chrony.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/6_chrony.conf
@@ -1,0 +1,51 @@
+# This file was converted from tests/data/ntpconfs/6_ntp.conf.
+
+# The following directives were ignored in the conversion:
+# server 127.127.8.1 mode 2 minpoll 3 maxpoll 3 noselect
+# server 127.127.8.0 mode 5 minpoll 6 maxpoll 6 noselect
+# server 127.127.20.0 mode 80 minpoll 3 maxpoll 3 prefer
+# server 127.127.28.2 mode 1
+
+# Specify time sources.
+
+# Record the rate at which the system clock gains/losses time.
+#driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access.
+allow 0.0.0.0/0
+allow ::/0
+
+# Allow remote monitoring.
+cmdallow 0.0.0.0/0
+cmdallow ::/0
+bindcmdaddress 0.0.0.0
+bindcmdaddress ::
+
+# Serve time even if not synchronized to a time source.
+local stratum 5
+
+# Specify file containing keys for NTP authentication.
+keyfile tests/data/chronyconfs/6_chrony.keys
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/7_chrony.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/chronyconfs/7_chrony.conf
@@ -1,0 +1,50 @@
+# This file was converted from tests/data/ntpconfs/7_ntp.conf.
+
+# The following directives were ignored in the conversion:
+# server 192.168.1.3 nosuchoption
+
+# Specify time sources.
+server 192.168.1.1 minpoll 3 maxpoll 12 iburst presend 6
+server 192.168.1.2 noselect prefer trust xleave
+
+# Record the rate at which the system clock gains/losses time.
+#driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access.
+allow 0.0.0.0/0
+allow ::/0
+
+# Allow remote monitoring.
+cmdallow 0.0.0.0/0
+cmdallow ::/0
+bindcmdaddress 0.0.0.0
+bindcmdaddress ::
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+keyfile tests/data/chronyconfs/7_chrony.keys
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntp.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntp.conf
@@ -1,0 +1,45 @@
+################################################################################
+## /etc/ntp.conf
+##
+## Sample NTP configuration file for basic unit tests.
+## It's main purpose is to check ntp config parsing and minimal conversion.
+## For real-world like scenarios another set of configs will be used.
+##
+##
+################################################################################
+
+
+# By default, exchange time with everybody, but don't allow configuration.
+restrict -4 default notrap nomodify nopeer noquery
+restrict -6 default notrap nomodify nopeer noquery
+
+# Local users may interrogate the ntp server more closely.
+restrict 127.0.0.1
+restrict ::1
+
+# Clients from this (example!) subnet have unlimited access, but only if
+# cryptographically authenticated.
+#restrict 192.168.123.0 mask 255.255.255.0 notrust
+
+##
+## Miscellaneous stuff
+##
+
+driftfile /var/lib/ntp/drift/ntp.drift # path for drift file
+
+logfile   /var/log/ntp		# alternate log file
+# logconfig =syncstatus + sysevents
+# logconfig =all
+
+# statsdir /var/log/ntpstats/		# directory for statistics files
+# filegen peerstats  file peerstats  type day enable
+# filegen loopstats  file loopstats  type day enable
+# filegen clockstats file clockstats type day enable
+
+#
+# Authentication stuff
+#
+keys tests/data/ntp.keys	# path for keys file
+trustedkey 42			# define trusted keys
+requestkey 22			# key (7) for accessing server variables
+controlkey 22			# key (6) for accessing server variables

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntp.keys
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntp.keys
@@ -1,0 +1,3 @@
+22 M Catch
+42 M SorryForInconvenience
+2702 M LavenderRose

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/1_ntp.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/1_ntp.conf
@@ -1,0 +1,4 @@
+restrict 127.0.0.1
+restrict default kod nomodify notrap
+driftfile /var/lib/ntp/drift
+server ntpserver

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/2_ntp.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/2_ntp.conf
@@ -1,0 +1,54 @@
+# For more information about this file, see the man pages
+# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).
+
+driftfile /var/lib/ntp/drift
+
+# Permit time synchronization with our time source, but do not
+# permit the source to query or modify the service on this system.
+restrict default kod nomodify notrap nopeer noquery
+restrict -6 default kod nomodify notrap nopeer noquery
+
+# Permit all access over the loopback interface.  This could
+# be tightened as well, but to do so would effect some of
+# the administrative functions.
+restrict 127.0.0.1
+restrict -6 ::1
+
+# Hosts on local network are less restricted.
+#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 0.rhel.pool.ntp.org
+server 1.rhel.pool.ntp.org
+server 2.rhel.pool.ntp.org
+
+#broadcast 192.168.1.255 autokey	# broadcast server
+#broadcastclient			# broadcast client
+#broadcast 224.0.1.1 autokey		# multicast server
+#multicastclient 224.0.1.1		# multicast client
+#manycastserver 239.255.254.254		# manycast server
+#manycastclient 239.255.254.254 autokey # manycast client
+
+# Undisciplined Local Clock. This is a fake driver intended for backup
+# and when no outside source of synchronized time is available.
+#server	127.127.1.0	# local clock
+#fudge	127.127.1.0 stratum 10
+
+# Key file containing the keys and key identifiers used when operating
+# with symmetric key cryptography.
+keys tests/data/ntpconfs/2_ntp.keys
+
+# Specify the key identifiers which are trusted.
+#trustedkey 4 8 42
+
+# Specify the key identifier to use with the ntpdc utility.
+#requestkey 8
+
+# Specify the key identifier to use with the ntpq utility.
+#controlkey 8
+
+# Enable writing of statistics records.
+#statistics clockstats cryptostats loopstats peerstats
+server  172.18.242.69 prefer
+server  172.18.242.71 prefer

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/2_ntp.keys
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/2_ntp.keys
@@ -1,0 +1,3 @@
+42 M SorryForInconvenience
+22 M Catch
+2702 M LavenderRose

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/3_ntp.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/3_ntp.conf
@@ -1,0 +1,59 @@
+# For more information about this file, see the man pages
+# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).
+
+driftfile /var/lib/ntp/drift
+
+# Permit time synchronization with our time source, but do not
+# permit the source to query or modify the service on this system.
+restrict default kod nomodify notrap nopeer noquery
+restrict -6 default kod nomodify notrap nopeer noquery
+
+# Permit all access over the loopback interface.  This could
+# be tightened as well, but to do so would effect some of
+# the administrative functions.
+restrict 127.0.0.1
+restrict -6 ::1
+
+# Hosts on local network are less restricted.
+#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 0.rhel.pool.ntp.org
+server 1.rhel.pool.ntp.org
+server 2.rhel.pool.ntp.org
+
+#broadcast 192.168.1.255 autokey	# broadcast server
+#broadcastclient			# broadcast client
+#broadcast 224.0.1.1 autokey		# multicast server
+#multicastclient 224.0.1.1		# multicast client
+#manycastserver 239.255.254.254		# manycast server
+#manycastclient 239.255.254.254 autokey # manycast client
+
+# Undisciplined Local Clock. This is a fake driver intended for backup
+# and when no outside source of synchronized time is available.
+#server	127.127.1.0	# local clock
+#fudge	127.127.1.0 stratum 10
+
+# Enable public key cryptography.
+#crypto
+
+includefile tests/data/ntpconfs/3_ntp.includefile
+
+# Key file containing the keys and key identifiers used when operating
+# with symmetric key cryptography.
+# keys tests/data/ntpconfs/3_ntp.keys
+
+# Specify the key identifiers which are trusted.
+# trustedkey 42
+
+# Specify the key identifier to use with the ntpdc utility.
+#requestkey 8
+
+# Specify the key identifier to use with the ntpq utility.
+#controlkey 8
+
+# Enable writing of statistics records.
+#statistics clockstats cryptostats loopstats peerstats
+server  172.18.242.69 prefer
+server  172.18.242.71 prefer

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/3_ntp.includefile
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/3_ntp.includefile
@@ -1,0 +1,50 @@
+# Permit time synchronization with our time source, but do not
+# permit the source to query or modify the service on this system.
+restrict default kod nomodify notrap nopeer noquery
+restrict -6 default kod nomodify notrap nopeer noquery
+
+# Permit all access over the loopback interface.  This could
+# be tightened as well, but to do so would effect some of
+# the administrative functions.
+restrict 127.0.0.1
+restrict -6 ::1
+
+# Hosts on local network are less restricted.
+#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 0.rhel.pool.ntp.org
+server 1.rhel.pool.ntp.org
+server 2.rhel.pool.ntp.org
+
+#broadcast 192.168.1.255 key 42		# broadcast server
+#broadcastclient			# broadcast client
+#broadcast 224.0.1.1 key 42		# multicast server
+#multicastclient 224.0.1.1		# multicast client
+#manycastserver 239.255.254.254		# manycast server
+#manycastclient 239.255.254.254 key 42	# manycast client
+
+# Undisciplined Local Clock. This is a fake driver intended for backup
+# and when no outside source of synchronized time is available.
+server	127.127.1.0	# local clock
+fudge	127.127.1.0 stratum 10
+
+# Drift file.  Put this in a directory which the daemon can write to.
+# No symbolic links allowed, either, since the daemon updates the file
+# by creating a temporary in the same directory and then rename()'ing
+# it to the file.
+driftfile /var/lib/ntp/drift
+
+# Key file containing the keys and key identifiers used when operating
+# with symmetric key cryptography.
+keys tests/data/ntpconfs/3_ntp.keys
+
+# Specify the key identifiers which are trusted.
+trustedkey 42
+
+# Specify the key identifier to use with the ntpdc utility.
+#requestkey 8
+
+# Specify the key identifier to use with the ntpq utility.
+#controlkey 8

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/3_ntp.keys
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/3_ntp.keys
@@ -1,0 +1,1 @@
+42 M MarvinTheDepressiveAndroid

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/4_ntp.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/4_ntp.conf
@@ -1,0 +1,15 @@
+restrict 127.0.0.1
+restrict default kod nomodify notrap
+driftfile /var/lib/ntp/drift
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 0.pool.ntp.org
+server 1.pool.ntp.org
+server 2.pool.ntp.org
+server 3.pool.ntp.org
+server 0.rhel.pool.ntp.org
+server 1.rhel.pool.ntp.org
+server 2.rhel.pool.ntp.org
+server 3.rhel.pool.ntp.org
+server 42.rhel.pool.ntp.org

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/5_ntp.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/5_ntp.conf
@@ -1,0 +1,9 @@
+restrict 127.0.0.1
+restrict default kod nomodify notrap
+driftfile /var/lib/ntp/drift
+
+server 0.pool.ntp.org
+server 1.pool.ntp.org
+server 2.pool.ntp.org
+server 3.pool.ntp.org
+peer 0.pool.ntp.org

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/6_ntp.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/6_ntp.conf
@@ -1,0 +1,8 @@
+server 127.127.1.0 minpoll 4 maxpoll 4
+fudge 127.127.1.0 stratum 5
+server 127.127.8.1 mode 2 minpoll 3 maxpoll 3 noselect
+server 127.127.8.0 mode 5 minpoll 6 maxpoll 6 noselect
+fudge 127.127.8.0 time1 0.03
+server 127.127.20.0 mode 80 minpoll 3 maxpoll 3 prefer
+fudge 127.127.20.0 flag1 1 time2 0.5
+server 127.127.28.2 mode 1

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/7_ntp.conf
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/ntpconfs/7_ntp.conf
@@ -1,0 +1,3 @@
+server 192.168.1.1 minpoll 3 maxpoll 12 iburst burst
+server 192.168.1.2 noselect prefer true xleave
+server 192.168.1.3 nosuchoption

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/step_tickers
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/data/step_tickers
@@ -1,0 +1,3 @@
+0.sample.pool.ntp.org
+1.sample.pool.ntp.org
+2.sample.pool.ntp.org

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/test_converter.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/test_converter.py
@@ -1,0 +1,72 @@
+import os
+
+from leapp.libraries.actor import ntp2chrony
+
+NTP_CONF = "tests/data/ntp.conf"
+STEP_TICKERS = "tests/data/step_tickers"
+NTP_MATCH_DIR = "tests/data/ntpconfs/"
+CHRONY_MATCH_DIR = "tests/data/chronyconfs/"
+
+
+class TestConverter(object):
+    def test_basic(self):
+        config = ntp2chrony.NtpConfiguration('', NTP_CONF, step_tickers=STEP_TICKERS)
+        present = [config.restrictions, config.driftfile, config.trusted_keys, config.keys,
+                   config.step_tickers, config.restrictions]
+        for section in present:
+            assert section
+        chrony_conf = config.get_chrony_conf('/etc/chrony.keys')
+        # additional verification section by section for each param in present?
+
+        # verify step_tickers -> initstepslew
+        initstepslew_line = next((l for l in chrony_conf.split('\n')
+                                  if l.startswith('initstepslew')), None)
+        assert initstepslew_line and initstepslew_line.endswith(' '.join(config.step_tickers))
+        chrony_keys = config.get_chrony_keys()
+        # verify keys generation
+        for num, _, key in config.keys:
+            expected = ('%(num)s MD5 %(key)s' %
+                        {'key': 'HEX:' if len(key) > 20 else 'ASCII:' + key, 'num': num})
+            # keys not from trusted keys are commented out by default
+            if not any(num in range(x, y+1) for (x, y) in config.trusted_keys):
+                expected = '#' + expected
+            assert expected in chrony_keys
+
+
+class TestConfigConversion(object):
+    def _do_match(self, expected_file, actual):
+        expected_lines = []
+        actual_lines = []
+        with open(expected_file) as f:
+            expected_lines = [l.strip() for l in f.readlines()
+                              if l.strip() and not l.strip().startswith('#')]
+        actual_lines = [l.strip() for l in actual.split('\n')
+                        if l.strip() and not l.strip().startswith('#')]
+        assert expected_lines == actual_lines
+
+    def _check_existance(self, fname, default=''):
+        if os.path.exists(fname):
+            return fname
+        return default
+
+    def test_match(self):
+
+        for f in [f for f in os.listdir(NTP_MATCH_DIR) if f.endswith('conf')]:
+            # get recorded actual result
+            num = f.split('.')[0].split('_')[0]
+            ntp_conf = os.path.join(NTP_MATCH_DIR, f)
+            step_tickers = self._check_existance(
+                    os.path.join(NTP_MATCH_DIR, '%s_step_tickers' % num))
+            config = ntp2chrony.NtpConfiguration('',
+                                                 ntp_conf,
+                                                 step_tickers=step_tickers)
+            potential_chrony_keys = os.path.join(CHRONY_MATCH_DIR, "%s_chrony.keys" % num)
+            actual_data = config.get_chrony_conf(chrony_keys_path=potential_chrony_keys)
+            expected_fname = os.path.join(CHRONY_MATCH_DIR, "%s_chrony.conf" % num)
+            # make sure recorded and generated configs match
+            self._do_match(expected_fname, actual_data)
+            actual_keys = config.get_chrony_keys()
+            expected_keys_file = self._check_existance(potential_chrony_keys)
+            # if keys are recorded or generated make sure they match
+            if actual_keys and expected_keys_file != '':
+                self._do_match(expected_keys_file, actual_keys)

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/unit_test.py
@@ -1,6 +1,7 @@
 from leapp.libraries.actor import library
 from leapp.libraries.common import reporting
 
+
 class report_generic_mocked(object):
     def __init__(self):
         self.called = 0
@@ -84,7 +85,8 @@ def test_migration(monkeypatch):
                 assert library.write_file.name == '/etc/ntp.conf.nosources'
                 assert 'without ntp configuration' in library.write_file.content
             assert library.ntp2chrony.called == 1
-            assert library.ntp2chrony.args == ('/',
+            assert library.ntp2chrony.args == (
+                    '/',
                     '/etc/ntp.conf' if 'ntpd' in ntp_services else '/etc/ntp.conf.nosources',
                     '/etc/ntp/step-tickers' if 'ntpdate' in ntp_services else '')
         else:

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/unit_test.py
@@ -1,0 +1,95 @@
+from leapp.libraries.actor import library
+from leapp.libraries.common import reporting
+
+class report_generic_mocked(object):
+    def __init__(self):
+        self.called = 0
+
+    def __call__(self, **report_fields):
+        self.called += 1
+        self.report_fields = report_fields
+
+
+class extract_tgz64_mocked(object):
+    def __init__(self):
+        self.called = 0
+
+    def __call__(self, s):
+        self.called += 1
+        self.s = s
+
+
+class enable_service_mocked(object):
+    def __init__(self):
+        self.called = 0
+        self.names = []
+
+    def __call__(self, name):
+        self.called += 1
+        self.names.append(name)
+
+
+class write_file_mocked(object):
+    def __init__(self):
+        self.called = 0
+
+    def __call__(self, name, content):
+        self.called += 1
+        self.name = name
+        self.content = content
+
+
+class ntp2chrony_mocked(object):
+    def __init__(self, lines):
+        self.called = 0
+        self.ignored_lines = lines
+
+    def __call__(self, *args):
+        self.called += 1
+        self.args = args
+        return self.ignored_lines * ['a line']
+
+
+def test_migration(monkeypatch):
+    for ntp_services, chrony_services, ignored_lines in [
+                ([], [], 0),
+                (['ntpd'], ['chronyd'], 0),
+                (['ntpdate'], ['chronyd'], 1),
+                (['ntp-wait'], ['chrony-wait'], 0),
+                (['ntpd', 'ntpdate', 'ntp-wait'], ['chronyd', 'chronyd', 'chrony-wait'], 1),
+            ]:
+        monkeypatch.setattr(reporting, 'report_generic', report_generic_mocked())
+        monkeypatch.setattr(library, 'extract_tgz64', extract_tgz64_mocked())
+        monkeypatch.setattr(library, 'enable_service', enable_service_mocked())
+        monkeypatch.setattr(library, 'write_file', write_file_mocked())
+        monkeypatch.setattr(library, 'ntp2chrony', ntp2chrony_mocked(ignored_lines))
+
+        library.migrate_ntp(ntp_services, 'abcdef')
+
+        if len(ntp_services) > 0:
+            assert reporting.report_generic.called == 1
+            if ignored_lines > 0:
+                assert 'configuration partially migrated to chrony' in \
+                        reporting.report_generic.report_fields['title']
+            else:
+                assert 'configuration migrated to chrony' in \
+                        reporting.report_generic.report_fields['title']
+
+            assert library.extract_tgz64.called == 1
+            assert library.extract_tgz64.s == 'abcdef'
+            assert library.enable_service.called == len(chrony_services)
+            assert library.enable_service.names == chrony_services
+            assert library.write_file.called == (0 if 'ntpd' in ntp_services else 1)
+            if library.write_file.called:
+                assert library.write_file.name == '/etc/ntp.conf.nosources'
+                assert 'without ntp configuration' in library.write_file.content
+            assert library.ntp2chrony.called == 1
+            assert library.ntp2chrony.args == ('/',
+                    '/etc/ntp.conf' if 'ntpd' in ntp_services else '/etc/ntp.conf.nosources',
+                    '/etc/ntp/step-tickers' if 'ntpdate' in ntp_services else '')
+        else:
+            assert reporting.report_generic.called == 0
+            assert library.extract_tgz64.called == 0
+            assert library.enable_service.called == 0
+            assert library.write_file.called == 0
+            assert library.ntp2chrony.called == 0

--- a/repos/system_upgrade/el7toel8/models/ntpmigrationdecision.py
+++ b/repos/system_upgrade/el7toel8/models/ntpmigrationdecision.py
@@ -1,0 +1,8 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class NtpMigrationDecision(Model):
+    topic = SystemInfoTopic
+    migrate_services = fields.List(fields.String())
+    config_tgz64 = fields.String()


### PR DESCRIPTION
Add CheckNtp actor to check if the ntpd and/or ntpdate services are
enabled, active and their configuration files exist. Also, save the
configuration files in a string containing a base64-encoded compressed
tarball to avoid having to deal with .rpmsave files when the packages
are removed in the rpm upgrade.

Add MigrateNtp actor to enable the chronyd service, restore the
ntp/ntpdate configuration files, and run the included ntp2chrony
migration script. Produce a warning with a suggestion to check the
generated /etc/chrony.conf if some lines in ntp.conf were ignored in the
migration.