### PR TITLE
Append Leapp upgrade.log file instead of backup it

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/removeoldlog/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldlog/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.library import remove_log
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+
+
+class RemoveOldLog(Actor):
+    """
+    Removes the old log from the previous Leapp run
+    to ensure that you have only valid and updated logs for debugging.
+    """
+
+    name = 'remove_old_log'
+    consumes = ()
+    produces = ()
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        remove_log()

--- a/repos/system_upgrade/el7toel8/actors/removeoldlog/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldlog/actor.py
@@ -5,9 +5,11 @@ from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 class RemoveOldLog(Actor):
     """
-    Removes the old log from the previous Leapp run
-    to ensure that you have only valid and updated logs for debugging.
+    Remove old log from previous Leapp run.
+     
+    This is necessary to ensure that you have only valid and updated logs for debugging.
     """
+
 
     name = 'remove_old_log'
     consumes = ()

--- a/repos/system_upgrade/el7toel8/actors/removeoldlog/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldlog/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.library import remove_log
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.tags import IPUWorkflowTag, InterimPreparationPhaseTag
 
 
 class RemoveOldLog(Actor):
@@ -10,11 +10,10 @@ class RemoveOldLog(Actor):
     This is necessary to ensure that you have only valid and updated logs for debugging.
     """
 
-
     name = 'remove_old_log'
     consumes = ()
     produces = ()
-    tags = (IPUWorkflowTag, FactsPhaseTag)
+    tags = (IPUWorkflowTag, InterimPreparationPhaseTag)
 
     def process(self):
         remove_log()

--- a/repos/system_upgrade/el7toel8/actors/removeoldlog/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldlog/libraries/library.py
@@ -1,0 +1,17 @@
+import os
+
+from leapp.libraries.stdlib import api
+
+
+def remove_log():
+    filepath = '/var/log/upgrade.log'
+    if os.path.isfile(filepath):
+        api.current_logger().info('already exists a log file from a previous Leapp run, it will be removed')
+        remove_file(filepath)
+
+
+def remove_file(filepath):
+    try:
+        os.remove(filepath)
+    except OSError as err:
+        api.current_logger().error('Could not remove {0}: {1}.'.format(filepath, err))

--- a/repos/system_upgrade/el7toel8/actors/removeoldlog/tests/test_removeoldlog.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldlog/tests/test_removeoldlog.py
@@ -1,0 +1,64 @@
+import pytest
+
+from leapp.libraries.stdlib import api
+from leapp.libraries.actor import library
+
+
+class remove_file_mocked(object):
+    def __init__(self):
+        self.file = ''
+
+    def __call__(self, file):
+        self.file = file
+
+
+class logger_mocked(object):
+    def __init__(self):
+        self.infomsg = ''
+        self.errmsg = ''
+
+    def info(self, msg):
+        self.infomsg = msg
+
+    def error(self, msg):
+        self.errmsg = msg
+
+    def __call__(self):
+        return self
+
+
+def test_remove_log_exists(monkeypatch):
+    def file_exists(filepath):
+        return True
+    monkeypatch.setattr('os.path.isfile', file_exists)
+    monkeypatch.setattr(library, 'remove_file', remove_file_mocked())
+    monkeypatch.setattr('leapp.libraries.stdlib.api.current_logger', logger_mocked())
+
+    library.remove_log()
+
+    assert library.remove_file.file == '/var/log/upgrade.log'
+    assert "already exists a log" in api.current_logger.infomsg
+
+
+def test_remove_log_no_exists(monkeypatch):
+    def file_no_exists(filepath):
+        return False
+    monkeypatch.setattr('os.path.isfile', file_no_exists)
+    monkeypatch.setattr(library, 'remove_file', remove_file_mocked())
+    monkeypatch.setattr('leapp.libraries.stdlib.api.current_logger', logger_mocked())
+
+    library.remove_log()
+
+    assert not library.remove_file.file
+    assert not api.current_logger.infomsg
+
+
+def test_remove_file_that_does_not_exist(monkeypatch):
+    def remove_mocked(filepath):
+        raise OSError
+    monkeypatch.setattr('os.remove', remove_mocked)
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    library.remove_file('/filepath')
+
+    assert "Could not remove /filepath" in api.current_logger.errmsg

--- a/sources/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/sources/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -57,11 +57,11 @@ save_journal() {
 
     local logfile="$NEWROOT/var/log/upgrade.log"
 
-    # back up old logfile, if present
-    [ -e $logfile ] && rm -rf $logfile.old && mv $logfile $logfile.old
+    # Add a separator if file exists
+    [ -e $logfile ] && echo "### LEAPP reboot ###" >> $logfile
 
     # write out the logfile
-    journalctl -a -m > $logfile
+    journalctl -a -m >> $logfile
 }
 
 


### PR DESCRIPTION
The previous behavior was to save only the last log file, which causes log loss if it goes into a looping process.

Now the log file will be appended.