### PR TITLE
Copy yum v3 configuration data to yum v4 /etc/dnf directory

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -1,2 +1,1 @@
-yum
 redhat-rpm-config

--- a/repos/system_upgrade/el7toel8/actors/yumupgradability/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/yumupgradability/actor.py
@@ -1,0 +1,25 @@
+from leapp.actors import Actor
+from leapp.tags import IPUWorkflowTag, ExperimentalTag, PreparationPhaseTag
+from leapp.libraries.actor.yumupgradability import secure_yum_upgradability
+
+
+class YumUpgradability(Actor):
+    """
+    Copy yum v3 configuration to yum v4 /etc/dnf directory
+
+    Steps
+        1) Create /etc/dnf directory
+        2) Copy yum configuration to the /etc/dnf directory
+        3) Make symlinks under /etc/yum
+    """
+
+    name = 'yum_upgradability'
+    consumes = ()
+    produces = ()
+    tags = (IPUWorkflowTag, PreparationPhaseTag)
+
+    def process(self):
+        """
+        Process yum upgradability actor
+        """
+        secure_yum_upgradability()

--- a/repos/system_upgrade/el7toel8/actors/yumupgradability/libraries/yumupgradability.py
+++ b/repos/system_upgrade/el7toel8/actors/yumupgradability/libraries/yumupgradability.py
@@ -1,0 +1,43 @@
+from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import CalledProcessError
+from leapp.libraries.stdlib import run
+
+CMDS = [
+    ['mkdir', '-p', '/etc/dnf'],
+    ['cp', '-af', '/etc/yum/*', '/etc/dnf/'],
+    ['rm', '-rf', '/etc/yum/pluginconf.d', '/etc/yum/protected.d', '/etc/yum/vars'],
+    ['ln', '-s', '/etc/dnf/plugins/', '/etc/yum/pluginconf.d'],
+    ['ln', '-s', '/etc/dnf/protected.d/', '/etc/yum/protected.d'],
+    ['ln', '-s', '/etc/dnf/vars/', '/etc/yum/vars']
+]
+
+
+def run_cmd(cmd):
+    """
+    Carry out the command
+
+    :param cmd:
+    :return: Yellow Flag flag
+    """
+    yellow_flag = False
+    try:
+        run(cmd)
+    except (CalledProcessError, OSError) as error:
+        api.current_logger().warning('Yum upgradability may be affected:' + str(error))
+        yellow_flag = True
+    return yellow_flag
+
+
+def secure_yum_upgradability():
+    """
+    Copy yum v3 configuration to yum v4 /etc/dnf directory
+
+    :return: Yellow Flag flag
+    """
+
+    yellow_flag = False
+    for cmd in CMDS:
+        if run_cmd(cmd):
+            yellow_flag = True
+
+    return yellow_flag

--- a/repos/system_upgrade/el7toel8/actors/yumupgradability/tests/test_yumupgradability.py
+++ b/repos/system_upgrade/el7toel8/actors/yumupgradability/tests/test_yumupgradability.py
@@ -1,0 +1,17 @@
+from subprocess import call
+
+from leapp.libraries.actor import yumupgradability
+
+
+def test_secure_yum_upgradability(monkeypatch):
+    """
+    Test Secure Yum upgradability library function
+
+    :return: Indicates Pass/Fail - whether tests succeeded
+    """
+
+    monkeypatch.setattr(yumupgradability, "CMDS", [['whoami'], ['ls']])
+    monkeypatch.setattr(yumupgradability, 'run_cmd', call)
+    expected_yellow_flag = False
+    actual_yellow_flag = yumupgradability.secure_yum_upgradability()
+    assert actual_yellow_flag == expected_yellow_flag


### PR DESCRIPTION
Yum package from RHEL7 is upgradable to RHEL8 without having to remove the yum package during the upgrade transaction
    The solution is proposed by YUM/DNF developers.
Using chroot
 1) Create /etc/dnf directory
 2) Copy yum configuration to the /etc/dnf directory

[Addressing https://github.com/oamg/leapp-repository/issues/19]