### PR TITLE
Move the filterrpmtransactionevents actor to ChecksPhase

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/filterrpmtransactionevents/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/filterrpmtransactionevents/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.models import RpmTransactionTasks, FilteredRpmTransactionTasks, InstalledRedHatSignedRPM
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
 
 
 class FilterRpmTransactionTasks(Actor):
@@ -8,7 +8,7 @@ class FilterRpmTransactionTasks(Actor):
     description = 'Filters RPM transaction events to only include relevant events based on installed RPM'
     consumes = (RpmTransactionTasks, InstalledRedHatSignedRPM,)
     produces = (FilteredRpmTransactionTasks,)
-    tags = (IPUWorkflowTag, FactsPhaseTag)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
 
     def process(self):
         installed_pkgs = set()


### PR DESCRIPTION
The actor was originally in the FactsPhase phase. However, this is confusing as
 - it is supposed to consume RpmTransactionTasks msgs that itself suggest by name that these are the specific one that user should produce when they want to influence RPM transaction
 - the name itelf is check_rpm_transaction_events

*NOTE:* If you do not like this fix, we should discuss additional changes like names of related models and name of the actor as current state is definitely wrong, but I am not telling that this is the solution we have to apply. Feel free to write your opinion about this guys.