### PR TITLE
Increase diskimage size

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/libraries/preparetransaction.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/libraries/preparetransaction.py
@@ -246,7 +246,16 @@ def create_disk_image(path):
             summary='Error while trying to create destination path on the host system.',
             details=str(e))
 
-    cmds = [['/bin/dd', 'if=/dev/zero', 'of={}'.format(diskimage_path), 'bs=1M', 'count=1500'],
+    disk_size = os.getenv('LEAPP_OVL_SIZE', default='2048')
+
+    try:
+        int(disk_size)
+    except ValueError:
+        disk_size = '2048'
+        api.current_logger().warn(
+            'Invalid "LEAPP_OVL_SIZE" environment variable. Setting default "{}" value'.format(disk_size))
+
+    cmds = [['/bin/dd', 'if=/dev/zero', 'of={}'.format(diskimage_path), 'bs=1M', 'count={}'.format(disk_size)],
             ['/sbin/mkfs.ext4', '-F', diskimage_path],
             ['/bin/mount', '-o', 'loop', diskimage_path, mounts_path]]
 


### PR DESCRIPTION
In recent testing just encountered a scenario where our overlayfs2 disk image size was not large enough and got:

```Error Summary
-------------
Disk Requirements:
   At least 75MB more space needed on the / filesystem.
```


This is just a temporary workaround and we should think about
more robust solution and how to count total needed size for all
packages installation.

