### PR TITLE
Add actor and functions for detecting and fixing syntax error in grub…

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
-from leapp.libraries.actor.library import add_boot_entry
-from leapp.models import BootContent
+from leapp.libraries.actor.library import add_boot_entry, fix_grub_config_error
+from leapp.models import BootContent, GrubConfigError
 from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
 
 
@@ -12,9 +12,13 @@ class AddUpgradeBootEntry(Actor):
     """
 
     name = 'add_upgrade_boot_entry'
-    consumes = (BootContent,)
+    consumes = (BootContent, GrubConfigError)
     produces = ()
     tags = (IPUWorkflowTag, InterimPreparationPhaseTag)
 
     def process(self):
+        grub_config_error_detected = next(self.consume(GrubConfigError), GrubConfigError()).error_detected
+        if grub_config_error_detected:
+            fix_grub_config_error('/etc/default/grub')
+
         add_boot_entry()

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/files/grub_test.fixed
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/files/grub_test.fixed
@@ -1,0 +1,7 @@
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL_OUTPUT="console"
+GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+GRUB_DISABLE_RECOVERY="true"

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/files/grub_test.wrong
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/files/grub_test.wrong
@@ -1,0 +1,7 @@
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL_OUTPUT="console"
+GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto" console=ttyS0,115200n8 no_timer_check net.ifnames=0
+GRUB_DISABLE_RECOVERY="true"

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
@@ -51,4 +51,4 @@ def fix_grub_config_error(conf_file):
 
     config = config.replace(original_value, new_value)
 
-    return write_to_file(conf_file, config)
+    write_to_file(conf_file, config)

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.stdlib import api, call
@@ -30,3 +31,24 @@ def get_boot_file_paths():
                                       details={'details': 'Did not receive a message about the leapp-provided'
                                                           'kernel and initramfs'})
     return boot_content.kernel_path, boot_content.initram_path
+
+
+def write_to_file(filename, content):
+    with open(filename, 'w') as f:
+        f.write(content)
+
+
+def fix_grub_config_error(conf_file):
+    with open(conf_file, 'r') as f:
+        config = f.read()
+
+    # move misplaced '"' to the end
+    pattern = r'GRUB_CMDLINE_LINUX=.+?(?=GRUB|\Z)'
+    original_value = re.search(pattern, config, re.DOTALL).group()
+    parsed_value = original_value.split('"')
+    new_value = '{KEY}"{VALUE}"{END}'.format(KEY=parsed_value[0], VALUE=''.join(parsed_value[1:]).rstrip(),
+                                             END=original_value[-1])
+
+    config = config.replace(original_value, new_value)
+
+    return write_to_file(conf_file, config)

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
@@ -10,6 +10,11 @@ class call_mocked(object):
         self.args = args
 
 
+class write_to_file_mocked(object):
+    def __call__(self, filename, content):
+        self.content = content
+
+
 def test_add_boot_entry(monkeypatch):
     def get_boot_file_paths_mocked():
         return '/abc', '/def'
@@ -44,10 +49,8 @@ def test_get_boot_file_paths(monkeypatch):
 
 
 def test_fix_grub_config_error(monkeypatch):
-    def write_to_file_mocked(filename, content):
-        return content
-    monkeypatch.setattr(library, 'write_to_file', write_to_file_mocked)
-    fixed = library.fix_grub_config_error('files/grub_test.wrong')
+    monkeypatch.setattr(library, 'write_to_file', write_to_file_mocked())
+    library.fix_grub_config_error('files/grub_test.wrong')
 
     with open('files/grub_test.fixed') as f:
-        assert fixed == f.read()
+        assert library.write_to_file.content == f.read()

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
@@ -1,7 +1,6 @@
 import pytest
 
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries import stdlib
 from leapp.libraries.actor import library
 from leapp.models import BootContent
 
@@ -42,3 +41,13 @@ def test_get_boot_file_paths(monkeypatch):
 
     with pytest.raises(StopActorExecutionError):
         library.get_boot_file_paths()
+
+
+def test_fix_grub_config_error(monkeypatch):
+    def write_to_file_mocked(filename, content):
+        return content
+    monkeypatch.setattr(library, 'write_to_file', write_to_file_mocked)
+    fixed = library.fix_grub_config_error('files/grub_test.wrong')
+
+    with open('files/grub_test.fixed') as f:
+        assert fixed == f.read()

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/actor.py
@@ -1,0 +1,29 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.scanner import detect_config_error
+from leapp.models import CheckResult, GrubConfigError
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class DetectGrubConfigError(Actor):
+    """
+    Check grub configuration for syntax error in GRUB_CMDLINE_LINUX value.
+    """
+
+    name = 'detect_grub_config_error'
+    consumes = ()
+    produces = (CheckResult, GrubConfigError)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        error_detected = detect_config_error('/etc/default/grub')
+        if error_detected:
+            self.produce(CheckResult(
+                severity='Info',
+                result='Fixed',
+                summary='Syntax error detected in grub configuration.',
+                details='Syntax error was detected in GRUB_CMDLINE_LINUX value of grub configuration. '
+                        'This error is causing booting and other issues. '
+                        'Error is automatically fixed by add_upgrade_boot_entry actor.'
+            ))
+
+        self.produce(GrubConfigError(error_detected=error_detected))

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/files/grub.correct
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/files/grub.correct
@@ -1,0 +1,7 @@
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL_OUTPUT="console"
+GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+GRUB_DISABLE_RECOVERY="true"

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/files/grub.correct_trailing_space
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/files/grub.correct_trailing_space
@@ -1,0 +1,3 @@
+GRUB_TERMINAL_OUTPUT="console"
+GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto console=ttyS0,115200n8 no_timer_check net.ifnames=0" 
+GRUB_DISABLE_RECOVERY="true"

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/files/grub.wrong
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/files/grub.wrong
@@ -1,0 +1,7 @@
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL_OUTPUT="console"
+GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto" console=ttyS0,115200n8 no_timer_check net.ifnames=0
+GRUB_DISABLE_RECOVERY="true"

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/files/grub.wrong1
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/files/grub.wrong1
@@ -1,0 +1,1 @@
+GRUB_TERMINAL_OUTPUT="console" GRUB_CMDLINE_LINUX="vconsole.font=latarcyrheb-sun16 vconsole.keymap=us "rhgb quiet GRUB_DISABLE_RECOVERY="true"

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/libraries/scanner.py
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/libraries/scanner.py
@@ -1,0 +1,14 @@
+import re
+
+
+def detect_config_error(conf_file):
+    '''
+    Check grub configuration for syntax error in GRUB_CMDLINE_LINUX value.
+
+    :return: Function returns True if error was detected, otherwise False.
+    '''
+    with open(conf_file, 'r') as f:
+        config = f.read()
+
+    pattern = r'GRUB_CMDLINE_LINUX="[^"]+"(?!(\s*$)|(\s+GRUB))'
+    return re.search(pattern, config) is not None

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/tests/test_detectgrubconfigerror.py
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/tests/test_detectgrubconfigerror.py
@@ -1,0 +1,11 @@
+from leapp.libraries.actor.scanner import detect_config_error
+
+
+def test_correct_config():
+    assert not detect_config_error('files/grub.correct')
+    assert not detect_config_error('files/grub.correct_trailing_space')
+
+
+def test_wrong_config():
+    assert detect_config_error('files/grub.wrong')
+    assert detect_config_error('files/grub.wrong1')

--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/actor.py
@@ -11,7 +11,7 @@ from leapp.tags import IPUWorkflowTag, DownloadPhaseTag
 class PrepareUpgradeTransaction(Actor):
     """
     Actor responsible for executing multiple tasks to setup upgrade transaction.
-    
+
     Between the necessary steps to calculate and prepare DNF upgrade transaction, this actor will
     check if system has a valid subscription and move to inside a new created container using
     overlayfs. Once inside this container, necessary changes will be done on existing subscription,
@@ -316,4 +316,3 @@ class PrepareUpgradeTransaction(Actor):
         # produce msg for upgrading actor
         if not error_flag:
             self.produce_used_target_repos()
-

--- a/repos/system_upgrade/el7toel8/models/grubconfigerror.py
+++ b/repos/system_upgrade/el7toel8/models/grubconfigerror.py
@@ -1,0 +1,8 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemFactsTopic
+
+
+class GrubConfigError(Model):
+    topic = SystemFactsTopic
+
+    error_detected = fields.Boolean(default=False)


### PR DESCRIPTION
… configuration

There are images with syntax error in GRUB_CMDLINE_LINUX value of grub config,
which causes issues with booting, rhel8 kernel grub record and other issues.