### PR TITLE
Prevent showing our "gpg-pubkey" pkg as unsigned

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/filterrpmtransactionevents/tests/test_filterrpmtransactionevents.py
+++ b/repos/system_upgrade/el7toel8/actors/filterrpmtransactionevents/tests/test_filterrpmtransactionevents.py
@@ -2,6 +2,9 @@ from leapp.snactor.fixture import current_actor_context
 from leapp.models import RPM, InstalledRedHatSignedRPM, FilteredRpmTransactionTasks, RpmTransactionTasks
 
 
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+
+
 def test_actor_execution(current_actor_context):
     current_actor_context.run()
     assert current_actor_context.consume(FilteredRpmTransactionTasks)
@@ -9,8 +12,10 @@ def test_actor_execution(current_actor_context):
 
 def test_actor_execution_with_sample_data(current_actor_context):
     installed_rpm = [
-        RPM(name='sample01', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='SOME_PGP_SIG'),
-        RPM(name='sample02', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='SOME_PGP_SIG')]
+        RPM(name='sample01', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', 
+            pgpsig='SOME_PGP_SIG'),
+        RPM(name='sample02', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', 
+            pgpsig='SOME_PGP_SIG')]
     current_actor_context.feed(InstalledRedHatSignedRPM(items=installed_rpm))
     current_actor_context.feed(RpmTransactionTasks(
         to_remove=[rpm.name for rpm in installed_rpm],

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
@@ -2,6 +2,9 @@ from leapp.snactor.fixture import current_actor_context
 from leapp.models import RPM, InstalledUnsignedRPM, CheckResult
 
 
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+
+
 def test_actor_execution(current_actor_context):
     current_actor_context.feed(InstalledUnsignedRPM(items=[]))
     current_actor_context.run()
@@ -10,10 +13,14 @@ def test_actor_execution(current_actor_context):
 
 def test_actor_execution_with_unsigned_data(current_actor_context):
     installed_rpm = [
-        RPM(name='sample02', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
-        RPM(name='sample04', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
-        RPM(name='sample06', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
-        RPM(name='sample08', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='SOME_OTHER_SIG_X')]
+        RPM(name='sample02', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', 
+            pgpsig='SOME_OTHER_SIG_X'),
+        RPM(name='sample04', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', 
+            pgpsig='SOME_OTHER_SIG_X'),
+        RPM(name='sample06', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', 
+            pgpsig='SOME_OTHER_SIG_X'),
+        RPM(name='sample08', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', 
+            pgpsig='SOME_OTHER_SIG_X')]
 
     current_actor_context.feed(InstalledUnsignedRPM(items=installed_rpm))
     current_actor_context.run()

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmscanner/actor.py
@@ -30,7 +30,9 @@ class RedHatSignedRpmScanner(Actor):
 
         for rpm_pkgs in self.consume(InstalledRPM):
             for pkg in rpm_pkgs.items:
-                if any(key in pkg.pgpsig for key in RH_SIGS):
+                # "gpg-pubkey" is not signed as it would require another package to verify its signature
+                if any(key in pkg.pgpsig for key in RH_SIGS) or \
+                        (pkg.name == 'gpg-pubkey' and pkg.packager.startswith('Red Hat, Inc.')):
                     signed_pkgs.items.append(pkg)
                     continue
 

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmscanner/tests/test_redhatsignedrpmscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmscanner/tests/test_redhatsignedrpmscanner.py
@@ -2,6 +2,9 @@ from leapp.snactor.fixture import current_actor_context
 from leapp.models import RPM, InstalledRPM, InstalledRedHatSignedRPM, InstalledUnsignedRPM, CheckResult
 
 
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+
+
 def test_actor_execution(current_actor_context):
     current_actor_context.run()
     assert current_actor_context.consume(InstalledRedHatSignedRPM)
@@ -9,15 +12,15 @@ def test_actor_execution(current_actor_context):
 
 def test_actor_execution_with_signed_unsigned_data(current_actor_context):
     installed_rpm = [
-        RPM(name='sample01', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51'),
-        RPM(name='sample02', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
-        RPM(name='sample03', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 5326810137017186'),
-        RPM(name='sample04', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
-        RPM(name='sample05', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 938a80caf21541eb'),
-        RPM(name='sample06', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
-        RPM(name='sample07', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID fd372689897da07a'),
-        RPM(name='sample08', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
-        RPM(name='sample09', version='0.1', release='1.sm01', epoch='1', arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 45689c882fa658e0')]
+        RPM(name='sample01', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51'),
+        RPM(name='sample02', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
+        RPM(name='sample03', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 5326810137017186'),
+        RPM(name='sample04', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
+        RPM(name='sample05', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 938a80caf21541eb'),
+        RPM(name='sample06', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
+        RPM(name='sample07', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID fd372689897da07a'),
+        RPM(name='sample08', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='SOME_OTHER_SIG_X'),
+        RPM(name='sample09', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 45689c882fa658e0')]
 
     current_actor_context.feed(InstalledRPM(items=installed_rpm))
     current_actor_context.run()
@@ -25,3 +28,18 @@ def test_actor_execution_with_signed_unsigned_data(current_actor_context):
     assert len(current_actor_context.consume(InstalledRedHatSignedRPM)[0].items) == 5
     assert current_actor_context.consume(InstalledUnsignedRPM)
     assert len(current_actor_context.consume(InstalledUnsignedRPM)[0].items) == 4
+
+def test_gpg_pubkey_pkg(current_actor_context):
+    installed_rpm = [
+        RPM(name='gpg-pubkey', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+            pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID aa17105e03152d37'),
+        RPM(name='gpg-pubkey', version='0.1', release='1.sm01', epoch='1', packager='Tester', arch='noarch',
+            pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 9ea903b1361e896b'),
+    ]
+
+    current_actor_context.feed(InstalledRPM(items=installed_rpm))
+    current_actor_context.run()
+    assert current_actor_context.consume(InstalledRedHatSignedRPM)
+    assert len(current_actor_context.consume(InstalledRedHatSignedRPM)[0].items) == 1
+    assert current_actor_context.consume(InstalledUnsignedRPM)
+    assert len(current_actor_context.consume(InstalledUnsignedRPM)[0].items) == 1

--- a/repos/system_upgrade/el7toel8/actors/rpmscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmscanner/actor.py
@@ -22,18 +22,20 @@ class RpmScanner(Actor):
             '/bin/rpm',
             '-qa',
             '--queryformat',
-            r'%{NAME}|%{VERSION}|%{RELEASE}|%|EPOCH?{%{EPOCH}}:{}||%|ARCH?{%{ARCH}}:{}||%|DSAHEADER?{%{DSAHEADER:pgpsig}}:{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:{(none)}|}|\n'
+            r'%{NAME}|%{VERSION}|%{RELEASE}|%|EPOCH?{%{EPOCH}}:{(none)}||%|PACKAGER?{%{PACKAGER}}:{(none)}||%|'
+            r'ARCH?{%{ARCH}}:{}||%|DSAHEADER?{%{DSAHEADER:pgpsig}}:{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:{(none)}|}|\n'
         ])
         result = InstalledRPM()
         for entry in output.split('\n'):
             entry = entry.strip()
             if not entry:
                 continue
-            name, version, release, epoch, arch, pgpsig = entry.split('|')
+            name, version, release, epoch, packager, arch, pgpsig = entry.split('|')
             result.items.append(RPM(
                 name=name,
                 version=version,
                 epoch=epoch,
+                packager=packager,
                 arch=arch,
                 release=release,
                 pgpsig=pgpsig))

--- a/repos/system_upgrade/el7toel8/models/installedrpm.py
+++ b/repos/system_upgrade/el7toel8/models/installedrpm.py
@@ -5,6 +5,7 @@ class RPM(Model):
     topic = SystemInfoTopic
     name = fields.String()
     epoch = fields.String()
+    packager = fields.String()
     version = fields.String()
     release = fields.String()
     arch = fields.String()


### PR DESCRIPTION
Our package "gpg-pubkey" is not signed and we are currently suggesting our users in the RedHatSignedRpmCheck actor to remove it even as it is our pkg.

This will also be needed if we would like to inhibit the upgrade with unsigned packages.