### PR TITLE
Add actors for firewalld's lockdown whitelist

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/firewalldreadlockdownwhitelist/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldreadlockdownwhitelist/actor.py
@@ -1,0 +1,27 @@
+from leapp.actors import Actor
+from leapp.models import FirewalldLockdownWhitelist
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+from leapp.libraries.actor import private
+
+import xml.etree.ElementTree as ElementTree
+
+
+class FirewalldReadLockdownWhitelist(Actor):
+    """
+    Provides data about firewalld Lockdown Whitelist
+
+    After collecting data from the configuration file, a message with relevant
+    data will be produced.
+    """
+
+    name = 'firewalld_read_lockdown_whitelist'
+    consumes = ()
+    produces = (FirewalldLockdownWhitelist,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        tree = ElementTree.parse('/etc/firewalld/lockdown-whitelist.xml')
+        root = tree.getroot()
+
+        self.produce(private.getFirewalldLockdownWhitelistFromXML(root))

--- a/repos/system_upgrade/el7toel8/actors/firewalldreadlockdownwhitelist/libraries/private.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldreadlockdownwhitelist/libraries/private.py
@@ -1,0 +1,13 @@
+from leapp.models import FirewalldLockdownWhitelist
+
+
+def getFirewalldLockdownWhitelistFromXML(root):
+    lockdown_config = FirewalldLockdownWhitelist()
+
+    for command in root.iter('command'):
+        if 'name' in command.attrib and \
+           '/usr/bin/firewall-config' in command.attrib['name']:
+            lockdown_config.firewall_config_command = command.attrib['name']
+            break
+
+    return lockdown_config

--- a/repos/system_upgrade/el7toel8/actors/firewalldreadlockdownwhitelist/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldreadlockdownwhitelist/tests/unit_test.py
@@ -1,0 +1,33 @@
+from leapp.libraries.actor import private
+
+import xml.etree.ElementTree as ElementTree
+
+
+def test_firewalldreadlockdownwhitelist_library():
+    root = ElementTree.fromstring(
+        '''<?xml version="1.0" encoding="utf-8"?>
+           <whitelist>
+             <command name="/usr/bin/python -Es /usr/bin/firewall-config"/>
+             <selinux context="system_u:system_r:NetworkManager_t:s0"/>
+             <selinux context="system_u:system_r:virtd_t:s0-s0:c0.c1023"/>
+             <user id="0"/>
+           </whitelist>
+        ''')
+
+    lockdown_config = private.getFirewalldLockdownWhitelistFromXML(root)
+    assert lockdown_config.firewall_config_command == '/usr/bin/python -Es /usr/bin/firewall-config'
+
+
+def test_firewalldreadlockdownwhitelist_library_negative():
+    root = ElementTree.fromstring(
+        '''<?xml version="1.0" encoding="utf-8"?>
+           <whitelist>
+             <command name="/usr/bin/foobar"/>
+             <selinux context="system_u:system_r:NetworkManager_t:s0"/>
+             <selinux context="system_u:system_r:virtd_t:s0-s0:c0.c1023"/>
+             <user id="0"/>
+           </whitelist>
+        ''')
+
+    lockdown_config = private.getFirewalldLockdownWhitelistFromXML(root)
+    assert lockdown_config.firewall_config_command == ''

--- a/repos/system_upgrade/el7toel8/actors/firewalldupdatelockdownwhitelist/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldupdatelockdownwhitelist/actor.py
@@ -1,0 +1,36 @@
+from leapp.actors import Actor
+from leapp.models import FirewalldLockdownWhitelist
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+from leapp.libraries.actor import private
+
+import xml.etree.ElementTree as ElementTree
+
+
+class FirewalldUpdateLockdownWhitelist(Actor):
+    """
+    Updates the firewalld Lockdown Whitelist.
+
+    RHEL-8 uses a platform specific python interpreter for packaged
+    applications. For firewall-config, the interpreter path is part of the
+    lockdown list. In RHEL-7 this was simply /usr/bin/python, but in RHEL-8
+    it's /usr/libexec/platform-python. However, if the user made changes to the
+    lockdown whitelist it won't be replaced by RPM/dnf. As such we must update
+    the interpreter if the old value is there.
+    """
+
+    name = 'firewalld_update_lockdown_whitelist'
+    consumes = (FirewalldLockdownWhitelist,)
+    produces = ()
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        for lockdown_config in self.consume(FirewalldLockdownWhitelist):
+            if lockdown_config.firewall_config_command:
+                tree = ElementTree.parse('/etc/firewalld/lockdown-whitelist.xml')
+                root = tree.getroot()
+
+                need_write = private.updateFirewalldLockdownWhitelistXML(root, lockdown_config)
+
+                if need_write:
+                    tree.write('/etc/firewalld/lockdown-whitelist.xml')
+                    self.log.info('Updated lockdown whitelist')

--- a/repos/system_upgrade/el7toel8/actors/firewalldupdatelockdownwhitelist/libraries/private.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldupdatelockdownwhitelist/libraries/private.py
@@ -1,0 +1,13 @@
+def updateFirewalldLockdownWhitelistXML(root, lockdown_config):
+    changed = False
+
+    # Only update the command element that corresponds to firewall-config
+    firewall_config_command = '/usr/libexec/platform-python -s /usr/bin/firewall-config'
+    for command in root.iter('command'):
+        if 'name' in command.attrib and \
+           lockdown_config.firewall_config_command == command.attrib['name'] and \
+           lockdown_config.firewall_config_command != firewall_config_command:
+            command.attrib['name'] = firewall_config_command
+            changed = True
+
+    return changed

--- a/repos/system_upgrade/el7toel8/actors/firewalldupdatelockdownwhitelist/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldupdatelockdownwhitelist/tests/unit_test.py
@@ -1,0 +1,52 @@
+from leapp.models import FirewalldLockdownWhitelist
+from leapp.libraries.actor import private
+
+import xml.etree.ElementTree as ElementTree
+
+
+def test_firewalldupdatelockdownwhitelist_library():
+    root = ElementTree.fromstring(
+        '''<?xml version="1.0" encoding="utf-8"?>
+           <whitelist>
+             <command name="/usr/bin/python -Es /usr/bin/firewall-config"/>
+             <command name="/usr/bin/foobar"/>
+             <selinux context="system_u:system_r:NetworkManager_t:s0"/>
+             <selinux context="system_u:system_r:virtd_t:s0-s0:c0.c1023"/>
+             <user id="0"/>
+           </whitelist>
+        ''')
+
+    lockdown_config = FirewalldLockdownWhitelist()
+    lockdown_config.firewall_config_command = '/usr/bin/python -Es /usr/bin/firewall-config'
+    assert private.updateFirewalldLockdownWhitelistXML(root, lockdown_config)
+
+
+def test_firewalldupdatelockdownwhitelist_library_negative():
+    root = ElementTree.fromstring(
+        '''<?xml version="1.0" encoding="utf-8"?>
+           <whitelist>
+             <command name="/usr/bin/foobar"/>
+           </whitelist>
+        ''')
+
+    lockdown_config = FirewalldLockdownWhitelist()
+    lockdown_config.firewall_config_command = ''
+    assert not private.updateFirewalldLockdownWhitelistXML(root, lockdown_config)
+
+    lockdown_config = FirewalldLockdownWhitelist()
+    lockdown_config.firewall_config_command = '/usr/bin/python -Es /usr/bin/firewall-config'
+    assert not private.updateFirewalldLockdownWhitelistXML(root, lockdown_config)
+
+    root = ElementTree.fromstring(
+        '''<?xml version="1.0" encoding="utf-8"?>
+           <whitelist>
+             <command name="/usr/libexec/platform-python -s /usr/bin/firewall-config"/>
+             <selinux context="system_u:system_r:NetworkManager_t:s0"/>
+             <selinux context="system_u:system_r:virtd_t:s0-s0:c0.c1023"/>
+             <user id="0"/>
+           </whitelist>
+        ''')
+
+    lockdown_config = FirewalldLockdownWhitelist()
+    lockdown_config.firewall_config_command = '/usr/libexec/platform-python -s /usr/bin/firewall-config'
+    assert not private.updateFirewalldLockdownWhitelistXML(root, lockdown_config)

--- a/repos/system_upgrade/el7toel8/models/firewalldlockdownwhitelist.py
+++ b/repos/system_upgrade/el7toel8/models/firewalldlockdownwhitelist.py
@@ -1,0 +1,8 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class FirewalldLockdownWhitelist(Model):
+    """The model contains firewalld Lockdown Whitelist configuration."""
+    topic = SystemInfoTopic
+    firewall_config_command = fields.String(default='')


### PR DESCRIPTION
Firewalld's lockdown whitelist may contain paths to the python
interpreter. This needs to be updated for RHEL8.

This is only applicable if the user has made manual changes to the
lockdown whitelist, otherwise the file is updated by a normal package
upgrade.