### PR TITLE
add redhat-rpm-config into to_remove

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -1,1 +1,2 @@
 yum
+redhat-rpm-config


### PR DESCRIPTION
The rpm contains richdependencies which makes upgrade failing.
Regarding several reported issues in last week(s) would be better
to ensure the rpm is really removed.