### PR TITLE
Add actor to inhibit upgrade if broute used in firewalld

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/firewalldcheckebtablesbroute/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldcheckebtablesbroute/actor.py
@@ -1,0 +1,36 @@
+from leapp.actors import Actor
+from leapp.models import Inhibitor
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.libraries.actor import private
+
+import os
+import xml.etree.ElementTree as ElementTree
+
+
+class FirewalldCheckEbtablesBroute(Actor):
+    """
+    In RHEL-8 the ebtables table broute is not available. If the user is using
+    firewalld direct rules that utilize this table then we need to inhibit the
+    upgrade.
+    """
+
+    name = 'firewalld_check_ebtables_broute'
+    consumes = ()
+    produces = (Inhibitor,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        path = '/etc/firewalld/direct.xml'
+        if not os.path.exists(path):
+            return
+
+        tree = ElementTree.parse(path)
+        root = tree.getroot()
+
+        if private.isEbtablesBrouteTableInUse(root):
+            self.produce(
+                Inhibitor(
+                    summary='Firewalld is using ebtables broute table.',
+                    details='ebtables in RHEL-8 does not support the broute table.',
+                    solutions='Remove firewalld direct rules that use ebtables broute table.'
+                    ))

--- a/repos/system_upgrade/el7toel8/actors/firewalldcheckebtablesbroute/libraries/private.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldcheckebtablesbroute/libraries/private.py
@@ -1,0 +1,17 @@
+def isEbtablesBrouteTableInUse(root):
+    for rule in root.iter('rule'):
+        if 'ipv' in rule.attrib and rule.attrib['ipv'] == 'eb' and \
+           'table' in rule.attrib and rule.attrib['table'] == 'broute':
+            return True
+
+    for passthrough in root.iter('passthrough'):
+        if 'ipv' in passthrough.attrib and passthrough.attrib['ipv'] == 'eb':
+            rule = passthrough.text.split()
+            try:
+                i = rule.index('-t')
+                if rule[i+1] == 'broute':
+                    return True
+            except ValueError:
+                pass
+            
+    return False

--- a/repos/system_upgrade/el7toel8/actors/firewalldcheckebtablesbroute/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldcheckebtablesbroute/tests/unit_test.py
@@ -1,0 +1,41 @@
+from leapp.libraries.actor import private
+
+import xml.etree.ElementTree as ElementTree
+
+
+def test_firewalldcheckebtablesbroute_library():
+    root = ElementTree.fromstring(
+        '''<?xml version="1.0" encoding="utf-8"?>
+           <direct>
+             <passthrough ipv="eb">-t broute -I BROUTING 1 -j ACCEPT</passthrough>
+           </direct>
+        ''')
+    assert private.isEbtablesBrouteTableInUse(root)
+
+    root = ElementTree.fromstring(
+        '''<?xml version="1.0" encoding="utf-8"?>
+           <direct>
+             <rule priority="1" table="broute" ipv="eb" chain="BROUTING">-j ACCEPT</rule>
+           </direct>
+        ''')
+    assert private.isEbtablesBrouteTableInUse(root)
+
+    root = ElementTree.fromstring(
+        '''<?xml version="1.0" encoding="utf-8"?>
+           <direct>
+             <rule priority="1" table="broute" ipv="eb" chain="BROUTING">-j ACCEPT</rule>
+             <passthrough ipv="eb">-t broute -I BROUTING 1 -j ACCEPT</passthrough>
+           </direct>
+        ''')
+    assert private.isEbtablesBrouteTableInUse(root)
+
+
+def test_firewalldcheckebtablesbroute_library_negative():
+    root = ElementTree.fromstring(
+        '''<?xml version="1.0" encoding="utf-8"?>
+           <direct>
+             <rule priority="1" table="filter" ipv="ipv4" chain="INPUT">-j ACCEPT</rule>
+             <passthrough ipv="ipv4">-t filter -I BROUTING 1 -j ACCEPT</passthrough>
+           </direct>
+        ''')
+    assert not private.isEbtablesBrouteTableInUse(root)


### PR DESCRIPTION
The broute table is not available in RHEL-8. As such we can't do an
upgrade of firewalld's rules if they're attempting to use the broute
table.