### PR TITLE
Add actors for firewalld ipset types

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/firewalldcheckipsettypes/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldcheckipsettypes/actor.py
@@ -1,0 +1,46 @@
+from leapp.actors import Actor
+from leapp.models import Inhibitor
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.libraries.actor import private
+
+import os
+import xml.etree.ElementTree as ElementTree
+
+
+class FirewalldCheckIpsetTypes(Actor):
+    """
+    firewalld's nftables backend does not yet support all ipset types. Support
+    is missing in nftables (sets with concatenations and intervals). The
+    nftables backend is the preferred backend in RHEL-8 so we must catch
+    configurations that use the unsupported ipset types.
+
+    This is expected to be a temporary actor. nftables support for set
+    concatenations with intervals is a work in progress.
+    """
+
+    name = 'firewalld_check_ipset_types'
+    consumes = ()
+    produces = (Inhibitor,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process_ipset(self, name, path):
+        tree = ElementTree.parse(path)
+        root = tree.getroot()
+
+        for ipset in root.iter('ipset'):
+            if 'type' in ipset.attrib and \
+               not private.isIpsetTypeSupportedByNftables(ipset.attrib['type']):
+                self.produce(
+                    Inhibitor(
+                        summary='Firewalld is using an unsupported ipset type.',
+                        details='ipset \'{}\' is of type \'{}\' which is not supported by firewalld\'s nftables backend.'.format(name, ipset.attrib['type']),
+                        solutions='Remove ipsets of type {} from firewalld.'.format(ipset.attrib['type'])
+                        ))
+
+    def process(self):
+        directory = '/etc/firewalld/ipsets'
+        for file in os.listdir(directory):
+            if not file.endswith('.xml'):
+                continue
+
+            self.process_ipset(file[:-4], os.path.join(directory, file))

--- a/repos/system_upgrade/el7toel8/actors/firewalldcheckipsettypes/libraries/private.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldcheckipsettypes/libraries/private.py
@@ -1,0 +1,5 @@
+def isIpsetTypeSupportedByNftables(ipset_type):
+    if ipset_type in ['hash:ip', 'hash:mac', 'hash:net']:
+        return True
+
+    return False

--- a/repos/system_upgrade/el7toel8/actors/firewalldcheckipsettypes/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldcheckipsettypes/tests/unit_test.py
@@ -1,0 +1,18 @@
+from leapp.libraries.actor import private
+
+
+def test_firewalldcheckipsettypes_library():
+    assert private.isIpsetTypeSupportedByNftables('hash:mac')
+    assert private.isIpsetTypeSupportedByNftables('hash:ip')
+    assert private.isIpsetTypeSupportedByNftables('hash:net')
+
+
+def test_firewalldcheckipsettypes_library_negative():
+    assert not private.isIpsetTypeSupportedByNftables('hash:ip,mark')
+    assert not private.isIpsetTypeSupportedByNftables('hash:ip,port')
+    assert not private.isIpsetTypeSupportedByNftables('hash:ip,port,ip')
+    assert not private.isIpsetTypeSupportedByNftables('hash:ip,port,net')
+    assert not private.isIpsetTypeSupportedByNftables('hash:net,iface')
+    assert not private.isIpsetTypeSupportedByNftables('hash:net,net')
+    assert not private.isIpsetTypeSupportedByNftables('hash:net,port')
+    assert not private.isIpsetTypeSupportedByNftables('hash:net,port,net')


### PR DESCRIPTION
firewalld's nftables backend does not yet support all "ipset" types.
Support is missing in nftables (sets with concatenations and intervals).
The nftables backend is the preferred backend so we must catch
configurations that use the unsupported ipset types.