### PR TITLE
Get rid of the leapp-repository-data subpackage and data file

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -99,6 +99,7 @@ install -m 0755 -d %{buildroot}%{repositorydir}
 cp -r repos/* %{buildroot}%{repositorydir}/
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/repos.d/
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/transaction/
+install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/files/
 install -m 0644 etc/leapp/transaction/* %{buildroot}%{_sysconfdir}/leapp/transaction
 
 # Remove irrelevant repositories - We don't want to ship them
@@ -137,6 +138,7 @@ rm -f %{py3_sos_report_plugindir}/leapp.py*
 %doc README.md
 %license LICENSE
 %dir %{_sysconfdir}/leapp/transaction
+%dir %{_sysconfdir}/leapp/files
 %dir %{leapp_datadir}
 %dir %{repositorydir}
 %dir %{custom_repositorydir}


### PR DESCRIPTION
We do not plan to use this subpackage anymore, neither provide the data file in rpm.

Note: **Do not hurry with merging** in case you approve the changes. It would be better to coordinate work with @artmello so we will have prepared infrastructure.

Note: Added Obsoletes & Provides is temporary to ensure the subpackage is removed from the system after the upgrade. It would happen that someone would use pretty old data from the past and I prefer to get "issue" about missing data than spend a time on traceback because of the old data format (e.g.).

~Note: Currently the rpm will contain the "empty" pes-event.json file. It is expected as the removal of the file from the repository will be part of following PR.~ (relevant PR has been merged already)