### PR TITLE
Introduction of initial sos plugin for leapp

### DIFF
--- a/sources/sos-report/leapp.py
+++ b/sources/sos-report/leapp.py
@@ -1,0 +1,19 @@
+from sos.plugins import Plugin, RedHatPlugin
+
+
+class Leapp(Plugin, RedHatPlugin):
+    """
+    This plugin is used to gather all information necessary for reporting
+    problems in regards to the leapp application.
+    """
+
+    plugin_name = 'leapp'
+    packages = ('leapp', 'leapp-repository')
+
+    def setup(self):
+        self.add_copy_spec([
+            '/var/lib/leapp/leapp.db',
+            '/tmp/download-debugdata',
+            '/var/log/upgrade.log',
+            '/tmp/leapp-report.txt'
+        ])


### PR DESCRIPTION
In order to allow an easier collection of data needed for debugging,
we will add a plugin for the sos tool to include our data to be
collected. That would include the upgrade.log, the leapp.db and
potential debugdata from dnf generated during the upgrade.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>