### PR TITLE
removed systemd-mount usage

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checknfs/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checknfs/actor.py
@@ -9,7 +9,7 @@ class CheckNfs(Actor):
     """
     Check if NFS filesystem is in use. If yes, inhibit the upgrade process.
 
-    Actor looks for NFS in the following sources: /ets/fstab, mount and systemd-mount.
+    Actor looks for NFS in the following sources: /ets/fstab and mount.
     If there is NFS in any of the mentioned sources, actors inhibits the upgrade.
     """
     name = "check_nfs"
@@ -35,13 +35,6 @@ class CheckNfs(Actor):
                 if mount.tp == "nfs":
                     nfs_found = True
                     details += "- Currently mounted NFS shares\n"
-                    break
-
-            # Check systemd-mount
-            for systemdmount in storage.systemdmount:
-                if systemdmount.fs_type == "nfs":
-                    nfs_found = True
-                    details += "- One or more configured NFS mounts in systemd-mount\n"
                     break
 
         if nfs_found:

--- a/repos/system_upgrade/el7toel8/actors/checknfs/tests/test_checknfs.py
+++ b/repos/system_upgrade/el7toel8/actors/checknfs/tests/test_checknfs.py
@@ -1,27 +1,6 @@
 from leapp.snactor.fixture import current_actor_context
-from leapp.models import StorageInfo, SystemdMountEntry, FstabEntry, MountEntry
+from leapp.models import StorageInfo, FstabEntry, MountEntry
 from leapp.reporting import Report
-
-
-def test_actor_with_systemdmount_entry(current_actor_context):
-    with_systemdmount_entry = [SystemdMountEntry(node="nfs", path="n/a", model="n/a",
-                                                 wwn="n/a", fs_type="nfs", label="n/a",
-                                                 uuid="n/a")]
-    current_actor_context.feed(StorageInfo(systemdmount=with_systemdmount_entry))
-    current_actor_context.run()
-    assert 'inhibitor' in current_actor_context.consume(Report)[0].flags
-
-
-def test_actor_without_systemdmount_entry(current_actor_context):
-    without_systemdmount_entry = [SystemdMountEntry(node="/dev/sda1",
-                                                    path="pci-0000:00:17.0-ata-2",
-                                                    model="TOSHIBA_THNSNJ512GDNU_A",
-                                                    wwn="0x500080d9108e8753",
-                                                    fs_type="ext4", label="n/a",
-                                                    uuid="5675d309-eff7-4eb1-9c27-58bc5880ec72")]
-    current_actor_context.feed(StorageInfo(systemdmount=without_systemdmount_entry))
-    current_actor_context.run()
-    assert not current_actor_context.consume(Report)
 
 
 def test_actor_with_fstab_entry(current_actor_context):
@@ -42,6 +21,7 @@ def test_actor_without_fstab_entry(current_actor_context):
     current_actor_context.feed(StorageInfo(fstab=without_fstab_entry))
     current_actor_context.run()
     assert not current_actor_context.consume(Report)
+
 
 def test_actor_with_mount_share(current_actor_context):
     with_mount_share = [MountEntry(name="nfs", mount="/mnt/data", tp="nfs",

--- a/repos/system_upgrade/el7toel8/actors/checkxfs/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkxfs/actor.py
@@ -7,7 +7,7 @@ from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 class CheckXFS(Actor):
     """
     Check if XFS filesystem is in use.
-    
+
     If XFS filesystem without ftype is in use, produce a message to influence
     PrepareUpgradeTransaction actor about necessary steps during execution.
     """

--- a/repos/system_upgrade/el7toel8/actors/checkxfs/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkxfs/libraries/library.py
@@ -21,23 +21,14 @@ def check_xfs_mount(data):
     return mountpoints
 
 
-def check_xfs_systemdmount(data):
-    mountpoints = set()
-    for entry in data:
-        if entry.fs_type == "xfs":
-            mountpoints.add(entry.path)
-
-    return mountpoints
-
-
 def is_xfs_without_ftype(mp):
     for l in call(['/usr/sbin/xfs_info', '{}'.format(mp)]):
         if 'ftype=0' in l:
             return True
-    
+
     return False
 
-   
+
 def check_xfs():
     storage_info_msgs = api.consume(StorageInfo)
     storage_info = next(storage_info_msgs, None)
@@ -51,10 +42,9 @@ def check_xfs():
 
     fstab_data = check_xfs_fstab(storage_info.fstab)
     mount_data = check_xfs_mount(storage_info.mount)
-    systemdmount_data = check_xfs_systemdmount(storage_info.systemdmount)
 
-    mountpoints = fstab_data | mount_data | systemdmount_data
-    
+    mountpoints = fstab_data | mount_data
+
     xfs_presence = XFSPresence()
     # By now, we only care for XFS without ftype in use for /var
     has_xfs_without_ftype = False

--- a/repos/system_upgrade/el7toel8/actors/checkxfs/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkxfs/tests/unit_test.py
@@ -3,7 +3,7 @@ import pytest
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import library
 from leapp.libraries.stdlib import api
-from leapp.models import StorageInfo, FstabEntry, MountEntry, SystemdMountEntry, XFSPresence
+from leapp.models import StorageInfo, FstabEntry, MountEntry, XFSPresence
 
 
 class call_mocked(object):
@@ -13,7 +13,7 @@ class call_mocked(object):
     def __call__(self, args, split=True):
         self.called += 1
         self.args = args
-        
+
         with_ftype = [
             "meta-data=/dev/loop0             isize=512    agcount=4, agsize=131072 blks",
             "         =                       sectsz=512   attr=2, projid32bit=1",
@@ -93,32 +93,6 @@ def test_check_xfs_mount(monkeypatch):
 
     mountpoints = library.check_xfs_mount([MountEntry(**mount_data_xfs)])
     assert mountpoints == {"/boot"}
-
-
-def test_check_xfs_systemdmount(monkeypatch):
-    systemdmount_data_no_xfs = {
-        "node": "/dev/sda1",
-        "path": "pci-0000:00:17.0-ata-2",
-        "model": "TOSHIBA_THNSNJ512GDNU_A",
-        "wwn": "0x500080d9108e8753",
-        "fs_type": "ext4",
-        "label": "n/a",
-        "uuid": "5675d309-eff7-4eb1-9c27-58bc5880ec72"}
-
-    mountpoints = library.check_xfs_systemdmount([SystemdMountEntry(**systemdmount_data_no_xfs)])
-    assert len(mountpoints) == 0
-
-    systemdmount_data_xfs = {
-        "node": "/dev/sda1",
-        "path": "/var",
-        "model": "n/a",
-        "wwn": "n/a",
-        "fs_type": "xfs",
-        "label": "n/a",
-        "uuid": "n/a"}
-
-    mountpoints = library.check_xfs_systemdmount([SystemdMountEntry(**systemdmount_data_xfs)])
-    assert mountpoints == {"/var"}
 
 
 def test_is_xfs_without_ftype(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/storagescanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/storagescanner/actor.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 
 from leapp.actors import Actor
-from leapp.models import StorageInfo, PartitionEntry, FstabEntry, MountEntry, LsblkEntry, PvsEntry, VgsEntry, LvdisplayEntry, SystemdMountEntry
+from leapp.models import StorageInfo, PartitionEntry, FstabEntry, MountEntry, LsblkEntry, PvsEntry, VgsEntry, LvdisplayEntry
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 
@@ -149,21 +149,5 @@ class StorageScanner(Actor):
                 log=log,
                 cpy_sync=cpy_sync,
                 convert=convert))
-
-        for entry in self.get_cmd_output(['systemd-mount', '--list'], ' ', 7):
-            # We need to filter the entry because there is a ton of whitespace.
-            node, path, model, wwn, fs_type, label, uuid = list(filter(lambda x: x != '', entry))
-            if node == "NODE":
-                # First row of the "systemd-mount --list" output is a header.
-                # Just skip it.
-                continue
-            result.systemdmount.append(SystemdMountEntry(
-                node=node,
-                path=path,
-                model=model,
-                wwn=wwn,
-                fs_type=fs_type,
-                label=label,
-                uuid=uuid))
 
         self.produce(result)

--- a/repos/system_upgrade/el7toel8/models/storageinfo.py
+++ b/repos/system_upgrade/el7toel8/models/storageinfo.py
@@ -83,18 +83,6 @@ class LvdisplayEntry(Model):
     convert = fields.String()
 
 
-class SystemdMountEntry(Model):
-    topic = SystemInfoTopic
-
-    node = fields.String()
-    path = fields.String()
-    model = fields.String()
-    wwn = fields.String()
-    fs_type = fields.String()
-    label = fields.String()
-    uuid = fields.String()
-
-
 class StorageInfo(Model):
     topic = SystemInfoTopic
     partitions = fields.List(fields.Model(PartitionEntry), default=[])
@@ -104,5 +92,4 @@ class StorageInfo(Model):
     pvs = fields.List(fields.Model(PvsEntry), default=[])
     vgs = fields.List(fields.Model(VgsEntry), default=[])
     lvdisplay = fields.List(fields.Model(LvdisplayEntry), default=[])
-    systemdmount = fields.List(fields.Model(SystemdMountEntry), default=[])
 


### PR DESCRIPTION
systemd-mount is not needed. When searching for nfs/xfs, it should be enough to look into mount/fstab. Also, systemd-mount may not be installed on the system by default.

- removed systemd-mount usage from checknfs and checkxfc actors and tests
- removed systemd-mount collector from storagescanner actor
- removed SystemdMountEntry model
