### PR TITLE
Handle the yum configuration files

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -1,2 +1,1 @@
-yum
 redhat-rpm-config

--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/actor.py
@@ -181,6 +181,12 @@ class PrepareUpgradeTransaction(Actor):
 
         debugsolver = True if os.environ.get('LEAPP_DEBUG', '0') == '1' else False
 
+        yum_script_path = self.get_tool_path('handleyumconfig')
+        cmd = ['--', '/bin/bash', '-c', yum_script_path]
+        _unused, error = preparetransaction.guard_container_call(overlayfs_info, cmd)
+        if error:
+            return error
+
         error = preparetransaction.mount_dnf_cache(overlayfs_info)
         if error:
             return error

--- a/repos/system_upgrade/el7toel8/actors/prepareyumconfig/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareyumconfig/actor.py
@@ -1,0 +1,27 @@
+from leapp.actors import Actor
+from leapp.tags import IPUWorkflowTag, PreparationPhaseTag
+from leapp.libraries.stdlib import run, CalledProcessError
+
+
+class Prepareyumconfig(Actor):
+    """
+    Handle migration of the yum configuration files
+    
+    RPM cannot handle replacement of directories by symlinks by default
+    without the %pretrans scriptlet. As yum package is packaged wrong,
+    we have to workround that by migration of the yum configuration files
+    before the rpm transaction is processed.
+    """
+
+    name = 'prepareyumconfig'
+    consumes = ()
+    produces = ()
+    tags = (IPUWorkflowTag, PreparationPhaseTag)
+
+    def process(self):
+        try:
+            run(['handleyumconfig'])
+        except CalledProcessError as e:
+            raise StopActorExecutionError(
+                    'Migration of yum configuration failed.',
+                    details={'details': str(e)})

--- a/repos/system_upgrade/el7toel8/tools/handleyumconfig
+++ b/repos/system_upgrade/el7toel8/tools/handleyumconfig
@@ -1,0 +1,34 @@
+#!/usr/bin/bash -e
+
+# just in case of hidden files.. not sure why would someone do that, it's more
+# like forgotten cache file possibility, but rather do that..
+shopt -s dotglob
+
+is_dir_empty() {
+  test -z "$(ls -A $1)"
+}
+
+handle_dir() {
+    # Move all files from $1 to $2 when the /etc/yum/$1 is not empty
+    # Then remove the $1 directory and relink it to $2
+    # param $1: dirname under /etc/yum path
+    # param $2: dirname under /etc/dnf path
+    if ! is_dir_empty "/etc/yum/$1"; then
+        mv /etc/yum/$1/* /etc/dnf/$2/
+    fi
+
+    # FIXME: do not care whether these were already symlinks for now
+    #        just remove it
+    rm -rf /etc/yum/$1
+
+    #relink
+    ln -s ../dnf/$2 /etc/yum/$1
+
+    return 0
+}
+
+
+# assume the directories are not removed by user..
+handle_dir pluginconf.d plugins
+handle_dir protected.d  protected.d
+handle_dir vars vars


### PR DESCRIPTION
RPM cannot handle replace of directories by symlinks by default
without the %pretrans scriptlet. As yum package is packaged wrong,
we have to workround that by actors so we will be able to keep
installed yum package.

Current solution handle the yum configuration files to replace
relevant directories by symlinks as expected on target system. This
change is done on two places:
- inside the container when RPM transactions is calculated and rpms
  are downloaded (the preupgradeupgradetransaction actor)
  - system is unaffected by this change
- before the upgrade itself (PreparationPhase) in the prepareyumconfig
  actor.

The important code handling that migration is stored in the tools
directory of the el7toel8 repository. See the handleyumconfig tool.

Fixes #19 