### PR TITLE
Print stderr of DNF command only in debug mode

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/libraries/preparetransaction.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/libraries/preparetransaction.py
@@ -10,6 +10,7 @@ from six.moves.urllib.request import urlopen
 from leapp.libraries.stdlib import api
 from leapp.libraries.stdlib import call, run
 from leapp.libraries.stdlib.call import STDOUT
+from leapp.libraries.stdlib.config import is_debug
 
 
 OverlayfsInfo = namedtuple('OverlayfsInfo', ['upper', 'work', 'merged'])
@@ -54,15 +55,17 @@ def permission_guard():
     # FIXME: Not implemented yet. Is it even useful?
     raise NotImplementedError
 
+
 def _logging_handler(fd_info, buffer):
-    '''Custom log handler to always show DNF output, no matter if in VERBOSE or DEBUG_MODE'''
+    '''Custom log handler to always show DNF stdout to console and stderr only in DEBUG mode'''
     (_unused, fd_type) = fd_info
 
     if fd_type == STDOUT:
         sys.stdout.write(buffer)
     else:
-        if os.environ.get('LEAPP_VERBOSE', '0') == '1':
+        if is_debug():
             sys.stderr.write(buffer)
+
 
 def guard_call(cmd, guards=(), print_output=False):
     try:


### PR DESCRIPTION
For have more consistent information levels we change to only print _stderr_ of _dnf_ command in debug-mode.

It's because the user doesn't know with command is running in verbose mode and got this message from _systemd-nspawn_ :
`Host and machine ids are equal (0e88963ac0f34a51a42c4e7a1dd50043): refusing to link journals`
In debug mode, the running command is printed and the user has the context.