### PR TITLE
Add a warning message if found packages unsigned by Red Hat in system

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/actor.py
@@ -1,10 +1,9 @@
-import os
-
 from leapp.actors import Actor
+from leapp.libraries.actor.library import check_unsigned_packages, skip_check
 from leapp.models import InstalledUnsignedRPM
-from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
 from leapp.reporting import Report
-from leapp.libraries.common.reporting import report_generic, report_with_remediation
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
 
 class RedHatSignedRpmCheck(Actor):
     """
@@ -20,22 +19,5 @@ class RedHatSignedRpmCheck(Actor):
     tags = (IPUWorkflowTag, ChecksPhaseTag)
 
     def process(self):
-        skip_check = os.getenv('LEAPP_SKIP_CHECK_SIGNED_PACKAGES')
-        if skip_check:
-            report_generic(title='Skipped signed packages check', 
-                           severity='low',
-                           summary='Signed packages check skipped via LEAPP_SKIP_CHECK_SIGNED_PACKAGES env var')
-            return
-
-        unsigned_pkgs = next(self.consume(InstalledUnsignedRPM), InstalledUnsignedRPM())
-
-        if len(unsigned_pkgs.items):
-            unsigned_packages_new_line = '\n'.join([pkg.name for pkg in unsigned_pkgs.items])
-            unsigned_packages = ' '.join([pkg.name for pkg in unsigned_pkgs.items])
-            remediation = 'yum remove {}'.format(unsigned_packages)
-            report_with_remediation(
-                title='Packages not signed by Red Hat found in the system',
-                summary='Following packages were not signed by Red Hat:\n    {}.'.format(unsigned_packages_new_line),
-                remediation=remediation,
-                severity='high',
-                )
+        skip_check()
+        check_unsigned_packages()

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/libraries/library.py
@@ -1,0 +1,50 @@
+import os
+
+from leapp.exceptions import StopActorExecution
+from leapp.libraries.common import reporting
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledUnsignedRPM
+
+
+def skip_check():
+    """ Check if has environment variable to skip this actor checks """
+    if os.getenv('LEAPP_SKIP_CHECK_SIGNED_PACKAGES'):
+        reporting.report_generic(title='Skipped signed packages check',
+                                 severity='low',
+                                 summary='Signed packages check skipped via LEAPP_SKIP_CHECK_SIGNED_PACKAGES env var')
+        raise StopActorExecution()
+
+
+def generate_report(packages):
+    """ Generate a report if exists packages unsigned in the system """
+    if not len(packages):
+        return
+    unsigned_packages_new_line = '\n'.join(packages)
+    unsigned_packages = ' '.join(packages)
+    remediation = 'yum remove {}'.format(unsigned_packages)
+    summary = 'The following packages have not been signed by Red Hat ' \
+              'and may be removed in the upgrade process:\n{}'.format(unsigned_packages_new_line)
+    reporting.report_with_remediation(
+        title='Packages not signed by Red Hat found in the system',
+        summary=summary,
+        remediation=remediation,
+        severity='high',
+    )
+
+
+def get_unsigned_packages():
+    """ Get list of unsigned packages installed in the system """
+    rpm_messages = api.consume(InstalledUnsignedRPM)
+    data = next(rpm_messages, InstalledUnsignedRPM())
+    if list(rpm_messages):
+        api.current_logger().warning('Unexpectedly received more than one InstalledUnsignedRPM message.')
+    unsigned_packages = set()
+    unsigned_packages.update([pkg.name for pkg in data.items])
+    unsigned_packages = list(unsigned_packages)
+    unsigned_packages.sort()
+    return unsigned_packages
+
+
+def check_unsigned_packages():
+    """ Check and generate reports if system contains unsigned installed packages"""
+    generate_report(get_unsigned_packages())

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
@@ -1,28 +1,85 @@
-from leapp.snactor.fixture import current_actor_context
-from leapp.models import RPM, InstalledUnsignedRPM
-from leapp.reporting import Report
+import os
 
+import pytest
+from leapp.exceptions import StopActorExecution
+from leapp.libraries.actor import library
+from leapp.libraries.common import reporting
+from leapp.libraries.stdlib import api
+from leapp.models import RPM, InstalledUnsignedRPM
 
 RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
 
 
-def test_actor_execution(current_actor_context):
-    current_actor_context.feed(InstalledUnsignedRPM(items=[]))
-    current_actor_context.run()
-    assert not current_actor_context.consume(Report)
+class produce_mocked(object):
+    def __init__(self):
+        self.called = 0
+        self.model_instances = []
+
+    def __call__(self, *model_instances):
+        self.called += 1
+        self.model_instances.append(model_instances[0])
 
 
-def test_actor_execution_with_unsigned_data(current_actor_context):
-    installed_rpm = [
-        RPM(name='sample02', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', 
-            pgpsig='SOME_OTHER_SIG_X'),
-        RPM(name='sample04', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', 
-            pgpsig='SOME_OTHER_SIG_X'),
-        RPM(name='sample06', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', 
-            pgpsig='SOME_OTHER_SIG_X'),
-        RPM(name='sample08', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch', 
-            pgpsig='SOME_OTHER_SIG_X')]
+class report_generic_mocked(object):
+    def __init__(self):
+        self.called = 0
 
-    current_actor_context.feed(InstalledUnsignedRPM(items=installed_rpm))
-    current_actor_context.run()
-    assert current_actor_context.consume(Report)
+    def __call__(self, **report_fields):
+        self.called += 1
+        self.report_fields = report_fields
+
+
+def test_skip_check(monkeypatch):
+    monkeypatch.setattr(os, "getenv", lambda(_): True)
+    monkeypatch.setattr(reporting, "report_generic", report_generic_mocked())
+    with pytest.raises(StopActorExecution):
+        library.skip_check()
+    assert reporting.report_generic.called == 1
+    assert 'Skipped signed packages check' in reporting.report_generic.report_fields['title']
+
+
+def test_no_skip_check(monkeypatch):
+    monkeypatch.setattr(os, "getenv", lambda(_): False)
+    monkeypatch.setattr(reporting, "report_generic", report_generic_mocked())
+
+    library.skip_check()
+    assert reporting.report_generic.called == 0
+
+
+def test_actor_execution_without_unsigned_data(monkeypatch):
+    def consume_unsigned_message_mocked(*models):
+        installed_rpm = []
+        yield InstalledUnsignedRPM(items=installed_rpm)
+    monkeypatch.setattr(api, "consume", consume_unsigned_message_mocked)
+    monkeypatch.setattr(api, "produce", produce_mocked())
+    monkeypatch.setattr(reporting, "report_with_remediation", report_generic_mocked())
+
+    packages = library.get_unsigned_packages()
+    assert len(packages) == 0
+    library.generate_report(packages)
+    assert reporting.report_with_remediation.called == 0
+
+
+def test_actor_execution_with_unsigned_data(monkeypatch):
+    def consume_unsigned_message_mocked(*models):
+        installed_rpm = [
+            RPM(name='sample02', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+                pgpsig='SOME_OTHER_SIG_X'),
+            RPM(name='sample04', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+                pgpsig='SOME_OTHER_SIG_X'),
+            RPM(name='sample06', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+                pgpsig='SOME_OTHER_SIG_X'),
+            RPM(name='sample08', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+                pgpsig='SOME_OTHER_SIG_X')]
+        yield InstalledUnsignedRPM(items=installed_rpm)
+
+    monkeypatch.setattr(api, "consume", consume_unsigned_message_mocked)
+    monkeypatch.setattr(api, "produce", produce_mocked())
+    monkeypatch.setattr(reporting, "report_with_remediation", report_generic_mocked())
+
+    packages = library.get_unsigned_packages()
+    assert len(packages) == 4
+    library.generate_report(packages)
+    assert reporting.report_with_remediation.called == 1
+    assert 'Packages not signed by Red Hat found' in reporting.report_with_remediation.report_fields['title']
+    assert 'yum remove sample' in reporting.report_with_remediation.report_fields['remediation']


### PR DESCRIPTION
The purpose of this PR is to alert the user to the non-signed Red Hat packages found in the system and to alert them that they can be removed in the upgrade process

In addition to the report this message will be printed on the console:

```
7 packages have not been signed by Red Hat and may be removed in the upgrade process
- leapp
- leapp-deps
- leapp-repository
- leapp-repository-deps
- leapp-repository-sos-plugin
- python2-leapp
- snactor
```
