### PR TITLE
Fix notification of missing actor's Makefile

### DIFF
--- a/utils/install_actor_deps.py
+++ b/utils/install_actor_deps.py
@@ -36,7 +36,7 @@ def install_actor_deps(actor, directory):
             if os.path.isfile(makefile_path):
                 install(makefile_path)
             else:
-                sys.stderr.write("Actor '{}' doesn't have Makefile!\n")
+                sys.stderr.write("Actor '{}' doesn't have Makefile!\n".format(actor))
             return
     error("Actor '{}' doesn't exist!\n".format(actor), 1)
 


### PR DESCRIPTION
This PR fixes the situation, when running `install-deps` Makefile target for specific actor, that does not have a Makefile, e.g.
```
ACTOR=checknfs make install-deps
```
and incomplete message is written to stderr:
```
Actor '{}' doesn't have Makefile!
```
