### PR TITLE
StorageScanner: changed log level from warning to debug

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/storagescanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/storagescanner/actor.py
@@ -35,7 +35,7 @@ class StorageScanner(Actor):
             # In our case /dev/urandom has other fd opened, probably for caching purposes.
             output = subprocess.check_output(cmd, env={'LVM_SUPPRESS_FD_WARNINGS': '1', 'PATH': os.environ['PATH']})
         except subprocess.CalledProcessError as e:
-            self.log.warning("Command '%s' return non-zero exit status: %s" % (" ".join(cmd), e.returncode))
+            self.log.debug("Command '%s' return non-zero exit status: %s" % (" ".join(cmd), e.returncode))
             raise StopIteration()
 
         for entry in output.split('\n'):


### PR DESCRIPTION
Changed log level from warning to debug in the get_cmd_output method.
StorageScanner calls systemd-mount, which might not be on the system. With this change, the error message will be on the debug level instead of warning level.