### PR TITLE
Add output to console in verbose mode about unsigned pkgs

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/libraries/library.py
@@ -3,6 +3,7 @@ import os
 from leapp.exceptions import StopActorExecution
 from leapp.libraries.common import reporting
 from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib.config import is_verbose
 from leapp.models import InstalledUnsignedRPM
 
 
@@ -19,7 +20,7 @@ def generate_report(packages):
     """ Generate a report if exists packages unsigned in the system """
     if not len(packages):
         return
-    unsigned_packages_new_line = '\n'.join(packages)
+    unsigned_packages_new_line = '\n'.join(['- ' + p for p in packages])
     unsigned_packages = ' '.join(packages)
     remediation = 'yum remove {}'.format(unsigned_packages)
     summary = 'The following packages have not been signed by Red Hat ' \
@@ -30,6 +31,8 @@ def generate_report(packages):
         remediation=remediation,
         severity='high',
     )
+    if is_verbose():
+        api.show_message(summary)
 
 
 def get_unsigned_packages():

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
@@ -52,6 +52,7 @@ def test_actor_execution_without_unsigned_data(monkeypatch):
         yield InstalledUnsignedRPM(items=installed_rpm)
     monkeypatch.setattr(api, "consume", consume_unsigned_message_mocked)
     monkeypatch.setattr(api, "produce", produce_mocked())
+    monkeypatch.setattr(api, "show_message", lambda x: True)
     monkeypatch.setattr(reporting, "report_with_remediation", report_generic_mocked())
 
     packages = library.get_unsigned_packages()
@@ -75,6 +76,7 @@ def test_actor_execution_with_unsigned_data(monkeypatch):
 
     monkeypatch.setattr(api, "consume", consume_unsigned_message_mocked)
     monkeypatch.setattr(api, "produce", produce_mocked())
+    monkeypatch.setattr(api, "show_message", lambda x: True)
     monkeypatch.setattr(reporting, "report_with_remediation", report_generic_mocked())
 
     packages = library.get_unsigned_packages()


### PR DESCRIPTION
Print in the console in **verbose mode** the information about packages that can be removed because they are not signed by Red Hat.

Right now this information is only present in the report but to make it more like  `PesEventsScanner` actor this change is needed.
