### PR TITLE
Py3 after upgrade

### DIFF
--- a/packaging/leapp-el7toel8-deps.spec
+++ b/packaging/leapp-el7toel8-deps.spec
@@ -18,11 +18,12 @@ URL:        https://oamg.github.io/leapp/
 ##################################################
 %package -n %{lrdname}
 Summary:    Meta-package with system dependencies for leapp repository
-Provides:   leapp-repository-dependencies = 2
+Provides:   leapp-repository-dependencies = 3
 Obsoletes:  leapp-repository-deps
 
 Requires:   dnf >= 4
 Requires:   pciutils
+Requires:   python3
 
 %description -n %{lrdname}
 %{summary}

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -30,7 +30,7 @@ BuildRequires:  python-devel
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Provides in deps subpackage
-Requires:       leapp-repository-dependencies = 2
+Requires:       leapp-repository-dependencies = 3
 
 # That's temporary to ensure the obsoleted subpackage is not installed
 # and will be removed when the current version of leapp-repository is installed
@@ -58,7 +58,7 @@ Summary:    Meta-package with system dependencies of %{name} package
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Requires in main package
-Provides:  leapp-repository-dependencies = 2
+Provides:  leapp-repository-dependencies = 3
 ##################################################
 # Real requirements for the leapp-repository HERE
 ##################################################

--- a/repos/system_upgrade/el7toel8/actors/preparepythonworkround/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/preparepythonworkround/actor.py
@@ -1,0 +1,39 @@
+import os
+
+from leapp.actors import Actor
+from leapp.tags import IPUWorkflowTag,  RPMUpgradePhaseTag
+
+
+class PreparePythonWorkround(Actor):
+    """
+    Prepare environment to be able to run leapp with Python3 in initrd.
+
+    These are the current necessary steps to be able to run Leapp with Python3.
+    Basically, we create directory (now /root/tmp_leapp_py3/). We will put
+    symlinks inside which will point to leapp python packages. Additionally,
+    we create new script that will import expected modules and run leapp again.
+    """
+
+    name = 'prepare_python_workround'
+    consumes = ()
+    produces = ()
+    tags = (IPUWorkflowTag, RPMUpgradePhaseTag)
+
+    def process(self):
+        leapp_home = "/root/tmp_leapp_py3"
+        py3_leapp = os.path.join(leapp_home, "leapp3")
+        os.mkdir(leapp_home)
+        os.symlink(
+                "/usr/lib/python2.7/site-packages/leapp",
+                os.path.join(leapp_home, "leapp"))
+        with open(py3_leapp, "w") as f:
+            f_content = [
+                "#!/usr/bin/python3",
+                "import sys",
+                "sys.path.append('{}')".format(leapp_home),
+                "",
+                "import leapp.cli",
+                "sys.exit(leapp.cli.main())",
+                ]
+            f.write("{}\n\n".format("\n".join(f_content)))
+        os.chmod(py3_leapp, 0o770)

--- a/repos/system_upgrade/el7toel8/workflows/inplace_upgrade.py
+++ b/repos/system_upgrade/el7toel8/workflows/inplace_upgrade.py
@@ -130,7 +130,7 @@ class IPUWorkflow(Workflow):
         filter = TagFilter(RPMUpgradePhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
-        flags = Flags()
+        flags = Flags(is_checkpoint=True)
 
     class ApplicationsPhase(Phase):
         '''Perform the neccessary steps to finish upgrade of applications provided by Red Hat.


### PR DESCRIPTION
Start leapp with Python3 after RPMUpgradePhase
    
    We found several issues using Python2 after the RPM transaction, e.g.
    missing python libraries which are no longer provided for Python2 or
    mixture of loaded libraries from RHEL 7 and RHEL 8 when run leapp
    in one neverending process.
    
    To resolve this, we will stop the IPUWorkflow after the RPM
    transaction (RPMUpgradePhase) and restart it with Python3.
    Additionally, initramdisk is modified as well to start the new
    leapp script with python3 as expected.
    
    To stop the processing of the workflow, use the is_checkpoint flag
    which has been provided recently. Current solution is hacky as we
    are creating directory with files inside under the /root/ - but
    this is necessary hack now. We will try to come with better solution.
    
    Added RPM dependency for the python3 package and bumped capability.


**IMPORTANT**: You have to use the new initrd. (means, create that for yourself of follow the email with testing instructions - just internal, sorry).