### PR TITLE
Release v0.6.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -15,7 +15,7 @@ py2_byte_compile "%1" "%2"}
 
 
 Name:           leapp-repository
-Version:        0.5.0
+Version:        0.6.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 
@@ -34,8 +34,8 @@ Requires:       leapp-repository-dependencies = 2
 
 # That's temporary to ensure the obsoleted subpackage is not installed
 # and will be removed when the current version of leapp-repository is installed
-Obsoletes:      leapp-repository-data <= 0.5.1
-Provides:       leapp-repository-data <= 0.5.1
+Obsoletes:      leapp-repository-data <= 0.6.1
+Provides:       leapp-repository-data <= 0.6.1
 
 %description
 Repositories for leapp


### PR DESCRIPTION
**Change license** from AGPL 3.0 to Apache 2.0

Upgrade handling
- bind mount udev database during upgrade
- Inhibitor model is used by actors in case the upgrade process is to be stopped
- introduction of sos plugin for collecting data needed for debugging

Removed actors
- FirewallDecision
- FirewallDisable
- NetIfaceScanner
- CreateInitRdBootEntry
- RemoveInitRdBootEntry

Added actors
- PCIDevicesScanner
- AddUpgradeBootEntry
- CheckBootAvailSpace
- CheckNfs
- CheckXFS
- CopyToBoot
- DetectGrubConfigError
- NetworkManagerReadConfig
- NetworkManagerUpdateConfig
- NetworkManagerUpdateService
- Prepareyumconfig
- RemoveBootFiles
- RemoveOldLog
- RemoveUpgradeBootEntry
- RepositoriesMapping
- SCTPChecks
- SCTPConfigRead
- SCTPConfigUpdate

Changed actors
- StorageScanner - suppress LVM leaked fd warnings
- PrepareUpgradeTransaction - mount overlayfs into diskimage to avoid problems with xfs ftype=0
- SetupTargetRepos - enable repositories based on PES data
- RedHatSignedRpmCheck - report is generated if packages not signed by Red Hat are found in the system
- PesEventsScanner - inhibit upgrade if PES data file is missing/invalid
- RepositoriesMapping - inhibit upgrade if repository mapping file is missing/invalid

Refactoring
- use new reporting model
- use run function from stdlib to execute external commands

Packaging
- new dependencies: python2-jinja2, pciutils
- removal of leapp-repository-data subpackage
- new directory /etc/leapp/files for storing PES and repository maping data
- precompile python files to avoid left over pyc files
