### PR TITLE
Add chrony check actor

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkchrony/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkchrony/actor.py
@@ -1,0 +1,29 @@
+from leapp.actors import Actor
+from leapp.models import InstalledRedHatSignedRPM
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.libraries.actor.library import check_chrony
+
+
+class CheckChrony(Actor):
+    """
+    Check for incompatible changes in chrony configuration.
+
+    Warn that the default chrony configuration in RHEL8 uses the leapsectz
+    directive.
+    """
+
+    name = 'check_chrony'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        installed_packages = set()
+
+        signed_rpms = self.consume(InstalledRedHatSignedRPM)
+        for rpm_pkgs in signed_rpms:
+            for pkg in rpm_pkgs.items:
+                installed_packages.add(pkg.name)
+
+        check_chrony('chrony' in installed_packages)

--- a/repos/system_upgrade/el7toel8/actors/checkchrony/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkchrony/libraries/library.py
@@ -1,0 +1,28 @@
+from leapp.libraries.common import reporting
+from leapp.libraries.stdlib import api, run
+
+# Check if the chrony config file was not modified since installation
+def is_config_default():
+    try:
+        result = run(['rpm', '-V', '--nomtime', 'chrony'], checked=False)
+        return '/etc/chrony.conf' not in result['stdout']
+    except OSError as e:
+        api.current_logger().warn("rpm verification failed: %s", str(e))
+        return True
+
+# Report potential issues in chrony configuration
+def check_chrony(chrony_installed):
+    if not chrony_installed:
+        api.current_logger().info('chrony package is not installed')
+        return
+
+    if is_config_default():
+        reporting.report_generic(
+                title='chrony using default configuration',
+                summary='default chrony configuration in RHEL8 uses leapsectz directive, which cannot be used with leap smearing NTP servers, and uses a single pool directive instead of four server directives',
+                severity='medium')
+    else:
+        reporting.report_generic(
+                title='chrony using non-default configuration',
+                summary='chrony behavior will not change in RHEL8',
+                severity='low')

--- a/repos/system_upgrade/el7toel8/actors/checkchrony/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkchrony/tests/unit_test.py
@@ -1,0 +1,43 @@
+from leapp.libraries.actor import library
+from leapp.libraries.common import reporting
+
+
+class report_generic_mocked(object):
+    def __init__(self):
+        self.called = 0
+
+    def __call__(self, **report_fields):
+        self.called += 1
+        self.report_fields = report_fields
+
+
+def test_uninstalled(monkeypatch):
+    for config_default in (False, True):
+        monkeypatch.setattr(reporting, 'report_generic', report_generic_mocked())
+        monkeypatch.setattr(library, 'is_config_default', lambda: config_default)
+
+        library.check_chrony(False)
+
+        assert reporting.report_generic.called == 0
+
+
+def test_installed_defconf(monkeypatch):
+    monkeypatch.setattr(reporting, 'report_generic', report_generic_mocked())
+    monkeypatch.setattr(library, 'is_config_default', lambda: True)
+
+    library.check_chrony(True)
+
+    assert reporting.report_generic.called == 1
+    assert reporting.report_generic.report_fields['title'] == \
+            'chrony using default configuration'
+
+
+def test_installed_nodefconf(monkeypatch):
+    monkeypatch.setattr(reporting, 'report_generic', report_generic_mocked())
+    monkeypatch.setattr(library, 'is_config_default', lambda: False)
+
+    library.check_chrony(True)
+
+    assert reporting.report_generic.called == 1
+    assert reporting.report_generic.report_fields['title'] == \
+            'chrony using non-default configuration'


### PR DESCRIPTION
Check if chrony is installed and using the default chrony.conf. Warn
that the new default config in RHEL8 uses the leapsectz directive, which
does not work with leap smearing NTP servers.