### PR TITLE
Change error report message in console

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/verifycheckresults/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/verifycheckresults/actor.py
@@ -21,7 +21,7 @@ class VerifyCheckResults(Actor):
         results = list(self.consume(Report))
         inhibitors = [msg for msg in results if 'inhibitor' in msg.flags]
         high_sev_msgs = [msg for msg in results if msg.severity == 'high' and 'inhibitor' not in msg.flags]
-        msgs_to_report = inhibitors+high_sev_msgs
+        msgs_to_report = inhibitors + high_sev_msgs
 
         report_file = '/tmp/leapp-report.txt'
         error = report.generate_report(msgs_to_report, report_file)
@@ -32,7 +32,7 @@ class VerifyCheckResults(Actor):
 
         if inhibitors:
             for e in inhibitors:
-                self.report_error('%s: %s: %s' % (e.title, e.severity, e.detail['summary']))
+                self.report_error(e.title)
 
             self.report_error('Ending process due to errors found during checks, see {} for detailed report.'
                               .format(report_file))


### PR DESCRIPTION
The error report on the console is very long, this PR aims to summarize this.

Old report example:
```

============================================================
                        ERRORS
============================================================

2019-04-10 14:26:02.318108 [ERROR] Actor: verify_check_results Message: Missing/Invalid PES data file (/etc/leapp/files/pes-events.json): high: Read documentation at: https://access.redhat.com/articles/3664871 for more information about how to retrieve the files
2019-04-10 14:26:02.327669 [ERROR] Actor: verify_check_results Message: Repositories map file not found (/etc/leapp/files/repomap.csv): high: Read documentation at: https://access.redhat.com/articles/3664871 for more information about how to retrieve the files
2019-04-10 14:26:02.334891 [ERROR] Actor: verify_check_results Message: Ending process due to errors found during checks, see /tmp/leapp-report.txt for detailed report.

============================================================
                     END OF ERRORS
============================================================
```

Proposed new output:

```
============================================================
                        ERRORS
============================================================

2019-04-10 14:27:13.077643 [ERROR] Actor: verify_check_results Message: Missing/Invalid PES data file (/etc/leapp/files/pes-events.json)
2019-04-10 14:27:13.088024 [ERROR] Actor: verify_check_results Message: Repositories map file not found (/etc/leapp/files/repomap.csv)
2019-04-10 14:27:13.094819 [ERROR] Actor: verify_check_results Message: Ending process due to errors found during checks, see /tmp/leapp-report.txt for detailed report.

============================================================
                     END OF ERRORS
============================================================
```

New output only shows the title of the error message, the complete message can be found in the report file.