### PR TITLE
initrdinclude: use replace the -k option by --kver for dracut

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/initrdinclude/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/initrdinclude/actor.py
@@ -48,7 +48,7 @@ class InitrdInclude(Actor):
                        "Cannot get info about the installed kernel.",
                        details={"details": str(e)})
         try:
-            cmd = ["dracut", "--install", " ".join(files), "-f", "-k", kernel_version]
+            cmd = ["dracut", "--install", " ".join(files), "-f", "--kver", kernel_version]
             run(cmd)
         except CalledProcessError as e:
             # NOTE(pstodulk) same note as above


### PR DESCRIPTION
The original command in the actor expects to get the version of the
RHEL-8 kernel but -k option requires path to the directory. Use the
--kver option so dracut image is rebuilt with for the specified
kernel version.