### PR TITLE
Change to umount directory only if it's mounted.

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/libraries/preparetransaction.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/libraries/preparetransaction.py
@@ -281,5 +281,6 @@ def create_disk_image(path):
 
 
 def remove_disk_image(path):
-    guard_call(['/bin/umount', '-fl', os.path.join(path, 'mounts')])
+    if os.path.ismount(os.path.join(path, 'mounts')):
+        guard_call(['/bin/umount', '-fl', os.path.join(path, 'mounts')])
     shutil.rmtree(path, ignore_errors=True)


### PR DESCRIPTION
The actor `prepareupgradetransaction` needs to remove the previous disk image before creating a new one, which often does not exist, a small check is added to prevent printing error on the console in such case.

Old output:

```
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
umount: /var/lib/leapp/scratch/mounts: mountpoint not found
```