### PR TITLE
nm-update-client-ids.py: remove shebang

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/networkmanagerupdateconnections/tools/nm-update-client-ids.py
+++ b/repos/system_upgrade/el7toel8/actors/networkmanagerupdateconnections/tools/nm-update-client-ids.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import sys
 import gi
 gi.require_version('NM', '1.0')

--- a/repos/system_upgrade/el7toel8/actors/networkmanagerupdateconnections/tools/nm-update-client-ids.py
+++ b/repos/system_upgrade/el7toel8/actors/networkmanagerupdateconnections/tools/nm-update-client-ids.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import sys
 import gi
 gi.require_version('NM', '1.0')


### PR DESCRIPTION
Removed python shebang from the ```networkmanagerupdateconnections/tools/nm-update-client-ids.py```.

Fixed #72 