### PR TITLE
Do not allow upgrade without RHEL 8 repos available

### DIFF
--- a/repos/system_upgrade/el7toel8/files/rhel_upgrade.py
+++ b/repos/system_upgrade/el7toel8/files/rhel_upgrade.py
@@ -49,8 +49,8 @@ class RhelUpgradeCommand(dnf.cli.Command):
         self.base.repos.all().disable()
         for repo in self.base.repos.all():
             if repo.id in enabled_repos:
+                repo.skip_if_unavailable = False
                 repo.enable()
-
 
     def run(self):
         self.base.add_remote_rpms(self.plugin_data['pkgs_info']['local_rpms'])
@@ -82,4 +82,3 @@ class RhelUpgradePlugin(dnf.Plugin):
         super(RhelUpgradePlugin, self).__init__(base, cli)
         if cli:
             cli.register_command(RhelUpgradeCommand)
-


### PR DESCRIPTION
Without this, Leapp continues with the transaction calculation even when AppStream and BaseOS are not available. Then the transaction calculation fails later but with an error from which it's definitely not obvious what is the cause.
```
2019-04-05 07:32:57.758 DEBUG    PID: 23371 leapp.workflow.Download.prepare_upgrade_transaction: External command is started: [systemd-nspawn --register=no --quiet -D /var/lib/leapp/scratch/mounts/merged -- /bin/bash -c /usr/bin/dnf rhel-upgrade download /var/lib/leapp/dnf-plugin-data.txt]
Red Hat Enterprise Linux 8 for x86_64 - AppStre 0.0  B/s |   0  B     00:00    
Red Hat Enterprise Linux 8 for x86_64 - BaseOS  0.0  B/s |   0  B     00:00    
Failed to synchronize cache for repo 'rhel-8-for-x86_64-appstream-rpms', ignoring this repo.
Failed to synchronize cache for repo 'rhel-8-for-x86_64-baseos-rpms', ignoring this repo.
Package php-common-5.4.16-46.el7.x86_64 is already installed.
Package mvapich2-2.0-2.0a-9.el7.x86_64 is already installed.
...
Error:
 Problem 1: conflicting requests
 Problem 2: package git-1.8.3.1-19.el7.x86_64 requires /usr/bin/python, but none of the providers can be installed
  - conflicting requests
...
...
```