### PR TITLE
dracut initrd: add sync commands and fix mounting from fstab in container after upgrade phase

### DIFF
--- a/sources/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/sources/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -51,7 +51,14 @@ do_upgrade() {
         # run leapp to proceed phases after the upgrade with Python3
         #PY_LEAPP_PATH=/usr/lib/python2.7/site-packages/leapp/
         #$NEWROOT/bin/systemd-nspawn $nspawn_opts -D $NEWROOT -E PYTHONPATH="${PYTHONPATH}:${PY_LEAPP_PATH}" /usr/bin/python3 $LEAPPBIN upgrade --resume $args
-        $NEWROOT/bin/systemd-nspawn $nspawn_opts -D $NEWROOT /usr/bin/python3 $LEAPP3_BIN upgrade --resume $args
+
+        # NOTE:
+        # mount everything from FSTAB before run of the leapp as mount inside
+        # the container is not persistent and we need to have mounted /boot
+        # all FSTAB partitions. As mount was working before, hopefully will
+        # work now as well. Later this should be probably modified as we will
+        # need to handle more stuff around storage at all.
+        $NEWROOT/bin/systemd-nspawn $nspawn_opts -D $NEWROOT /usr/bin/bash -c "mount -a; /usr/bin/python3 $LEAPP3_BIN upgrade --resume $args"
         rv=$?
     fi
 

--- a/sources/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/sources/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -40,6 +40,9 @@ do_upgrade() {
     $NEWROOT/bin/systemd-nspawn $nspawn_opts -D $NEWROOT $LEAPPBIN upgrade --resume $args
     rv=$?
 
+    # NOTE: flush the cached content to disk to ensure everything is written
+    sync
+
     #FIXME: for debugging purposes; this will be removed or redefined in future
     getarg 'rd.upgrade.break=leapp-upgrade' 'rd.break=leapp-upgrade' && \
         emergency_shell -n upgrade "Break after LEAPP upgrade stop"
@@ -112,6 +115,9 @@ result=$?
 
 ##### safe the data and remount $NEWROOT as it was previously mounted #####
 save_journal
+
+# NOTE: flush the cached content to disk to ensure everything is written
+sync
 mount -o "remount,$old_opts" $NEWROOT
 exit $result
 

--- a/sources/dracut/85sys-upgrade-redhat/module-setup.sh
+++ b/sources/dracut/85sys-upgrade-redhat/module-setup.sh
@@ -69,7 +69,10 @@ install() {
     # probably not so easy to decide & realize how we will resolve that. Let's
     # keep that for discussion
     # Q: Would we hack that in way of copy whole initramfs into the root, mount
-    #    mount it and set envars 
+    #    mount it and set envars
+
+    # install this one to ensure we are able to sync write
+    inst_binary sync
 
     # script to actually run the upgrader binary
     inst_hook upgrade 50 "$moddir/do-upgrade.sh"


### PR DESCRIPTION
We found some issues that are *maybe* related to cache. Use the sync
command on several places in initrd to ensure we are not hit by that
on some machines.

ADDITIONALLY!!!!
There are errors made because the partitions from FSTAB are not
mounted. It should be save to call "mount -a" after the upgrade
as already proceed earlier and we require to mount additional
partitions to be able to process the rest of workflow.