### PR TITLE
Release v0.7.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -15,7 +15,7 @@ py2_byte_compile "%1" "%2"}
 
 
 Name:           leapp-repository
-Version:        0.6.0
+Version:        0.7.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
Packaging
- leapp-sos-plugin subpackage is licensed under the same license as the base package
- new dependencies: python3, python*-pyudev

Upgrade handling
- upgrade process is interrupted after RPMUpgradePhase and resumed with Python 3
- upgrade of NetworkManager is fixed
- name changes of network interfaces are handled
- upgrade of firewalld is handled
- leftover RHEL 7 packages are reported after the upgrade
- HTB repositories used for upgrades are replaced with the ones used for GA
- tpm2-abrmd and all packages that depend on redhat-rpm-config are removed during upgrade
- handling of the upgrade RPM transaction is improved
- sync command is used in initrd to avoid issues related to cache
- networking naming changes are handled
- disable udev's persistent network interface naming scheme when the only NIC is eth0
- inhibit upgrade when ethX is detected and more NICs exist
- check whether all target upgrade repositories are available

Logging and reporting
- output of dnf tool is shown in initram whend --debug option is used
- report with differences in Python between RHEL 7 and 8 is generated
- all logs and reports are stored in /var/log/leapp/ directory
