### PR TITLE
dracut: Ensure the $NEWROOT is set and use default otherwise

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -11,6 +11,8 @@ export LEAPPBIN=/usr/bin/leapp
 export LEAPPHOME=/root/tmp_leapp_py3
 export LEAPP3_BIN=$LEAPPHOME/leapp3
 
+export NEWROOT=${NEWROOT:-"/sysroot"}
+
 do_upgrade() {
     local args="" rv=0
     #FIXME: set here params we would like to possible use...


### PR DESCRIPTION

    dracut: Ensure the $NEWROOT is set and use default otherwise
    
    We hit *somtimes* on some machines problem that we are not even able
    to mount the rootfs. In such cases, there is just err message like
           mount: bad usage
           Try 'mount --help' for more information.
    
    It's weird, some modules checks the  $NEWROOT variable, some not.
    So just from this point to ensure whether this would be the source
    of the issue, putting here the initialisation when NEWROOT is not
    defined.
