### PR TITLE
using directory listing of /sys/module instead of lsmod fixes #46

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
@@ -77,13 +77,10 @@ def get_system_groups_status():
 
 @aslist
 def _get_active_kernel_modules(logger):
-    lines = run(['ls',"-d","/sys/module"], split=True)['stdout'] # can be implemented by os.lisdir(\'/sys/module\')
-    for l in lines[1:]:
-        name = l.split(' ')[0]
+    lines = [module for module in os.listdir("/sys/module") if os.path.isdir("/sys/module/{}".format(module))]
 
-        # Read parameters of the given module as exposed by the
-        # `/sys` VFS, if there are no parameters exposed we just
-        # take the name of the module
+    for l in lines:
+        name = l
         base_path = '/sys/module/{module}'.format(module=name)
         parameters_path = os.path.join(base_path, 'parameters')
         if not os.path.exists(parameters_path):

--- a/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
@@ -77,7 +77,7 @@ def get_system_groups_status():
 
 @aslist
 def _get_active_kernel_modules(logger):
-    lines = run(['lsmod'], split=True)['stdout']
+    lines = run(['ls',"-d","/sys/module"], split=True)['stdout'] # can be implemented by os.lisdir(\'/sys/module\')
     for l in lines[1:]:
         name = l.split(' ')[0]
 


### PR DESCRIPTION
As Issue #46 needed, This PR uses such directory listing. 
Possible: Since This directory listing can be done with the simple os.listdir(), should this PR be modified with such call ?