### PR TITLE
Remove squid and python-docs during the upgrade

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -47,3 +47,5 @@ varnish
 varnish-devel
 varnish-modules
 tpm2-abrmd
+squid
+python-docs


### PR DESCRIPTION
- these two packages cause the upgrade to fail
- the issue with squid is reported in [rhbz#1703117](https://bugzilla.redhat.com/show_bug.cgi?id=1703117)
- python-docs has non-versioned Obsoletes:
  - `Obsoletes: python2-docs`
  - `Provides: python2-docs = %{version}`
  - this causes transaction failure because we mandate installation of python2-docs but dnf does not do that because _python-docs_ already provides _python2-docs_