### PR TITLE
Add SSSDCheck actor

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/sssdcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sssdcheck/actor.py
@@ -1,0 +1,64 @@
+from leapp.actors import Actor
+from leapp.libraries.common.reporting import report_generic, report_with_remediation
+from leapp.models import SSSDConfig
+from leapp.reporting import Report
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+
+
+class SSSDCheck(Actor):
+    '''
+    Check SSSD configuration for changes in RHEL8 and report them.
+
+    These changes are:
+    - id_provider=local is no longer supported and will be ignored
+    - ldap_groups_use_matching_rule_in_chain was removed and will be ignored
+    - ldap_initgroups_use_matching_rule_in_chain was removed and will be ignored
+    - ldap_sudo_include_regexp changed default from true to false
+    '''
+
+    name = 'sssd_check'
+    consumes = (SSSDConfig,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        model = next(self.consume(SSSDConfig), None)
+        if not model:
+            return
+
+        for domain in model.domains:
+            if 'local_provider' in domain.options:
+                self.reportLocalProvider(domain)
+
+            if 'groups_chain' in domain.options:
+                self.reportRemovedOption(domain, 'ldap_groups_use_matching_rule_in_chain')
+
+            if 'initgroups_chain' in domain.options:
+                self.reportRemovedOption(domain, 'ldap_initgroups_use_matching_rule_in_chain')
+
+            if 'sudo_regexp' in domain.options:
+                self.reportSudoRegexp(domain)
+
+    def reportLocalProvider(self, domain):
+        report_generic(
+            title='SSSD Domain "%s": local provider is no longer '
+                  'supported and the domain will be ignored.' % domain,
+            summary='Local provider is no longer supported.'
+        )
+
+    def reportRemovedOption(self, domain, option):
+        report_generic(
+            title='SSSD Domain "%s": option %s has no longer '
+                  'any effect' % (domain, option),
+            summary='Option %s was removed and it will be ignored.' % option
+        )
+
+    def reportSudoRegexp(self, domain):
+        report_with_remediation(
+            title='SSSD Domain "%s": sudo rules containing wildcards '
+                  'will stop working.' % domain,
+            summary='Default value of ldap_sudo_include_regexp changed '
+                    'from true to false for performance reason.',
+            remediation='If you use sudo rules with wildcards, set this option '
+                        'to true explicitly.'
+        )

--- a/repos/system_upgrade/el7toel8/actors/sssdfacts/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sssdfacts/actor.py
@@ -1,0 +1,34 @@
+from six.moves import configparser
+
+from leapp.actors import Actor
+from leapp.libraries.actor.library import SSSDFactsLibrary
+from leapp.models import SSSDConfig
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+
+
+class SSSDFacts(Actor):
+    '''
+    Check SSSD configuration for changes in RHEL8 and report them in model.
+
+    These changes are:
+    - id_provider=local is no longer supported and will be ignored
+    - ldap_groups_use_matching_rule_in_chain was removed and will be ignored
+    - ldap_initgroups_use_matching_rule_in_chain was removed and will be ignored
+    - ldap_sudo_include_regexp changed default from true to false
+    '''
+
+    name = 'sssd_facts'
+    consumes = ()
+    produces = (SSSDConfig,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        try:
+            config = configparser.RawConfigParser()
+            config.read('/etc/sssd/sssd.conf')
+        except configparser.Error:
+            # SSSD is not configured properly. Nothing to do.
+            self.log.warn('SSSD configuration unreadable.')
+            return
+
+        self.produce(SSSDFactsLibrary(config).process())

--- a/repos/system_upgrade/el7toel8/actors/sssdfacts/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/sssdfacts/libraries/library.py
@@ -1,0 +1,105 @@
+from leapp.models import SSSDConfig, SSSDDomainConfig
+
+
+class SSSDFactsLibrary(object):
+    """
+    Helper library from SSSDFacts actor to allow unit testing.
+    """
+    def __init__(self, config):
+        self.config = config
+
+    def process(self):
+        """
+        Check SSSD configuration for changes in RHEL8 and return them in SSSDConfig
+        model.
+
+        These changes are:
+        - id_provider=local is no longer supported and will be ignored
+        - ldap_groups_use_matching_rule_in_chain was removed and will be ignored
+        - ldap_initgroups_use_matching_rule_in_chain was removed and will be ignored
+        - ldap_sudo_include_regexp changed default from true to false
+        """
+        facts = SSSDConfig(domains=[])
+
+        for section in self.config.sections():
+            # We are interested only in domains.
+            if not section.startswith('domain/'):
+                continue
+
+            domain = SSSDDomainConfig(
+                name=section[len('domain/'):],
+                options=[]
+            )
+
+            steps = {
+                'local_provider': self.checkLocalProvider(domain.name),
+                'groups_chain': self.checkRemovedOption(
+                    domain.name, 'ldap_groups_use_matching_rule_in_chain'
+                ),
+                'initgroups_chain': self.checkRemovedOption(
+                    domain.name, 'ldap_initgroups_use_matching_rule_in_chain'
+                ),
+                'sudo_regexp': self.checkSudoRegexp(domain.name)
+            }
+
+            for key, value in steps.items():
+                if value:
+                    domain.options.append(key)
+
+            facts.domains.append(domain)
+
+        return facts
+
+    def checkLocalProvider(self, domain):
+        """
+        Check if any id_provider=local is configured.
+        """
+        provider = self.get_provider(domain, 'id_provider')
+        if provider != 'local':
+            return False
+
+        return True
+
+    def checkRemovedOption(self, domain, option):
+        """
+        Check if specific option that has been removed is present.
+        """
+        section = self.get_domain_section(domain)
+        if not self.config.has_option(section, option):
+            return False
+
+        return True
+
+    def checkSudoRegexp(self, domain):
+        """
+        Check if ldap_sudo_include_regexp is not set explicitly.
+        """
+        section = self.get_domain_section(domain)
+        provider = self.get_provider(domain, 'sudo_provider', ['id_provider'])
+
+        if provider not in ['ad', 'ldap']:
+            return False
+
+        if self.config.has_option(section, 'ldap_sudo_include_regexp'):
+            return False
+
+        return True
+
+    def get_domain_section(self, domain):
+        """
+        Convert domain name to ini format section.
+        """
+        return 'domain/' + domain
+
+    def get_provider(self, domain, provider, fallbacks=None):
+        """
+        Return configured provider.
+        """
+        providers = [provider] + (fallbacks if fallbacks else [])
+
+        section = self.get_domain_section(domain)
+        for option in providers:
+            if self.config.has_option(section, option):
+                return self.config.get(section, option)
+
+        return None

--- a/repos/system_upgrade/el7toel8/actors/sssdfacts/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/sssdfacts/tests/unit_test.py
@@ -1,0 +1,182 @@
+import textwrap
+
+from six.moves import configparser
+from six import StringIO
+
+from leapp.libraries.actor.library import SSSDFactsLibrary
+from leapp.models import SSSDConfig, SSSDDomainConfig
+
+
+def get_config(content):
+    config = configparser.ConfigParser()
+    config.readfp(StringIO(textwrap.dedent(content)))
+
+    return config
+
+
+def test_empty_config():
+    config = configparser.ConfigParser()
+    facts = SSSDFactsLibrary(config).process()
+
+    assert not facts.domains
+
+
+def test_local_domain():
+    config = get_config("""
+    [domain/local]
+    id_provider = local
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert len(facts.domains) == 1
+    assert facts.domains[0].name == "local"
+    assert len(facts.domains[0].options) == 1
+    assert "local_provider" in facts.domains[0].options
+
+
+def test_groups_chain():
+    config = get_config("""
+    [domain/ldap]
+    id_provider = ldap
+    ldap_groups_use_matching_rule_in_chain = True
+
+    # Set this option to avoid reporting its change
+    ldap_sudo_include_regexp = True
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert len(facts.domains) == 1
+    assert facts.domains[0].name == "ldap"
+    assert len(facts.domains[0].options) == 1
+    assert "groups_chain" in facts.domains[0].options
+
+
+def test_initgroups_chain():
+    config = get_config("""
+    [domain/ldap]
+    id_provider = ldap
+    ldap_initgroups_use_matching_rule_in_chain = True
+
+    # Set this option to avoid reporting its change
+    ldap_sudo_include_regexp = True
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert len(facts.domains) == 1
+    assert facts.domains[0].name == "ldap"
+    assert len(facts.domains[0].options) == 1
+    assert "initgroups_chain" in facts.domains[0].options
+
+
+def test_sudo_regexp__ldap():
+    config = get_config("""
+    [domain/ldap]
+    id_provider = ldap
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert len(facts.domains) == 1
+    assert facts.domains[0].name == "ldap"
+    assert len(facts.domains[0].options) == 1
+    assert "sudo_regexp" in facts.domains[0].options
+
+
+def test_sudo_regexp__ad():
+    config = get_config("""
+    [domain/ad]
+    id_provider = ad
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert len(facts.domains) == 1
+    assert facts.domains[0].name == "ad"
+    assert len(facts.domains[0].options) == 1
+    assert "sudo_regexp" in facts.domains[0].options
+
+
+def test_sudo_regexp__ipa():
+    config = get_config("""
+    [domain/ipa]
+    id_provider = ipa
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert len(facts.domains) == 1
+    assert facts.domains[0].name == "ipa"
+    assert not facts.domains[0].options
+
+
+def test_complex():
+    config = get_config("""
+    [sssd]
+    user = root
+    services = nss, pam, sudo
+
+    [domain/local]
+    id_provider = local
+
+    [domain/ldap]
+    id_provider = ldap
+    ldap_groups_use_matching_rule_in_chain = True
+
+    [domain/ipa]
+    id_provider = ipa
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert len(facts.domains) == 3
+
+    assert facts.domains[0].name == "local"
+    assert len(facts.domains[0].options) == 1
+    assert "local_provider" in facts.domains[0].options
+
+    assert facts.domains[1].name == "ldap"
+    assert len(facts.domains[1].options) == 2
+    assert "groups_chain" in facts.domains[1].options
+    assert "sudo_regexp" in facts.domains[1].options
+
+    assert facts.domains[2].name == "ipa"
+    assert not facts.domains[2].options
+
+
+def test_get_domain_section():
+    config = configparser.ConfigParser()
+    library = SSSDFactsLibrary(config)
+
+    assert library.get_domain_section("ldap") == "domain/ldap"
+
+
+def test_get_provider__none():
+    config = get_config("""
+    [domain/local]
+    """)
+    library = SSSDFactsLibrary(config)
+
+    assert library.get_provider("local", "id_provider") is None
+
+
+def test_get_provider__without_fallback():
+    config = get_config("""
+    [domain/local]
+    id_provider = local
+    """)
+    library = SSSDFactsLibrary(config)
+
+    assert library.get_provider("local", "id_provider") == "local"
+
+
+def test_get_provider__with_fallback():
+    config = get_config("""
+    [domain/ldap]
+    id_provider = ldap
+    """)
+    library = SSSDFactsLibrary(config)
+
+    assert library.get_provider("ldap", "sudo_provider", ["id_provider"]) == "ldap"

--- a/repos/system_upgrade/el7toel8/models/sssd.py
+++ b/repos/system_upgrade/el7toel8/models/sssd.py
@@ -1,0 +1,32 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class SSSDDomainConfig(Model):
+    """
+    Facts found about an SSSD domain.
+    """
+    topic = SystemInfoTopic
+
+    name = fields.String()
+    """
+    Domain name.
+    """
+
+    options = fields.List(fields.String(), default=list())
+    """
+    List of options related to this domain that affects the upgrade process.
+    """
+
+
+class SSSDConfig(Model):
+    """
+    List of SSSD domains and their configuration that is related to the
+    upgrade process.
+    """
+    topic = SystemInfoTopic
+
+    domains = fields.List(fields.Model(SSSDDomainConfig), default=list())
+    """
+    SSSD Domains configuration.
+    """


### PR DESCRIPTION
Check SSSD configuration for changes in RHEL8 and report them.

These changes are:
- id_provider=local is no longer supported and will be ignored
- ldap_groups_use_matching_rule_in_chain was removed and will be ignored
- ldap_initgroups_use_matching_rule_in_chain was removed and will be ignored
- ldap_sudo_include_regexp changed default from true to false