### PR TITLE
selinux: fix getting facts

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
@@ -225,7 +225,8 @@ def get_selinux_status():
 
     try:
         outdata['runtime_mode'] = "enforcing" if selinux.security_getenforce() == 1 else "permissive"
-        enforce_mode = selinux.selinux_getenforcemode()
+        # FIXME: check selinux_getenforcemode[0] (that should be return value of a underneath function)
+        enforce_mode = selinux.selinux_getenforcemode()[1]
         if enforce_mode >= 0:
             outdata['static_mode'] = "enforcing" if enforce_mode == 1 else "permissive"
         else:

--- a/repos/system_upgrade/el7toel8/actors/systemfacts/tests/test_systemfacts_selinux.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/tests/test_systemfacts_selinux.py
@@ -3,6 +3,7 @@ import selinux
 from leapp.libraries.actor.systemfacts import get_selinux_status
 from leapp.models import SELinuxFacts
 
+# FIXME: create valid tests...
 
 def test_selinux_enabled_enforcing(monkeypatch):
     """
@@ -10,9 +11,9 @@ def test_selinux_enabled_enforcing(monkeypatch):
     """
     monkeypatch.setattr(selinux, 'is_selinux_mls_enabled', lambda: 1)
     monkeypatch.setattr(selinux, 'security_getenforce', lambda: 1)
-    monkeypatch.setattr(selinux, 'selinux_getenforcemode', lambda: 1)
+    monkeypatch.setattr(selinux, 'selinux_getenforcemode', lambda: [0, 1])
     monkeypatch.setattr(selinux, 'is_selinux_enabled', lambda: 1)
-    monkeypatch.setattr(selinux, 'selinux_getpolicytype', lambda: ('', 'targeted'))
+    monkeypatch.setattr(selinux, 'selinux_getpolicytype', lambda: [0, 'targeted'])
     expected_data = {'policy': 'targeted',
                      'mls_enabled': True,
                      'enabled': True,
@@ -27,9 +28,9 @@ def test_selinux_enabled_permissive(monkeypatch):
     """
     monkeypatch.setattr(selinux, 'is_selinux_mls_enabled', lambda: 1)
     monkeypatch.setattr(selinux, 'security_getenforce', lambda: 0)
-    monkeypatch.setattr(selinux, 'selinux_getenforcemode', lambda: 0)
+    monkeypatch.setattr(selinux, 'selinux_getenforcemode', lambda: [0, 0])
     monkeypatch.setattr(selinux, 'is_selinux_enabled', lambda: 1)
-    monkeypatch.setattr(selinux, 'selinux_getpolicytype', lambda: ('', 'targeted'))
+    monkeypatch.setattr(selinux, 'selinux_getpolicytype', lambda: [0, 'targeted'])
     expected_data = {'policy': 'targeted',
                      'mls_enabled': True,
                      'enabled': True,
@@ -44,9 +45,9 @@ def test_selinux_disabled(monkeypatch):
     """
     monkeypatch.setattr(selinux, 'is_selinux_mls_enabled', lambda: 0)
     monkeypatch.setattr(selinux, 'security_getenforce', lambda: 0)
-    monkeypatch.setattr(selinux, 'selinux_getenforcemode', lambda: 0)
+    monkeypatch.setattr(selinux, 'selinux_getenforcemode', lambda: [0, 0])
     monkeypatch.setattr(selinux, 'is_selinux_enabled', lambda: 0)
-    monkeypatch.setattr(selinux, 'selinux_getpolicytype', lambda: ('', 'targeted'))
+    monkeypatch.setattr(selinux, 'selinux_getpolicytype', lambda: [0, 'targeted'])
     expected_data = {'policy': 'targeted',
                      'mls_enabled': False,
                      'enabled': False,
@@ -68,7 +69,7 @@ def test_selinux_disabled_no_config_file(monkeypatch):
     monkeypatch.setattr(selinux, 'security_getenforce', lambda: 0)
     monkeypatch.setattr(selinux, 'selinux_getenforcemode', MockNoConfigFileOSError)
     monkeypatch.setattr(selinux, 'is_selinux_enabled', lambda: 0)
-    monkeypatch.setattr(selinux, 'selinux_getpolicytype', lambda: ('', 'targeted'))
+    monkeypatch.setattr(selinux, 'selinux_getpolicytype', lambda: [0, 'targeted'])
     expected_data = {'policy': 'targeted',
                      'mls_enabled': False,
                      'enabled': False,


### PR DESCRIPTION
    selinux: fix getting facts
    
    The selinux.selinux_getenforcemode function returns list
      [ret, int] - where int is -1 when disabled in config file
                                 0 when permissive
                                 1 when enforcing
                 - ret value is return value of underneath function(s).
    Originally the actor expected just int instead of list. Take just
    the second value now.
    
    FIXME: Ignoring for now the first value
