### PR TITLE
Do not install python2-docs, python3-docs

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -49,3 +49,5 @@ varnish-modules
 tpm2-abrmd
 squid
 python-docs
+python2-docs
+python3-docs


### PR DESCRIPTION
- Due to a bug in the peseventscanner actor described in https://github.com/oamg/leapp-repository/issues/177, if python-docs is installed, leapp correctly tells dnf to remove it but at the same time it tells dnf to install python2-docs and python3-docs based on the PES event about split of python-docs to python2-docs and python3-docs. That's incorrect and causes an error during transaction calculation:
```
Error: 
 Problem: cannot install the best candidate for the job
  - conflicting requests
```
- This is a temporary solution before the above issue is fixed
- This tries to fulfil the intent of the PR https://github.com/oamg/leapp-repository/pull/173