### PR TITLE
sane-backends migration actors

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/sanebackendsmigrate/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sanebackendsmigrate/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import InstalledRedHatSignedRPM
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class SanebackendsMigrate(Actor):
+    """
+    Actor for migrating sane-backends configuration files.
+
+    Adds USB quirks for support specific USB scanners if they
+    are not added during package manager transaction.
+    """
+
+    name = 'sanebackends_migrate'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = ()
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        library.update_sane()

--- a/repos/system_upgrade/el7toel8/actors/sanebackendsmigrate/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/sanebackendsmigrate/libraries/library.py
@@ -1,0 +1,319 @@
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM
+
+
+# Database of changes in configuration files of sane-backends
+# between RHELs
+
+CANON_DR = [
+    '# P-150M',
+    'usb 0x1083 0x162c',
+    '# DR-M160',
+    'option extra-status 1',
+    'option duplex-offset 400',
+    'usb 0x1083 0x163e',
+    '# DR-M140',
+    'option extra-status 1',
+    'option duplex-offset 400',
+    'usb 0x1083 0x163f',
+    '# DR-C125',
+    'option duplex-offset 400',
+    'usb 0x1083 0x1640',
+    '# DR-P215',
+    'usb 0x1083 0x1641',
+    '# FSU-201',
+    'usb 0x1083 0x1648',
+    '# DR-C130',
+    'usb 0x1083 0x164a',
+    '# DR-P208',
+    'usb 0x1083 0x164b',
+    '# DR-G1130',
+    'option buffer-size 8000000',
+    'usb 0x1083 0x164f',
+    '# DR-G1100',
+    'option buffer-size 8000000',
+    'usb 0x1083 0x1650',
+    '# DR-C120',
+    'usb 0x1083 0x1651',
+    '# P-201',
+    'usb 0x1083 0x1652',
+    '# DR-F120',
+    'option duplex-offset 1640',
+    'usb 0x1083 0x1654',
+    '# DR-M1060',
+    'usb 0x1083 0x1657',
+    '# DR-C225',
+    'usb 0x1083 0x1658',
+    '# DR-P215II',
+    'usb 0x1083 0x1659',
+    '# P-215II',
+    'usb 0x1083 0x165b',
+    '# DR-P208II',
+    'usb 0x1083 0x165d',
+    '# P-208II',
+    'usb 0x1083 0x165f'
+]
+
+CARDSCAN = [
+    '# Sanford Cardscan 800c',
+    'usb 0x0451 0x6250'
+]
+
+DLL = ['epsonds']
+
+EPJITSU = [
+    '# Fujitsu fi-65F',
+    'firmware /usr/share/sane/epjitsu/65f_0A01.nal',
+    'usb 0x04c5 0x11bd',
+    '# Fujitsu S1100',
+    'firmware /usr/share/sane/epjitsu/1100_0B00.nal',
+    'usb 0x04c5 0x1200',
+    '# Fujitsu S1300i',
+    'firmware /usr/share/sane/epjitsu/1300i_0D12.nal',
+    'usb 0x04c5 0x128d',
+    '# Fujitsu S1100i',
+    'firmware /usr/share/sane/epjitsu/1100i_0A00.nal',
+    'usb 0x04c5 0x1447'
+]
+
+FUJITSU = [
+    '#fi-6125',
+    'usb 0x04c5 0x11ee',
+    '#fi-6225',
+    'usb 0x04c5 0x11ef',
+    '#ScanSnap SV600',
+    'usb 0x04c5 0x128e',
+    '#fi-7180',
+    'usb 0x04c5 0x132c',
+    '#fi-7280',
+    'usb 0x04c5 0x132d',
+    '#fi-7160',
+    'usb 0x04c5 0x132e',
+    '#fi-7260',
+    'usb 0x04c5 0x132f',
+    '#ScanSnap iX500EE',
+    'usb 0x04c5 0x13f3',
+    '#ScanSnap iX100',
+    'usb 0x04c5 0x13f4',
+    '#ScanPartner SP25',
+    'usb 0x04c5 0x1409',
+    '#ScanPartner SP30',
+    'usb 0x04c5 0x140a',
+    '#ScanPartner SP30F',
+    'usb 0x04c5 0x140c',
+    '#fi-6140ZLA',
+    'usb 0x04c5 0x145f',
+    '#fi-6240ZLA',
+    'usb 0x04c5 0x1460',
+    '#fi-6130ZLA',
+    'usb 0x04c5 0x1461',
+    '#fi-6230ZLA',
+    'usb 0x04c5 0x1462',
+    '#fi-6125ZLA',
+    'usb 0x04c5 0x1463',
+    '#fi-6225ZLA',
+    'usb 0x04c5 0x1464',
+    '#fi-6135ZLA',
+    'usb 0x04c5 0x146b',
+    '#fi-6235ZLA',
+    'usb 0x04c5 0x146c',
+    '#fi-6120ZLA',
+    'usb 0x04c5 0x146d',
+    '#fi-6220ZLA',
+    'usb 0x04c5 0x146e',
+    '#N7100',
+    'usb 0x04c5 0x146f',
+    '#fi-6400',
+    'usb 0x04c5 0x14ac',
+    '#fi-7480',
+    'usb 0x04c5 0x14b8',
+    '#fi-6420',
+    'usb 0x04c5 0x14bd',
+    '#fi-7460',
+    'usb 0x04c5 0x14be',
+    '#fi-7140',
+    'usb 0x04c5 0x14df',
+    '#fi-7240',
+    'usb 0x04c5 0x14e0',
+    '#fi-7135',
+    'usb 0x04c5 0x14e1',
+    '#fi-7235',
+    'usb 0x04c5 0x14e2',
+    '#fi-7130',
+    'usb 0x04c5 0x14e3',
+    '#fi-7230',
+    'usb 0x04c5 0x14e4',
+    '#fi-7125',
+    'usb 0x04c5 0x14e5',
+    '#fi-7225',
+    'usb 0x04c5 0x14e6',
+    '#fi-7120',
+    'usb 0x04c5 0x14e7',
+    '#fi-7220',
+    'usb 0x04c5 0x14e8',
+    '#fi-400F',
+    'usb 0x04c5 0x151e',
+    '#fi-7030',
+    'usb 0x04c5 0x151f',
+    '#fi-7700',
+    'usb 0x04c5 0x1520',
+    '#fi-7600',
+    'usb 0x04c5 0x1521',
+    '#fi-7700S',
+    'usb 0x04c5 0x1522'
+]
+
+CANON = [
+    '# Canon LiDE 80',
+    'usb 0x04a9 0x2214',
+    '# Canon LiDE 120',
+    'usb 0x04a9 0x190e',
+    '# Canon LiDE 220',
+    'usb 0x04a9 0x190f'
+]
+
+XEROX_MFP = [
+    '#Samsung X4300 Series',
+    'usb 0x04e8 0x3324',
+    '#Samsung K4350 Series',
+    'usb 0x04e8 0x3325',
+    '#Samsung X7600 Series',
+    'usb 0x04e8 0x3326',
+    '#Samsung K7600 Series',
+    'usb 0x04e8 0x3327',
+    '#Samsung K703 Series',
+    'usb 0x04e8 0x3331',
+    '#Samsung X703 Series',
+    'usb 0x04e8 0x3332',
+    '#Samsung M458x Series',
+    'usb 0x04e8 0x346f',
+    '#Samsung M4370 5370 Series',
+    'usb 0x04e8 0x3471',
+    '#Samsung X401 Series',
+    'usb 0x04e8 0x3477',
+    '#Samsung K401 Series',
+    'usb 0x04e8 0x3478',
+    '#Samsung K3250 Series',
+    'usb 0x04e8 0x3481',
+    '#Samsung X3220 Series',
+    'usb 0x04e8 0x3482'
+]
+
+NEW_QUIRKS = {
+    '/etc/sane.d/canon_dr.conf': CANON_DR,
+    '/etc/sane.d/cardscan.conf': CARDSCAN,
+    '/etc/sane.d/dll.conf': DLL,
+    '/etc/sane.d/epjitsu.conf': EPJITSU,
+    '/etc/sane.d/fujitsu.conf': FUJITSU,
+    '/etc/sane.d/canon.conf': CANON,
+    '/etc/sane.d/xerox_mfp.conf': XEROX_MFP
+}
+"""
+Dictionary of configuration files which changes in 1.0.27
+"""
+
+
+def _macro_exists(path, macro):
+    """
+    Check if macro is in the file.
+
+    :param str path: string representing the full path of the config file
+    :param str macro: new directive to be added
+    :return boolean res: macro does/does not exist in the file
+    """
+    with open(path, 'r') as f:
+        lines = f.readlines()
+
+    for line in lines:
+        if line.lstrip().startswith(macro):
+            return True
+    return False
+
+
+def _append_string(path, content):
+    """
+    Append string at the end of file.
+
+    :param str path: string representing the full path of file
+    :param str content: preformatted string to be added
+    """
+    with open(path, 'a') as f:
+        f.write(content)
+
+
+def update_config(path,
+                  quirks,
+                  check_function=_macro_exists,
+                  append_function=_append_string):
+    """
+    Insert expected content into the file on the path if it is not
+    in the file already.
+
+    :param str path: string representing the full path of the config file
+    :param func check_function: function to be used to check if string is in the file
+    :param func append_function: function to be used to append string
+    """
+
+    macros = []
+    for macro in quirks:
+        if not check_function(path, macro):
+            macros.append(macro)
+
+    if not macros:
+        return
+
+    fmt_input = "\n{comment_line}\n{content}\n".format(comment_line='# content added by Leapp',
+                                                       content='\n'.join(macros))
+
+    try:
+        append_function(path, fmt_input)
+    except IOError:
+        raise IOError('Error during writing to file: {}.'.format(path))
+
+
+def _check_package(pkg_name):
+    """
+    Checks if the package is installed and signed by Red Hat
+
+    :param str pkg_name: name of package
+    """
+
+    return has_package(InstalledRedHatSignedRPM, pkg_name)
+
+
+def update_sane(debug_log=api.current_logger().debug,
+                error_log=api.current_logger().error,
+                is_installed=_check_package,
+                append_function=_append_string,
+                check_function=_macro_exists):
+    """
+    Iterate over dictionary and updates each configuration file.
+
+    :param func debug_log: function for debug logging
+    :param func error_log: function for error logging
+    :param func is_installed: checks if the package is installed
+    :param func append_function: appends a string into file
+    :param func check_function: checks if a string exists in file
+    """
+
+    error_list = []
+
+    if not is_installed('sane-backends'):
+        return
+
+    for path, lines in NEW_QUIRKS.items():
+
+        debug_log('Updating SANE configuration file {}.'.format(path))
+
+        try:
+            update_config(path, lines, check_function, append_function)
+        except (OSError, IOError) as error:
+            error_list.append((path, error))
+
+    if error_list:
+        error_log('The files below have not been modified '
+                  '(error message included):' +
+                  ''.join(['\n    - {}: {}'.format(err[0], err[1])
+                          for err in error_list]))
+        return

--- a/repos/system_upgrade/el7toel8/actors/sanebackendsmigrate/tests/test_update_config.py
+++ b/repos/system_upgrade/el7toel8/actors/sanebackendsmigrate/tests/test_update_config.py
@@ -1,0 +1,231 @@
+import pytest
+
+from leapp.libraries.actor.library import CANON, CANON_DR, CARDSCAN, DLL
+from leapp.libraries.actor.library import EPJITSU, FUJITSU, XEROX_MFP
+from leapp.libraries.actor.library import update_config
+
+
+def _pattern_exists(content, macro):
+    for line in content.split('\n'):
+        if line.lstrip().startswith(macro):
+            return True
+    return False
+
+
+def _create_original_file(file_content):
+    content = ''
+    for line in file_content:
+        fmt_line = '{}\n'.format(line)
+        content += fmt_line
+    return content
+
+
+def _create_expected_file(original_content, new_content):
+    macros = []
+    for line in new_content:
+        if not _pattern_exists(original_content, line):
+            macros.append(line)
+
+    fmt_input = ''
+    if macros:
+        fmt_input = "\n{comment_line}\n{content}\n".format(comment_line='# content added by Leapp',
+                                                           content='\n'.join(macros))
+
+    return '\n'.join((original_content, fmt_input))
+
+
+testdata = [
+    (
+        _create_original_file(['']),
+        _create_expected_file('', CANON),
+        CANON
+    ),
+    (
+        _create_original_file(['']),
+        _create_expected_file('', CANON_DR),
+        CANON_DR
+    ),
+    (
+        _create_original_file(['']),
+        _create_expected_file('', CARDSCAN),
+        CARDSCAN
+    ),
+    (
+        _create_original_file(['']),
+        _create_expected_file('', DLL),
+        DLL
+    ),
+    (
+        _create_original_file(['']),
+        _create_expected_file('', EPJITSU),
+        EPJITSU
+    ),
+    (
+        _create_original_file(['']),
+        _create_expected_file('', FUJITSU),
+        FUJITSU
+    ),
+    (
+        _create_original_file(['']),
+        _create_expected_file('', XEROX_MFP),
+        XEROX_MFP
+    ),
+    (
+        _create_original_file(['fdfdfdr']),
+        _create_expected_file('fdfdfdr', CANON),
+        CANON
+    ),
+    (
+        _create_original_file(['fdfdfdr']),
+        _create_expected_file('fdfdfdr', CANON_DR),
+        CANON_DR
+    ),
+    (
+        _create_original_file(['fdfdfdr']),
+        _create_expected_file('fdfdfdr', CARDSCAN),
+        CARDSCAN
+    ),
+    (
+        _create_original_file(['fdfdfdr']),
+        _create_expected_file('fdfdfdr', DLL),
+        DLL
+    ),
+    (
+        _create_original_file(['fdfdfdr']),
+        _create_expected_file('fdfdfdr', EPJITSU),
+        EPJITSU
+    ),
+    (
+        _create_original_file(['fdfdfdr']),
+        _create_expected_file('fdfdfdr', FUJITSU),
+        FUJITSU
+    ),
+    (
+        _create_original_file(['fdfdfdr']),
+        _create_expected_file('fdfdfdr', XEROX_MFP),
+        XEROX_MFP
+    ),
+    (
+        _create_original_file(['usb 0x04a9 0x2214']),
+        _create_expected_file('usb 0x04a9 0x2214', CANON),
+        CANON
+    ),
+    (
+        _create_original_file(['usb 0x1083 0x162c']),
+        _create_expected_file('usb 0x1083 0x162c', CANON_DR),
+        CANON_DR
+    ),
+    (
+        _create_original_file(['usb 0x0451 0x6250']),
+        _create_expected_file('usb 0x0451 0x6250', CARDSCAN),
+        CARDSCAN
+    ),
+    (
+        _create_original_file(['#usb 0x0451 0x6250']),
+        _create_expected_file('#usb 0x0451 0x6250', CARDSCAN),
+        CARDSCAN
+    ),
+    (
+        _create_original_file(['epsonds']),
+        _create_expected_file('epsonds', DLL),
+        DLL
+    ),
+    (
+        _create_original_file(['usb 0x04c5 0x11bd']),
+        _create_expected_file('usb 0x04c5 0x11bd', EPJITSU),
+        EPJITSU
+    ),
+    (
+        _create_original_file(['usb 0x04c5 0x132c']),
+        _create_expected_file('usb 0x04c5 0x132c', FUJITSU),
+        FUJITSU
+    ),
+    (
+        _create_original_file(['usb 0x04e8 0x3471']),
+        _create_expected_file('usb 0x04e8 0x3471', XEROX_MFP),
+        XEROX_MFP
+    ),
+    (
+        _create_original_file(CANON),
+        _create_original_file(CANON),
+        CANON
+    ),
+    (
+        _create_original_file(CANON_DR),
+        _create_original_file(CANON_DR),
+        CANON_DR
+    ),
+    (
+        _create_original_file(CARDSCAN),
+        _create_original_file(CARDSCAN),
+        CARDSCAN
+    ),
+    (
+        _create_original_file(DLL),
+        _create_original_file(DLL),
+        DLL
+    ),
+    (
+        _create_original_file(EPJITSU),
+        _create_original_file(EPJITSU),
+        EPJITSU
+    ),
+    (
+        _create_original_file(FUJITSU),
+        _create_original_file(FUJITSU),
+        FUJITSU
+    ),
+    (
+        _create_original_file(XEROX_MFP),
+        _create_original_file(XEROX_MFP),
+        XEROX_MFP
+    )
+]
+"""
+3-tuple of original file, file after migration and list of lines which
+will be tried to add
+"""
+
+
+class MockFile(object):
+    def __init__(self, path, content=None):
+        self.path = path
+        self.content = content
+        self.error = False
+
+    def append(self, path, content):
+        if path != self.path:
+            self.error = True
+        if not self.error:
+            self.content += content
+            return self.content
+        raise IOError('Error during writing to file: {}.'.format(path))
+
+    def exists(self, path, macro):
+        for line in self.content.split('\n'):
+            if line.lstrip().startswith(macro) and self.path == path:
+                return True
+        return False
+
+
+def test_update_config_file_errors():
+    path = 'foo'
+    new_content = ['fdfgdfg', 'gnbfgnf']
+
+    f = MockFile(path, content='')
+
+    with pytest.raises(IOError):
+        update_config('bar', new_content, f.exists, f.append)
+
+    assert f.content == ''
+
+
+@pytest.mark.parametrize('orig_content,expected_result,content_to_add', testdata)
+def test_update_config_append_into_file(orig_content,
+                                        expected_result,
+                                        content_to_add):
+    f = MockFile('foo', orig_content)
+
+    update_config('foo', content_to_add, f.exists, f.append)
+
+    assert f.content == expected_result

--- a/repos/system_upgrade/el7toel8/actors/sanebackendsmigrate/tests/test_update_sane.py
+++ b/repos/system_upgrade/el7toel8/actors/sanebackendsmigrate/tests/test_update_sane.py
@@ -1,0 +1,116 @@
+import pytest
+
+from leapp.libraries.actor.library import update_sane, NEW_QUIRKS
+
+
+testdata = [
+    {'sane-backends': '/etc/sane.d/canon_dr.conf'},
+    {'sane-backends': ''},
+    {'ble': ''}
+]
+
+
+class MockLogger(object):
+    def __init__(self):
+        self.debugmsg = ''
+        self.errmsg = ''
+
+    def debug(self, message):
+        self.debugmsg += message
+
+    def error(self, message):
+        self.errmsg += message
+
+
+class MockPackage(object):
+    def __init__(self, name, config):
+        self.name = name
+        self.config = config
+        self.config_content = ''
+
+
+class MockPackageSet(object):
+    def __init__(self):
+        self.installed_packages = None
+
+    def add_packages(self, pkgs):
+        if self.installed_packages is None:
+            self.installed_packages = []
+
+        for rpm, config in pkgs.items():
+            self.installed_packages.append(MockPackage(rpm, config))
+
+    def is_installed(self, pkg):
+        for rpm in self.installed_packages:
+            if pkg == rpm.name:
+                return True
+        return False
+
+    def append_content(self, path, content):
+        found = False
+
+        for rpm in self.installed_packages:
+            if path == rpm.config:
+                found = True
+                rpm.config_content += content
+        if not found:
+            raise IOError('Error during writing to file: {}.'.format(path))
+
+    def check_content(self, path, content):
+        found = False
+
+        for rpm in self.installed_packages:
+            if path == rpm.config and content in rpm.config_content:
+                found = True
+
+        return found
+
+
+class ExpectedOutput(object):
+    def __init__(self):
+        self.debugmsg = ''
+        self.errmsg = ''
+
+    def create(self, rpms):
+        error_list = []
+        found = False
+
+        for pkg, config in rpms.items():
+            if pkg == 'sane-backends':
+                found = True
+                break
+
+        if found:
+            for sane_config in NEW_QUIRKS.keys():
+                self.debugmsg += ('Updating SANE configuration file {}.'
+                                  .format(sane_config))
+                if config == '' or config != sane_config:
+                    error_list.append((sane_config,
+                                       'Error during writing to file: {}.'
+                                       .format(sane_config)))
+
+        if error_list:
+            self.errmsg = ('The files below have not been modified '
+                           '(error message included):' +
+                           ''.join(['\n    - {}: {}'.format(err[0], err[1])
+                                   for err in error_list]))
+
+
+@pytest.mark.parametrize("rpms", testdata)
+def test_actor_check_report(rpms):
+    logger = MockLogger()
+    installed_packages = MockPackageSet()
+
+    installed_packages.add_packages(rpms)
+
+    expected = ExpectedOutput()
+    expected.create(rpms)
+
+    update_sane(logger.debug,
+                logger.error,
+                installed_packages.is_installed,
+                installed_packages.append_content,
+                installed_packages.check_content)
+
+    assert expected.debugmsg == logger.debugmsg
+    assert expected.errmsg == logger.errmsg


### PR DESCRIPTION
Hi!

I created two actors for sane-backends migration - sanebackends-report and sanebackends-migration. The code is currently 'working prototype', tested only manually for now.
I will move all 'non-actor' methods to outside module and create unit tests after my PTO, would you mind reviewing the code in meanwhile?

P.S. License of library is GPLv2+, because of the line in paragraph which is in the .py file - 'version 2 of the License, or (at your option) any later version'.

Thank you in advance!

Zdenek