### PR TITLE
Add tcp_wrappers and vsftpd actors

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/tcpwrappersconfigread/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/tcpwrappersconfigread/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import TcpWrappersFacts
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class TcpWrappersConfigRead(Actor):
+    '''
+    Parse tcp_wrappers configuration files /etc/hosts.{allow,deny}.
+    '''
+
+    name = 'tcp_wrappers_config_read'
+    consumes = ()
+    produces = (TcpWrappersFacts,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        self.produce(library.get_tcp_wrappers_facts())

--- a/repos/system_upgrade/el7toel8/actors/tcpwrappersconfigread/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/tcpwrappersconfigread/libraries/library.py
@@ -1,0 +1,54 @@
+import errno
+import re
+
+from leapp.libraries.stdlib import api
+from leapp.models import DaemonList, TcpWrappersFacts
+
+CONFIG_FILES = ['/etc/hosts.allow', '/etc/hosts.deny']
+
+
+def _read_file(path):
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def _get_lines(content):
+    content = re.sub(r'\\\n', '', content)
+    return content.split('\n')
+
+
+def _is_comment(line):
+    return len(line) == 0 or line.isspace() or line.startswith('#')
+
+
+def _get_daemon_list_in_line(line):
+    daemon_list = line.split(':', 1)[0]
+    daemon_list = re.split(',| |\t', daemon_list)
+    daemon_list = [word for word in daemon_list if len(word) > 0]
+    return DaemonList(value=daemon_list)
+
+
+def _get_daemon_lists_in_file(path, read_func=_read_file):
+    ret = []
+    try:
+        content = read_func(path)
+    except IOError as e:
+        if e.errno != errno.ENOENT:
+            api.current_logger().warning('Failed to read %s: %s' % (path, e))
+        return ret
+    lines = [line for line in _get_lines(content) if not _is_comment(line)]
+    for line in lines:
+        ret.append(_get_daemon_list_in_line(line))
+    return ret
+
+
+def _get_daemon_lists(read_func=_read_file):
+    daemon_lists = []
+    for path in CONFIG_FILES:
+        daemon_lists.extend(_get_daemon_lists_in_file(path, read_func=read_func))
+    return daemon_lists
+
+
+def get_tcp_wrappers_facts(read_func=_read_file):
+    daemon_lists = _get_daemon_lists(read_func=read_func)
+    return TcpWrappersFacts(daemon_lists=daemon_lists)

--- a/repos/system_upgrade/el7toel8/actors/tcpwrappersconfigread/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/tcpwrappersconfigread/tests/test_library.py
@@ -1,0 +1,168 @@
+import errno
+
+from leapp.libraries.actor import library
+from leapp.libraries.common.testutils import make_IOError
+
+
+class MockFileReader(object):
+    def __init__(self):
+        self.files = {}
+        self.files_read = {}
+        self.read_called = 0
+
+    def _increment_read_counters(self, path):
+        self.read_called += 1
+        self.files_read.setdefault(path, 0)
+        self.files_read[path] += 1
+
+    def read(self, path):
+        self._increment_read_counters(path)
+        try:
+            return self.files[path]
+        except KeyError:
+            raise make_IOError(errno.ENOENT)
+
+
+def test_get_daemon_list_in_line_simple():
+    line = 'vsftpd : 192.168.2.*'
+    daemon_list = library._get_daemon_list_in_line(line)
+    assert daemon_list.value == ['vsftpd']
+
+
+def test_get_daemon_list_in_line_multiple():
+    line = 'vsftpd, sendmail : 192.168.2.*'
+    daemon_list = library._get_daemon_list_in_line(line)
+    assert daemon_list.value == ['vsftpd', 'sendmail']
+
+    line = 'ALL EXCEPT sendmail : 192.168.2.*'
+    daemon_list = library._get_daemon_list_in_line(line)
+    assert daemon_list.value == ['ALL', 'EXCEPT', 'sendmail']
+
+    # different separators
+    line = 'vsftpd,sendmail : 192.168.2.*'
+    daemon_list = library._get_daemon_list_in_line(line)
+    assert daemon_list.value == ['vsftpd', 'sendmail']
+
+    line = 'vsftpd\tsendmail : 192.168.2.*'
+    daemon_list = library._get_daemon_list_in_line(line)
+    assert daemon_list.value == ['vsftpd', 'sendmail']
+
+    line = 'vsftpd, \t sendmail : 192.168.2.*'
+    daemon_list = library._get_daemon_list_in_line(line)
+    assert daemon_list.value == ['vsftpd', 'sendmail']
+
+
+def test_get_daemon_list_in_line_malformed():
+    line = 'foo'
+    daemon_list = library._get_daemon_list_in_line(line)
+    # tcp_wrappers actually ignores lines like this, but there's no harm in being
+    # over-sensitive here.
+    assert daemon_list.value == ['foo']
+
+
+def test_get_lines_empty():
+    content = ''
+    lines = library._get_lines(content)
+    assert lines == ['']
+
+
+def test_get_lines_simple():
+    content = 'vsftpd : 192.168.2.*\n' \
+              'ALL : 192.168.1.*\n'
+    lines = library._get_lines(content)
+    assert lines == content.split('\n')
+
+
+def test_get_lines_continued_line():
+    content = 'vsftpd : 192.168\\\n.2.*'
+    lines = library._get_lines(content)
+    expected = ['vsftpd : 192.168.2.*']
+    assert lines == expected
+
+
+def test_get_lines_backslash_followed_by_whitespace():
+    content = 'foo \\ \n' \
+              'this is not a continuation line'
+    lines = library._get_lines(content)
+    expected = ['foo \\ ', 'this is not a continuation line']
+    assert lines == expected
+
+
+def test_get_lines_continued_comment():
+    content = '# foo \\\n' \
+              'this is still a comment'
+    lines = library._get_lines(content)
+    expected = ['# foo this is still a comment']
+    assert lines == expected
+
+
+def test_is_comment():
+    assert library._is_comment('') is True
+    assert library._is_comment('  ') is True
+    assert library._is_comment('# foo') is True
+    assert library._is_comment('#') is True
+    assert library._is_comment(' # foo') is False
+    assert library._is_comment('foo') is False
+    assert library._is_comment(' foo') is False
+
+
+def test_get_daemon_lists_in_file():
+    path = '/etc/hosts.allow'
+    reader = MockFileReader()
+    reader.files[path] = 'vsftpd : 192.168.2.*\n' \
+                         'ALL : 192.168.1.*\n'
+
+    daemon_lists = library._get_daemon_lists_in_file(path, read_func=reader.read)
+
+    num_lines = 2
+    assert len(daemon_lists) == num_lines
+    assert daemon_lists[0].value == ['vsftpd']
+    assert daemon_lists[1].value == ['ALL']
+
+
+def test_get_daemon_lists_in_file_nonexistent():
+    reader = MockFileReader()
+    daemon_lists = library._get_daemon_lists_in_file('/etc/hosts.allow', read_func=reader.read)
+    assert len(daemon_lists) == 0
+
+
+def test_get_daemon_lists():
+    reader = MockFileReader()
+    reader.files['/etc/hosts.allow'] = 'vsftpd : 192.168.2.*\n' \
+                                       'ALL : 192.168.1.*\n'
+    reader.files['/etc/hosts.deny'] = 'sendmail : 192.168.2.*\n'
+
+    daemon_lists = library._get_daemon_lists(read_func=reader.read)
+
+    num_lines = 3
+    assert len(daemon_lists) == num_lines
+    assert daemon_lists[0].value == ['vsftpd']
+    assert daemon_lists[1].value == ['ALL']
+    assert daemon_lists[2].value == ['sendmail']
+
+
+def test_get_daemon_lists_nonexistent_config():
+    reader = MockFileReader()
+    daemon_lists = library._get_daemon_lists(read_func=reader.read)
+    assert len(daemon_lists) == 0
+
+
+def test_get_tcp_wrappers_facts():
+    reader = MockFileReader()
+    reader.files['/etc/hosts.allow'] = 'vsftpd : 192.168.2.*\n' \
+                                       'ALL : 192.168.1.*\n'
+    reader.files['/etc/hosts.deny'] = 'sendmail : 192.168.2.*\n'
+
+    facts = library.get_tcp_wrappers_facts(read_func=reader.read)
+
+    num_lines = 3
+    assert len(facts.daemon_lists) == num_lines
+    assert facts.daemon_lists[0].value == ['vsftpd']
+    assert facts.daemon_lists[1].value == ['ALL']
+    assert facts.daemon_lists[2].value == ['sendmail']
+
+
+def test_get_tcp_wrappers_facts_nonexistent_config():
+    reader = MockFileReader()
+    facts = library.get_tcp_wrappers_facts(read_func=reader.read)
+    assert len(facts.daemon_lists) == 0

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigcheck/actor.py
@@ -1,0 +1,26 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import TcpWrappersFacts, VsftpdFacts
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class VsftpdConfigCheck(Actor):
+    """
+    Checks whether the vsftpd configuration is supported in RHEL-8. Namely checks that
+    configuration files don't set tcp_wrappers=YES and vsftpd-related configuration is
+    not present in tcp_wrappers configuration files at the same time.
+    """
+
+    name = 'vsftpd_config_check'
+    consumes = (TcpWrappersFacts, VsftpdFacts,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        try:
+            vsftpd_facts = next(self.consume(VsftpdFacts))
+        except StopIteration:
+            return
+        tcp_wrappers_facts = next(self.consume(TcpWrappersFacts))
+        library.check_config_supported(tcp_wrappers_facts, vsftpd_facts)

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigcheck/libraries/library.py
@@ -1,0 +1,20 @@
+from leapp.libraries.common.reporting import report_with_links
+from leapp.libraries.common.tcpwrappersutils import config_applies_to_daemon
+
+
+def check_config_supported(tcpwrap_facts, vsftpd_facts):
+    bad_configs = [config.path for config in vsftpd_facts.configs if config.tcp_wrappers]
+    if len(bad_configs) > 0 and config_applies_to_daemon(tcpwrap_facts, 'vsftpd'):
+        list_separator_fmt = '\n    - '
+        report_with_links(title='Unsupported vsftpd configuration',
+                          summary=('tcp_wrappers support has been removed in RHEL-8. '
+                                   'Some configuration files set the tcp_wrappers option to true and '
+                                   'there is some vsftpd-related configuration in /etc/hosts.deny '
+                                   'or /etc/hosts.allow. Please migrate it manually. '
+                                   'The list of problematic configuration files:{}{}'
+                                  ).format(list_separator_fmt,
+                                           list_separator_fmt.join(bad_configs)),
+                          links=[{'title': 'Replacing TCP Wrappers in RHEL 8',
+                                  'href': 'https://access.redhat.com/solutions/3906701'}],
+                          severity='high',
+                          flags=['inhibitor'])

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigcheck/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigcheck/tests/test_library.py
@@ -1,0 +1,81 @@
+from leapp.models import DaemonList, TcpWrappersFacts, VsftpdConfig, VsftpdFacts
+from leapp.reporting import Report
+from leapp.snactor.fixture import current_actor_context
+
+
+def test_actor_with_unsupported_tcpwrap_and_vsftpd_config(current_actor_context):
+    config1 = VsftpdConfig(path='/etc/vsftpd/foo.conf', tcp_wrappers=False)
+    config2 = VsftpdConfig(path='/etc/vsftpd/bar.conf', tcp_wrappers=True)
+    vsftpd_facts = VsftpdFacts(configs=[config1, config2])
+    daemon_list = DaemonList(value=['vsftpd'])
+    tcpwrap_facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+
+    current_actor_context.feed(vsftpd_facts)
+    current_actor_context.feed(tcpwrap_facts)
+    current_actor_context.run()
+    report = current_actor_context.consume(Report)[0]
+
+    assert 'inhibitor' in report.flags
+    assert 'foo.conf' not in report.detail['summary']
+    assert 'bar.conf' in report.detail['summary']
+
+
+def test_actor_with_unsupported_tcpwrap_multiple_unsupported_vsftpd_configs(current_actor_context):
+    config1 = VsftpdConfig(path='/etc/vsftpd/foo.conf', tcp_wrappers=True)
+    config2 = VsftpdConfig(path='/etc/vsftpd/bar.conf', tcp_wrappers=False)
+    config3 = VsftpdConfig(path='/etc/vsftpd/goo.conf', tcp_wrappers=True)
+    vsftpd_facts = VsftpdFacts(configs=[config1, config2, config3])
+    daemon_list = DaemonList(value=['vsftpd'])
+    tcpwrap_facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+
+    current_actor_context.feed(vsftpd_facts)
+    current_actor_context.feed(tcpwrap_facts)
+    current_actor_context.run()
+    report = current_actor_context.consume(Report)[0]
+
+    assert 'inhibitor' in report.flags
+    assert 'foo.conf' in report.detail['summary']
+    assert 'bar.conf' not in report.detail['summary']
+    assert 'goo.conf' in report.detail['summary']
+
+
+def test_actor_with_unsupported_tcpwrap_config(current_actor_context):
+    config1 = VsftpdConfig(path='/etc/vsftpd/foo.conf', tcp_wrappers=False)
+    config2 = VsftpdConfig(path='/etc/vsftpd/bar.conf', tcp_wrappers=None)
+    vsftpd_facts = VsftpdFacts(configs=[config1, config2])
+    daemon_list = DaemonList(value=['vsftpd'])
+    tcpwrap_facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+
+    current_actor_context.feed(vsftpd_facts)
+    current_actor_context.feed(tcpwrap_facts)
+    current_actor_context.run()
+
+    assert not current_actor_context.consume(Report)
+
+
+def test_actor_with_unsupported_vsftpd_config(current_actor_context):
+    config1 = VsftpdConfig(path='/etc/vsftpd/foo.conf', tcp_wrappers=False)
+    config2 = VsftpdConfig(path='/etc/vsftpd/bar.conf', tcp_wrappers=True)
+    vsftpd_facts = VsftpdFacts(configs=[config1, config2])
+    daemon_list = DaemonList(value=['all', 'except', 'vsftpd'])
+    tcpwrap_facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+
+    current_actor_context.feed(vsftpd_facts)
+    current_actor_context.feed(tcpwrap_facts)
+    current_actor_context.run()
+
+    assert not current_actor_context.consume(Report)
+
+
+def test_actor_with_supported_tcpwrap_and_vsftpd_config(current_actor_context):
+    config1 = VsftpdConfig(path='/etc/vsftpd/foo.conf', tcp_wrappers=False)
+    config2 = VsftpdConfig(path='/etc/vsftpd/bar.conf', tcp_wrappers=False)
+    vsftpd_facts = VsftpdFacts(configs=[config1, config2])
+    daemon_list = DaemonList(value=['all', 'except', 'vsftpd'])
+    tcpwrap_facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+
+    current_actor_context.feed(vsftpd_facts)
+    current_actor_context.feed(tcpwrap_facts)
+    current_actor_context.run()
+
+    assert not current_actor_context.consume(Report)

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import InstalledRedHatSignedRPM, VsftpdFacts
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class VsftpdConfigRead(Actor):
+    '''
+    Reads vsftpd configuration files (/etc/vsftpd/*.conf) and extracts necessary information.
+    '''
+
+    name = 'vsftpd_config_read'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (VsftpdFacts,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        installed_rpm_facts = next(self.consume(InstalledRedHatSignedRPM))
+        if library.is_processable(installed_rpm_facts):
+            self.produce(library.get_vsftpd_facts())

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/libraries/config_parser.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/libraries/config_parser.py
@@ -1,0 +1,103 @@
+class ParsingError(Exception):
+    pass
+
+
+class VsftpdConfigOptionParser(object):
+    def _get_string_options(self):
+        return ["secure_chroot_dir", "ftp_username", "chown_username", "xferlog_file",
+                "vsftpd_log_file", "message_file", "nopriv_user", "ftpd_banner",
+                "banned_email_file", "chroot_list_file", "pam_service_name", "guest_username",
+                "userlist_file", "anon_root", "local_root", "banner_file", "pasv_address",
+                "listen_address", "user_config_dir", "listen_address6", "cmds_allowed",
+                "hide_file", "deny_file", "user_sub_token", "email_password_file",
+                "rsa_cert_file", "dsa_cert_file", "dh_param_file", "ecdh_param_file",
+                "ssl_ciphers", "rsa_private_key_file", "dsa_private_key_file", "ca_certs_file",
+                "cmds_denied"]
+
+    def _get_boolean_options(self):
+        return ["anonymous_enable", "local_enable", "pasv_enable", "port_enable",
+                "chroot_local_user", "write_enable", "anon_upload_enable",
+                "anon_mkdir_write_enable", "anon_other_write_enable", "chown_uploads",
+                "connect_from_port_20", "xferlog_enable", "dirmessage_enable",
+                "anon_world_readable_only", "async_abor_enable", "ascii_upload_enable",
+                "ascii_download_enable", "one_process_model", "xferlog_std_format",
+                "pasv_promiscuous", "deny_email_enable", "chroot_list_enable",
+                "setproctitle_enable", "text_userdb_names", "ls_recurse_enable",
+                "log_ftp_protocol", "guest_enable", "userlist_enable", "userlist_deny",
+                "use_localtime", "check_shell", "hide_ids", "listen", "port_promiscuous",
+                "passwd_chroot_enable", "no_anon_password", "tcp_wrappers", "use_sendfile",
+                "force_dot_files", "listen_ipv6", "dual_log_enable", "syslog_enable",
+                "background", "virtual_use_local_privs", "session_support", "download_enable",
+                "dirlist_enable", "chmod_enable", "secure_email_list_enable",
+                "run_as_launching_user", "no_log_lock", "ssl_enable", "allow_anon_ssl",
+                "force_local_logins_ssl", "force_local_data_ssl", "ssl_sslv2", "ssl_sslv3",
+                "ssl_tlsv1", "ssl_tlsv1_1", "ssl_tlsv1_2", "tilde_user_enable",
+                "force_anon_logins_ssl", "force_anon_data_ssl", "mdtm_write",
+                "lock_upload_files", "pasv_addr_resolve", "reverse_lookup_enable",
+                "userlist_log", "debug_ssl", "require_cert", "validate_cert",
+                "strict_ssl_read_eof", "strict_ssl_write_shutdown", "ssl_request_cert",
+                "delete_failed_uploads", "implicit_ssl", "ptrace_sandbox", "require_ssl_reuse",
+                "isolate", "isolate_network", "ftp_enable", "http_enable", "seccomp_sandbox",
+                "allow_writeable_chroot", "better_stou", "log_die"]
+
+    def _get_integer_options(self):
+        return ["accept_timeout", "connect_timeout", "local_umask", "anon_umask",
+                "ftp_data_port", "idle_session_timeout", "data_connection_timeout",
+                "pasv_min_port", "pasv_max_port", "anon_max_rate", "local_max_rate",
+                "listen_port", "max_clients", "file_open_mode", "max_per_ip", "trans_chunk_size",
+                "delay_failed_login", "delay_successful_login", "max_login_fails",
+                "chown_upload_mode", "bind_retries"]
+
+    def _get_boolean(self, option, value):
+        value = value.upper()
+        if value in ['YES', 'TRUE', '1']:
+            return True
+        elif value in ['NO', 'FALSE', '0']:
+            return False
+        else:
+            raise ParsingError("Boolean option '%s' contains a non-boolean value '%s'"
+                               % (option, value))
+
+    def _get_integer(self, option, value):
+        try:
+            return int(value)
+        except ValueError:
+            raise ParsingError("Integer option '%s' contains a non-integer value '%s'"
+                               % (option, value))
+
+    def parse_value(self, option, value):
+        if option in self._get_string_options():
+            return value
+        elif option in self._get_boolean_options():
+            return self._get_boolean(option, value)
+        elif option in self._get_integer_options():
+            return self._get_integer(option, value)
+        else:
+            raise ParsingError("Unknown option: '%s'" % option)
+
+
+class VsftpdConfigParser(object):
+    def __init__(self, config_content):
+        self._option_parser = VsftpdConfigOptionParser()
+        self.parsed_config = self._parse_config(config_content)
+
+    def _parse_config_line(self, line, conf_dict):
+        if len(line) == 0 or line.startswith('#') or line.isspace():
+            return
+        try:
+            option, value = line.split('=', 1)
+        except ValueError:
+            raise ParsingError("The line does not have the form 'option=value': %s" % line)
+        option = option.strip()
+        value = value.strip()
+        value = self._option_parser.parse_value(option, value)
+        conf_dict[option] = value
+
+    def _parse_config(self, contents):
+        res = {}
+        try:
+            for (ix, line) in enumerate(contents.split('\n')):
+                self._parse_config_line(line, res)
+            return res
+        except ParsingError as e:
+            raise ParsingError("Syntax error on line %d: %s" % (ix + 1, e))

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/libraries/library.py
@@ -1,0 +1,58 @@
+import errno
+import os
+
+from leapp.libraries.actor import config_parser
+from leapp.libraries.common.vsftpdutils import get_config_contents, get_default_config_hash, \
+                                               read_file, \
+                                               VSFTPD_CONFIG_DIR, \
+                                               STRICT_SSL_READ_EOF, TCP_WRAPPERS
+from leapp.libraries.stdlib import api
+from leapp.models import VsftpdConfig, VsftpdFacts
+
+
+def _parse_config(path, content):
+    try:
+        parser = config_parser.VsftpdConfigParser(content)
+        return parser.parsed_config
+    except config_parser.ParsingError:
+        api.current_logger().info('File %s does not look like vsftpd configuration, skipping.'
+                                  % path)
+        return None
+
+
+def _get_parsed_configs(read_func=read_file, listdir=os.listdir):
+    res = []
+    try:
+        for fname in listdir(VSFTPD_CONFIG_DIR):
+            path = os.path.join(VSFTPD_CONFIG_DIR, fname)
+            if not path.endswith('.conf'):
+                continue
+            content = get_config_contents(path, read_func=read_func)
+            if content is None:
+                continue
+            parsed = _parse_config(path, content)
+            if parsed is not None:
+                res.append((path, parsed))
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            api.current_logger().warning('Failed to read vsftpd configuration directory: %s'
+                                         % e)
+    return res
+
+
+def get_vsftpd_facts(read_func=read_file, listdir=os.listdir):
+    config_hash = get_default_config_hash(read_func=read_func)
+    configs = _get_parsed_configs(read_func=read_func, listdir=listdir)
+    res_configs = []
+    for path, config in configs:
+        res_configs.append(VsftpdConfig(path=path,
+                                        strict_ssl_read_eof=config.get(STRICT_SSL_READ_EOF),
+                                        tcp_wrappers=config.get(TCP_WRAPPERS)))
+    return VsftpdFacts(default_config_hash=config_hash, configs=res_configs)
+
+
+def is_processable(installed_rpm_facts):
+    for pkg in installed_rpm_facts.items:
+        if pkg.name == 'vsftpd':
+            return True
+    return False

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/tests/test_config_parser.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/tests/test_config_parser.py
@@ -1,0 +1,99 @@
+import pytest
+
+from leapp.libraries.actor.config_parser import ParsingError, VsftpdConfigOptionParser, \
+    VsftpdConfigParser
+
+
+def test_VsftpdConfigOptionParser_invalid_syntax():
+    parser = VsftpdConfigOptionParser()
+
+    with pytest.raises(ParsingError):
+        parser.parse_value('unknown option', 'foo')
+    with pytest.raises(ParsingError):
+        parser.parse_value('anonymous_enable', 'non-boolean value')
+    with pytest.raises(ParsingError):
+        parser.parse_value('require_cert', 'non-boolean value')
+    with pytest.raises(ParsingError):
+        parser.parse_value('anon_mkdir_write_enable', '')
+    with pytest.raises(ParsingError):
+        parser.parse_value('accept_timeout', 'non-integer value')
+    with pytest.raises(ParsingError):
+        parser.parse_value('max_per_ip', 'non-integer value')
+    with pytest.raises(ParsingError):
+        parser.parse_value('listen_port', '')
+
+
+def test_VsftpdConfigOptionParser_string_option():
+    parser = VsftpdConfigOptionParser()
+
+    assert parser.parse_value('secure_chroot_dir', 'foo') == 'foo'
+    assert parser.parse_value('user_config_dir', '') == ''
+    assert parser.parse_value('dsa_cert_file', 'value with spaces') == 'value with spaces'
+
+
+def test_VsftpdConfigOptionParser_boolean_option():
+    parser = VsftpdConfigOptionParser()
+
+    assert parser.parse_value('background', 'TRUE') is True
+    assert parser.parse_value('run_as_launching_user', 'true') is True
+    assert parser.parse_value('no_log_lock', 'YES') is True
+    assert parser.parse_value('force_local_data_ssl', 'yES') is True
+    assert parser.parse_value('ssl_tlsv1_2', '1') is True
+
+    assert parser.parse_value('background', 'FALSE') is False
+    assert parser.parse_value('run_as_launching_user', 'false') is False
+    assert parser.parse_value('no_log_lock', 'NO') is False
+    assert parser.parse_value('force_local_data_ssl', 'No') is False
+    assert parser.parse_value('ssl_tlsv1_2', '0') is False
+
+
+def test_VsftpdConfigOptionParser_integer_option():
+    parser = VsftpdConfigOptionParser()
+
+    assert parser.parse_value('connect_timeout', '0') == 0
+    assert parser.parse_value('idle_session_timeout', '1') == 1
+    assert parser.parse_value('data_connection_timeout', '2') == 2
+    assert parser.parse_value('pasv_max_port', '6234') == 6234
+
+
+def test_VsftpdConfigParser_invalid_syntax():
+    with pytest.raises(ParsingError):
+        VsftpdConfigParser('unknown_option=foo')
+    with pytest.raises(ParsingError):
+        VsftpdConfigParser('anonymous_enable=non-boolean')
+    with pytest.raises(ParsingError):
+        VsftpdConfigParser(' # comment with whitespace before the # character')
+    with pytest.raises(ParsingError):
+        VsftpdConfigParser('anonymous_enable')
+
+
+def test_VsftpdConfigParser_empty_config():
+    parser = VsftpdConfigParser('')
+    assert isinstance(parser.parsed_config, dict)
+    assert len(parser.parsed_config) == 0
+
+
+def test_VsftpdConfigParser_only_comments():
+    parser = VsftpdConfigParser('# foo\n\n#bar\n')
+    assert isinstance(parser.parsed_config, dict)
+    assert len(parser.parsed_config) == 0
+
+    parser = VsftpdConfigParser('#anonymous_enable=yes\n')
+    assert isinstance(parser.parsed_config, dict)
+    assert len(parser.parsed_config) == 0
+
+
+def test_VsftpdConfigParser_one_option():
+    parser = VsftpdConfigParser('anonymous_enable=yes\n')
+    assert len(parser.parsed_config) == 1
+    assert parser.parsed_config['anonymous_enable'] is True
+
+
+def test_VsftpdConfigParser_multiple_options():
+    content = '# foo\n\nanonymous_enable=no\nbanned_email_file=/foo/bar\n# bar\nmax_login_fails=3\n'
+    parser = VsftpdConfigParser(content)
+
+    assert len(parser.parsed_config) == 3
+    assert parser.parsed_config['anonymous_enable'] is False
+    assert parser.parsed_config['banned_email_file'] == '/foo/bar'
+    assert parser.parsed_config['max_login_fails'] == 3

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/tests/test_library.py
@@ -1,0 +1,214 @@
+import errno
+import os
+
+from leapp.libraries.actor import library
+from leapp.libraries.common.testutils import make_IOError, make_OSError
+from leapp.models import InstalledRedHatSignedRPM, RPM
+
+
+class MockFileOperations(object):
+    def __init__(self):
+        self.files = {}
+        self.files_read = {}
+        self.read_called = 0
+
+    def _increment_read_counters(self, path):
+        self.read_called += 1
+        self.files_read.setdefault(path, 0)
+        self.files_read[path] += 1
+
+    def read(self, path):
+        self._increment_read_counters(path)
+        try:
+            return self.files[path]
+        except KeyError:
+            raise make_IOError(errno.ENOENT)
+
+
+class MockListDir(object):
+    def __init__(self, path=None, file_names=None, to_raise=None):
+        self.path = None if path is None else os.path.normpath(path)
+        self.file_names = file_names
+        self.to_raise = to_raise
+        self.error = False
+
+    def listdir(self, path):
+        if self.to_raise:
+            raise self.to_raise
+        if os.path.normpath(path) == self.path:
+            return self.file_names
+        else:
+            self.error = True
+            raise make_OSError(errno.ENOENT)
+
+
+def test_parse_config():
+    content = 'anonymous_enable=YES'
+    path = 'my_file'
+
+    parsed = library._parse_config(path, content)
+
+    assert parsed['anonymous_enable'] is True
+
+
+def test_parsing_bad_config_gives_None():
+    content = 'foo'
+    path = 'my_file'
+
+    parsed = library._parse_config(path, content)
+
+    assert parsed is None
+
+
+def test_get_parsed_configs():
+    directory = '/etc/vsftpd'
+    file_names = ['vsftpd.conf', 'foo.conf']
+    listdir = MockListDir(directory, file_names)
+    fileops = MockFileOperations()
+    fileops.files[os.path.join(directory, file_names[0])] = 'anonymous_enable=YES\n' \
+                                                            'ca_certs_file=/foo/bar\n'
+    fileops.files[os.path.join(directory, file_names[1])] = 'anonymous_enable=NO\n'
+
+    parsed_configs = list(library._get_parsed_configs(read_func=fileops.read,
+                                                      listdir=listdir.listdir))
+
+    assert not listdir.error
+    assert len(fileops.files_read) == 2
+    assert os.path.join(directory, file_names[0]) in fileops.files_read
+    assert os.path.join(directory, file_names[1]) in fileops.files_read
+    assert len(parsed_configs) == 2
+    if parsed_configs[0][0] != os.path.join(directory, file_names[0]):
+        parsed_configs.reverse()
+    assert (os.path.join(directory, file_names[0]), {'anonymous_enable': True,
+                                                     'ca_certs_file': '/foo/bar'}) in parsed_configs
+    assert (os.path.join(directory, file_names[1]), {'anonymous_enable': False}) in parsed_configs
+
+
+def test_get_parsed_configs_empty_dir():
+    directory = '/etc/vsftpd'
+    listdir = MockListDir(directory, [])
+    fileops = MockFileOperations()
+
+    parsed_configs = library._get_parsed_configs(read_func=fileops.read,
+                                                 listdir=listdir.listdir)
+
+    assert not listdir.error
+    assert fileops.read_called == 0
+    assert len(parsed_configs) == 0
+
+
+def test_get_parsed_configs_nonexistent_dir():
+    listdir = MockListDir(to_raise=make_OSError(errno.ENOENT))
+    fileops = MockFileOperations()
+
+    parsed_configs = library._get_parsed_configs(read_func=fileops.read,
+                                                 listdir=listdir.listdir)
+
+    assert fileops.read_called == 0
+    assert len(parsed_configs) == 0
+
+
+def test_get_parsed_configs_inaccessible_dir():
+    listdir = MockListDir(to_raise=make_OSError(errno.EACCES))
+    fileops = MockFileOperations()
+
+    parsed_configs = library._get_parsed_configs(read_func=fileops.read,
+                                                 listdir=listdir.listdir)
+
+    assert fileops.read_called == 0
+    assert len(parsed_configs) == 0
+
+
+def test_get_vsftpd_facts():
+    directory = '/etc/vsftpd'
+    file_names = ['vsftpd.conf', 'foo.conf', 'bar.conf']
+    listdir = MockListDir(directory, file_names)
+    fileops = MockFileOperations()
+    fileops.files[os.path.join(directory, file_names[0])] = 'anonymous_enable=YES\n' \
+                                                            'ca_certs_file=/foo/bar\n'
+    fileops.files[os.path.join(directory, file_names[1])] = 'anonymous_enable=NO\n' \
+                                                            'tcp_wrappers=YES\n'
+    fileops.files[os.path.join(directory, file_names[2])] = 'strict_ssl_read_eof=yes\n' \
+                                                            'tcp_wrappers=no\n'
+
+    facts = library.get_vsftpd_facts(read_func=fileops.read, listdir=listdir.listdir)
+
+    assert facts.default_config_hash == '892bae7b69eb66ec16afe842a15e53a5242155a4'
+    assert len(facts.configs) == 3
+    used_indices = set()
+    for config in facts.configs:
+        assert os.path.dirname(config.path) == directory
+        file_name = os.path.basename(config.path)
+        ix = file_names.index(file_name)
+        if ix in used_indices:
+            assert False
+        used_indices.add(ix)
+        if ix == 0:
+            assert config.strict_ssl_read_eof is None
+            assert config.tcp_wrappers is None
+        elif ix == 1:
+            assert config.strict_ssl_read_eof is None
+            assert config.tcp_wrappers is True
+        elif ix == 2:
+            assert config.strict_ssl_read_eof is True
+            assert config.tcp_wrappers is False
+        else:
+            assert False
+
+
+def test_get_vsftpd_facts_empty_dir():
+    listdir = MockListDir('/etc/vsftpd', [])
+    fileops = MockFileOperations()
+
+    facts = library.get_vsftpd_facts(read_func=fileops.read, listdir=listdir.listdir)
+
+    assert facts.default_config_hash is None
+    assert len(facts.configs) == 0
+
+
+def test_get_vsftpd_facts_nonexistent_dir():
+    listdir = MockListDir(to_raise=make_OSError(errno.ENOENT))
+    fileops = MockFileOperations()
+
+    facts = library.get_vsftpd_facts(read_func=fileops.read, listdir=listdir.listdir)
+
+    assert facts.default_config_hash is None
+    assert len(facts.configs) == 0
+
+
+def test_get_vsftpd_facts_inaccessible_dir():
+    listdir = MockListDir(to_raise=make_OSError(errno.EACCES))
+    fileops = MockFileOperations()
+
+    facts = library.get_vsftpd_facts(read_func=fileops.read, listdir=listdir.listdir)
+
+    assert facts.default_config_hash is None
+    assert len(facts.configs) == 0
+
+
+def test_is_processable_vsftpd_installed():
+    installed_rpms = [
+        RPM(name='sendmail', version='8.14.7', release='5.el7', epoch='0',
+            packager='foo', arch='x86_64', pgpsig='bar'),
+        RPM(name='vsftpd', version='3.0.2', release='25.el7', epoch='0',
+            packager='foo', arch='x86_64', pgpsig='bar'),
+        RPM(name='postfix', version='2.10.1', release='7.el7', epoch='0',
+            packager='foo', arch='x86_64', pgpsig='bar')]
+    installed_rpm_facts = InstalledRedHatSignedRPM(items=installed_rpms)
+
+    res = library.is_processable(installed_rpm_facts)
+
+    assert res is True
+
+
+def test_is_processable_vsftpd_not_installed():
+    installed_rpms = [
+        RPM(name='sendmail', version='8.14.7', release='5.el7', epoch='0',
+            packager='foo', arch='x86_64', pgpsig='bar'),
+        RPM(name='postfix', version='2.10.1', release='7.el7', epoch='0',
+            packager='foo', arch='x86_64', pgpsig='bar')]
+    installed_rpm_facts = InstalledRedHatSignedRPM(items=installed_rpms)
+
+    res = library.is_processable(installed_rpm_facts)
+
+    assert res is False

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigupdate/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigupdate/actor.py
@@ -1,0 +1,33 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import VsftpdFacts
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class VsftpdConfigUpdate(Actor):
+    """
+    Modifies vsftpd configuration files on the target RHEL-8 system so that the effective
+    configuration is the same, where possible. This means doing two things:
+    1. Reverting the default configuration file (/etc/vsftpd/vsftpd.conf) to its state
+       before the upgrade (where it makes sense), if the configuration file was being used
+       with its default content (i.e., unmodified) on the source system (the configuration
+       file gets replaced with a new version during the RPM upgrade in this case).
+       The anonymous_enable option falls in this category.
+    2. Adding 'option=old_effective_value' to configuration files for options whose default
+       value has changed, if the option is not explicitly specified in the configuration file.
+       The strict_ssl_read_eof option falls in this category.
+    3. Disabling options that cannot be enabled, otherwise vsftpd wouldn't work.
+       The tcp_wrappers option falls in this category.
+    """
+
+    name = 'vsftpd_config_update'
+    consumes = (VsftpdFacts,)
+    produces = ()
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        try:
+            vsftpd_facts = next(self.consume(VsftpdFacts))
+        except StopIteration:
+            return
+        library.migrate_configs(vsftpd_facts)

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigupdate/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigupdate/libraries/library.py
@@ -1,0 +1,79 @@
+import re
+
+from leapp.libraries.common.vsftpdutils import get_default_config_hash, \
+                                               STRICT_SSL_READ_EOF, TCP_WRAPPERS, \
+                                               VSFTPD_DEFAULT_CONFIG_PATH
+from leapp.libraries.stdlib import api
+
+ANONYMOUS_ENABLE = 'anonymous_enable'
+
+
+class FileOperations(object):
+    def read(self, path):
+        with open(path, 'r') as f:
+            return f.read()
+
+    def write(self, path, content):
+        with open(path, 'w') as f:
+            f.write(content)
+
+
+def _replace_in_config(config_lines, option, value):
+    res = []
+    for line in config_lines:
+        if re.match(r'^\s*' + option, line) is None:
+            res.append(line)
+        else:
+            res.append('# Commented out by Leapp:')
+            res.append('#' + line)
+    if value is not None:
+        res.append('# Added by Leapp:')
+        res.append('%s=%s' % (option, value))
+    return res
+
+
+def _restore_default_config_file(fileops=FileOperations()):
+    try:
+        content = fileops.read(VSFTPD_DEFAULT_CONFIG_PATH)
+    except IOError as e:
+        api.current_logger().warning('Failed to read vsftpd configuration file: %s' % e)
+        return
+    lines = content.split('\n')
+    lines = _replace_in_config(lines, ANONYMOUS_ENABLE, 'YES')
+    content = '\n'.join(lines)
+    content += '\n'
+    fileops.write(VSFTPD_DEFAULT_CONFIG_PATH, content)
+
+
+def _migrate_config(config, fileops=FileOperations()):
+    if not config.tcp_wrappers and config.strict_ssl_read_eof is not None:
+        return
+    try:
+        content = fileops.read(config.path)
+    except IOError as e:
+        api.current_logger().warning('Failed to read vsftpd configuration file %s: %s'
+                                     % (config.path, e))
+        return
+    lines = content.split('\n')
+    if config.tcp_wrappers:
+        lines = _replace_in_config(lines, TCP_WRAPPERS, 'NO')
+    if config.strict_ssl_read_eof is None:
+        lines = _replace_in_config(lines, STRICT_SSL_READ_EOF, 'NO')
+    content = '\n'.join(lines)
+    content += '\n'
+    try:
+        fileops.write(config.path, content)
+    except IOError as e:
+        api.current_logger().warning('Failed to write vsftpd configuration file %s: %s'
+                                     % (config.path, e))
+
+
+def migrate_configs(facts, fileops=FileOperations()):
+    if facts.default_config_hash is not None:
+        new_hash = get_default_config_hash(read_func=fileops.read)
+        # If the default config file was unmodified, it got replaced during the RPM upgrade,
+        # so we have to change it back.
+        if facts.default_config_hash != new_hash:
+            _restore_default_config_file(fileops=fileops)
+    for config in facts.configs:
+        _migrate_config(config, fileops=fileops)

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigupdate/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigupdate/tests/test_library.py
@@ -1,0 +1,110 @@
+import errno
+
+from leapp.libraries.actor.library import migrate_configs
+from leapp.libraries.common.testutils import make_IOError
+from leapp.libraries.common.vsftpdutils import VSFTPD_DEFAULT_CONFIG_PATH
+from leapp.models import VsftpdConfig, VsftpdFacts
+
+
+class MockFileOperations(object):
+    def __init__(self):
+        self.files = {}
+        self.files_read = {}
+        self.files_written = {}
+        self.read_called = 0
+        self.write_called = 0
+
+    def _increment_read_counters(self, path):
+        self.read_called += 1
+        self.files_read.setdefault(path, 0)
+        self.files_read[path] += 1
+
+    def read(self, path):
+        self._increment_read_counters(path)
+        try:
+            return self.files[path]
+        except KeyError:
+            raise make_IOError(errno.ENOENT)
+
+    def _increment_write_counters(self, path):
+        self.write_called += 1
+        self.files_written.setdefault(path, 0)
+        self.files_written[path] += 1
+
+    def write(self, path, content):
+        self._increment_write_counters(path)
+        self.files[path] = content
+
+
+def test_restoring_default_config():
+    content = 'anonymous_enable=NO\n' \
+              'tcp_wrappers=NO\n' \
+              'strict_ssl_read_eof=NO\n'
+    fileops = MockFileOperations()
+    fileops.files[VSFTPD_DEFAULT_CONFIG_PATH] = content
+    config = VsftpdConfig(path=VSFTPD_DEFAULT_CONFIG_PATH,
+                          tcp_wrappers=False, strict_ssl_read_eof=False)
+    facts = VsftpdFacts(default_config_hash='foobar', configs=[config])
+
+    migrate_configs(facts, fileops=fileops)
+
+    assert len(fileops.files_read) == 1
+    assert VSFTPD_DEFAULT_CONFIG_PATH in fileops.files_read
+    assert len(fileops.files_written) == 1
+    assert VSFTPD_DEFAULT_CONFIG_PATH in fileops.files_written
+    expected_lines = ['# Commented out by Leapp:',
+                      '#anonymous_enable=NO',
+                      'tcp_wrappers=NO',
+                      'strict_ssl_read_eof=NO',
+                      '',
+                      '# Added by Leapp:',
+                      'anonymous_enable=YES',
+                      '']
+    assert fileops.files[VSFTPD_DEFAULT_CONFIG_PATH] == '\n'.join(expected_lines)
+
+
+def test_setting_tcp_wrappers():
+    path = '/etc/vsftpd/foo.conf'
+    content = 'tcp_wrappers=YES\n' \
+              'strict_ssl_read_eof=NO\n'
+    fileops = MockFileOperations()
+    fileops.files[path] = content
+    config = VsftpdConfig(path=path,
+                          tcp_wrappers=True, strict_ssl_read_eof=False)
+    facts = VsftpdFacts(configs=[config])
+
+    migrate_configs(facts, fileops=fileops)
+
+    assert path in fileops.files_read
+    assert len(fileops.files_written) == 1
+    assert path in fileops.files_written
+    expected_lines = ['# Commented out by Leapp:',
+                      '#tcp_wrappers=YES',
+                      'strict_ssl_read_eof=NO',
+                      '',
+                      '# Added by Leapp:',
+                      'tcp_wrappers=NO',
+                      '']
+    assert fileops.files[path] == '\n'.join(expected_lines)
+
+
+def test_setting_strict_ssl_read_eof():
+    path = '/etc/vsftpd/bar.conf'
+    content = 'local_enable=YES\n'
+    fileops = MockFileOperations()
+    fileops.files[path] = content
+    config = VsftpdConfig(path=path,
+                          tcp_wrappers=None, strict_ssl_read_eof=None)
+    facts = VsftpdFacts(configs=[config])
+
+    migrate_configs(facts, fileops=fileops)
+
+    assert path in fileops.files_read
+    assert len(fileops.files_written) == 1
+    assert path in fileops.files_written
+    expected_lines = ['local_enable=YES',
+                      '',
+                      '# Added by Leapp:',
+                      'strict_ssl_read_eof=NO',
+                      '']
+    assert fileops.files[path] == '\n'.join(expected_lines)

--- a/repos/system_upgrade/el7toel8/libraries/tcpwrappersutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/tcpwrappersutils.py
@@ -1,0 +1,83 @@
+import re
+
+
+def _build_regex(pattern):
+    regex = '^'
+    part_beginning = 0
+    while part_beginning < len(pattern):
+        ix1 = pattern.find('*', part_beginning)
+        ix2 = pattern.find('?', part_beginning)
+        ix1 = len(pattern) if ix1 < 0 else ix1
+        ix2 = len(pattern) if ix2 < 0 else ix2
+        part_end = min(ix1, ix2)
+
+        regex += re.escape(pattern[part_beginning:part_end])
+
+        if part_end < len(pattern):
+            if pattern[part_end] == '*':
+                regex += '.*'
+            else:
+                regex += '.'
+
+        part_beginning = part_end + 1
+
+    regex += '$'
+    return regex
+
+
+def _pattern_matches(pattern, string):
+    if pattern.lower() == 'all':
+        return True
+    regex = _build_regex(pattern)
+    return re.match(regex, string, re.IGNORECASE) is not None
+
+
+def _daemon_list_matches_daemon(daemon_list, daemon, recursion_depth):
+    try:
+        cur_list_end = daemon_list.index('except')
+    except ValueError:
+        cur_list_end = len(daemon_list)
+    cur_list = daemon_list[:cur_list_end]
+    matches_cur_list = False
+    for item in cur_list:
+        try:
+            ix = item.index('@')
+            # For simplicity, we ignore the host part. So we must make sure
+            # that a daemon list containing a host-based pattern will always match
+            # the daemon part of that host-based pattern (e.g. 'all except vsftpd@localhost
+            # matches 'vsftpd'). See test_config_applies_to_daemon_with_host_except().
+            if recursion_depth % 2 == 1:
+                continue
+            pattern = item[:ix]
+        except ValueError:
+            pattern = item
+        if _pattern_matches(pattern, daemon):
+            matches_cur_list = True
+            break
+
+    next_list = daemon_list[cur_list_end + 1:]
+    if len(next_list) == 0:
+        matches_next_list = False
+    else:
+        matches_next_list = _daemon_list_matches_daemon(next_list, daemon, recursion_depth + 1)
+
+    return matches_cur_list and not matches_next_list
+
+
+def config_applies_to_daemon(facts, daemon):
+    '''
+    Returns True if the specified tcp_wrappers configuration applies to the specified daemon.
+    Otherwise returns False.
+
+    This information is intended to be used in the Checks phase to check whether there is
+    any tcp_wrappers configuration that the user needs to migrate manually and whether we
+    should inhibit the upgrade, so that the upgraded system is not insecure.
+
+    :param facts: A TcpWrappersFacts representation of the tcp_wrappers configuration
+    :param daemon: The daemon name
+    '''
+    for daemon_list in facts.daemon_lists:
+        value = [item.lower() for item in daemon_list.value]
+        if _daemon_list_matches_daemon(value, daemon, 0):
+            return True
+    return False

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_tcpwrappersutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_tcpwrappersutils.py
@@ -1,0 +1,176 @@
+import leapp.libraries.common.tcpwrappersutils as lib
+from leapp.models import DaemonList, TcpWrappersFacts
+
+
+def test_config_applies_to_daemon_simple():
+    daemon_list = DaemonList(value=['vsftpd'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+    assert lib.config_applies_to_daemon(facts, 'VsfTpd') is True
+    assert lib.config_applies_to_daemon(facts, 'ftp') is False
+    assert lib.config_applies_to_daemon(facts, 'foo') is False
+
+
+def test_config_applies_to_daemon_multiple_lists():
+    list1 = DaemonList(value=['vsftpd', 'sendmail'])
+    list2 = DaemonList(value=['postfix'])
+    facts = TcpWrappersFacts(daemon_lists=[list1, list2])
+
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+    assert lib.config_applies_to_daemon(facts, 'sendmail') is True
+    assert lib.config_applies_to_daemon(facts, 'postfix') is True
+    assert lib.config_applies_to_daemon(facts, 'foo') is False
+
+
+def test_config_applies_to_daemon_except():
+    list1 = DaemonList(value=['all', 'except', 'sendmail'])
+    list2 = DaemonList(value=['postfix'])
+    facts = TcpWrappersFacts(daemon_lists=[list1, list2])
+
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+    assert lib.config_applies_to_daemon(facts, 'sendmail') is False
+    assert lib.config_applies_to_daemon(facts, 'postfix') is True
+    assert lib.config_applies_to_daemon(facts, 'foo') is True
+
+    list1 = DaemonList(value=['all', 'except', 'b*', 'EXCEPT', 'bar'])
+    facts = TcpWrappersFacts(daemon_lists=[list1])
+    assert lib.config_applies_to_daemon(facts, 'foo') is True
+    assert lib.config_applies_to_daemon(facts, 'bar') is True
+    assert lib.config_applies_to_daemon(facts, 'baar') is False
+
+    list1 = DaemonList(value=['all', 'except', 'vsftpd'])
+    facts = TcpWrappersFacts(daemon_lists=[list1])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+    list1 = DaemonList(value=['all', 'except', 'all', 'except', 'vsftpd'])
+    facts = TcpWrappersFacts(daemon_lists=[list1])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    list1 = DaemonList(value=['all', 'except', 'all', 'except', 'all', 'except', 'vsftpd'])
+    facts = TcpWrappersFacts(daemon_lists=[list1])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+
+def test_config_applies_to_daemon_except_empty():
+    daemon_list = DaemonList(value=['all', 'except'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+
+def test_config_applies_to_daemon_with_host():
+    list1 = DaemonList(value=['vsftpd@localhost', 'sendmail'])
+    list2 = DaemonList(value=['postfix'])
+    facts = TcpWrappersFacts(daemon_lists=[list1, list2])
+
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+    assert lib.config_applies_to_daemon(facts, 'sendmail') is True
+    assert lib.config_applies_to_daemon(facts, 'postfix') is True
+    assert lib.config_applies_to_daemon(facts, 'foo') is False
+
+
+def test_config_applies_to_daemon_with_host_except():
+    daemon_list = DaemonList(value=['vsftpd@localhost', 'except', 'vsftpd'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+    # It works like this for simplicity.
+    daemon_list = DaemonList(value=['vsftpd@localhost', 'except', 'vsftpd@localhost'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['vsftpd@localhost'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['all', 'except', 'vsftpd@localhost'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['all', 'except', 'all', 'except', 'vsftpd@localhost'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['all', 'except', 'all', 'except', 'all',
+                                    'except' 'vsftpd@localhost'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['all', 'except', 'all', 'except', 'all', 'except', 'all',
+                                    'except', 'vsftpd@localhost'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+
+def test_config_applies_to_daemon_empty():
+    daemon_list = DaemonList(value=[''])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+    daemon_list = DaemonList(value=[])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+
+def test_config_applies_to_daemon_whole_word():
+    daemon_list = DaemonList(value=['ftp'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+
+def test_config_applies_to_daemon_asterisk_wildcard():
+    daemon_list = DaemonList(value=['*ftp*'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['************'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['*'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['*foo*'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+
+def test_config_applies_to_daemon_question_mark_wildcard():
+    daemon_list = DaemonList(value=['vs?tpd'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['vsf?tpd'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+    daemon_list = DaemonList(value=['?'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+    daemon_list = DaemonList(value=['??????'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+
+def test_config_applies_to_daemon_all_wildcard():
+    daemon_list = DaemonList(value=['all'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['aLl'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is True
+
+    daemon_list = DaemonList(value=['al'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+    daemon_list = DaemonList(value=['ll'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False
+
+    daemon_list = DaemonList(value=['valld'])
+    facts = TcpWrappersFacts(daemon_lists=[daemon_list])
+    assert lib.config_applies_to_daemon(facts, 'vsftpd') is False

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_testutils.py
@@ -1,0 +1,23 @@
+import errno
+
+from leapp.libraries.common.testutils import make_IOError, make_OSError
+
+
+def test_make_IOError():
+    exception = make_IOError(errno.ENOENT)
+    assert isinstance(exception, IOError)
+    assert exception.errno == errno.ENOENT
+
+    exception = make_IOError(errno.ENOTDIR)
+    assert isinstance(exception, IOError)
+    assert exception.errno == errno.ENOTDIR
+
+
+def test_make_OSError():
+    exception = make_OSError(errno.ENOENT)
+    assert isinstance(exception, OSError)
+    assert exception.errno == errno.ENOENT
+
+    exception = make_OSError(errno.ENOTDIR)
+    assert isinstance(exception, OSError)
+    assert exception.errno == errno.ENOTDIR

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_vsftpdutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_vsftpdutils.py
@@ -1,0 +1,82 @@
+import errno
+
+from leapp.libraries.common.testutils import make_IOError
+from leapp.libraries.common.vsftpdutils import get_config_contents, get_default_config_hash
+
+
+class MockFile(object):
+    def __init__(self, path, content=None, to_raise=None):
+        self.path = path
+        self.content = content
+        self.to_raise = to_raise
+        self.error = False
+
+    def read_file(self, path):
+        if path != self.path:
+            self.error = True
+            raise ValueError
+        if not self.to_raise:
+            return self.content
+        raise self.to_raise
+
+
+def test_getting_nonexistent_config_gives_None():
+    path = 'my_file'
+    f = MockFile(path, to_raise=make_IOError(errno.ENOENT))
+
+    res = get_config_contents(path, read_func=f.read_file)
+
+    assert not f.error
+    assert res is None
+
+
+def test_getting_inaccessible_config_gives_None():
+    path = 'my_file'
+    f = MockFile(path, to_raise=make_IOError(errno.EACCES))
+
+    res = get_config_contents(path, read_func=f.read_file)
+
+    assert not f.error
+    assert res is None
+
+
+def test_getting_empty_config_gives_empty_string():
+    path = 'my_file'
+    f = MockFile(path, content='')
+
+    res = get_config_contents(path, read_func=f.read_file)
+
+    assert not f.error
+    assert res == ''
+
+
+def test_getting_nonempty_config_gives_the_content():
+    path = 'my_file'
+    content = 'foo\nbar\n'
+    f = MockFile(path, content=content)
+
+    res = get_config_contents(path, read_func=f.read_file)
+
+    assert not f.error
+    assert res == content
+
+
+def test_hash_of_default_config_is_correct():
+    path = '/etc/vsftpd/vsftpd.conf'
+    content = 'foo\n'
+    f = MockFile(path, content=content)
+
+    h = get_default_config_hash(read_func=f.read_file)
+
+    assert h == 'f1d2d2f924e986ac86fdf7b36c94bcdf32beec15'
+    assert not f.error
+
+
+def test_hash_of_nonexistent_default_config_is_None():
+    path = '/etc/vsftpd/vsftpd.conf'
+    f = MockFile(path, to_raise=make_IOError(errno.ENOENT))
+
+    h = get_default_config_hash(read_func=f.read_file)
+
+    assert h is None
+    assert not f.error

--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -1,0 +1,23 @@
+import os
+
+
+def make_IOError(error):
+    '''
+    Create an IOError instance
+
+    Create an IOError instance with the given error number.
+
+    :param error: the error number, e.g. errno.ENOENT
+    '''
+    return IOError(error, os.strerror(error))
+
+
+def make_OSError(error):
+    '''
+    Create an OSError instance
+
+    Create an OSError instance with the given error number.
+
+    :param error: the error number, e.g. errno.ENOENT
+    '''
+    return OSError(error, os.strerror(error))

--- a/repos/system_upgrade/el7toel8/libraries/vsftpdutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/vsftpdutils.py
@@ -1,0 +1,51 @@
+import errno
+import hashlib
+
+from leapp.libraries.stdlib import api
+
+VSFTPD_CONFIG_DIR = '/etc/vsftpd'
+VSFTPD_DEFAULT_CONFIG_PATH = '/etc/vsftpd/vsftpd.conf'
+STRICT_SSL_READ_EOF = 'strict_ssl_read_eof'
+TCP_WRAPPERS = 'tcp_wrappers'
+
+
+def read_file(path):
+    '''
+    Read a file in text mode and return the contents.
+
+    :param path: File path
+    '''
+    with open(path, 'r') as f:
+        return f.read()
+
+
+def get_config_contents(path, read_func=read_file):
+    '''
+    Try to read a vsftpd configuration file
+
+    Try to read a vsftpd configuration file, log a warning if an error happens.
+    :param path: File path
+    :param read_func: Function to use to read the file. This is meant to be overriden in tests.
+    :return: File contents or None, if the file could not be read
+    '''
+    try:
+        return read_func(path)
+    except IOError as e:
+        if e.errno != errno.ENOENT:
+            api.current_logger().warn('Failed to read vsftpd configuration file: %s' % e)
+        return None
+
+
+def get_default_config_hash(read_func=read_file):
+    '''
+    Read the default vsftpd configuration file (/etc/vsftpd/vsftpd.conf) and return its hash.
+
+    :param read_func: Function to use to read the file. This is meant to be overriden in tests.
+    :return SHA1 hash of the configuration file, or None if the file could not be read.
+    '''
+    content = get_config_contents(VSFTPD_DEFAULT_CONFIG_PATH, read_func=read_func)
+    if content is None:
+        return None
+    content = content.encode(encoding='utf-8')
+    h = hashlib.sha1(content)
+    return h.hexdigest()

--- a/repos/system_upgrade/el7toel8/models/tcpwrappersfacts.py
+++ b/repos/system_upgrade/el7toel8/models/tcpwrappersfacts.py
@@ -1,0 +1,24 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class DaemonList(Model):
+    '''
+    A split up representation of a daemon_list (see host_access(5)). Example value of the
+    'value' attribute: ["ALL", "EXCEPT", "in.fingerd"]
+    '''
+    topic = SystemInfoTopic
+
+    value = fields.List(fields.String())
+
+
+class TcpWrappersFacts(Model):
+    '''
+    A representation of tcp_wrappers configuration. Currently it only contains a list
+    of daemon lists that are present in the tcp_wrappers configuration files. From this
+    you can extract information on whether there is any configuration that applies to
+    a specific daemon (see leapp.libraries.common.tcpwrappersutils.config_applies_to_daemon()).
+    '''
+    topic = SystemInfoTopic
+
+    daemon_lists = fields.List(fields.Model(DaemonList))

--- a/repos/system_upgrade/el7toel8/models/vsftpdfacts.py
+++ b/repos/system_upgrade/el7toel8/models/vsftpdfacts.py
@@ -1,0 +1,31 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class VsftpdConfig(Model):
+    '''
+    Model representing some aspects of a vsftpd configuration file.
+
+    The attributes representing the state of configuration options are nullable, so that
+    they can represent the real state of the option in the file: if an option is set to "YES"
+    in the configuration file, the corresponding attribute is set to True; if the option
+    is set to NO, the attribute is set to False; if the option is not present in the config
+    file at all, the attribute is set to None.
+    '''
+    topic = SystemInfoTopic
+
+    path = fields.String()
+    '''Path to the vsftpd configuration file'''
+    strict_ssl_read_eof = fields.Nullable(fields.Boolean())
+    '''Represents the state of the strict_ssl_read_eof option in the config file'''
+    tcp_wrappers = fields.Nullable(fields.Boolean())
+    '''Represents the state of the tcp_wrappers option in the config file'''
+
+
+class VsftpdFacts(Model):
+    topic = SystemInfoTopic
+
+    default_config_hash = fields.Nullable(fields.String())
+    '''SHA1 hash of the /etc/vsftpd/vsftpd.conf file, if it exists, None otherwise'''
+    configs = fields.List(fields.Model(VsftpdConfig))
+    '''List of vsftpd configuration files'''


### PR DESCRIPTION
This pull request adds a couple of actors and some helpers for testing.

The `TcpWrappersConfigRead` actor reads the tcp_wrappers configuration (/etc/hosts.{allow,deny}) and stores some data about it in the `TcpWrappersFacts` model. An instance of that model can then be passed to the `config_applies_to_daemon` library function which can be used in other actors to determine, if the tcp_wrappers configuration applies to the specified daemon.

The `VsftpdConfigRead` actor gathers some data about the vsftpd configuration (but only if vsftpd is installed) and  stores it in the `VsftpdFacts` model.

The `VsftpdConfigCheck` actor consumes `TcpWrappersFacts` and `VsftpdFacts`. The actor determines, whether the vsftpd configuration is supported in RHEL-8. If it is not, it inhibits the upgrade. Namely, it checks whether vsftpd was using tcp_wrappers, which is not supported in RHEL-8.

The `VsftpdConfigUpdate` actor consumes `VsftpdFacts` and modifies the vsftpd config files so that they still work in RHEL-8, and so that the effective configuration is as close to the original as possible. See the comit message of the last commit for more details.