### PR TITLE
rpmscanner: move get_package_repository_data to library

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/rpmscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmscanner/actor.py
@@ -1,8 +1,6 @@
-import yum
-
 from leapp.actors import Actor
+from leapp.libraries.actors import get_package_repository_data
 from leapp.libraries.common.rpms import get_installed_rpms
-from leapp.libraries.stdlib import run
 from leapp.models import InstalledRPM, RPM
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
@@ -19,19 +17,9 @@ class RpmScanner(Actor):
     produces = (InstalledRPM,)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
-    def get_package_repository_data(self):
-        """ Return dictionary mapping package name with repository from which it was installed """
-        yum_base = yum.YumBase()
-        pkg_repos = {}
-        for pkg in yum_base.doPackageLists().installed:
-            pkg_repos[pkg.name] = pkg.ui_from_repo.lstrip('@')
-
-        return pkg_repos
-
-
     def process(self):
         output = get_installed_rpms()
-        pkg_repos = self.get_package_repository_data()
+        pkg_repos = get_package_repository_data()
 
         result = InstalledRPM()
         for entry in output:

--- a/repos/system_upgrade/el7toel8/actors/rpmscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmscanner/actor.py
@@ -1,5 +1,5 @@
 from leapp.actors import Actor
-from leapp.libraries.actors import get_package_repository_data
+from leapp.libraries.actor.library import get_package_repository_data
 from leapp.libraries.common.rpms import get_installed_rpms
 from leapp.models import InstalledRPM, RPM
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag

--- a/repos/system_upgrade/el7toel8/actors/rpmscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmscanner/libraries/library.py
@@ -1,0 +1,12 @@
+
+def get_package_repository_data(self):
+    """ Return dictionary mapping package name with repository from which it was installed """
+    # import has to be inside the function to obey troubles with non-existing
+    # module in Python3 (where we do not need this function anymore)
+    import yum
+    yum_base = yum.YumBase()
+    pkg_repos = {}
+    for pkg in yum_base.doPackageLists().installed:
+        pkg_repos[pkg.name] = pkg.ui_from_repo.lstrip('@')
+
+    return pkg_repos

--- a/repos/system_upgrade/el7toel8/actors/rpmscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmscanner/libraries/library.py
@@ -1,7 +1,7 @@
 
-def get_package_repository_data(self):
+def get_package_repository_data():
     """ Return dictionary mapping package name with repository from which it was installed """
-    # import has to be inside the function to obey troubles with non-existing
+    # import has to be inside the function to avoid troubles with non-existing
     # module in Python3 (where we do not need this function anymore)
     import yum
     yum_base = yum.YumBase()


### PR DESCRIPTION
Because of `import yum` upgrades started to be broken as when we
start leapp under Python3 (after the rpmupgrade phase) leapp crashes
during the scanning of the repository because the yum module for
Python3 doesn't exist.

Moving the functionality into the actor's library as it is not
necessary to parse the code when it is not used (the function is
used just during the FactsCollectionPhase phase.