### PR TITLE
Add LEAPP_DEVEL_DM_DISABLE_UDEV env var

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
@@ -8,13 +8,23 @@ CURRENT_TARGET_VERSION = '8.1'
 ENV_IGNORE = ('LEAPP_CURRENT_PHASE', 'LEAPP_CURRENT_ACTOR', 'LEAPP_VERBOSE',
               'LEAPP_DEBUG')
 
+ENV_MAPPING = {'LEAPP_DEVEL_DM_DISABLE_UDEV': 'DM_DISABLE_UDEV'}
+
 
 def get_env_vars():
     """
-    Gather LEAPP_DEVEL environment variables and provide them as messages to be
+    Gather LEAPP_DEVEL environment variables and respective mappings to provide them as messages to be
     available after reboot.
     """
-    return [EnvVar(name=k, value=v) for (k, v) in os.environ.items() if k.startswith('LEAPP_') and k not in ENV_IGNORE]
+    env_vars = []
+    leapp_vars = {k: v for (k, v) in os.environ.items() if k.startswith('LEAPP_') and k not in ENV_IGNORE}
+    for k, v in leapp_vars.items():
+        if k in ENV_MAPPING:
+            env_vars.append(EnvVar(name=ENV_MAPPING.get(k), value=v))
+            continue
+        env_vars.append(EnvVar(name=k, value=v))
+
+    return env_vars
 
 
 def get_os_release(path):

--- a/repos/system_upgrade/el7toel8/libraries/config/__init__.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/__init__.py
@@ -1,0 +1,14 @@
+from leapp.libraries.stdlib import api
+
+
+def get_env(name, default=None):
+    """ Return Leapp environment variable value if matched by name """
+    for var in api.current_actor().configuration.leapp_env_vars:
+        if var.name == name:
+            return var.value
+    return default
+
+
+def get_all_envs():
+    """ Return all Leapp environment variables (both name and value) """
+    return api.current_actor().configuration.leapp_env_vars

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_getenvvars.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_getenvvars.py
@@ -1,0 +1,18 @@
+from collections import namedtuple
+
+from leapp.libraries.common.config import get_env
+from leapp.libraries.stdlib import api
+from leapp.models import EnvVar
+
+
+class CurrentActorMocked(object):
+    env_vars = [EnvVar(name='LEAPP_DEVEL_SKIP_WIP', value='0'),
+                EnvVar(name='LEAPP_DEVEL_SKIP_DIP', value='1')]
+    configuration = namedtuple('configuration', ['leapp_env_vars'])(env_vars)
+
+
+def test_env_var_match(monkeypatch):
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    assert get_env('LEAPP_DEVEL_SKIP_WIP') == '0'
+    assert not get_env('LEAPP_DEVEL_SKIP_PIP')

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_getenvvars.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_getenvvars.py
@@ -1,13 +1,14 @@
 from collections import namedtuple
 
-from leapp.libraries.common.config import get_env
+from leapp.libraries.common.config import get_env, get_all_envs
 from leapp.libraries.stdlib import api
 from leapp.models import EnvVar
 
 
 class CurrentActorMocked(object):
     env_vars = [EnvVar(name='LEAPP_DEVEL_SKIP_WIP', value='0'),
-                EnvVar(name='LEAPP_DEVEL_SKIP_DIP', value='1')]
+                EnvVar(name='LEAPP_DEVEL_SKIP_DIP', value='1'),
+                EnvVar(name='LEAPP_DEVEL_SKIP_RIP', value='2')]
     configuration = namedtuple('configuration', ['leapp_env_vars'])(env_vars)
 
 
@@ -16,3 +17,9 @@ def test_env_var_match(monkeypatch):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
     assert get_env('LEAPP_DEVEL_SKIP_WIP') == '0'
     assert not get_env('LEAPP_DEVEL_SKIP_PIP')
+
+
+def test_get_all_vars(monkeypatch):
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    assert len(get_all_envs()) == 3


### PR DESCRIPTION
When, during dnf upgrade transaction, some package calls
device_mapper which requires udev to properly release a cookie
set by device mapper, the transaction gets stuck as udev on the
host cannot see namespaced IPC inside our container.

We workaround this by setting "DM_DISABLE_UDEV=1" env var.