### PR TITLE
Enable travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+git:
+  depth: 3
+language: python
+env:
+services:
+python:
+matrix:
+  include:
+    - python: "2.7"
+      env: CONTAINER=centos:7
+      services:
+        - docker
+      sudo: required
+install:
+    - docker pull ${CONTAINER}
+    - docker build -t leapp-tests -f utils/docker-tests/Dockerfile utils/docker-tests
+
+script:
+    - docker run --rm -ti -v ${PWD}:/payload leapp-tests

--- a/utils/docker-tests/Dockerfile
+++ b/utils/docker-tests/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos:7
+
+VOLUME /payload
+
+RUN yum update -y && \
+    yum install python-virtualenv make git -y
+
+WORKDIR /payload
+ENTRYPOINT make install-deps && make test


### PR DESCRIPTION
This patch will enable running our unit tests on travis to get faster
feedback and have a link that can be viewed by any contributor
associated with the PR.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>