### PR TITLE
[DO NOT MERGE] travis: Create builds for leapp-repository on COPR

### DIFF
--- a/.copr.enc
+++ b/.copr.enc
@@ -1,0 +1,2 @@
+À‚CF€ÿÌILËˆÀGûc£þAóA]î]¿ÿžC2]cùUH{å9¦å»G¹Aˆ$ÚsÎ=Þz‚hêPg­pÃ`žéÍ0¹ä“6Ü}êå^ûv.¨æ©òÁäÝí§ò~žÂÅEùÙ—WX_òvîã·ãŒI'éQ3;¹Ä³í–â«x%¿>^²	òŒ4A‡ÿ„Aû·âh¥–íúëI:{þ¤´Š.–/C›àÓ
+Xš†ûxÊ¯Óº'Âdh±Ë3{TSÓ

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,37 @@
-git:
-  depth: 3
 language: python
-env:
-services:
-python:
-matrix:
+python: "2.7"
+git:
+  depth: false
+jobs:
   include:
-    - python: "2.7"
+    - stage: unittests
+      name: "Unit tests"
       env: CONTAINER=centos:7
       services:
         - docker
+      install:
+        - docker pull ${CONTAINER}
+        - docker build -t leapp-tests -f utils/docker-tests/Dockerfile utils/docker-tests
+      script:
+        - docker run --rm -ti -v ${PWD}:/payload leapp-tests
+    - stage: pr_cd
+      name: "Deployment to COPR @leapp/leapp-pr-builds"
+      before_install:
+        - openssl aes-256-cbc -K $encrypted_2088d124a3c7_key -iv $encrypted_2088d124a3c7_iv -in .copr.enc -out ${HOME}/.config/copr -d
+      install:
+        - pip install copr-cli
+        - pip install configparser
+        - sudo apt-get install rpm
+      env:
+        COPR_REPO: "@leapp/leapp-pr-builds"
+        COPR_REPO_TMP: "@leapp/leapp-tmp"
+        COPR_CONFIG: "~/.config/copr"
       sudo: required
-install:
-    - docker pull ${CONTAINER}
-    - docker build -t leapp-tests -f utils/docker-tests/Dockerfile utils/docker-tests
-
-script:
-    - docker run --rm -ti -v ${PWD}:/payload leapp-tests
+      script:
+        - sudo ln -sf /bin/bash /bin/sh
+        - command -v copr || sudo ln -sf $(command -v copr-cli) /bin/copr
+        - make copr_build
+stages:
+  - name: unittests
+  - name: pr_cd
+    if: type == pull_request

--- a/get_latest_copr_build
+++ b/get_latest_copr_build
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import json
+import os
+import sys
+
+import copr.v3
+
+ownername = os.getenv('COPR_OWNER')
+projectname = os.getenv('COPR_PROJECT')
+packagename = os.getenv('COPR_PACKAGE')
+if not ownername:
+    ownername, projectname = os.getenv('COPR_REPO', '').split('/', 1)
+
+CONFIG_PATH = os.path.expandvars(os.getenv('_COPR_CONFIG', '~/.config/copr'))
+client = copr.v3.Client(copr.v3.config_from_file(path=CONFIG_PATH))
+builds = client.build_proxy.get_list(
+    status='succeeded',
+    pagination={'limit': 1, 'order': 'id', 'order_type': 'DESC'},
+    ownername=ownername,
+    projectname=projectname,
+    packagename=packagename)
+
+if builds:
+    if '--id' in sys.argv:
+        print(builds[0]['id'])
+    else:
+        json.dump(builds, sys.stdout, sort_keys=True, indent=2)


### PR DESCRIPTION
This patch adds the functionality that builds on COPR are created for
pull requests after a successful unittest execution.

The data .copr.env is created from the COPR api key and can be encrypted
with the `travis tool`
The command for encrypting it for this repository is:

$ travis login # Login to travis via GitHub
$ travis encrypt-file -r oamg/leapp-repository /path/to/your/copr_config_file/copr .copr.enc

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>