### PR TITLE
Makefile: Fix copr-cli incompatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION=`grep -m1 "^Version:" packaging/$(PKGNAME).spec | grep -om1 "[0-9].[0-9.
 DEPS_VERSION=`grep -m1 "^Version:" packaging/$(DEPS_PKGNAME).spec | grep -om1 "[0-9].[0-9.]**"`
 
 # needed only in case the Python2 should be used
-_PYTHON_INTERPRETER=$$(_PYTHON_INTERPRETER)
+_PYTHON_INTERPRETER=$${_PYTHON_INTERPRETER}
 
 # by default use values you can see below, but in case the COPR_* var is defined
 # use it instead of the default

--- a/Makefile
+++ b/Makefile
@@ -83,14 +83,6 @@ _list_approved_builds:
 		| sed 's/"state": "succeeded",/----------------------/' \
 		| grep -A1 -B2 '"pkg_version".*-[1-9]'
 
-# FIXME: incompatible with newer version of copr-cli
-_list_all_builds:
-	@copr --config $(_COPR_CONFIG) get-package $(_COPR_REPO) \
-		--name $(__PKGNAME) --with-all-builds \
-		| grep -E '"(built_packages|id|state|pkg_version)"' | grep -B3 "succeeded" \
-		| sed 's/"state": "succeeded",/----------------------/'
-
-
 source: prepare
 	@echo "--- Create source tarball ---"
 	@echo git archive --prefix "$(PKGNAME)-$(VERSION)/" -o "packaging/sources/$(PKGNAME)-$(VERSION).tar.gz" HEAD
@@ -98,11 +90,8 @@ source: prepare
 	@echo "--- PREPARE DEPS PKGS ---"
 	mkdir -p packaging/tmp/
 	@__TIMESTAMP=$(TIMESTAMP) $(MAKE) _copr_build_deps_subpkg
-	@# THIS IS NOT TYPO! COPR_REPO=_COPR_REPO_TMP!!
-	@__TIMESTAMP=$(TIMESTAMP) _PKGNAME=$(DEPS_PKGNAME) COPR_REPO=$(_COPR_REPO_TMP) $(MAKE) _list_all_builds \
-		| grep -EB3 "pkg_version.*-$(RELEASE)" \
-		| grep -m1 '"id"' | grep -o "[0-9][0-9]*" > packaging/tmp/deps_build_id
-	@copr --config $(_COPR_CONFIG) download-build -d packaging/tmp `cat packaging/tmp/deps_build_id`
+	@copr --config $(_COPR_CONFIG) download-build -d packaging/tmp \
+		`COPR_REPO=$(_COPR_REPO_TMP) COPR_PACKAGE=$(DEPS_PKGNAME) ./utils/get_latest_copr_build --id`
 	@mv `find packaging/tmp/ | grep "rpm$$" | grep -v "src"` packaging/tmp
 	@tar -czf packaging/sources/deps-pkgs.tar.gz -C packaging/tmp/ `ls packaging/tmp | grep -o "[^/]*rpm$$"`
 	@rm -rf packaging/tmp

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VERSION=`grep -m1 "^Version:" packaging/$(PKGNAME).spec | grep -om1 "[0-9].[0-9.
 DEPS_VERSION=`grep -m1 "^Version:" packaging/$(DEPS_PKGNAME).spec | grep -om1 "[0-9].[0-9.]**"`
 
 # needed only in case the Python2 should be used
-_PYTHON_INTERPRETER=$${_PYTHON_INTERPRETER}
+_USE_PYTHON_INTERPRETER=$${_PYTHON_INTERPRETER}
 
 # by default use values you can see below, but in case the COPR_* var is defined
 # use it instead of the default
@@ -87,7 +87,7 @@ source: prepare
 	@__TIMESTAMP=$(TIMESTAMP) $(MAKE) _copr_build_deps_subpkg
 	@PKG_RELEASE=$(RELEASE) _COPR_CONFIG=$(_COPR_CONFIG) \
 		COPR_REPO=$(_COPR_REPO_TMP) COPR_PACKAGE=$(DEPS_PKGNAME) \
-		$(_PYTHON_INTERPRETER) ./utils/get_latest_copr_build > packaging/tmp/deps_build_id
+		$(_USE_PYTHON_INTERPRETER) ./utils/get_latest_copr_build > packaging/tmp/deps_build_id
 	@copr --config $(_COPR_CONFIG) download-build -d packaging/tmp `cat packaging/tmp/deps_build_id`
 	@mv `find packaging/tmp/ | grep "rpm$$" | grep -v "src"` packaging/tmp
 	@tar -czf packaging/sources/deps-pkgs.tar.gz -C packaging/tmp/ `ls packaging/tmp | grep -o "[^/]*rpm$$"`

--- a/utils/get_latest_copr_build
+++ b/utils/get_latest_copr_build
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 
 import json
 import os
@@ -6,23 +6,49 @@ import sys
 
 import copr.v3
 
+CONFIG_PATH = os.path.expandvars(os.getenv('_COPR_CONFIG', '~/.config/copr'))
+client = copr.v3.Client(copr.v3.config_from_file(path=CONFIG_PATH))
+
+# In case we are not able to retrieve from env vars, use defaults from the
+# configuration files.
 ownername = os.getenv('COPR_OWNER')
 projectname = os.getenv('COPR_PROJECT')
 packagename = os.getenv('COPR_PACKAGE')
-if not ownername:
-    ownername, projectname = os.getenv('COPR_REPO', '').split('/', 1)
+pkgrelease = os.getenv('PKG_RELEASE')
+if not ownername or not projectname:
+    copr_repo = os.getenv('COPR_REPO', '').split('/', 1)
+    if len(copr_repo) == 2:
+        ownername, projectname = os.getenv('COPR_REPO', '').split('/', 1)
+    else:
+        # We have just the name of project inside COPR_REPO value, it is
+        # expected when user is owner of the project. So set the user as
+        # owner from the config file.
+        projectname = copr_repo[0]
+        ownername = client.config['username']
 
-CONFIG_PATH = os.path.expandvars(os.getenv('_COPR_CONFIG', '~/.config/copr'))
-client = copr.v3.Client(copr.v3.config_from_file(path=CONFIG_PATH))
+# limit set to 10 as it is not expected that there would be more packages build
+# in such short time
 builds = client.build_proxy.get_list(
     status='succeeded',
-    pagination={'limit': 1, 'order': 'id', 'order_type': 'DESC'},
+    pagination={'limit': 10, 'order': 'id', 'order_type': 'DESC'},
     ownername=ownername,
     projectname=projectname,
     packagename=packagename)
 
-if builds:
-    if '--id' in sys.argv:
-        print(builds[0]['id'])
-    else:
-        json.dump(builds, sys.stdout, sort_keys=True, indent=2)
+if '--debug' not in sys.argv:
+    json.dump(builds, sys.stderr, sort_keys=True, indent=2)
+
+for build in builds:
+    # Version in COPR contains VERSION-RELEASE string. We need just the
+    # release. Additionally we do not care about *elX* suffix. So remove it
+    # when compare.
+    _release = build['source_package']['version'].split("-")[-1]
+    # FIXME: instead of rsplit(.el8) remove whole elx.* as it can contain
+    # later e.g. .el8_0 instead of .el8
+    if _release.rstrip(".el8") == pkgrelease:
+        print(build['id'])
+        break
+else:
+    sys.stderr.write('Error: The build with the required release has not been found: {}'.format(pkgrelease))
+    sys.exit(1)
+

--- a/utils/get_latest_copr_build
+++ b/utils/get_latest_copr_build
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import json
+import os
+import sys
+
+import copr.v3
+
+ownername = os.getenv('COPR_OWNER')
+projectname = os.getenv('COPR_PROJECT')
+packagename = os.getenv('COPR_PACKAGE')
+if not ownername:
+    ownername, projectname = os.getenv('COPR_REPO', '').split('/', 1)
+
+CONFIG_PATH = os.path.expandvars(os.getenv('_COPR_CONFIG', '~/.config/copr'))
+client = copr.v3.Client(copr.v3.config_from_file(path=CONFIG_PATH))
+builds = client.build_proxy.get_list(
+    status='succeeded',
+    pagination={'limit': 1, 'order': 'id', 'order_type': 'DESC'},
+    ownername=ownername,
+    projectname=projectname,
+    packagename=packagename)
+
+if builds:
+    if '--id' in sys.argv:
+        print(builds[0]['id'])
+    else:
+        json.dump(builds, sys.stdout, sort_keys=True, indent=2)


### PR DESCRIPTION
This patch introduces a script to retrieve the latest build id from
COPR via the v3 client API.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>