### PR TITLE
WIP: Unify rpm installation source

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/dnfshellrpmupgrade/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/dnfshellrpmupgrade/actor.py
@@ -72,7 +72,6 @@ class DnfShellRpmUpgrade(Actor):
         plugin_data = {
             'pkgs_info':
                 {
-                    'local_rpms': [pkg for pkg in data.local_rpms],
                     'to_install': [pkg for pkg in data.to_install],
                     'to_remove': [pkg for pkg in data.to_remove]
                 },

--- a/repos/system_upgrade/el7toel8/actors/filterrpmtransactionevents/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/filterrpmtransactionevents/actor.py
@@ -24,12 +24,10 @@ class FilterRpmTransactionTasks(Actor):
         for rpm_pkgs in self.consume(InstalledRedHatSignedRPM):
             installed_pkgs.update([pkg.name for pkg in rpm_pkgs.items])
 
-        local_rpms = set()
         to_install = set()
         to_remove = set()
         to_keep = set()
         for event in self.consume(RpmTransactionTasks, PESRpmTransactionTasks):
-            local_rpms.update(event.local_rpms)
             to_install.update(event.to_install)
             to_remove.update(installed_pkgs.intersection(event.to_remove))
             to_keep.update(installed_pkgs.intersection(event.to_keep))
@@ -37,7 +35,6 @@ class FilterRpmTransactionTasks(Actor):
         to_remove.difference_update(to_keep)
 
         self.produce(FilteredRpmTransactionTasks(
-            local_rpms=list(local_rpms),
             to_install=list(to_install),
             to_remove=list(to_remove),
             to_keep=list(to_keep)))

--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/actor.py
@@ -197,7 +197,6 @@ class PrepareUpgradeTransaction(Actor):
 
         plugin_data = {
             'pkgs_info': {
-                'local_rpms': [pkg for pkg in data.local_rpms],
                 'to_install': [pkg for pkg in data.to_install],
                 'to_remove': [pkg for pkg in data.to_remove]
             },

--- a/repos/system_upgrade/el7toel8/actors/transactionworkarounds/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/transactionworkarounds/actor.py
@@ -19,9 +19,8 @@ class TransactionWorkarounds(Actor):
 
     def process(self):
         location = self.get_folder_path('bundled-rpms')
-        local_rpms = []
+        to_install = []
         for name in os.listdir(location):
-            if name.endswith('.rpm'):
-                local_rpms.append(os.path.join(location, name))
-        if local_rpms:
-            self.produce(RpmTransactionTasks(local_rpms=local_rpms))
+            to_install.append(os.path.join(location, name))
+        if to_install:
+            self.produce(RpmTransactionTasks(to_install=to_install))

--- a/repos/system_upgrade/el7toel8/actors/transactionworkarounds/tests/test_transaction_workarounds.py
+++ b/repos/system_upgrade/el7toel8/actors/transactionworkarounds/tests/test_transaction_workarounds.py
@@ -5,7 +5,6 @@ from leapp.models import RpmTransactionTasks
 def test_execution(current_actor_context):
     current_actor_context.run()
     assert current_actor_context.consume(RpmTransactionTasks)
-    assert current_actor_context.consume(RpmTransactionTasks)[0].local_rpms
-    assert not current_actor_context.consume(RpmTransactionTasks)[0].to_install
+    assert current_actor_context.consume(RpmTransactionTasks)[0].to_install
     assert not current_actor_context.consume(RpmTransactionTasks)[0].to_remove
     assert not current_actor_context.consume(RpmTransactionTasks)[0].to_keep

--- a/repos/system_upgrade/el7toel8/models/rpmtransactiontasks.py
+++ b/repos/system_upgrade/el7toel8/models/rpmtransactiontasks.py
@@ -5,7 +5,6 @@ from leapp.topics import TransactionTopic
 class RpmTransactionTasks(Model):
     topic = TransactionTopic
 
-    local_rpms = fields.List(fields.String(), default=[])
     to_install = fields.List(fields.String(), default=[])
     to_keep = fields.List(fields.String(), default=[])
     to_remove = fields.List(fields.String(), default=[])


### PR DESCRIPTION
Put local/remote rpm paths into the same bucket with
to_install pkg names and decide install method in the
plugin.

This also fixes/enables including remote/local rpms
coming from /etc/transaction files