### PR TITLE
lint: introduce linter check with pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,63 @@
+[MESSAGES CONTROL]
+disable=
+# "F" Fatal errors that prevent further processing
+ import-error,
+# "I" Informational noise
+# "E" Error for important programming issues (likely bugs)
+ no-member,
+ no-name-in-module,
+ raising-bad-type,
+ undefined-variable,
+# "W" Warnings for stylistic problems or minor programming issues
+ anomalous-backslash-in-string,
+ arguments-differ,
+ attribute-defined-outside-init,
+ bad-indentation,
+ broad-except,
+ cell-var-from-loop,
+ deprecated-lambda,
+ fixme,
+ logging-not-lazy,
+ lost-exception,
+ no-init,
+ pointless-string-statement,
+ protected-access,
+ redefined-builtin,
+ redefined-outer-name,
+ relative-import,
+ undefined-loop-variable,
+ unsupported-membership-test,
+ unsubscriptable-object,
+ unused-argument,
+ unused-import,
+ unused-variable,
+# "C" Coding convention violations
+ bad-continuation,
+ bad-whitespace,
+ consider-iterating-dictionary,
+ invalid-name,
+ len-as-condition,
+ line-too-long,
+ missing-docstring,
+ old-style-class,
+ superfluous-parens,
+ trailing-newlines,
+ trailing-whitespace,
+ unidiomatic-typecheck,
+ wrong-import-order,
+ wrong-import-position,
+# "R" Refactor recommendations
+ duplicate-code,
+ inconsistent-return-statements,
+ no-else-return,
+ no-self-use,
+ too-few-public-methods,
+ too-many-branches,
+ too-many-locals,
+ too-many-statements,
+# new for python3 version of pylint
+ useless-object-inheritance
+
+[FORMAT]
+# Maximum number of characters on a single line.
+max-line-length=119

--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,13 @@ install-deps:
 	pip install --upgrade -r requirements.txt
 	python utils/install_actor_deps.py --actor=$(ACTOR)
 
-test:
+test:	lint
 	. tut/bin/activate; \
 	python utils/run_pytest.py --actor=$(ACTOR) --report=$(REPORT)
+
+lint:
+	. tut/bin/activate; \
+	bash -c "find repos -name '*.py' | xargs pylint"
 
 .PHONY: clean test install-deps build srpm
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 ### Additional requirements
 
+funcsigs==1.0.2
+mock==2.0.0
+pylint
 # pytest is fixed at 3.6.4 because never version (3.7.*) requires scandir, which depends on gcc
 pytest==3.6.4
 pytest-ordering==0.5
-funcsigs==1.0.2
-mock==2.0.0
 git+https://github.com/leapp-to/leapp


### PR DESCRIPTION
Added a minimal pylint config with everything disabled,
so that removing any line from disabled checks will
cause pylint falures on existing codebase.
The following commits will remove checks from
.pylintrc step by step with the following necessary code
refactor to make linter happy again.