### PR TITLE
execute repositories_mapping in FactsPhase

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/repositoriesmapping/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesmapping/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import scan_repositories
 from leapp.models import RepositoriesMap
 from leapp.reporting import Report
-from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
 class RepositoriesMapping(Actor):
@@ -13,7 +13,7 @@ class RepositoriesMapping(Actor):
     name = 'repository_mapping'
     consumes = ()
     produces = (RepositoriesMap, Report,)
-    tags = (IPUWorkflowTag, ChecksPhaseTag)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
 
     def process(self):
         scan_repositories('/etc/leapp/files/repomap.csv')


### PR DESCRIPTION
The actor has been previously processed in ChecksPhase but it access
the storage / system so it cannot be executed in this phase. Move
it to the facts phase instead.