### PR TITLE
testing: Tweaked testing to allow one actor test

### DIFF
--- a/utils/actor_path.py
+++ b/utils/actor_path.py
@@ -1,0 +1,23 @@
+import logging
+import sys
+
+from leapp.repository.scan import find_and_scan_repositories
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, filename='/dev/null')
+    logger = logging.getLogger('run_pytest.py')
+
+    BASE_REPO = 'repos'
+    repos = find_and_scan_repositories(BASE_REPO, include_locals=True)
+    repos.load()
+    if len(sys.argv) > 1:
+        actor = repos.lookup_actor(sys.argv[1])
+        if actor:
+            print(actor.full_path)
+        else:
+            sys.stdout.write('No actor found for search "{}"\n'.format(sys.argv[1]))
+            sys.exit(1)
+    else:
+        sys.stdout.write('Missing commandline argument\n')
+        sys.exit(1)

--- a/utils/run_pytest.py
+++ b/utils/run_pytest.py
@@ -8,9 +8,6 @@ There can be two arguments:
 
  1. ACTOR=myactor
 
-    NOTE: This is currently disabled, we will enable this when the CI will
-          support "one actor, one container" testing.
-
  2. REPORT=myreport.xml
 
     Outputs xml report for the JUnit.
@@ -89,12 +86,6 @@ if __name__ == "__main__":
     parser.add_argument("--report", help="filepath where to save report")
     args = parser.parse_args()
 
-    # User wants to test single actor specified in the args.actor.
-    if args.actor:
-        # NOTE: ACTOR flag is disabled. Check module docstring for more info.
-        logger.critical(" ACTOR flag is currently disabled!")
-        sys.exit(1)
-
     shutil.rmtree(REPORT_DIR, ignore_errors=True)
     os.mkdir(REPORT_DIR)
 
@@ -104,8 +95,8 @@ if __name__ == "__main__":
     # Find and collect leapp repositories.
     repos = find_and_scan_repositories(BASE_REPO, include_locals=True)
     repos.load()
-
-    for i, actor in enumerate(repos.actors):
+    actors = repos.actors if not args.actor else (repos.lookup_actor(args.actor),)
+    for i, actor in enumerate(actors):
         # Run tests if actor has any.
         if not actor.tests:
             status = " Tests MISSING: {ACTOR} | class={CLASS}"


### PR DESCRIPTION
This patch allows to run tests without linting via
`make test_no_lint`

Additionally this patch introduces necessary changes to allow to specify
one actor whose tests are going to be run and none else.

This is very convenient when writing actors and not having to execute
the whole repository of tests every time.

`make test ACTOR=MyActorClassName`

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>