### PR TITLE
makefile: Fix date usage to be compatible with BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ MASTER_BRANCH=master
 # upstream solution). For upstream builds N_REL=1;
 N_REL=`_NR=$${PR:+0}; if test "$${_NR:-1}" == "1"; then _NR=$${MR:+0}; fi; git rev-parse --abbrev-ref HEAD | grep -qE "^($(MASTER_BRANCH)|stable)$$" || _NR=0;  echo $${_NR:-1}`
 
-TIMESTAMP:=$${__TIMESTAMP:-$(shell /bin/date "+%Y%m%d%H%MZ" -u)}
+TIMESTAMP:=$${__TIMESTAMP:-$(shell /bin/date -u "+%Y%m%d%H%MZ")}
 SHORT_SHA=`git rev-parse --short HEAD`
 BRANCH=`git rev-parse --abbrev-ref HEAD | tr '-' '_'`
 


### PR DESCRIPTION
Having the parameter -u after the format string is incompatible with BSD
date which is a problem for non linux environments such as MacOS etc.

Swapping the location easily fixes it.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>