### PR TITLE
pylint: Better output

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -52,3 +52,6 @@ max-line-length=119
 [DESIGN]
 max-args=11
 max-attributes=11
+
+[REPORTS]
+msg-template='[{msg_id} {symbol}] {msg} File: {path}, line {line}, in {obj}'


### PR DESCRIPTION
The previous output was vague and it was not clear which file was
causing the pylint errors. This output is a bit more verbose however
more informative now.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>