### PR TITLE
Upgrade only signed packages

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/filterrpmtransactionevents/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/filterrpmtransactionevents/actor.py
@@ -28,6 +28,7 @@ class FilterRpmTransactionTasks(Actor):
         to_install = set()
         to_remove = set()
         to_keep = set()
+        to_upgrade = set()
         for event in self.consume(RpmTransactionTasks, PESRpmTransactionTasks):
             local_rpms.update(event.local_rpms)
             to_install.update(event.to_install)
@@ -36,8 +37,12 @@ class FilterRpmTransactionTasks(Actor):
 
         to_remove.difference_update(to_keep)
 
+        # run upgrade for the rest of RH signed pkgs which we do not have rule for
+        to_upgrade = installed_pkgs - (to_install | to_remove)
+
         self.produce(FilteredRpmTransactionTasks(
             local_rpms=list(local_rpms),
             to_install=list(to_install),
             to_remove=list(to_remove),
-            to_keep=list(to_keep)))
+            to_keep=list(to_keep),
+            to_upgrade=list(to_upgrade)))

--- a/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
+++ b/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
@@ -41,7 +41,7 @@ def build_plugin_data(target_repoids, debug, test, tasks):
             'local_rpms': [os.path.join('/installroot', pkg.lstrip('/')) for pkg in tasks.local_rpms],
             'to_install': [pkg for pkg in tasks.to_install],
             'to_remove': [pkg for pkg in tasks.to_remove],
-            #            'to_upgrade': [pkg for pkg in tasks.to_upgrade]
+            'to_upgrade': [pkg for pkg in tasks.to_upgrade]
         },
         'dnf_conf': {
             'allow_erasing': True,

--- a/repos/system_upgrade/el7toel8/models/rpmtransactiontasks.py
+++ b/repos/system_upgrade/el7toel8/models/rpmtransactiontasks.py
@@ -9,6 +9,7 @@ class RpmTransactionTasks(Model):
     to_install = fields.List(fields.String(), default=[])
     to_keep = fields.List(fields.String(), default=[])
     to_remove = fields.List(fields.String(), default=[])
+    to_upgrade = fields.List(fields.String(), default=[])
 
 
 class FilteredRpmTransactionTasks(RpmTransactionTasks):


### PR DESCRIPTION
The current plugin implementation was putting pkgs to be upgraded
to the transaction sack based on list of rpms from dnf which was
not filtered for only signed packages.