### PR TITLE
lint: relaxing max-args and max-attributes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -50,8 +50,8 @@ disable=
 max-line-length=119
 
 [DESIGN]
-max-args=11
-max-attributes=11
+max-args=21
+max-attributes=21
 
 [REPORTS]
 msg-template='[{msg_id} {symbol}] {msg} File: {path}, line {line}, in {obj}'


### PR DESCRIPTION
Turns out having (x2 + 1) from the default value is too strict, setting to (x4 + 1).