### PR TITLE
biosdevname: make doc string accurate

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/biosdevname/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/biosdevname/actor.py
@@ -9,7 +9,7 @@ from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 class Biosdevname(Actor):
     """
-    Enable biosdevname on RHEL8 if all interfaces on RHEL-7 used biosdevname naming scheme and if machine vendor is DELL
+    Enable biosdevname on RHEL8 if all interfaces on RHEL7 use biosdevname naming scheme and if machine vendor is DELL
     """
 
     name = 'biosdevname'

--- a/repos/system_upgrade/el7toel8/actors/biosdevname/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/biosdevname/actor.py
@@ -9,7 +9,7 @@ from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 class Biosdevname(Actor):
     """
-    Enable biosdevname on RHEL8 if all interfaces on RHEL-7 used biosdevname naming scheme or if machine vendor is DELL
+    Enable biosdevname on RHEL8 if all interfaces on RHEL-7 used biosdevname naming scheme and if machine vendor is DELL
     """
 
     name = 'biosdevname'


### PR DESCRIPTION
We enable biosdevname only if system is a Dell box and used biosdevname previously on all physical network interfaces.