### PR TITLE
lint: enable some more checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,16 +9,12 @@ disable=
  raising-bad-type,
 # "W" Warnings for stylistic problems or minor programming issues
  arguments-differ,
- attribute-defined-outside-init,
  cell-var-from-loop,
- deprecated-lambda,
  fixme,
- logging-not-lazy,
  lost-exception,
  no-init,
  pointless-string-statement,
  protected-access,
- redefined-builtin,
  redefined-outer-name,
  relative-import,
  undefined-loop-variable,
@@ -28,16 +24,9 @@ disable=
 # "C" Coding convention violations
  bad-continuation,
  invalid-name,
- len-as-condition,
  missing-docstring,
- old-style-class,
- superfluous-parens,
- unidiomatic-typecheck,
- wrong-import-order,
 # "R" Refactor recommendations
  duplicate-code,
- inconsistent-return-statements,
- no-else-return,
  no-self-use,
  too-few-public-methods,
  too-many-branches,
@@ -50,8 +39,8 @@ disable=
 max-line-length=119
 
 [DESIGN]
-max-args=21
-max-attributes=21
+max-args=11  # 2x + 1 from default
+max-attributes=21  # 4x + 1 from default
 
 [REPORTS]
 msg-template='[{msg_id} {symbol}] {msg} File: {path}, line {line}, in {obj}'

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
@@ -6,11 +6,17 @@ from leapp.models import BootContent
 
 
 class run_mocked(object):
+    def __init__(self):
+        self.args = None
+
     def __call__(self, args, split=False):
         self.args = args
 
 
 class write_to_file_mocked(object):
+    def __init__(self):
+        self.content = None
+
     def __call__(self, filename, content):
         self.content = content
 

--- a/repos/system_upgrade/el7toel8/actors/checkacpid/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkacpid/tests/component_test.py
@@ -18,7 +18,7 @@ def test_actor_with_acpid_package(current_actor_context):
 
     current_actor_context.feed(create_modulesfacts(installed_rpm=with_acpid))
     current_actor_context.run()
-    assert len(current_actor_context.consume(Report)) > 0
+    assert current_actor_context.consume(Report)
 
 
 def test_actor_without_acpid_package(current_actor_context):

--- a/repos/system_upgrade/el7toel8/actors/checkbootavailspace/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkbootavailspace/tests/unit_test.py
@@ -2,15 +2,7 @@ from leapp.libraries.actor.library import (MIN_AVAIL_BYTES_FOR_BOOT,
                                            check_avail_space_on_boot,
                                            inhibit_upgrade)
 from leapp.libraries.common import reporting
-
-
-class report_generic_mocked(object):
-    def __init__(self):
-        self.called = 0
-
-    def __call__(self, **report_fields):
-        self.called += 1
-        self.report_fields = report_fields
+from leapp.libraries.common.testutils import report_generic_mocked
 
 
 class fake_get_avail_bytes_on_boot(object):

--- a/repos/system_upgrade/el7toel8/actors/checkchrony/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkchrony/tests/unit_test.py
@@ -1,14 +1,6 @@
 from leapp.libraries.actor import library
 from leapp.libraries.common import reporting
-
-
-class report_generic_mocked(object):
-    def __init__(self):
-        self.called = 0
-
-    def __call__(self, **report_fields):
-        self.called += 1
-        self.report_fields = report_fields
+from leapp.libraries.common.testutils import report_generic_mocked
 
 
 def test_uninstalled(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/checkdosfstools/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkdosfstools/tests/component_test.py
@@ -18,7 +18,7 @@ def test_actor_with_dosfstools_package(current_actor_context):
 
     current_actor_context.feed(create_modulesfacts(installed_rpm=with_dosfstools))
     current_actor_context.run()
-    assert len(current_actor_context.consume(Report)) > 0
+    assert current_actor_context.consume(Report)
 
 
 def test_actor_without_dosfstools_package(current_actor_context):

--- a/repos/system_upgrade/el7toel8/actors/checkgrep/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkgrep/tests/component_test.py
@@ -18,7 +18,7 @@ def test_actor_with_grep_package(current_actor_context):
 
     current_actor_context.feed(create_modulesfacts(installed_rpm=with_grep))
     current_actor_context.run()
-    assert len(current_actor_context.consume(Report)) > 0
+    assert current_actor_context.consume(Report)
 
 
 def test_actor_without_grep_package(current_actor_context):

--- a/repos/system_upgrade/el7toel8/actors/checkhacluster/tests/test_check_ha_cluster.py
+++ b/repos/system_upgrade/el7toel8/actors/checkhacluster/tests/test_check_ha_cluster.py
@@ -11,7 +11,7 @@ def assert_inhibits(reports, node_type):
 def test_no_inhibit_when_no_ha_cluster(monkeypatch, current_actor_context):
     monkeypatch.setattr("os.path.isfile", lambda path: False)
     current_actor_context.run()
-    assert len(current_actor_context.consume(Report)) == 0
+    assert not current_actor_context.consume(Report)
 
 
 def test_inhibits_when_cluster_node(monkeypatch, current_actor_context):

--- a/repos/system_upgrade/el7toel8/actors/checkirssi/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkirssi/tests/component_test.py
@@ -18,7 +18,7 @@ def test_actor_with_irssi_package(current_actor_context):
 
     current_actor_context.feed(create_modulesfacts(installed_rpm=with_irssi))
     current_actor_context.run()
-    assert len(current_actor_context.consume(Report)) > 0
+    assert current_actor_context.consume(Report)
 
 
 def test_actor_without_irssi_package(current_actor_context):

--- a/repos/system_upgrade/el7toel8/actors/checkmemcached/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmemcached/tests/unit_test.py
@@ -1,14 +1,6 @@
 from leapp.libraries.actor import library
 from leapp.libraries.common import reporting
-
-
-class report_generic_mocked(object):
-    def __init__(self):
-        self.called = 0
-
-    def __call__(self, **report_fields):
-        self.called += 1
-        self.report_fields = report_fields
+from leapp.libraries.common.testutils import report_generic_mocked
 
 
 def test_uninstalled(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/checkntp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/libraries/library.py
@@ -54,7 +54,7 @@ def check_ntp(installed_packages):
             if main_config:
                 migrate_configs.append(service)
 
-    if len(migrate_configs):
+    if migrate_configs:
         reporting.report_generic(
              title='{} configuration will be migrated'.format(' and '.join(migrate_configs)),
              summary='{} service(s) detected to be enabled and active'.format(', '.join(migrate_services)),

--- a/repos/system_upgrade/el7toel8/actors/checkntp/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/tests/unit_test.py
@@ -7,15 +7,7 @@ import tempfile
 
 from leapp.libraries.actor import library
 from leapp.libraries.common import reporting
-
-
-class report_generic_mocked(object):
-    def __init__(self):
-        self.called = 0
-
-    def __call__(self, **report_fields):
-        self.called += 1
-        self.report_fields = report_fields
+from leapp.libraries.common.testutils import report_generic_mocked
 
 
 def test_nomigration(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/checkosrelease/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkosrelease/actor.py
@@ -36,7 +36,7 @@ class CheckOSRelease(Actor):
         }
 
         for facts in self.consume(OSReleaseFacts):
-            if facts.id not in min_supported_version.keys():
+            if facts.release_id not in min_supported_version.keys():
                 report_generic(
                     title='Unsupported OS id',
                     summary='Supported OS ids for upgrade process: ' + ','.join(min_supported_version.keys()),
@@ -44,7 +44,7 @@ class CheckOSRelease(Actor):
                 )
                 return
 
-            min_version = [int(x) for x in min_supported_version[facts.id].split('.')]
+            min_version = [int(x) for x in min_supported_version[facts.release_id].split('.')]
             os_version = [int(x) for x in facts.version_id.split('.')]
 
             for current, minimal in zip(os_version, min_version):
@@ -54,7 +54,8 @@ class CheckOSRelease(Actor):
                 if current < minimal:
                     report_generic(
                         title='Unsupported OS version',
-                        summary='Minimal supported OS version for upgrade process: ' + min_supported_version[facts.id],
+                        summary='Minimal supported OS version for upgrade process: {}'.format(
+                            min_supported_version[facts.release_id]),
                         flags=['inhibitor']
                     )
                     return

--- a/repos/system_upgrade/el7toel8/actors/checkosrelease/tests/test_checkosrelease.py
+++ b/repos/system_upgrade/el7toel8/actors/checkosrelease/tests/test_checkosrelease.py
@@ -6,7 +6,7 @@ from leapp.snactor.fixture import current_actor_context
 def create_osrelease(release_id, version_id=None):
     version_id = version_id or '42'
     return OSReleaseFacts(
-        id=release_id,
+        release_id=release_id,
         name='test',
         pretty_name='test {}'.format(version_id),
         version='Some Test {}'.format(version_id),

--- a/repos/system_upgrade/el7toel8/actors/checkosrelease/tests/test_checkosrelease.py
+++ b/repos/system_upgrade/el7toel8/actors/checkosrelease/tests/test_checkosrelease.py
@@ -3,10 +3,10 @@ from leapp.reporting import Report
 from leapp.snactor.fixture import current_actor_context
 
 
-def create_osrelease(id, version_id=None):
+def create_osrelease(release_id, version_id=None):
     version_id = version_id or '42'
     return OSReleaseFacts(
-        id=id,
+        id=release_id,
         name='test',
         pretty_name='test {}'.format(version_id),
         version='Some Test {}'.format(version_id),
@@ -17,7 +17,7 @@ def create_osrelease(id, version_id=None):
 
 
 def test_not_supported_id(current_actor_context):
-    current_actor_context.feed(create_osrelease(id='not_supported_id'))
+    current_actor_context.feed(create_osrelease(release_id='not_supported_id'))
     current_actor_context.run()
     assert current_actor_context.consume(Report)
     assert current_actor_context.consume(Report)[0].title == 'Unsupported OS id'
@@ -25,7 +25,7 @@ def test_not_supported_id(current_actor_context):
 
 
 def test_not_supported_major_version(current_actor_context):
-    current_actor_context.feed(create_osrelease(id='rhel', version_id='6.6'))
+    current_actor_context.feed(create_osrelease(release_id='rhel', version_id='6.6'))
     current_actor_context.run()
     assert current_actor_context.consume(Report)
     assert current_actor_context.consume(Report)[0].title == 'Unsupported OS version'
@@ -33,7 +33,7 @@ def test_not_supported_major_version(current_actor_context):
 
 
 def test_not_supported_minor_version(current_actor_context):
-    current_actor_context.feed(create_osrelease(id='rhel', version_id='7.5'))
+    current_actor_context.feed(create_osrelease(release_id='rhel', version_id='7.5'))
     current_actor_context.run()
     assert current_actor_context.consume(Report)
     assert current_actor_context.consume(Report)[0].title == 'Unsupported OS version'
@@ -41,18 +41,18 @@ def test_not_supported_minor_version(current_actor_context):
 
 
 def test_supported_major_version(current_actor_context):
-    current_actor_context.feed(create_osrelease(id='rhel', version_id='8.5'))
+    current_actor_context.feed(create_osrelease(release_id='rhel', version_id='8.5'))
     current_actor_context.run()
     assert not current_actor_context.consume(Report)
 
 
 def test_supported_minor_version(current_actor_context):
-    current_actor_context.feed(create_osrelease(id='rhel', version_id='7.7'))
+    current_actor_context.feed(create_osrelease(release_id='rhel', version_id='7.7'))
     current_actor_context.run()
     assert not current_actor_context.consume(Report)
 
 
 def test_same_supported_release(current_actor_context):
-    current_actor_context.feed(create_osrelease(id='rhel', version_id='7.6'))
+    current_actor_context.feed(create_osrelease(release_id='rhel', version_id='7.6'))
     current_actor_context.run()
     assert not current_actor_context.consume(Report)

--- a/repos/system_upgrade/el7toel8/actors/checkpostfix/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkpostfix/tests/component_test.py
@@ -31,4 +31,4 @@ def test_actor_without_postfix_package(current_actor_context):
 def test_actor_with_postfix_package(current_actor_context):
     current_actor_context.feed(create_modulesfacts(installed_rpm=with_postfix))
     current_actor_context.run()
-    assert len(current_actor_context.consume(Report)) > 0
+    assert current_actor_context.consume(Report)

--- a/repos/system_upgrade/el7toel8/actors/dnfshellrpmupgrade/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/dnfshellrpmupgrade/actor.py
@@ -12,15 +12,15 @@ from leapp.models import FilteredRpmTransactionTasks, UsedTargetRepositories, Tr
 from leapp.tags import RPMUpgradePhaseTag, IPUWorkflowTag
 
 
-def _logging_handler(fd_info, buffer):
+def _logging_handler(fd_info, a_buffer):
     '''Custom log handler to always show DNF stdout to console and stderr only in DEBUG mode'''
     (_unused, fd_type) = fd_info
 
     if fd_type == STDOUT:
-        sys.stdout.write(buffer)
+        sys.stdout.write(a_buffer)
     else:
         if is_debug():
-            sys.stderr.write(buffer)
+            sys.stderr.write(a_buffer)
 
 
 class DnfShellRpmUpgrade(Actor):

--- a/repos/system_upgrade/el7toel8/actors/firewalldfactsactor/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldfactsactor/actor.py
@@ -1,11 +1,10 @@
-from leapp.actors import Actor
-from leapp.models import FirewalldFacts
-from leapp.tags import FactsPhaseTag, IPUWorkflowTag
-
-from leapp.libraries.actor import private
-
 import os
 import xml.etree.ElementTree as ElementTree
+
+from leapp.actors import Actor
+from leapp.libraries.actor import private
+from leapp.models import FirewalldFacts
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
 class FirewalldFactsActor(Actor):
@@ -40,11 +39,11 @@ class FirewalldFactsActor(Actor):
         ipsetTypesInUse = set()
         directory = '/etc/firewalld/ipsets'
         try:
-            for file in os.listdir(directory):
-                if not file.endswith('.xml'):
+            for filename in os.listdir(directory):
+                if not filename.endswith('.xml'):
                     continue
                 try:
-                    tree = ElementTree.parse(os.path.join(directory, file))
+                    tree = ElementTree.parse(os.path.join(directory, filename))
                     root = tree.getroot()
                     ipsetTypesInUse |= set(private.getIpsetTypesInUse(root))
                 except IOError:

--- a/repos/system_upgrade/el7toel8/actors/firewalldfactsactor/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldfactsactor/tests/unit_test.py
@@ -1,6 +1,6 @@
-from leapp.libraries.actor import private
-
 import xml.etree.ElementTree as ElementTree
+
+from leapp.libraries.actor import private
 
 
 def test_firewalldfactsactor_direct():

--- a/repos/system_upgrade/el7toel8/actors/firewalldupdatelockdownwhitelist/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldupdatelockdownwhitelist/actor.py
@@ -1,9 +1,9 @@
+import xml.etree.ElementTree as ElementTree
+
 from leapp.actors import Actor
+from leapp.libraries.actor import private
 from leapp.models import FirewalldFacts
 from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
-from leapp.libraries.actor import private
-
-import xml.etree.ElementTree as ElementTree
 
 
 class FirewalldUpdateLockdownWhitelist(Actor):

--- a/repos/system_upgrade/el7toel8/actors/firewalldupdatelockdownwhitelist/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/firewalldupdatelockdownwhitelist/tests/unit_test.py
@@ -1,6 +1,6 @@
-from leapp.libraries.actor import private
-
 import xml.etree.ElementTree as ElementTree
+
+from leapp.libraries.actor import private
 
 
 def test_firewalldupdatelockdownwhitelist_library():

--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
@@ -54,7 +54,7 @@ def migrate_ntp(migrate_services, config_tgz64):
             'driftfile /var/lib/ntp/drift\n'
             'restrict default ignore nomodify notrap nopeer noquery\n')
 
-    if len(migrate_services) == 0:
+    if not migrate_services:
         # Nothing to migrate
         return
 
@@ -79,7 +79,7 @@ def migrate_ntp(migrate_services, config_tgz64):
 
     ignored_lines = ntp2chrony('/', ntp_conf, step_tickers)
 
-    if len(ignored_lines) == 0:
+    if not ignored_lines:
         reporting.report_generic(
                 title='{} configuration migrated to chrony'.format(' and '.join(migrate_configs)),
                 summary='ntp2chrony executed successfully',

--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/ntp2chrony.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/ntp2chrony.py
@@ -24,6 +24,7 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+from __future__ import print_function
 import argparse
 import ipaddress
 import logging

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/unit_test.py
@@ -1,19 +1,12 @@
 from leapp.libraries.actor import library
 from leapp.libraries.common import reporting
-
-
-class report_generic_mocked(object):
-    def __init__(self):
-        self.called = 0
-
-    def __call__(self, **report_fields):
-        self.called += 1
-        self.report_fields = report_fields
+from leapp.libraries.common.testutils import report_generic_mocked
 
 
 class extract_tgz64_mocked(object):
     def __init__(self):
         self.called = 0
+        self.s = None
 
     def __call__(self, s):
         self.called += 1
@@ -33,6 +26,8 @@ class enable_service_mocked(object):
 class write_file_mocked(object):
     def __init__(self):
         self.called = 0
+        self.name = None
+        self.content = None
 
     def __call__(self, name, content):
         self.called += 1
@@ -44,6 +39,7 @@ class ntp2chrony_mocked(object):
     def __init__(self, lines):
         self.called = 0
         self.ignored_lines = lines
+        self.args = None
 
     def __call__(self, *args):
         self.called += 1
@@ -67,7 +63,7 @@ def test_migration(monkeypatch):
 
         library.migrate_ntp(ntp_services, 'abcdef')
 
-        if len(ntp_services) > 0:
+        if ntp_services:
             assert reporting.report_generic.called == 1
             if ignored_lines > 0:
                 assert 'configuration partially migrated to chrony' in \

--- a/repos/system_upgrade/el7toel8/actors/networkmanagerreadconfig/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/networkmanagerreadconfig/actor.py
@@ -1,8 +1,9 @@
+from six.moves.configparser import ConfigParser, ParsingError
+
 from leapp.actors import Actor
 from leapp.libraries.stdlib import CalledProcessError, run
 from leapp.models import NetworkManagerConfig
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
-from six.moves.configparser import ConfigParser, ParsingError
 
 
 class NetworkManagerReadConfig(Actor):

--- a/repos/system_upgrade/el7toel8/actors/networkmanagerupdateconnections/tools/nm-update-client-ids.py
+++ b/repos/system_upgrade/el7toel8/actors/networkmanagerupdateconnections/tools/nm-update-client-ids.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import gi
 gi.require_version('NM', '1.0')

--- a/repos/system_upgrade/el7toel8/actors/networkmanagerupdateservice/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/networkmanagerupdateservice/actor.py
@@ -47,7 +47,7 @@ class NetworkManagerUpdateService(Actor):
     def unit_enabled(self, name):
         try:
             ret = run(['systemctl', 'is-enabled', name], split=True)['stdout']
-            if len(ret) > 0:
+            if ret:
                 enabled = ret[0] == 'enabled'
             else:
                 enabled = False

--- a/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
@@ -19,7 +19,7 @@ class OpenSshPermitRootLoginCheck(Actor):
 
     def process(self):
         for config in self.consume(OpenSshConfig):
-            if len(config.permit_root_login) == 0:
+            if not config.permit_root_login:
                 # TODO find out whether the file was modified and will be
                 # replaced by the update. If so, this message is bogus
                 report_with_remediation(

--- a/repos/system_upgrade/el7toel8/actors/osreleasecollector/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/osreleasecollector/libraries/library.py
@@ -17,7 +17,7 @@ def get_os_release_info(path):
         return None
 
     return OSReleaseFacts(
-        id=data.get('ID', '').strip('"'),
+        release_id=data.get('ID', '').strip('"'),
         name=data.get('NAME', '').strip('"'),
         pretty_name=data.get('PRETTY_NAME', '').strip('"'),
         version=data.get('VERSION', '').strip('"'),

--- a/repos/system_upgrade/el7toel8/actors/osreleasecollector/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/osreleasecollector/tests/unit_test.py
@@ -1,25 +1,7 @@
 from leapp.libraries.actor.library import get_os_release_info
 from leapp.libraries.common import reporting
+from leapp.libraries.common.testutils import produce_mocked, report_generic_mocked
 from leapp.models import OSReleaseFacts
-
-
-class produce_mocked(object):
-    def __init__(self):
-        self.called = 0
-        self.model_instances = []
-
-    def __call__(self, *model_instances):
-        self.called += 1
-        self.model_instances.append(model_instances[0])
-
-
-class report_generic_mocked(object):
-    def __init__(self):
-        self.called = 0
-
-    def __call__(self, **report_fields):
-        self.called += 1
-        self.report_fields = report_fields
 
 
 def test_get_os_release_info(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/osreleasecollector/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/osreleasecollector/tests/unit_test.py
@@ -9,7 +9,7 @@ def test_get_os_release_info(monkeypatch):
     monkeypatch.setattr(reporting, 'report_generic', report_generic_mocked())
 
     expected = OSReleaseFacts(
-        id='rhel',
+        release_id='rhel',
         name='Red Hat Enterprise Linux Server',
         pretty_name='Red Hat Enterprise Linux',
         version='7.6 (Maipo)',

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -330,7 +330,7 @@ def filter_out_transaction_conf_pkgs(to_install, to_remove, transaction_configur
             to_install.pop(pes_based_pkg_to_install)
             pes_based_pkgs_not_to_be_installed.append(pes_based_pkg_to_install)
     for pes_based_pkg_to_remove in to_remove.keys():
-        if pes_based_pkg_to_remove in (transaction_configuration.to_install + transaction_configuration.to_keep):
+        if pes_based_pkg_to_remove in transaction_configuration.to_install + transaction_configuration.to_keep:
             to_remove.pop(pes_based_pkg_to_remove)
             pes_based_pkgs_not_to_be_removed.append(pes_based_pkg_to_remove)
 

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
@@ -15,6 +15,7 @@ from leapp.libraries.actor.library import (Event,
                                            process_events,
                                            report_skipped_packages)
 from leapp.libraries.common import reporting
+from leapp.libraries.common.testutils import produce_mocked, report_generic_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import RpmTransactionTasks
 
@@ -22,32 +23,14 @@ from leapp.models import RpmTransactionTasks
 class show_message_mocked(object):
     def __init__(self):
         self.called = 0
+        self.msg = None
 
     def __call__(self, msg):
         self.called += 1
         self.msg = msg
 
 
-class produce_mocked(object):
-    def __init__(self):
-        self.called = 0
-        self.model_instances = []
-
-    def __call__(self, *model_instances):
-        self.called += 1
-        self.model_instances.append(model_instances[0])
-
-
-class report_generic_mocked(object):
-    def __init__(self):
-        self.called = 0
-
-    def __call__(self, **report_fields):
-        self.called += 1
-        self.report_fields = report_fields
-
-
-class get_repos_blacklisted_mocked():
+class get_repos_blacklisted_mocked(object):
     def __init__(self, blacklisted):
         self.blacklisted = blacklisted
 

--- a/repos/system_upgrade/el7toel8/actors/powertop/tests/component_test.py
+++ b/repos/system_upgrade/el7toel8/actors/powertop/tests/component_test.py
@@ -18,7 +18,7 @@ def test_actor_with_powertop_package(current_actor_context):
 
     current_actor_context.feed(create_modulesfacts(installed_rpm=with_powertop))
     current_actor_context.run()
-    assert len(current_actor_context.consume(Report)) > 0
+    assert current_actor_context.consume(Report)
 
 
 def test_actor_without_powertop_package(current_actor_context):

--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/actor.py
@@ -118,7 +118,7 @@ class PrepareUpgradeTransaction(Actor):
 
         Return ErrorData or None.
         """
-        self.target_repoids = []
+        self.target_repoids = []  # noqa; pylint: disable=attribute-defined-outside-init
         skip_rhsm = os.getenv('LEAPP_DEVEL_SKIP_RHSM', '0') == '1'
 
         # TODO: skip_rhsm will work for now, but later it should be refactored better
@@ -335,10 +335,10 @@ class PrepareUpgradeTransaction(Actor):
             dnfplugin_dpath = '/lib/python2.7/site-packages/dnf-plugins'
 
             error = preparetransaction.copy_file_to_container(ofs_info, dnfplugin_spath, dnfplugin_dpath)
-            if error:
-                return error
 
-        error = self.dnf_plugin_rpm_download(ofs_info)
+        if not error:
+            error = self.dnf_plugin_rpm_download(ofs_info)
+
         if not error:
             error = preparetransaction.copy_file_from_container(
                 ofs_info,

--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/libraries/preparetransaction.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/libraries/preparetransaction.py
@@ -43,9 +43,8 @@ def space_guard(path='/', min_free_mb=100):
         free_mb = (info.f_bavail * info.f_frsize) >> 20
         if free_mb >= min_free_mb:
             return None
-        else:
-            return ('''Not enough free disk space in '{path}', needed: {min} M, available: {avail} M.'''
-                    ' Free more disk space and try again.'.format(path=path, min=min_free_mb, avail=free_mb))
+        return ('''Not enough free disk space in '{path}', needed: {min} M, available: {avail} M.'''
+                ' Free more disk space and try again.'.format(path=path, min=min_free_mb, avail=free_mb))
     return closure
 
 
@@ -54,15 +53,15 @@ def permission_guard():
     raise NotImplementedError
 
 
-def _logging_handler(fd_info, buffer):
+def _logging_handler(fd_info, a_buffer):
     '''Custom log handler to always show DNF stdout to console and stderr only in DEBUG mode'''
     (_unused, fd_type) = fd_info
 
     if fd_type == STDOUT:
-        sys.stdout.write(buffer)
+        sys.stdout.write(a_buffer)
     else:
         if is_debug():
-            sys.stderr.write(buffer)
+            sys.stderr.write(a_buffer)
 
 
 def guard_call(cmd, guards=(), print_output=False):

--- a/repos/system_upgrade/el7toel8/actors/prepareyumconfig/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareyumconfig/tests/unit_test.py
@@ -4,6 +4,7 @@ from leapp.libraries.actor import library
 class run_mocked(object):
     def __init__(self):
         self.called = 0
+        self.args = None
 
     def __call__(self, args, split=True):
         self.called += 1

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/libraries/library.py
@@ -18,7 +18,7 @@ def skip_check():
 
 def generate_report(packages):
     """ Generate a report if exists packages unsigned in the system """
-    if not len(packages):
+    if not packages:
         return
     unsigned_packages_new_line = '\n'.join(['- ' + p for p in packages])
     unsigned_packages = ' '.join(packages)

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
@@ -4,29 +4,11 @@ import pytest
 from leapp.exceptions import StopActorExecution
 from leapp.libraries.actor import library
 from leapp.libraries.common import reporting
+from leapp.libraries.common.testutils import produce_mocked, report_generic_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import RPM, InstalledUnsignedRPM
 
 RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
-
-
-class produce_mocked(object):
-    def __init__(self):
-        self.called = 0
-        self.model_instances = []
-
-    def __call__(self, *model_instances):
-        self.called += 1
-        self.model_instances.append(model_instances[0])
-
-
-class report_generic_mocked(object):
-    def __init__(self):
-        self.called = 0
-
-    def __call__(self, **report_fields):
-        self.called += 1
-        self.report_fields = report_fields
 
 
 def test_skip_check(monkeypatch):
@@ -56,7 +38,7 @@ def test_actor_execution_without_unsigned_data(monkeypatch):
     monkeypatch.setattr(reporting, "report_with_remediation", report_generic_mocked())
 
     packages = library.get_unsigned_packages()
-    assert len(packages) == 0
+    assert not packages
     library.generate_report(packages)
     assert reporting.report_with_remediation.called == 0
 

--- a/repos/system_upgrade/el7toel8/actors/removebootfiles/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/removebootfiles/tests/unit_test.py
@@ -11,12 +11,16 @@ class remove_file_mocked(object):
         self.called = 0
         self.files_to_remove = []
 
-    def __call__(self, file):
+    def __call__(self, filename):
         self.called += 1
-        self.files_to_remove.append(file)
+        self.files_to_remove.append(filename)
 
 
 class logger_mocked(object):
+    def __init__(self):
+        self.warnmsg = None
+        self.errmsg = None
+
     def warning(self, msg):
         self.warnmsg = msg
 

--- a/repos/system_upgrade/el7toel8/actors/repositoriesmapping/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesmapping/libraries/library.py
@@ -43,7 +43,7 @@ def scan_repositories(path):
             except ModelViolationError as err:
                 inhibit_upgrade('Repositories map file is invalid ({})'.format(err))
 
-    if len(repositories) == 0:
+    if not repositories:
         inhibit_upgrade('Repositories map file is invalid ({})'.format(path))
 
     api.produce(RepositoriesMap(repositories=repositories))

--- a/repos/system_upgrade/el7toel8/actors/repositoriesmapping/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesmapping/tests/unit_test.py
@@ -3,27 +3,9 @@ import pytest
 from leapp.exceptions import StopActorExecution
 from leapp.libraries.actor.library import scan_repositories
 from leapp.libraries.common import reporting
+from leapp.libraries.common.testutils import produce_mocked, report_generic_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import RepositoriesMap, RepositoryMap
-
-
-class produce_mocked(object):
-    def __init__(self):
-        self.called = 0
-        self.model_instances = []
-
-    def __call__(self, *model_instances):
-        self.called += 1
-        self.model_instances.append(model_instances[0])
-
-
-class report_generic_mocked(object):
-    def __init__(self):
-        self.called = 0
-
-    def __call__(self, **report_fields):
-        self.called += 1
-        self.report_fields = report_fields
 
 
 def test_scan_valid_file(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/rpmscanner/tests/test_rpmscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmscanner/tests/test_rpmscanner.py
@@ -5,4 +5,4 @@ from leapp.models import InstalledRPM
 def test_actor_execution(current_actor_context):
     current_actor_context.run()
     assert current_actor_context.consume(InstalledRPM)
-    assert len(current_actor_context.consume(InstalledRPM)[0].items) > 0
+    assert current_actor_context.consume(InstalledRPM)[0].items

--- a/repos/system_upgrade/el7toel8/actors/storagescanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/storagescanner/libraries/library.py
@@ -178,7 +178,7 @@ def _get_systemd_mount_info():
     ''' Collect storage info from systemd-mount command '''
     for entry in _get_cmd_output(['systemd-mount', '--list'], ' ', 7):
         # We need to filter the entry because there is a ton of whitespace.
-        node, path, model, wwn, fs_type, label, uuid = list(filter(lambda x: x != '', entry))
+        node, path, model, wwn, fs_type, label, uuid = [x for x in entry if x != '']
         if node == "NODE":
             # First row of the "systemd-mount --list" output is a header.
             # Just skip it.

--- a/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
@@ -7,7 +7,7 @@ import os
 import pwd
 import re
 
-from six.moves.configparser import ConfigParser as configparser
+from six.moves import configparser
 import six
 
 from leapp.libraries.stdlib import CalledProcessError, api, run

--- a/repos/system_upgrade/el7toel8/actors/systemfacts/tests/test_systemfacts.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/tests/test_systemfacts.py
@@ -1,8 +1,8 @@
+from leapp.libraries.actor.systemfacts import anyhasprefix, anyendswith, aslist
 from leapp.snactor.fixture import current_actor_libraries
 
 
 def test_anyendswith(current_actor_libraries):
-    from leapp.libraries.actor.systemfacts import anyendswith
     value = 'this_is_a_test'
 
     assert anyendswith(value, ['a_test'])
@@ -13,7 +13,6 @@ def test_anyendswith(current_actor_libraries):
 
 
 def test_anyhasprefix(current_actor_libraries):
-    from leapp.libraries.actor.systemfacts import anyhasprefix
     value = 'this_is_a_test'
 
     assert anyhasprefix(value, ['this'])
@@ -24,7 +23,6 @@ def test_anyhasprefix(current_actor_libraries):
 
 
 def test_aslist(current_actor_libraries):
-    from leapp.libraries.actor.systemfacts import aslist
 
     @aslist
     def local():

--- a/repos/system_upgrade/el7toel8/actors/systemfacts/tests/test_systemfacts_selinux.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/tests/test_systemfacts_selinux.py
@@ -57,7 +57,7 @@ def test_selinux_disabled(monkeypatch):
     assert SELinuxFacts(**expected_data) == get_selinux_status()
 
 
-class MockNoConfigFileOSError:
+class MockNoConfigFileOSError(object):
     def __init__(self):
         raise OSError
 

--- a/repos/system_upgrade/el7toel8/actors/tcpwrappersconfigread/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/tcpwrappersconfigread/tests/test_library.py
@@ -123,7 +123,7 @@ def test_get_daemon_lists_in_file():
 def test_get_daemon_lists_in_file_nonexistent():
     reader = MockFileReader()
     daemon_lists = library._get_daemon_lists_in_file('/etc/hosts.allow', read_func=reader.read)
-    assert len(daemon_lists) == 0
+    assert not daemon_lists
 
 
 def test_get_daemon_lists():
@@ -144,7 +144,7 @@ def test_get_daemon_lists():
 def test_get_daemon_lists_nonexistent_config():
     reader = MockFileReader()
     daemon_lists = library._get_daemon_lists(read_func=reader.read)
-    assert len(daemon_lists) == 0
+    assert not daemon_lists
 
 
 def test_get_tcp_wrappers_facts():
@@ -165,4 +165,4 @@ def test_get_tcp_wrappers_facts():
 def test_get_tcp_wrappers_facts_nonexistent_config():
     reader = MockFileReader()
     facts = library.get_tcp_wrappers_facts(read_func=reader.read)
-    assert len(facts.daemon_lists) == 0
+    assert not facts.daemon_lists

--- a/repos/system_upgrade/el7toel8/actors/updateetcsysconfigkernel/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/updateetcsysconfigkernel/tests/unit_test.py
@@ -1,6 +1,7 @@
 import os
-import pytest
 import tempfile
+
+import pytest
 
 from leapp.libraries.actor import library
 

--- a/repos/system_upgrade/el7toel8/actors/verifycheckresults/libraries/report.py
+++ b/repos/system_upgrade/el7toel8/actors/verifycheckresults/libraries/report.py
@@ -1,7 +1,7 @@
 import json
 
 
-class PlainTextReport:
+class PlainTextReport(object):
     def header(self, report_file):
         pass
 
@@ -17,7 +17,7 @@ class PlainTextReport:
         pass
 
 
-class JSONReport:
+class JSONReport(object):
     _first_entry = True
 
     def header(self, report_file):

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigcheck/libraries/library.py
@@ -4,7 +4,7 @@ from leapp.libraries.common.tcpwrappersutils import config_applies_to_daemon
 
 def check_config_supported(tcpwrap_facts, vsftpd_facts):
     bad_configs = [config.path for config in vsftpd_facts.configs if config.tcp_wrappers]
-    if len(bad_configs) > 0 and config_applies_to_daemon(tcpwrap_facts, 'vsftpd'):
+    if bad_configs and config_applies_to_daemon(tcpwrap_facts, 'vsftpd'):
         list_separator_fmt = '\n    - '
         report_with_links(title='Unsupported vsftpd configuration',
                           summary=('tcp_wrappers support has been removed in RHEL-8. '

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/libraries/config_parser.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/libraries/config_parser.py
@@ -82,7 +82,7 @@ class VsftpdConfigParser(object):
         self.parsed_config = self._parse_config(config_content)
 
     def _parse_config_line(self, line, conf_dict):
-        if len(line) == 0 or line.startswith('#') or line.isspace():
+        if not line or line.startswith('#') or line.isspace():
             return
         try:
             option, value = line.split('=', 1)

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/tests/test_config_parser.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/tests/test_config_parser.py
@@ -70,17 +70,17 @@ def test_VsftpdConfigParser_invalid_syntax():
 def test_VsftpdConfigParser_empty_config():
     parser = VsftpdConfigParser('')
     assert isinstance(parser.parsed_config, dict)
-    assert len(parser.parsed_config) == 0
+    assert not parser.parsed_config
 
 
 def test_VsftpdConfigParser_only_comments():
     parser = VsftpdConfigParser('# foo\n\n#bar\n')
     assert isinstance(parser.parsed_config, dict)
-    assert len(parser.parsed_config) == 0
+    assert not parser.parsed_config
 
     parser = VsftpdConfigParser('#anonymous_enable=yes\n')
     assert isinstance(parser.parsed_config, dict)
-    assert len(parser.parsed_config) == 0
+    assert not parser.parsed_config
 
 
 def test_VsftpdConfigParser_one_option():

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/tests/test_library.py
@@ -94,7 +94,7 @@ def test_get_parsed_configs_empty_dir():
 
     assert not listdir.error
     assert fileops.read_called == 0
-    assert len(parsed_configs) == 0
+    assert not parsed_configs
 
 
 def test_get_parsed_configs_nonexistent_dir():
@@ -105,7 +105,7 @@ def test_get_parsed_configs_nonexistent_dir():
                                                  listdir=listdir.listdir)
 
     assert fileops.read_called == 0
-    assert len(parsed_configs) == 0
+    assert not parsed_configs
 
 
 def test_get_parsed_configs_inaccessible_dir():
@@ -116,7 +116,7 @@ def test_get_parsed_configs_inaccessible_dir():
                                                  listdir=listdir.listdir)
 
     assert fileops.read_called == 0
-    assert len(parsed_configs) == 0
+    assert not parsed_configs
 
 
 def test_get_vsftpd_facts():
@@ -163,7 +163,7 @@ def test_get_vsftpd_facts_empty_dir():
     facts = library.get_vsftpd_facts(read_func=fileops.read, listdir=listdir.listdir)
 
     assert facts.default_config_hash is None
-    assert len(facts.configs) == 0
+    assert not facts.configs
 
 
 def test_get_vsftpd_facts_nonexistent_dir():
@@ -173,7 +173,7 @@ def test_get_vsftpd_facts_nonexistent_dir():
     facts = library.get_vsftpd_facts(read_func=fileops.read, listdir=listdir.listdir)
 
     assert facts.default_config_hash is None
-    assert len(facts.configs) == 0
+    assert not facts.configs
 
 
 def test_get_vsftpd_facts_inaccessible_dir():
@@ -183,7 +183,7 @@ def test_get_vsftpd_facts_inaccessible_dir():
     facts = library.get_vsftpd_facts(read_func=fileops.read, listdir=listdir.listdir)
 
     assert facts.default_config_hash is None
-    assert len(facts.configs) == 0
+    assert not facts.configs
 
 
 def test_is_processable_vsftpd_installed():

--- a/repos/system_upgrade/el7toel8/libraries/persistentnetnames.py
+++ b/repos/system_upgrade/el7toel8/libraries/persistentnetnames.py
@@ -11,7 +11,7 @@ def physical_interfaces():
     Returns a list of pyudev.Device objects for all physical network interfaces
     """
     enumerator = pyudev.Enumerator(udev_context).match_subsystem('net')
-    return (d for d in enumerator if not d.device_path.startswith('/devices/virtual/'))
+    return [d for d in enumerator if not d.device_path.startswith('/devices/virtual/')]
 
 
 def pci_info(path):

--- a/repos/system_upgrade/el7toel8/libraries/persistentnetnames.py
+++ b/repos/system_upgrade/el7toel8/libraries/persistentnetnames.py
@@ -11,7 +11,7 @@ def physical_interfaces():
     Returns a list of pyudev.Device objects for all physical network interfaces
     """
     enumerator = pyudev.Enumerator(udev_context).match_subsystem('net')
-    return filter(lambda d: not d.device_path.startswith('/devices/virtual/'), enumerator)
+    return (d for d in enumerator if not d.device_path.startswith('/devices/virtual/'))
 
 
 def pci_info(path):

--- a/repos/system_upgrade/el7toel8/libraries/tcpwrappersutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/tcpwrappersutils.py
@@ -56,7 +56,7 @@ def _daemon_list_matches_daemon(daemon_list, daemon, recursion_depth):
             break
 
     next_list = daemon_list[cur_list_end + 1:]
-    if len(next_list) == 0:
+    if not next_list:
         matches_next_list = False
     else:
         matches_next_list = _daemon_list_matches_daemon(next_list, daemon, recursion_depth + 1)

--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -1,6 +1,26 @@
 import os
 
 
+class produce_mocked(object):
+    def __init__(self):
+        self.called = 0
+        self.model_instances = []
+
+    def __call__(self, *model_instances):
+        self.called += 1
+        self.model_instances.append(model_instances[0])
+
+
+class report_generic_mocked(object):
+    def __init__(self):
+        self.called = 0
+        self.report_fields = None
+
+    def __call__(self, **report_fields):
+        self.called += 1
+        self.report_fields = report_fields
+
+
 def make_IOError(error):
     '''
     Create an IOError instance

--- a/repos/system_upgrade/el7toel8/models/osreleasefacts.py
+++ b/repos/system_upgrade/el7toel8/models/osreleasefacts.py
@@ -5,7 +5,7 @@ from leapp.topics import SystemInfoTopic
 class OSReleaseFacts(Model):
     topic = SystemInfoTopic
 
-    id = fields.String()
+    release_id = fields.String()
     name = fields.String()
     pretty_name = fields.String()
     version = fields.String()


### PR DESCRIPTION
Enabled:
- attribute-defined-outside-init,
- deprecated-lambda,
- logging-not-lazy,
- redefined-builtin,
- undefined-loop-variable [possibly uncovered a bug in SetupTargetRepos actor]

Besides some duplicated code from tests has been moved to
leapp.library.common.testutils module, other tests that were
using report_generic_mocked and produce_mocked refactored.