### PR TITLE
Use rhel8 systemd-nspawn

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -38,8 +38,8 @@ do_upgrade() {
     # NOTE: in case we would need to run leapp before pivot, we would need to
     #       specify where the root is, e.g. --root=/sysroot
     # TODO: update: systemd-nspawn
-    nspawn_opts="--capability=all --bind=/sys --bind=/dev --bind=/proc --bind=/run/udev --keep-unit --register=no"
-    $NEWROOT/bin/systemd-nspawn $nspawn_opts -D $NEWROOT $LEAPPBIN upgrade --resume $args
+    nspawn_opts="--capability=all --bind=/sys --bind=/dev --bind=/proc --bind=/run/udev --keep-unit --register=no --timezone=off --resolv-conf=off"
+    /bin/systemd-nspawn $nspawn_opts -D $NEWROOT $LEAPPBIN upgrade --resume $args
     rv=$?
 
     # NOTE: flush the cached content to disk to ensure everything is written
@@ -60,7 +60,7 @@ do_upgrade() {
         # all FSTAB partitions. As mount was working before, hopefully will
         # work now as well. Later this should be probably modified as we will
         # need to handle more stuff around storage at all.
-        $NEWROOT/bin/systemd-nspawn $nspawn_opts -D $NEWROOT /usr/bin/bash -c "mount -a; /usr/bin/python3 $LEAPP3_BIN upgrade --resume $args"
+        /bin/systemd-nspawn $nspawn_opts -D $NEWROOT /usr/bin/bash -c "mount -a; /usr/bin/python3 $LEAPP3_BIN upgrade --resume $args"
         rv=$?
     fi
 

--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/files/generate-initram.sh
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/files/generate-initram.sh
@@ -42,6 +42,7 @@ build() {
         --confdir /var/empty \
         --force \
         --add sys-upgrade \
+        --install systemd-nspawn \
         --no-hostonly \
         --nolvmconf \
         --nomdadmconf \


### PR DESCRIPTION
In order to use new "--resolv-conf=" and "--timezone=" parameters
we need systemd-nspawn at least of version 239. Currently we are
using v219.

The above mentioned parameters are needed in order to avoid
removing "/etc/localtime" symlink and "/etc/resolv.conf" file
during the upgrade.