### PR TITLE
WIP: Display message with path to generated report

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/verifycheckresults/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/verifycheckresults/actor.py
@@ -1,4 +1,5 @@
 from leapp.actors import Actor
+from leapp.dialogs import RawMessageDialog
 from leapp.libraries.actor import report
 from leapp.reporting import Report
 from leapp.tags import ReportPhaseTag, IPUWorkflowTag
@@ -29,6 +30,9 @@ class VerifyCheckResults(Actor):
             self.report_error('Report Error: ' + error)
         else:
             self.log.info('Generated report at ' + report_file)
+            self.messaging.request_answers(
+                RawMessageDialog(message='Generated report at ' + report_file)
+            )
 
         if inhibitors:
             for e in inhibitors:


### PR DESCRIPTION
Related to https://github.com/oamg/leapp/pull/515.

After `leapp preupgrade` successfully ends, there's no info about where the report was generated (unless running in debug/verbose mode). This PR attempts to change that. Since the report path is known by the actor only, the message is generated from inside the actor.