### PR TITLE
Avoid possible misinterpratation of grubby --title parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ ENV/
 # All kinds of vim stuff
 **/*~
 *.sw[a-z]
+
+# visual studio code configuration
+.vscode

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
@@ -14,7 +14,7 @@ def add_boot_entry():
         '/usr/sbin/grubby',
         '--add-kernel={0}'.format(kernel_dst_path),
         '--initrd={0}'.format(initram_dst_path),
-        '--title=RHEL Upgrade Initramfs',
+        '--title="RHEL Upgrade Initramfs"',
         '--copy-default',
         '--make-default',
         '--args="{DEBUG} enforcing=0 rd.plymouth=0 plymouth.enable=0"'.format(DEBUG=debug)

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
@@ -24,8 +24,8 @@ def test_add_boot_entry(monkeypatch):
 
     library.add_boot_entry()
 
-    assert ' '.join(library.run.args) == ('/usr/sbin/grubby --add-kernel=/abc --initrd=/def --title=RHEL'
-                                          ' Upgrade Initramfs --copy-default --make-default --args="debug'
+    assert ' '.join(library.run.args) == ('/usr/sbin/grubby --add-kernel=/abc --initrd=/def --title="RHEL'
+                                          ' Upgrade Initramfs" --copy-default --make-default --args="debug'
                                           ' enforcing=0 rd.plymouth=0 plymouth.enable=0"')
 
 


### PR DESCRIPTION
Value of --title wasn't in quotes which could result in it being split and cause a failure of grubby