### PR TITLE
Fix failure to add grub upgrade entry

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
@@ -14,7 +14,7 @@ def add_boot_entry():
         '/usr/sbin/grubby',
         '--add-kernel={0}'.format(kernel_dst_path),
         '--initrd={0}'.format(initram_dst_path),
-        '--title=RHEL Upgrade Initramfs',
+        '--title="RHEL Upgrade Initramfs"',
         '--copy-default',
         '--make-default',
         '--args="{DEBUG} enforcing=0 rd.plymouth=0 plymouth.enable=0"'.format(DEBUG=debug)

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
@@ -30,8 +30,8 @@ def test_add_boot_entry(monkeypatch):
 
     library.add_boot_entry()
 
-    assert ' '.join(library.run.args) == ('/usr/sbin/grubby --add-kernel=/abc --initrd=/def --title=RHEL'
-                                          ' Upgrade Initramfs --copy-default --make-default --args="debug'
+    assert ' '.join(library.run.args) == ('/usr/sbin/grubby --add-kernel=/abc --initrd=/def --title="RHEL'
+                                          ' Upgrade Initramfs" --copy-default --make-default --args="debug'
                                           ' enforcing=0 rd.plymouth=0 plymouth.enable=0"')
 
 


### PR DESCRIPTION
The grub entry title with whitespace passed to grubby was missing quotation marks.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1718161