### PR TITLE
Add debug-shell service to dracut

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/files/generate-initram.sh
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/files/generate-initram.sh
@@ -42,6 +42,7 @@ build() {
         --confdir /var/empty \
         --force \
         --add sys-upgrade \
+        --install "/usr/lib/systemd/system/debug-shell.service /usr/lib/systemd/system-generators/systemd-debug-generator" \
         --no-hostonly \
         --nolvmconf \
         --nomdadmconf \


### PR DESCRIPTION
With debug-shell.service running we get another console
on tty9 which can help with debugging currently running
processes.

Unfortunately atm activating the service from kernel
cmdline using "systemd.debug-shell=1" does not seem
to work.

As a workaround we can drop to dracut emergency shell
using "rd.break=upgrade", then issue:

\# systemctl start debug-shell

then we can start the upgrade process manually and
switch to debug-shell to investigate \o/

One small step in the code, one giant Leapp for debugging.