### PR TITLE
Split grubby args and avoid need to quote

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
@@ -12,12 +12,12 @@ def add_boot_entry():
     kernel_dst_path, initram_dst_path = get_boot_file_paths()
     run([
         '/usr/sbin/grubby',
-        '--add-kernel={0}'.format(kernel_dst_path),
-        '--initrd={0}'.format(initram_dst_path),
-        '--title="RHEL Upgrade Initramfs"',
+        '--add-kernel', '{0}'.format(kernel_dst_path),
+        '--initrd', '{0}'.format(initram_dst_path),
+        '--title', 'RHEL Upgrade Initramfs',
         '--copy-default',
         '--make-default',
-        '--args="{DEBUG} enforcing=0 rd.plymouth=0 plymouth.enable=0"'.format(DEBUG=debug)
+        '--args', '{DEBUG} enforcing=0 rd.plymouth=0 plymouth.enable=0'.format(DEBUG=debug)
     ])
 
 

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
@@ -30,9 +30,14 @@ def test_add_boot_entry(monkeypatch):
 
     library.add_boot_entry()
 
-    assert ' '.join(library.run.args) == ('/usr/sbin/grubby --add-kernel /abc --initrd /def --title RHEL'
-                                          ' Upgrade Initramfs --copy-default --make-default --args debug'
-                                          ' enforcing=0 rd.plymouth=0 plymouth.enable=0')
+    assert library.run.args == ['/usr/sbin/grubby',
+                                '--add-kernel', '/abc',
+                                '--initrd', '/def',
+                                '--title', 'RHEL Upgrade Initramfs',
+                                '--copy-default',
+                                '--make-default',
+                                '--args',
+                                'debug enforcing=0 rd.plymouth=0 plymouth.enable=0']
 
 
 def test_get_boot_file_paths(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
@@ -30,9 +30,9 @@ def test_add_boot_entry(monkeypatch):
 
     library.add_boot_entry()
 
-    assert ' '.join(library.run.args) == ('/usr/sbin/grubby --add-kernel=/abc --initrd=/def --title="RHEL'
-                                          ' Upgrade Initramfs" --copy-default --make-default --args="debug'
-                                          ' enforcing=0 rd.plymouth=0 plymouth.enable=0"')
+    assert ' '.join(library.run.args) == ('/usr/sbin/grubby --add-kernel /abc --initrd /def --title RHEL'
+                                          ' Upgrade Initramfs --copy-default --make-default --args debug'
+                                          ' enforcing=0 rd.plymouth=0 plymouth.enable=0')
 
 
 def test_get_boot_file_paths(monkeypatch):


### PR DESCRIPTION
The --foo=bar syntax can be confusing at times, so let's avoid it.

Fixes: #242