### PR TITLE
lint: check imports order with flake8 plugin

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -25,6 +25,7 @@ disable=
  bad-continuation,
  invalid-name,
  missing-docstring,
+ wrong-import-order,
 # "R" Refactor recommendations
  duplicate-code,
  no-self-use,

--- a/repos/system_upgrade/el7toel8/actors/checkfirewalld/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfirewalld/actor.py
@@ -1,10 +1,9 @@
 from leapp.actors import Actor
 from leapp.models import FirewalldFacts
-from leapp.reporting import Report
-from leapp.libraries.common.reporting import report_with_remediation
-from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
-
 from leapp.libraries.actor import private
+from leapp.libraries.common.reporting import report_with_remediation
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
 class CheckFirewalld(Actor):

--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/ntp2chrony.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/ntp2chrony.py
@@ -25,6 +25,7 @@
 
 
 from __future__ import print_function
+
 import argparse
 import ipaddress
 import logging

--- a/repos/system_upgrade/el7toel8/actors/networkmanagerupdateconnections/tools/nm-update-client-ids.py
+++ b/repos/system_upgrade/el7toel8/actors/networkmanagerupdateconnections/tools/nm-update-client-ids.py
@@ -1,5 +1,7 @@
 from __future__ import print_function
+
 import sys
+
 import gi
 gi.require_version('NM', '1.0')
 from gi.repository import NM  # noqa: F402; pylint: disable=wrong-import-position

--- a/repos/system_upgrade/el7toel8/actors/persistentnetnames/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/persistentnetnames/actor.py
@@ -1,6 +1,5 @@
-from leapp.libraries.common import persistentnetnames
-
 from leapp.actors import Actor
+from leapp.libraries.common import persistentnetnames
 from leapp.models import PersistentNetNamesFacts
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 

--- a/repos/system_upgrade/el7toel8/actors/persistentnetnamesdisable/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/persistentnetnamesdisable/actor.py
@@ -1,8 +1,7 @@
 import re
 
-from leapp.libraries.common import reporting
-
 from leapp.actors import Actor
+from leapp.libraries.common import reporting
 from leapp.models import PersistentNetNamesFacts, KernelCmdlineArg
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 

--- a/repos/system_upgrade/el7toel8/actors/persistentnetnamesinitramfs/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/persistentnetnamesinitramfs/actor.py
@@ -1,6 +1,5 @@
-from leapp.libraries.common import persistentnetnames
-
 from leapp.actors import Actor
+from leapp.libraries.common import persistentnetnames
 from leapp.models import PersistentNetNamesFactsInitramfs
 from leapp.tags import LateTestsPhaseTag, IPUWorkflowTag
 

--- a/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/libraries/preparetransaction.py
+++ b/repos/system_upgrade/el7toel8/actors/prepareupgradetransaction/libraries/preparetransaction.py
@@ -1,8 +1,8 @@
+from collections import namedtuple
 import os
 import shutil
 import sys
 
-from collections import namedtuple
 from six.moves.urllib.error import URLError
 from six.moves.urllib.request import urlopen
 

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from leapp.exceptions import StopActorExecution
 from leapp.libraries.actor import library
 from leapp.libraries.common import reporting

--- a/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/libraries/scanner.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/libraries/scanner.py
@@ -1,4 +1,5 @@
 import os.path
+
 from leapp.models import RpmTransactionTasks
 
 

--- a/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/tests/test_load_tasks.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/tests/test_load_tasks.py
@@ -1,4 +1,5 @@
 import logging
+
 from leapp.libraries.actor.scanner import load_tasks_file, load_tasks
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 ### Additional requirements
 
 flake8
+flake8-import-order
 funcsigs==1.0.2
 mock==2.0.0
 pylint

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,8 @@ max-line-length = 119
     # 'leapp.snactor.fixture.current_actor_libraries' imported but unused
 per-file-ignores =
     repos/system_upgrade/el7toel8/actors/*/tests/*.py:F811,F401
+application-import-names = leapp
+# check only for correct group type and abc sorting without group
+import-order-style = pep8
+# default values + ignore strict alphabetical sorting within one module import
+ignore = E121,E123,E126,E133,E241,E242,E226,W503,W504,W505,I101


### PR DESCRIPTION
Pylint's wrong-import-order was not configurable
enough to treat leapp as an application and not a
3rd party dependency.
This patch addressed the issue by utilizing
flake8-import-order plugin that can be customized.
The alphabetical ordering within group will be
checked as well so some refactoring will be done to
align with the changes.