### PR TITLE
TcpWrappersCheck: New actor checking all daemons possibly affected by removal of the tcp wrappers package

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/opensshconfigscanner/tests/test_readopensshconfig.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshconfigscanner/tests/test_readopensshconfig.py
@@ -3,7 +3,7 @@ from leapp.libraries.actor.readopensshconfig import parse_config, \
     produce_config, line_empty, parse_config_modification
 
 
-def test_line_empty(current_actor_libraries):
+def test_line_empty():
     assert line_empty("".strip()) is True
     assert line_empty("     ".strip()) is True
     assert line_empty("   # comment".strip()) is True
@@ -12,7 +12,7 @@ def test_line_empty(current_actor_libraries):
     assert line_empty("    option".strip()) is False
 
 
-def test_parse_config(current_actor_libraries):
+def test_parse_config():
     config = [
         "# comment from file",
         "",  # empty line
@@ -37,7 +37,7 @@ def test_parse_config(current_actor_libraries):
     assert output.macs == "hmac-md5"
 
 
-def test_parse_config_case(current_actor_libraries):
+def test_parse_config_case():
     config = [
         "PermitRootLogin prohibit-password",
         "UsePrivilegeSeparation yes",
@@ -52,7 +52,7 @@ def test_parse_config_case(current_actor_libraries):
     assert output.protocol == "1"
 
 
-def test_parse_config_multiple(current_actor_libraries):
+def test_parse_config_multiple():
     config = [
         "PermitRootLogin prohibit-password",
         "PermitRootLogin no",
@@ -72,7 +72,7 @@ def test_parse_config_multiple(current_actor_libraries):
     assert output.ciphers == 'aes128-cbc'
 
 
-def test_parse_config_commented(current_actor_libraries):
+def test_parse_config_commented():
     config = [
         "#PermitRootLogin no",
         "#UsePrivilegeSeparation no",
@@ -86,7 +86,7 @@ def test_parse_config_commented(current_actor_libraries):
     assert output.protocol is None
 
 
-def test_parse_config_missing_argument(current_actor_libraries):
+def test_parse_config_missing_argument():
     config = [
         "PermitRootLogin",
         "UsePrivilegeSeparation",
@@ -100,7 +100,7 @@ def test_parse_config_missing_argument(current_actor_libraries):
     assert output.protocol is None
 
 
-def test_parse_config_match(current_actor_libraries):
+def test_parse_config_match():
     config = [
         "PermitRootLogin yes",
         "Match address 192.168.*",
@@ -118,7 +118,7 @@ def test_parse_config_match(current_actor_libraries):
     assert output.protocol is None
 
 
-def test_parse_config_deprecated(current_actor_libraries):
+def test_parse_config_deprecated():
     config = [
         "permitrootlogin without-password"
     ]
@@ -128,7 +128,7 @@ def test_parse_config_deprecated(current_actor_libraries):
     assert output.permit_root_login[0].value == "prohibit-password"
 
 
-def test_parse_config_empty(current_actor_libraries):
+def test_parse_config_empty():
     output = parse_config([])
     assert isinstance(output, OpenSshConfig)
     assert isinstance(output, OpenSshConfig)
@@ -137,7 +137,7 @@ def test_parse_config_empty(current_actor_libraries):
     assert output.protocol is None
 
 
-def test_parse_config_modification(current_actor_libraries):
+def test_parse_config_modification():
     # This one was modified
     data = [
         "S.5....T.  c /etc/ssh/sshd_config",
@@ -164,7 +164,7 @@ def test_parse_config_modification(current_actor_libraries):
     assert parse_config_modification(data)
 
 
-def test_produce_config(current_actor_libraries):
+def test_produce_config():
     output = []
 
     def fake_producer(*args):

--- a/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
@@ -2,6 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import semantics_changes
 from leapp.models import Report, OpenSshConfig
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.libraries.stdlib import api
 from leapp.libraries.common.reporting import report_with_remediation
 
 
@@ -18,38 +19,42 @@ class OpenSshPermitRootLoginCheck(Actor):
     tags = (ChecksPhaseTag, IPUWorkflowTag, )
 
     def process(self):
-        for config in self.consume(OpenSshConfig):
-            if not config.permit_root_login:
-                # TODO find out whether the file was modified and will be
-                # replaced by the update. If so, this message is bogus
-                report_with_remediation(
-                    title='Possible problems with remote login using root account',
-                    summary='OpenSSH configuration file does not explicitly state '
-                            'the option PermitRootLogin in sshd_config file, '
-                            'which will default in RHEL8 to "prohibit-password".',
-                    remediation='If you depend on remote root logins using '
-                                'passwords, condider setting up a different '
-                                'user for remote administration or adding '
-                                '"PermitRootLogin yes" to sshd_config.',
-                    severity='high',
-                    flags=['inhibitor'])
+        openssh_messages = self.consume(OpenSshConfig)
+        config = next(openssh_messages)
+        if list(openssh_messages):
+            api.current_logger().warning('Unexpectedly received more than one OpenSshConfig message.')
 
-            # Check if there is at least one PermitRootLogin other than "no"
-            # in match blocks (other than Match All).
-            # This usually means some more complicated setup depending on the
-            # default value being globally "yes" and being overwritten by this
-            # match block
-            if semantics_changes(config):
-                report_with_remediation(
-                    title='OpenSSH configured to allow root login',
-                    summary='OpenSSH is configured to deny root logins in match '
-                            'blocks, but not explicitly enabled in global or '
-                            '"Match all" context. This update changes the '
-                            'default to disable root logins using paswords '
-                            'so your server migth get inaccessible.',
-                    remediation='Consider using different user for administrative '
-                                'logins or make sure your configration file '
-                                'contains the line "PermitRootLogin yes" '
-                                'in global context if desired.',
-                    severity='high',
-                    flags=['inhibitor'])
+        if not config.permit_root_login:
+            # TODO find out whether the file was modified and will be
+            # replaced by the update. If so, this message is bogus
+            report_with_remediation(
+                title='Possible problems with remote login using root account',
+                summary='OpenSSH configuration file does not explicitly state '
+                        'the option PermitRootLogin in sshd_config file, '
+                        'which will default in RHEL8 to "prohibit-password".',
+                remediation='If you depend on remote root logins using '
+                            'passwords, condider setting up a different '
+                            'user for remote administration or adding '
+                            '"PermitRootLogin yes" to sshd_config.',
+                severity='high',
+                flags=['inhibitor'])
+
+        # Check if there is at least one PermitRootLogin other than "no"
+        # in match blocks (other than Match All).
+        # This usually means some more complicated setup depending on the
+        # default value being globally "yes" and being overwritten by this
+        # match block
+        if semantics_changes(config):
+            report_with_remediation(
+                title='OpenSSH configured to allow root login',
+                summary='OpenSSH is configured to deny root logins in match '
+                        'blocks, but not explicitly enabled in global or '
+                        '"Match all" context. This update changes the '
+                        'default to disable root logins using paswords '
+                        'so your server migth get inaccessible.',
+                remediation='Consider using different user for administrative '
+                            'logins or make sure your configration file '
+                            'contains the line "PermitRootLogin yes" '
+                            'in global context if desired.',
+                severity='high',
+                flags=['inhibitor'])

--- a/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/tests/test_library.py
@@ -2,7 +2,7 @@ from leapp.libraries.actor.library import semantics_changes
 from leapp.models import OpenSshConfig, OpenSshPermitRootLogin
 
 
-def test_globally_enabled(current_actor_context):
+def test_globally_enabled():
     """ Configuration file in this format:
 
         PermitRootLogin yes # explicit
@@ -18,7 +18,7 @@ def test_globally_enabled(current_actor_context):
     assert not semantics_changes(config)
 
 
-def test_globally_disabled(current_actor_context):
+def test_globally_disabled():
     """ Configuration file in this format:
 
         PermitRootLogin no # explicit
@@ -34,7 +34,7 @@ def test_globally_disabled(current_actor_context):
     assert not semantics_changes(config)
 
 
-def test_globally_disabled_password(current_actor_context):
+def test_globally_disabled_password():
     """ Configuration file in this format:
 
         PermitRootLogin prohibit-password # explicit
@@ -50,7 +50,7 @@ def test_globally_disabled_password(current_actor_context):
     assert not semantics_changes(config)
 
 
-def test_in_match_disabled(current_actor_context):
+def test_in_match_disabled():
     """ Configuration file in this format:
 
         # PermitRootLogin yes # implicit
@@ -68,7 +68,7 @@ def test_in_match_disabled(current_actor_context):
     assert semantics_changes(config)
 
 
-def test_in_match_disabled_password(current_actor_context):
+def test_in_match_disabled_password():
     """ Configuration file in this format:
 
         # PermitRootLogin yes # implicit
@@ -86,7 +86,7 @@ def test_in_match_disabled_password(current_actor_context):
     assert semantics_changes(config)
 
 
-def test_in_match_enabled(current_actor_context):
+def test_in_match_enabled():
     """ Configuration file in this format:
 
         # PermitRootLogin yes # implicit
@@ -105,7 +105,7 @@ def test_in_match_enabled(current_actor_context):
     assert not semantics_changes(config)
 
 
-def test_in_match_all_disabled(current_actor_context):
+def test_in_match_all_disabled():
     """ Configuration file in this format:
 
         # PermitRootLogin yes # implicit
@@ -123,7 +123,7 @@ def test_in_match_all_disabled(current_actor_context):
     assert not semantics_changes(config)
 
 
-def test_in_match_all_disabled_password(current_actor_context):
+def test_in_match_all_disabled_password():
     """ Configuration file in this format:
 
         # PermitRootLogin yes # implicit
@@ -141,7 +141,7 @@ def test_in_match_all_disabled_password(current_actor_context):
     assert not semantics_changes(config)
 
 
-def test_in_match_all_enabled(current_actor_context):
+def test_in_match_all_enabled():
     """ Configuration file in this format:
 
         # PermitRootLogin yes # implicit
@@ -159,7 +159,7 @@ def test_in_match_all_enabled(current_actor_context):
     assert not semantics_changes(config)
 
 
-def test_in_match_enabled_globally_disabled(current_actor_context):
+def test_in_match_enabled_globally_disabled():
     """ Configuration file in this format:
 
         PermitRootLogin no # explicit
@@ -180,7 +180,7 @@ def test_in_match_enabled_globally_disabled(current_actor_context):
     assert not semantics_changes(config)
 
 
-def test_in_match_disabled_globally_enabled(current_actor_context):
+def test_in_match_disabled_globally_enabled():
     """ Configuration file in this format:
 
         PermitRootLogin yes # explicit

--- a/repos/system_upgrade/el7toel8/actors/opensshprotocolcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshprotocolcheck/actor.py
@@ -1,6 +1,7 @@
 from leapp.actors import Actor
 from leapp.models import Report, OpenSshConfig
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.libraries.stdlib import api
 from leapp.libraries.common.reporting import report_generic
 
 
@@ -19,9 +20,12 @@ class OpenSshProtocolCheck(Actor):
     tags = (ChecksPhaseTag, IPUWorkflowTag, )
 
     def process(self):
-        for config in self.consume(OpenSshConfig):
-            if not config.protocol:
-                continue
+        openssh_messages = self.consume(OpenSshConfig)
+        config = next(openssh_messages)
+        if list(openssh_messages):
+            api.current_logger().warning('Unexpectedly received more than one OpenSshConfig message.')
+
+        if config.protocol:
             report_generic(
                 title='OpenSSH configured with removed configuration Protocol',
                 summary='OpenSSH is configured with removed configuration '

--- a/repos/system_upgrade/el7toel8/actors/tcpwrapperscheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/tcpwrapperscheck/actor.py
@@ -1,0 +1,66 @@
+from leapp.actors import Actor
+from leapp.models import Report, TcpWrappersFacts, InstalledRedHatSignedRPM
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.libraries.stdlib import api
+from leapp.libraries.actor.library import config_affects_daemons
+from leapp.libraries.common.rpms import create_lookup
+from leapp.libraries.common.reporting import report_with_links
+
+
+DAEMONS = [
+    ("audit", ["auditd"]),
+    ("bacula", ["bacula"]),
+    ("conserver", ["conserver"]),
+    ("cyrus-imapd", ["imap", "pop3", "imaps", "pop3s", "sieve", "lmtp"]),
+    ("dovecot", ["imap", "pop3", "imaps", "pop3s", "sieve", "lmtp"]),
+    ("nfs-utils", ["mountd", "statd"]),
+    ("openssh-server", ["sshd"]),
+    ("proftpd", ["proftpd"]),
+    ("quota", ["rquotad"]),
+    ("rpcbind", ["rpcbind"]),
+    # ("sendmail", ["sendmail"]),  # Handled in CheckSendmail Actor
+    ("slapi-nis", ["slapi-nis"]),
+    ("socat", ["socat"]),
+    ("stunnel", ["stunnel"]),
+    ("tftp-server", ["tftpd"]),
+    # ("vsftpd", ["vsftpd"]),  # Handled in VsftpdConfigCheck Actor
+    ("xinetd", ["xinetd"]),
+]
+
+
+class TcpWrappersCheck(Actor):
+    """
+    Check the list of packages previously compiled with TCP wrappers support
+    and check whether they have some rules configured in
+    /etc/hosts.{allow,deny} that are no longer honored by the daemons and
+    might make the service more accessible than expected.
+    """
+
+    name = 'tcp_wrappers_check'
+    consumes = (TcpWrappersFacts, InstalledRedHatSignedRPM,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        # Consume a single TCP Wrappers message
+        tcp_wrappers_messages = self.consume(TcpWrappersFacts)
+        tcp_wrappers_facts = next(tcp_wrappers_messages)
+        if list(tcp_wrappers_messages):
+            api.current_logger().warning('Unexpectedly received more than one TcpWrappersFacts message.')
+
+        # Convert installed packages message to list
+        packages = create_lookup(InstalledRedHatSignedRPM, field='items', key='name')
+
+        found_packages = config_affects_daemons(tcp_wrappers_facts, packages, DAEMONS)
+
+        if found_packages:
+            report_with_links(title='TCP Wrappers configuration affects some installed packages',
+                              summary=('tcp_wrappers support has been removed in RHEL-8. '
+                                       'There is some configuration affecting installed packages (namely {}) '
+                                       'in /etc/hosts.deny or /etc/hosts.allow, which '
+                                       'is no longer going to be effective after update. '
+                                       'Please migrate it manually.'.format(', '.join(found_packages))),
+                              links=[{'title': 'Replacing TCP Wrappers in RHEL 8',
+                                      'href': 'https://access.redhat.com/solutions/3906701'}],
+                              severity='high',
+                              flags=['inhibitor'])

--- a/repos/system_upgrade/el7toel8/actors/tcpwrapperscheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/tcpwrapperscheck/libraries/library.py
@@ -1,0 +1,30 @@
+from leapp.libraries.common.tcpwrappersutils import config_applies_to_daemon
+
+
+def config_affects_daemons(tcp_wrappers_facts, packages_list, daemons):
+    """
+    Check whether some of the daemons is installed and affected by existing
+    configuration of tcp_wrappers based on the.
+
+    :param tcp_wrappers_facts: Facts provided by the TcpWrappersFacts
+    :param packages_list: List of packages provided by InstalledRedHatSignedRPM
+    :param deamons: List of packages and keywords affecting daemons in this format:
+                    [{"package-name", ["daemon1", "daemon2", ...], ...}]
+    """
+    found_packages = set()
+
+    for (package, keywords) in daemons:
+        # We do not care for particular deamon if the providing package is not installed
+        if package not in packages_list:
+            continue
+
+        # Every package can have several deamons or deamons reacting to several keywords
+        for daemon in keywords:
+            # Is this daemon/keyword affected by the current configuration?
+            if not config_applies_to_daemon(tcp_wrappers_facts, daemon):
+                continue
+
+            # We do not report particular daemons, but just the high-level list of packages
+            found_packages.add(package)
+
+    return found_packages

--- a/repos/system_upgrade/el7toel8/actors/tcpwrapperscheck/tests/test_tcp_wrappers.py
+++ b/repos/system_upgrade/el7toel8/actors/tcpwrapperscheck/tests/test_tcp_wrappers.py
@@ -1,0 +1,55 @@
+from leapp.libraries.actor.library import config_affects_daemons
+from leapp.models import TcpWrappersFacts, DaemonList
+
+
+def test_empty_packages():
+    """ Test with empty package list """
+    w = TcpWrappersFacts(daemon_lists=[DaemonList(value=["ALL"])])
+    p = []
+    d = [("openssh", ["sshd"])]
+    packages = config_affects_daemons(w, p, d)
+
+    assert not packages
+
+
+def test_empty_tcp_wrappers():
+    """ Test with empty tcp_wrappers facts """
+    w = TcpWrappersFacts(daemon_lists=[])
+    p = ["openssh", "systemd", "pam"]
+    d = [("openssh", ["sshd"])]
+    packages = config_affects_daemons(w, p, d)
+
+    assert not packages
+
+
+def test_matching_package():
+    """ Test with matching package, but not daemon """
+    w = TcpWrappersFacts(daemon_lists=[DaemonList(value=["imap"])])
+    p = ["openssh", "systemd", "pam"]
+    d = [("openssh", ["sshd"])]
+    packages = config_affects_daemons(w, p, d)
+
+    assert not packages
+
+
+def test_matching_daemon():
+    """ Test with matching package with daemon """
+    w = TcpWrappersFacts(daemon_lists=[DaemonList(value=["sshd"])])
+    p = ["openssh", "systemd", "pam"]
+    d = [("openssh", ["sshd"])]
+    packages = config_affects_daemons(w, p, d)
+
+    assert len(packages) == 1
+    assert "openssh" in packages
+
+
+def test_matching_all():
+    """ Test with matching package with daemon """
+    w = TcpWrappersFacts(daemon_lists=[DaemonList(value=["ALL"])])
+    p = ["openssh", "systemd", "pam", "audit"]
+    d = [("openssh", ["sshd"]), ("audit", ["auditd"])]
+    packages = config_affects_daemons(w, p, d)
+
+    assert len(packages) == 2
+    assert "openssh" in packages
+    assert "audit" in packages


### PR DESCRIPTION
Based on the #186 and followup discussion, I created the list of packages and their keywords/daemons that were previously using tcp wrappers and that were in RHEL 7 and that are affected by the update.

I am actually not sure if all the values are correct for some of the packages so double-checking and review would be appreciated. Unfortunately some of the applications really have free-form of what is the service name in the tcp_wrappers configuration (glad we are getting rid of that) so they can be caugh only with the ALL keywords, that should match in all of the tools.

For the completeness there are also mentioned the packages that are already covered by other wrappers, which have also some more specific checks that this one general.