### PR TITLE
[WIP] Add shared function that blocks actor when requirements are not met

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/osreleasecollector/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/osreleasecollector/actor.py
@@ -18,4 +18,4 @@ class OSReleaseCollector(Actor):
     tags = (IPUWorkflowTag, FactsPhaseTag,)
 
     def process(self):
-        self.produce(library.get_os_release_info('/etc/os-release'))
+        self.produce(library.get_os_release_model('/etc/os-release'))

--- a/repos/system_upgrade/el7toel8/actors/osreleasecollector/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/osreleasecollector/libraries/library.py
@@ -1,27 +1,17 @@
-from leapp.libraries.common import reporting
+from leapp.libraries.common import requirearchver
 from leapp.models import OSReleaseFacts
 
 
-def get_os_release_info(path):
-    ''' Retrieve data about System OS release from provided file '''
-    data = {}
-    try:
-        with open(path) as f:
-            data = dict(l.strip().split('=', 1) for l in f.readlines() if '=' in l)
-    except IOError as e:
-        reporting.report_generic(
-            title='Error while collecting system OS facts',
-            summary=str(e),
-            severity='high',
-            flags=['inhibitor'])
-        return None
+def get_os_release_model(path):
+    """Return model created from OS release info from provided file."""
+    data = requirearchver.get_os_release_info(path)
 
     return OSReleaseFacts(
-        release_id=data.get('ID', '').strip('"'),
-        name=data.get('NAME', '').strip('"'),
-        pretty_name=data.get('PRETTY_NAME', '').strip('"'),
-        version=data.get('VERSION', '').strip('"'),
-        version_id=data.get('VERSION_ID', '').strip('"'),
-        variant=data.get('VARIANT', '').strip('"') or None,
-        variant_id=data.get('VARIANT_ID', '').strip('"') or None
+        release_id=data.get('ID', ''),
+        name=data.get('NAME', ''),
+        pretty_name=data.get('PRETTY_NAME', ''),
+        version=data.get('VERSION', ''),
+        version_id=data.get('VERSION_ID', ''),
+        variant=data.get('VARIANT', '') or None,
+        variant_id=data.get('VARIANT_ID', '') or None
     )

--- a/repos/system_upgrade/el7toel8/actors/osreleasecollector/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/osreleasecollector/tests/unit_test.py
@@ -1,13 +1,19 @@
-from leapp.libraries.actor.library import get_os_release_info
-from leapp.libraries.common import reporting
+from leapp.libraries.actor.library import get_os_release_model
+from leapp.libraries.common import requirearchver
 from leapp.libraries.common.testutils import produce_mocked, report_generic_mocked
 from leapp.models import OSReleaseFacts
 
 
-def test_get_os_release_info(monkeypatch):
-    monkeypatch.setattr('leapp.libraries.stdlib.api.produce', produce_mocked())
-    monkeypatch.setattr(reporting, 'report_generic', report_generic_mocked())
-
+def test_get_os_release_model(monkeypatch):
+    input_data = {
+        'ID': 'rhel',
+        'NAME': 'Red Hat Enterprise Linux Server',
+        'PRETTY_NAME': 'Red Hat Enterprise Linux',
+        'VARIANT': 'Server',
+        'VARIANT_ID': 'server',
+        'VERSION': '7.6 (Maipo)',
+        'VERSION_ID': '7.6'
+    }
     expected = OSReleaseFacts(
         release_id='rhel',
         name='Red Hat Enterprise Linux Server',
@@ -15,9 +21,8 @@ def test_get_os_release_info(monkeypatch):
         version='7.6 (Maipo)',
         version_id='7.6',
         variant='Server',
-        variant_id='server')
-    assert expected == get_os_release_info('tests/files/os-release')
+        variant_id='server'
+    )
 
-    assert not get_os_release_info('tests/files/unexistent-file')
-    assert reporting.report_generic.called == 1
-    assert 'inhibitor' in reporting.report_generic.report_fields['flags']
+    monkeypatch.setattr(requirearchver, 'get_os_release_info', lambda _unused: input_data)
+    assert expected == get_os_release_model('unused_in_test')

--- a/repos/system_upgrade/el7toel8/libraries/requirearchver.py
+++ b/repos/system_upgrade/el7toel8/libraries/requirearchver.py
@@ -1,0 +1,130 @@
+import operator
+import platform
+
+from leapp.exceptions import StopActorExecution
+from leapp.libraries.common import reporting
+from leapp.libraries.stdlib import api
+
+
+def get_os_release_info(path):
+    """
+    Retrieve data about System OS release from provided file.
+
+    :rtype: dictionary or None
+    """
+    try:
+        with open(path) as f:
+            data = dict(l.strip().split('=', 1) for l in f.readlines() if '=' in l)
+            return {key: value.strip('"') for key, value in data.items()}
+    except IOError as e:
+        reporting.report_generic(
+            title='Error while collecting system OS facts',
+            summary=str(e),
+            severity='high',
+            flags=['inhibitor'])
+        return None
+
+
+def _log_and_raise(reason, required, detected):
+    """Log that requirements were not met and stop actor's execution by raising a StopActorExecution exception."""
+    msg = 'Actor skipped, {reason} requirement not met, required: {required}, detected: {detected}'.format(
+        reason=reason, required=required, detected=detected)
+    api.current_logger().info(msg)
+    raise StopActorExecution
+
+
+def _log_passed(reason, required, detected):
+    """Log that requirements were fulfilled."""
+    msg = 'Requirement for {reason} fulfilled, required: {required}, detected: {detected}'.format(
+        reason=reason, required=required, detected=detected)
+    api.current_logger().debug(msg)
+
+
+def require_arch(required):
+    """
+    Stop actor's execution if requirement on architecture is not met.
+
+    :param required: list or tuple of vrchitectures
+    :type required: list, tuple
+    """
+    if not isinstance(required, (list, tuple)):
+        raise TypeError('Required architectures has to be a list or tuple: {}'.format(required))
+
+    accepted = set(('ppc64le', 's390x', 'aarch64', 'x86_64'))
+    unsupported = set(required).difference(accepted)
+    if unsupported:
+        api.current_logger().warn('Unsupported architecture specified: {}'.format(unsupported))
+
+    detected = platform.machine()
+    reason = 'architecture'
+    if detected not in required:
+        _log_and_raise(reason, required, detected)
+
+    _log_passed(reason, required, detected)
+
+
+def _require_minor_version(destination, required, detected):
+    """
+    Stop actor's execution if requirement on minor version is not met.
+
+    :param destination: 'source' or 'target'
+    :type destination: string
+    :param required: list or tuple of versions - integers or strings in the form '<integer>['+'|'>'|'-'|'<']'
+    :type required: list, tuple
+    :param detected: Detected version
+    :type detected: int
+    """
+
+    reason = "{}'s minor version".format(destination)
+
+    if not isinstance(required, (list, tuple)):
+        raise TypeError("Required {reason} has to be a list or tuple: {required}".format(
+            reason=reason, required=required))
+
+    if all(isinstance(r, int) for r in required):
+        # required is list of versions
+        if detected not in required:
+            _log_and_raise(reason, required, detected)
+    else:
+        # required should be list of '<integer>['+'|'>','-','<']' strings
+        fun_map = {'+': operator.gt, '>': operator.gt, '-': operator.lt, '<': operator.lt}
+        try:
+            if not all(fun_map[r[-1]](detected, int(r[:-1])) for r in required):
+                _log_and_raise(reason, required, detected)
+        except (KeyError, ValueError, TypeError):
+            raise TypeError("Required {reason} has to be a list or tuple of integers or strings in the "
+                            "form '<integer>['+'|'>'|'-'|'<']': {required}".format(
+                                reason=reason, required=required))
+
+    _log_passed(reason, required, detected)
+
+
+# TODO: target's minor version will be specified using dynamic configuration phase, see #505 (add tests afterward)
+# def require_tgt_minor_version(required):
+#     """
+#     Stop actor's execution if requirement on minor version of target system is not met.
+#
+#     :param destination: 'source' or 'target'
+#     :type destination: string
+#     :param required: list or tuple of versions - integers or strings in the form '<integer>['+'|'>'|'-'|'<']'
+#     :type required: list, tuple
+#     :param detected: Detected version
+#     :type detected: int
+#     """
+#     detected = 0
+#     _require_minor_version('target', required, detected)
+
+
+def require_src_minor_version(required):
+    """
+    Stop actor's execution if requirement on minor version of source system is not met.
+
+    :param destination: 'source' or 'target'
+    :type destination: string
+    :param required: list or tuple of versions - integers or strings in the form '<integer>['+'|'>'|'-'|'<']'
+    :type required: list, tuple
+    :param detected: Detected version
+    :type detected: int
+    """
+    detected = int(get_os_release_info('/etc/os-release')['VERSION_ID'].split('.')[1])
+    _require_minor_version('source', required, detected)

--- a/repos/system_upgrade/el7toel8/libraries/tests/files/os-release
+++ b/repos/system_upgrade/el7toel8/libraries/tests/files/os-release
@@ -1,0 +1,17 @@
+NAME="Red Hat Enterprise Linux Server"
+VERSION="7.6 (Maipo)"
+ID="rhel"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="7.6"
+PRETTY_NAME="Red Hat Enterprise Linux"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:7.6:GA:server"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
+REDHAT_BUGZILLA_PRODUCT_VERSION=7.6
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="7.6"

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_requirearchver.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_requirearchver.py
@@ -1,0 +1,89 @@
+import mock
+import pytest
+
+from leapp.exceptions import StopActorExecution
+from leapp.libraries.common import reporting, requirearchver
+from leapp.libraries.common.testutils import report_generic_mocked
+
+
+def test_get_os_release_info(monkeypatch):
+    expected = {
+        'ANSI_COLOR': '0;31',
+        'BUG_REPORT_URL': 'https://bugzilla.redhat.com/',
+        'CPE_NAME': 'cpe:/o:redhat:enterprise_linux:7.6:GA:server',
+        'HOME_URL': 'https://www.redhat.com/',
+        'ID': 'rhel',
+        'ID_LIKE': 'fedora',
+        'NAME': 'Red Hat Enterprise Linux Server',
+        'PRETTY_NAME': 'Red Hat Enterprise Linux',
+        'REDHAT_BUGZILLA_PRODUCT': 'Red Hat Enterprise Linux 7',
+        'REDHAT_BUGZILLA_PRODUCT_VERSION': '7.6',
+        'REDHAT_SUPPORT_PRODUCT': 'Red Hat Enterprise Linux',
+        'REDHAT_SUPPORT_PRODUCT_VERSION': '7.6',
+        'VARIANT': 'Server',
+        'VARIANT_ID': 'server',
+        'VERSION': '7.6 (Maipo)',
+        'VERSION_ID': '7.6'
+    }
+    assert expected == requirearchver.get_os_release_info('tests/files/os-release')
+
+    monkeypatch.setattr(reporting, 'report_generic', report_generic_mocked())
+    assert not requirearchver.get_os_release_info('tests/files/non-existent-file')
+    assert reporting.report_generic.called == 1
+    assert 'inhibitor' in reporting.report_generic.report_fields['flags']
+
+
+def test_require_src_minor_version_pass(monkeypatch):
+    monkeypatch.setattr(requirearchver, 'get_os_release_info', lambda _unused: {'VERSION_ID': '7.6'})
+    assert requirearchver.require_src_minor_version([5, 6, 7]) is None
+
+    assert requirearchver.require_src_minor_version(['5+']) is None
+
+    assert requirearchver.require_src_minor_version(['5>']) is None
+
+    assert requirearchver.require_src_minor_version(['7-']) is None
+
+    assert requirearchver.require_src_minor_version(['7<']) is None
+
+
+def test_require_src_minor_version_fail(monkeypatch):
+    monkeypatch.setattr(requirearchver, 'get_os_release_info', lambda _unused: {'VERSION_ID': '7.6'})
+    with pytest.raises(StopActorExecution):
+        requirearchver.require_src_minor_version([5])
+
+    with pytest.raises(StopActorExecution):
+        requirearchver.require_src_minor_version(['6+'])
+
+    with pytest.raises(StopActorExecution):
+        requirearchver.require_src_minor_version(['6-'])
+
+    with pytest.raises(StopActorExecution):
+        requirearchver.require_src_minor_version(['5+', '4-'])
+
+
+def test_require_src_minor_version_wrong_args():
+    with pytest.raises(TypeError):
+        requirearchver.require_src_minor_version('5')
+
+    with pytest.raises(TypeError):
+        requirearchver.require_src_minor_version(['5?'])
+
+    with pytest.raises(TypeError):
+        requirearchver.require_src_minor_version(['5+', 4])
+
+
+def test_require_arch_pass():
+    arch = 'some_arch'
+    with mock.patch('platform.machine', return_value=arch):
+        assert requirearchver.require_arch([arch, 'other_arch']) is None
+
+
+def test_require_arch_fail():
+    with mock.patch('platform.machine', return_value='some_arch'):
+        with pytest.raises(StopActorExecution):
+            requirearchver.require_arch(['other_arch'])
+
+
+def test_require_arch_wrong_args():
+    with pytest.raises(TypeError):
+        requirearchver.require_arch('some_arch')


### PR DESCRIPTION
Add `require_arch` and `require_src_minor_version` shared library functions that can be used to stop actor's execution (without stopping a workflow) if requirement on minor version of source system or architecture is not met.

`get_os_release_info` function from `OSReleaseCollector` actor is split into two functions:
- Part that parses the data from provided file is moved into the shared library as `get_os_release_info`. This function is used in the `require_src_minor_version` to check the source's system minor version.
- Part that converts the output of the former function to an `OSReleaseFacts` model. This function remains in `OSReleaseCollector` actor's library as `get_os_release_model`.