### PR TITLE
packaging: get_latest_copr_build: tmp fix pagination

### DIFF
--- a/utils/get_latest_copr_build
+++ b/utils/get_latest_copr_build
@@ -63,7 +63,7 @@ if not ENV_VARS['PKG_RELEASE']:
 # in such short time
 builds = client.build_proxy.get_list(
     status='succeeded',
-    pagination={'limit': 10, 'order': 'id', 'order_type': 'DESC'},
+    pagination={'order': 'id', 'order_type': 'DESC'},
     ownername=ownername,
     projectname=projectname,
     packagename=ENV_VARS['COPR_PACKAGE'])


### PR DESCRIPTION
There is bug in copr (or copr cli module) for pagination. Currently
sorting doesn't work so sometimes we cannot find the build we want.
Removing the limitation temporary to ensure we always get the build,
until the issue in copr will be fixed.