### PR TITLE
Ignore also "LEAPP_DEBUG" and "LEAPP_VERBOSE" env vars

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
@@ -4,7 +4,8 @@ from leapp.libraries.common import reporting
 from leapp.models import EnvVar, OSRelease
 
 
-ENV_IGNORE = ('LEAPP_CURRENT_PHASE', 'LEAPP_CURRENT_ACTOR')
+ENV_IGNORE = ('LEAPP_CURRENT_PHASE', 'LEAPP_CURRENT_ACTOR', 'LEAPP_VERBOSE',
+              'LEAPP_DEBUG')
 
 
 def get_env_vars():

--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/tests/test_ipuworkflowconfig.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/tests/test_ipuworkflowconfig.py
@@ -20,15 +20,15 @@ def _clean_leapp_envs(monkeypatch):
 
 def test_leapp_env_vars(monkeypatch):
     _clean_leapp_envs(monkeypatch)
+    monkeypatch.setenv('LEAPP_WHATEVER', '0')
     monkeypatch.setenv('LEAPP_VERBOSE', '1')
     monkeypatch.setenv('LEAPP_DEBUG', '1')
-    monkeypatch.setenv('LEAPP_WHATEVER', '0')
     monkeypatch.setenv('LEAPP_CURRENT_PHASE', 'test')
     monkeypatch.setenv('LEAPP_CURRENT_ACTOR', 'test')
     monkeypatch.setenv('TEST', 'test')
     monkeypatch.setenv('TEST2', 'test')
 
-    assert len(library.get_env_vars()) == 3
+    assert len(library.get_env_vars()) == 1
 
 
 def test_get_os_release_info(monkeypatch):


### PR DESCRIPTION
We want "LEAPP_DEBUG and LEAPP_VERBOSE" env vars to be checked
by our "is_debug()" and "is_verbose()" functions.