### PR TITLE
Fix traceback in targetuserspacegen

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -137,7 +137,7 @@ def perform():
 
     rhsm_info = next(api.consume(SourceRHSMInfo), None)
     if not rhsm_info and not rhsm.skip_rhsm():
-        api.log.warn("Could not receive RHSM information - Is this system registered?")
+        api.current_logger().warn("Could not receive RHSM information - Is this system registered?")
         return
 
     presence = next(api.consume(XFSPresence), XFSPresence())


### PR DESCRIPTION
There was a wrong call to logging in the userspacegen library that
causes a traceback when there are is no valid RHSM subscription available.

Fixes https://github.com/oamg/leapp-repository/issues/256