### PR TITLE
Set RHSM target release

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/actor.py
@@ -1,0 +1,27 @@
+from leapp.actors import Actor
+from leapp.libraries.common.reporting import report_generic
+from leapp.models import Report, TargetRHSMInfo
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class ReportSetTargetRelease(Actor):
+    """
+    Reports that a release will be set in the subscription-manager after the upgrade.
+    """
+
+    name = 'report_set_target_release'
+    consumes = (TargetRHSMInfo,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        info = next(self.consume(TargetRHSMInfo), None)
+        if info and info.release:
+            report_generic(
+                title='The subscription-manager release is going to be set to {release}'.format(release=info.release),
+                summary=(
+                    'After the upgrade has completed the release of the subscription-manager will be set to {release}.'
+                    ' This will ensure that you will receive and keep the version you choose to upgrade to.'
+                ).format(release=info.release),
+                severity='low'
+            )

--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/tests/test_targetreleasereport.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/tests/test_targetreleasereport.py
@@ -1,0 +1,23 @@
+from leapp.models import Report, TargetRHSMInfo
+
+
+def test_report_target_version(current_actor_context):
+    current_actor_context.feed(TargetRHSMInfo(release='6.6.6'))
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert reports and len(reports) == 1
+    assert '6.6.6' in reports[0].detail.get('summary', '')
+    assert '6.6.6' in reports[0].title
+
+
+def test_report_target_version_notset(current_actor_context):
+    current_actor_context.feed(TargetRHSMInfo(release=''))
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert not reports
+
+
+def test_report_target_version_nomessage(current_actor_context):
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert not reports

--- a/repos/system_upgrade/el7toel8/actors/setrhsmrelease/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/setrhsmrelease/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import setrelease
+from leapp.models import TargetRHSMInfo
+from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
+
+
+class SetRhsmRelease(Actor):
+    """
+    No documentation has been provided for the set_rhsm_release actor.
+    """
+
+    name = 'set_rhsm_release'
+    consumes = (TargetRHSMInfo,)
+    produces = ()
+    tags = (IPUWorkflowTag, FirstBootPhaseTag)
+
+    def process(self):
+        setrelease.process()

--- a/repos/system_upgrade/el7toel8/actors/setrhsmrelease/libraries/setrelease.py
+++ b/repos/system_upgrade/el7toel8/actors/setrhsmrelease/libraries/setrelease.py
@@ -1,0 +1,9 @@
+from leapp.libraries.common import mounting, rhsm
+from leapp.libraries.stdlib import api
+from leapp.models import TargetRHSMInfo
+
+
+def process():
+    info = next(api.consume(TargetRHSMInfo), None)
+    if info:
+        rhsm.set_release(mounting.NotIsolatedActions(base_dir='/'), info.release)

--- a/repos/system_upgrade/el7toel8/actors/setrhsmrelease/tests/test_setrhsmrelease.py
+++ b/repos/system_upgrade/el7toel8/actors/setrhsmrelease/tests/test_setrhsmrelease.py
@@ -1,0 +1,44 @@
+from leapp.libraries.actor import setrelease
+from leapp.libraries.common import mounting, rhsm
+from leapp.libraries.stdlib import api
+from leapp.models import TargetRHSMInfo
+
+
+def not_isolated_actions():
+    commands_called = []
+
+    class MockNotIsolatedActions(object):
+        def __init__(self, base_dir=None):
+            pass
+
+        def call(self, cmd, **kwargs):
+            commands_called.append((cmd, kwargs))
+    return (commands_called, MockNotIsolatedActions)
+
+
+def test_setrelease(monkeypatch):
+    commands_called, klass = not_isolated_actions()
+    monkeypatch.setattr(mounting, 'NotIsolatedActions', klass)
+    monkeypatch.setattr(api, 'consume', lambda *x: (x for x in (TargetRHSMInfo(release='6.6.6'),)))
+    setrelease.process()
+    assert commands_called and len(commands_called) == 1
+    assert commands_called[0][0][-1] == '6.6.6'
+
+
+def test_setrelease_no_message(monkeypatch):
+    commands_called, klass = not_isolated_actions()
+    monkeypatch.setattr(mounting, 'NotIsolatedActions', klass)
+    monkeypatch.setattr(api, 'consume', lambda *x: (x for x in ()))
+    setrelease.process()
+    assert not commands_called
+
+
+def test_setrelease_skip_rhsm(monkeypatch):
+    commands_called, klass = not_isolated_actions()
+    monkeypatch.setenv('LEAPP_DEVEL_SKIP_RHSM', '1')
+    # To make this work we need to re-apply the decorator, so it respects the environment variable
+    monkeypatch.setattr(rhsm, 'set_release', rhsm.with_rhsm(rhsm.set_release))
+    monkeypatch.setattr(mounting, 'NotIsolatedActions', klass)
+    monkeypatch.setattr(api, 'consume', lambda *x: (x for x in (TargetRHSMInfo(release='6.6.6'),)))
+    setrelease.process()
+    assert not commands_called

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -144,7 +144,8 @@ def perform():
             scratch_dir=constants.SCRATCH_DIR,
             xfs_present=xfs_present) as overlay:
         with overlay.nspawn() as context:
-            with rhsm.switched_certificate(context, rhsm_info, prod_cert_path) as target_rhsm_info:
+            target_version = api.current_actor().configuration.version.target
+            with rhsm.switched_certificate(context, rhsm_info, prod_cert_path, target_version) as target_rhsm_info:
                 api.current_logger().debug("Target RHSM Info: SKUs: {skus} Repositories: {repos}".format(
                     repos=target_rhsm_info.enabled_repos,
                     skus=rhsm_info.attached_skus if rhsm_info else []


### PR DESCRIPTION
Previously we did not set any explicit target version on RHSM which
could cause us to receive newer content than what actually is requested
for the upgrade.
We also did not unset the release after the upgrade, which could have
caused dnf update calls to fail, due to old version release value being
set. However if we unset the release and would not set the release the user
might end up updating the system to a newer version than the upgrade was
supposed to be upgrading to.

This PR solves this by setting first the release when we are setting up
all repositories and the target userspace and by setting the release in
the first boot phase after the upgrade has been completed.
Additionally it will let the user know about the changes applied, by
sending a report.