### PR TITLE
Add shared library for checking version and architecture

### DIFF
--- a/repos/system_upgrade/el7toel8/libraries/config/architecture.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/architecture.py
@@ -10,7 +10,7 @@ ARCH_S390X = 's390x'
 ARCH_ACCEPTED = (ARCH_X86_64, ARCH_ARM64, ARCH_PPC64LE, ARCH_S390X)
 
 
-def matches_architecture(match_list):
+def matches_architecture(*match_list):
     """
     Check if one of provided architectures matches the system's one.
 
@@ -19,11 +19,8 @@ def matches_architecture(match_list):
     :return: ``True`` if system's architecture matches one of the values in match_list, ``False`` otherwise
     :rtype: bool
     """
-    if not isinstance(match_list, (list, tuple)):
-        raise TypeError("Architectures to check against have to be a list or tuple "
-                        "but provided was {}: '{}'".format(type(match_list), match_list))
     if not all(isinstance(e, six.string_types) for e in match_list):
-        raise TypeError("Architectures to check against have to be a list or tuple of strings "
+        raise TypeError("Architectures to check against have to strings "
                         "but provided was {}: '{}'".format([type(e) for e in match_list], match_list))
     unsupported = set(match_list).difference(ARCH_ACCEPTED)
     if unsupported:

--- a/repos/system_upgrade/el7toel8/libraries/config/architecture.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/architecture.py
@@ -1,0 +1,31 @@
+import six
+
+from leapp.libraries.stdlib import api
+
+
+ARCH_X86_64 = 'x86_64'
+ARCH_ARM64 = 'aarch64'
+ARCH_PPC64LE = 'ppc64le'
+ARCH_S390X = 's390x'
+ARCH_ACCEPTED = (ARCH_X86_64, ARCH_ARM64, ARCH_PPC64LE, ARCH_S390X)
+
+
+def matches_architecture(match_list):
+    """
+    Check if one of provided architectures matches the system's one.
+
+    :param match: architectures to check against
+    :type match: list, tuple of strings
+    :return: ``True`` if system's architecture matches one of the values in match_list, ``False`` otherwise
+    :rtype: bool
+    """
+    if not isinstance(match_list, (list, tuple)):
+        raise TypeError("Architectures to check against have to be a list or tuple "
+                        "but provided was {}: '{}'".format(type(match_list), match_list))
+    if not all(isinstance(e, six.string_types) for e in match_list):
+        raise TypeError("Architectures to check against have to be a list or tuple of strings "
+                        "but provided was {}: '{}'".format([type(e) for e in match_list], match_list))
+    unsupported = set(match_list).difference(ARCH_ACCEPTED)
+    if unsupported:
+        api.current_logger().warn("Unsupported architecture specified: {}".format(unsupported))
+    return api.current_actor().configuration.architecture in match_list

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_architecture.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_architecture.py
@@ -12,15 +12,15 @@ class CurrentActorMocked(object):
 
 def test_matches_architecture_pass(monkeypatch):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
-    assert architecture.matches_architecture(architecture.ARCH_ACCEPTED)
+    assert architecture.matches_architecture(*architecture.ARCH_ACCEPTED)
 
 
 def test_matches_architecture_fail(monkeypatch):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
-    assert not architecture.matches_architecture([])
-    assert not architecture.matches_architecture(architecture.ARCH_ACCEPTED[1:])
+    assert not architecture.matches_architecture()
+    assert not architecture.matches_architecture(*architecture.ARCH_ACCEPTED[1:])
 
 
 def test_matches_architecture_wrong_args():
     with pytest.raises(TypeError):
-        architecture.matches_architecture(['aarch64', 1])
+        architecture.matches_architecture('aarch64', 1)

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_architecture.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_architecture.py
@@ -1,0 +1,24 @@
+import pytest
+
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+
+
+class current_actor_mocked(object):
+    architecture = architecture.ARCH_ACCEPTED[0]
+
+
+def test_matches_architecture_pass(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', current_actor_mocked)
+    assert architecture.matches_architecture(architecture.ARCH_ACCEPTED) is True
+
+
+def test_matches_architecture_fail(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', current_actor_mocked)
+    assert architecture.matches_architecture([]) is False
+    assert architecture.matches_architecture(architecture.ARCH_ACCEPTED[1:]) is False
+
+
+def test_matches_architecture_wrong_args():
+    with pytest.raises(TypeError):
+        architecture.matches_architecture(['aarch64', 1])

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_architecture.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_architecture.py
@@ -1,22 +1,24 @@
+from collections import namedtuple
+
 import pytest
 
 from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 
 
-class current_actor_mocked(object):
-    architecture = architecture.ARCH_ACCEPTED[0]
+class CurrentActorMocked(object):
+    configuration = namedtuple('configuration', ['architecture'])(architecture.ARCH_ACCEPTED[0])
 
 
 def test_matches_architecture_pass(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', current_actor_mocked)
-    assert architecture.matches_architecture(architecture.ARCH_ACCEPTED) is True
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    assert architecture.matches_architecture(architecture.ARCH_ACCEPTED)
 
 
 def test_matches_architecture_fail(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', current_actor_mocked)
-    assert architecture.matches_architecture([]) is False
-    assert architecture.matches_architecture(architecture.ARCH_ACCEPTED[1:]) is False
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    assert not architecture.matches_architecture([])
+    assert not architecture.matches_architecture(architecture.ARCH_ACCEPTED[1:])
 
 
 def test_matches_architecture_wrong_args():

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
@@ -1,6 +1,14 @@
+from collections import namedtuple
+
 import pytest
 
 from leapp.libraries.common.config import version
+from leapp.libraries.stdlib import api
+
+
+class CurrentActorMocked(object):
+    version = namedtuple('configuration', ['source', 'target'])('7.6', '8.0')
+    configuration = namedtuple('configuration', ['version'])(version)
 
 
 def test_version_to_tuple():
@@ -49,3 +57,23 @@ def test_matches_version_fail():
 def test_matches_version_pass():
     assert version.matches_version(['7.6', '7.7', '7.10'], '7.7')
     assert version.matches_version(['> 7.6', '< 7.10'], '7.7')
+
+
+def test_matches_source_version_pass(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    assert version.matches_source_version('7.6', '7.7')
+
+
+def test_matches_source_version_fail(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    assert not version.matches_source_version('7.5', '7.7')
+
+
+def test_matches_target_version_pass(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    assert version.matches_target_version('8.0', '8.1')
+
+
+def test_matches_source_targetn_fail(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    assert not version.matches_target_version('8.2')

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
@@ -1,0 +1,51 @@
+import pytest
+
+from leapp.libraries.common.config import version
+
+
+def test_version_to_tuple():
+    assert version._version_to_tuple('7.6') == (7, 6)
+
+
+def test_validate_versions():
+    assert version._validate_versions(['7.6', '7.7']) is None
+    with pytest.raises(ValueError):
+        assert version._validate_versions(['7.6', 'z.z'])
+
+
+def test_simple_versions():
+    assert version._simple_versions(['7.6', '7.7']) is True
+    assert version._simple_versions(['7.6', '< 7.7']) is False
+
+
+def test_cmp_versions():
+    assert version._cmp_versions(['>= 7.6', '< 7.7']) is True
+    assert version._cmp_versions(['>= 7.6', '& 7.7']) is False
+
+
+def test_matches_version_wrong_args():
+    with pytest.raises(TypeError):
+        version.matches_version('>= 7.6', '7.7')
+    with pytest.raises(TypeError):
+        version.matches_version([7.6, 7.7], '7.7')
+    with pytest.raises(TypeError):
+        version.matches_version(['7.6', '7.7'], 7.7)
+    with pytest.raises(ValueError):
+        version.matches_version(['>= 7.6', '> 7.7'], 'x.y')
+    with pytest.raises(ValueError):
+        version.matches_version(['>= 7.6', '7.7'], '7.7')
+    with pytest.raises(ValueError):
+        version.matches_version(['>= 7.6', '& 7.7'], '7.7')
+
+
+def test_matches_version_fail():
+    assert version.matches_version(['> 7.6', '< 7.7'], '7.6') is False
+    assert version.matches_version(['> 7.6', '< 7.7'], '7.7') is False
+    assert version.matches_version(['> 7.6', '< 7.10'], '7.6') is False
+    assert version.matches_version(['> 7.6', '< 7.10'], '7.10') is False
+    assert version.matches_version(['7.6', '7.7', '7.10'], '7.8') is False
+
+
+def test_matches_version_pass():
+    assert version.matches_version(['7.6', '7.7', '7.10'], '7.7') is True
+    assert version.matches_version(['> 7.6', '< 7.10'], '7.7') is True

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
@@ -8,19 +8,19 @@ def test_version_to_tuple():
 
 
 def test_validate_versions():
-    assert version._validate_versions(['7.6', '7.7']) is None
+    version._validate_versions(['7.6', '7.7'])
     with pytest.raises(ValueError):
         assert version._validate_versions(['7.6', 'z.z'])
 
 
 def test_simple_versions():
-    assert version._simple_versions(['7.6', '7.7']) is True
-    assert version._simple_versions(['7.6', '< 7.7']) is False
+    assert version._simple_versions(['7.6', '7.7'])
+    assert not version._simple_versions(['7.6', '< 7.7'])
 
 
 def test_cmp_versions():
-    assert version._cmp_versions(['>= 7.6', '< 7.7']) is True
-    assert version._cmp_versions(['>= 7.6', '& 7.7']) is False
+    assert version._cmp_versions(['>= 7.6', '< 7.7'])
+    assert not version._cmp_versions(['>= 7.6', '& 7.7'])
 
 
 def test_matches_version_wrong_args():
@@ -39,13 +39,13 @@ def test_matches_version_wrong_args():
 
 
 def test_matches_version_fail():
-    assert version.matches_version(['> 7.6', '< 7.7'], '7.6') is False
-    assert version.matches_version(['> 7.6', '< 7.7'], '7.7') is False
-    assert version.matches_version(['> 7.6', '< 7.10'], '7.6') is False
-    assert version.matches_version(['> 7.6', '< 7.10'], '7.10') is False
-    assert version.matches_version(['7.6', '7.7', '7.10'], '7.8') is False
+    assert not version.matches_version(['> 7.6', '< 7.7'], '7.6')
+    assert not version.matches_version(['> 7.6', '< 7.7'], '7.7')
+    assert not version.matches_version(['> 7.6', '< 7.10'], '7.6')
+    assert not version.matches_version(['> 7.6', '< 7.10'], '7.10')
+    assert not version.matches_version(['7.6', '7.7', '7.10'], '7.8')
 
 
 def test_matches_version_pass():
-    assert version.matches_version(['7.6', '7.7', '7.10'], '7.7') is True
-    assert version.matches_version(['> 7.6', '< 7.10'], '7.7') is True
+    assert version.matches_version(['7.6', '7.7', '7.10'], '7.7')
+    assert version.matches_version(['> 7.6', '< 7.10'], '7.7')

--- a/repos/system_upgrade/el7toel8/libraries/config/version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/version.py
@@ -1,0 +1,113 @@
+import operator
+
+import six
+
+from leapp.libraries.stdlib import api
+
+
+OP_MAP = {
+    '>': operator.gt,
+    '>=': operator.ge,
+    '<': operator.lt,
+    '<=': operator.le
+}
+
+
+def _version_to_tuple(version):
+    """Converts the version string ``major.minor`` to ``(major, minor)`` int tuple."""
+    major, minor = version.split('.')
+    return (int(major), int(minor))
+
+
+def _validate_versions(versions):
+    """Raise ``TypeError`` if provided versions are not strings in the form ``<integer>.<integer>``."""
+    for ver in versions:
+        split = ver.split('.')
+        if not len(split) == 2 or not all(x.isdigit() for x in split):
+            raise ValueError("Versions have to be in the form of '<integer>.<integer>' "
+                             "but provided was '{}'".format(versions))
+
+
+def _simple_versions(versions):
+    """Return ``True`` if provided versions are list of strings without comparison operators."""
+    return all(len(v.split()) == 1 for v in versions)
+
+
+def _cmp_versions(versions):
+    """Return ``True`` if provided versions are list of strings with comparison operators."""
+    split = [v.split() for v in versions]
+    if not all(len(s) == 2 for s in split):
+        return False
+
+    return all(s[0] in OP_MAP for s in split)
+
+
+def matches_version(match_list, detected):
+    """
+    Check if the `detected` version meets the criteria specified in `match_list`.
+
+    :param match_list: specification of versions to check against
+    :type match_list: list or tuple of strings in one of the two following forms:
+                      ``['>'|'>='|'<'|'<='] <integer>.<integer>`` form, where elements are ANDed,
+                      meaning that ``['>= 7.6', '< 7.8']`` would match for ``'7.6'``, and ``'7,7'`` only.
+                      ``<integer>.<integer>`` form, where elements are ORed, meaning that
+                      ``['7.6', '7.7']`` would match for ``'7.6'``, and ``'7,7'`` only.
+                      These two forms cannot be mixed, otherwise ``ValueError`` is raised.
+    :param detected: detected version
+    :type detected: string in the form ``<integer>.<integer>``
+    :return: ``True`` if `detected` value matches one of the values in `match_list`, ``False`` otherwise
+    :rtype: bool
+    """
+    if not isinstance(match_list, (list, tuple)):
+        raise TypeError("Versions to check against have to be a list or tuple "
+                        "but provided was {}: '{}'".format(type(match_list), match_list))
+    if not all(isinstance(e, six.string_types) for e in match_list):
+        raise TypeError("Versions to check against have to be a list or tuple of strings "
+                        "but provided was {}: '{}'".format([type(e) for e in match_list], match_list))
+    if not isinstance(detected, six.string_types):
+        raise TypeError("Detected version has to be a string "
+                        "but provided was {}: '{}'".format(type(detected), detected))
+    _validate_versions([detected])
+
+    if _simple_versions(match_list):
+        # match_list = ['7.6', '7.7', '7.8', '7.9']
+        _validate_versions(match_list)
+        return detected in match_list
+    elif _cmp_versions(match_list):
+        detected = _version_to_tuple(detected)
+        # match_list = ['>= 7.6', '< 7.10']
+        _validate_versions([s.split()[1] for s in match_list])
+        for match in match_list:
+            op, ver = match.split()
+            ver = _version_to_tuple(ver)
+            if not OP_MAP[op](detected, ver):
+                return False
+        return True
+    else:
+        raise ValueError("Versions have to be a list or tuple of strings in the form "
+                         "'['>'|'>='|'<'|'<='] <integer>.<integer>' or "
+                         "'<integer>.<integer>' but provided was '{}'".format(match_list))
+
+
+def matches_source_version(match_list):
+    """
+    Check if one of provided source versions matches the configured one.
+
+    :param match_list: specification of versions to check against
+    :type match_list: list or tuple of strings, for details see argument ``match_list``
+                      of function :func:`matches_version`.
+    """
+    source_version = api.current_actor().configuration.version.source
+    return matches_version(match_list, source_version)
+
+
+def matches_target_version(match_list):
+    """
+    Check if one of provided target versions matches the configured one.
+
+    :param match_list: specification of versions to check against
+    :type match_list: list or tuple of strings, for details see argument ``match_list``
+                      of function :func:`matches_version`.
+    """
+    target_version = api.current_actor().configuration.version.target
+    return matches_version(match_list, target_version)

--- a/repos/system_upgrade/el7toel8/libraries/config/version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/version.py
@@ -89,25 +89,23 @@ def matches_version(match_list, detected):
                          "'<integer>.<integer>' but provided was '{}'".format(match_list))
 
 
-def matches_source_version(match_list):
+def matches_source_version(*match_list):
     """
     Check if one of provided source versions matches the configured one.
 
     :param match_list: specification of versions to check against
-    :type match_list: list or tuple of strings, for details see argument ``match_list``
-                      of function :func:`matches_version`.
+    :type match_list: strings, for details see argument ``match_list`` of function :func:`matches_version`.
     """
     source_version = api.current_actor().configuration.version.source
     return matches_version(match_list, source_version)
 
 
-def matches_target_version(match_list):
+def matches_target_version(*match_list):
     """
     Check if one of provided target versions matches the configured one.
 
     :param match_list: specification of versions to check against
-    :type match_list: list or tuple of strings, for details see argument ``match_list``
-                      of function :func:`matches_version`.
+    :type match_list: strings, for details see argument ``match_list`` of function :func:`matches_version`.
     """
     target_version = api.current_actor().configuration.version.target
     return matches_version(match_list, target_version)


### PR DESCRIPTION
This library provides a functionality to test whether the upgraded system's
architecture or version (target or source) matches the provided ones.