### PR TITLE
Add support for linting and testing of repository libraries

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,26 +1,32 @@
 import os
+
 from leapp.utils.repository import find_repository_basedir
 from leapp.repository.scan import find_and_scan_repositories
 
 
 def pytest_sessionstart(session):
     actor_path = os.environ.get('LEAPP_TESTED_ACTOR', None)
-    if not actor_path:
-        return
-    repo = find_and_scan_repositories(find_repository_basedir(actor_path), include_locals=True)
-    repo.load()
+    library_path = os.environ.get('LEAPP_TESTED_LIBRARY', None)
 
-    actor = None
-    # find which actor is being tested
-    for a in repo.actors:
-        if a.full_path == actor_path.rstrip('/'):
-            actor = a
-            break
+    if actor_path:
+        repo = find_and_scan_repositories(find_repository_basedir(actor_path), include_locals=True)
+        repo.load()
 
-    if not actor:
-        return
+        actor = None
+        # find which actor is being tested
+        for a in repo.actors:
+            if a.full_path == actor_path.rstrip('/'):
+                actor = a
+                break
 
-    # load actor context so libraries can be imported on module level
-    session.leapp_repository = repo
-    session.actor_context = actor.injected_context()
-    session.actor_context.__enter__()
+        if not actor:
+            return
+
+        # load actor context so libraries can be imported on module level
+        session.leapp_repository = repo
+        session.actor_context = actor.injected_context()
+        session.actor_context.__enter__()
+    elif library_path:
+        repo = find_and_scan_repositories(find_repository_basedir(library_path), include_locals=True)
+        repo.load()
+        os.chdir(library_path)

--- a/utils/library_path.py
+++ b/utils/library_path.py
@@ -1,0 +1,15 @@
+import logging
+import sys
+
+from leapp.repository.scan import find_and_scan_repositories
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, filename='/dev/null')
+    logger = logging.getLogger('run_pytest.py')
+
+    BASE_REPO = 'repos'
+    repos = find_and_scan_repositories(BASE_REPO, include_locals=True)
+    repos.load()
+
+    print(','.join(repos.libraries))


### PR DESCRIPTION
This PR allows for testing and linting of repository libraries. When environment variable `TEST_LIBS` is used for Makefile targets `lint`, `test` and `test_no_lint`, linting and tests are carried out for repository libraries. When no environment variable is specified (neither `ACTOR` nor `TEST_LIBS`), linting and testing is carried out for the whole repo:

- `make test` -> whole repo
- `TEST_LIBS=y make test` -> repository libraries only
- `ACTOR=someactor make test` -> specified actor only
- `ACTOR=someactor TEST_LIBS=y make test` -> specified actor and repository libraries
