### PR TITLE
dnfplugin: Make repos also obey gpgcheck = False

### DIFF
--- a/repos/system_upgrade/el7toel8/files/rhel_upgrade.py
+++ b/repos/system_upgrade/el7toel8/files/rhel_upgrade.py
@@ -62,6 +62,8 @@ class RhelUpgradeCommand(dnf.cli.Command):
         for repo in self.base.repos.all():
             if repo.id in enabled_repos:
                 repo.skip_if_unavailable = False
+                if not self.base.conf.gpgcheck:
+                    repo.gpgcheck = False
                 repo.enable()
 
     def run(self):


### PR DESCRIPTION
In case of upgrades, we usually set the gpgcheck to false. However the
repositories have their own values which need to be explicitly
overridden by the plugin too, if we don't want the gpgcheck to be
performed.
This patch ensures, that the gpgcheck value is set to false explicitly
if we are instructed to set the gpgcheck=False through the plugin
config.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>