### PR TITLE
Handle the case of no enabled target repositories

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -151,6 +151,15 @@ def perform():
                 ))
                 target_repoids = gather_target_repositories(target_rhsm_info)
                 api.current_logger().debug("Gathered target repositories: {}".format(', '.join(target_repoids)))
+                if not target_repoids:
+                    raise StopActorExecutionError(
+                        message='There are no enabled target repositories for the upgrade process to proceed.',
+                        details={'hint': (
+                            'Ensure your system is correctly registered with the subscription manager and that'
+                            ' your current subscription is entitled to install the requested target version {version}'
+                            ).format(version=api.current_actor().configuration.version.target)
+                        }
+                    )
                 prepare_target_userspace(context, constants.TARGET_USERSPACE, target_repoids, list(packages))
                 _prep_repository_access(context, constants.TARGET_USERSPACE)
                 dnfplugin.install(constants.TARGET_USERSPACE)


### PR DESCRIPTION
Previously, when there were no enabled target repositories available,
leapp would just quit with some misleading log. Even though there was a
line saying that there were no enabled repositories, it was hard to
tell. This PR will make this more explicit and gives the user a hint on
how to handle this situation.
This commonly happens if someone would use the LEAPP_DEVEL_SKIP_RHSM
option but does not provide custom repositories, or has them being
injected in the wrong phase.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>