### PR TITLE
Do not call set_release if no release value

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/setrhsmrelease/libraries/setrelease.py
+++ b/repos/system_upgrade/el7toel8/actors/setrhsmrelease/libraries/setrelease.py
@@ -5,5 +5,5 @@ from leapp.models import TargetRHSMInfo
 
 def process():
     info = next(api.consume(TargetRHSMInfo), None)
-    if info:
+    if info and info.release:
         rhsm.set_release(mounting.NotIsolatedActions(base_dir='/'), info.release)


### PR DESCRIPTION
In case of skipping RHSM (LEAPP_DEVEL_SKIP_RHSM) no target release is
set and we should not try to set it.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>