### PR TITLE
pylint: Extend to test for Python3 compatibility

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,6 @@
+[MASTER]
+py3k=
+
 [MESSAGES CONTROL]
 disable=
 # "F" Fatal errors that prevent further processing
@@ -8,6 +11,7 @@ disable=
  no-name-in-module,
  raising-bad-type,
 # "W" Warnings for stylistic problems or minor programming issues
+ no-absolute-import,
  arguments-differ,
  cell-var-from-loop,
  fixme,

--- a/repos/system_upgrade/el7toel8/actors/checkbootavailspace/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkbootavailspace/libraries/library.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from os import statvfs
 
 from leapp.libraries.common import reporting

--- a/repos/system_upgrade/el7toel8/actors/checkbootavailspace/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkbootavailspace/tests/unit_test.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 from leapp.libraries.actor.library import (MIN_AVAIL_BYTES_FOR_BOOT,
                                            check_avail_space_on_boot,
                                            inhibit_upgrade)

--- a/repos/system_upgrade/el7toel8/actors/initramdiskgenerator/libraries/initramgen.py
+++ b/repos/system_upgrade/el7toel8/actors/initramdiskgenerator/libraries/initramgen.py
@@ -35,7 +35,7 @@ def copy_dracut_modules(context, modules):
             api.current_logger().error('Failed to copy dracut module "{name}" from "{source}" to "{target}"'.format(
                 name=module.name, source=module.module_path, target=context.full_path('/dracut')), exc_info=True)
             raise StopActorExecutionError(
-                message='Failed to install dracut modules required in the initram. Error: {}'.format(e.message)
+                message='Failed to install dracut modules required in the initram. Error: {}'.format(str(e))
             )
 
 

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/test_converter.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/test_converter.py
@@ -51,7 +51,7 @@ class TestConfigConversion(object):
 
     def test_match(self):
 
-        for f in [f for f in os.listdir(NTP_MATCH_DIR) if f.endswith('conf')]:
+        for f in [fe for fe in os.listdir(NTP_MATCH_DIR) if fe.endswith('conf')]:
             # get recorded actual result
             num = f.split('.')[0].split('_')[0]
             ntp_conf = os.path.join(NTP_MATCH_DIR, f)

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -266,7 +266,7 @@ def map_repositories(to_install):
     """Map repositories from PES data to RHSM repository id"""
     repo_not_mapped_pkgs = set()
     for pkg, repo in to_install.items():
-        if repo not in REPOSITORIES_MAPPING.keys():
+        if repo not in REPOSITORIES_MAPPING:
             repo_not_mapped_pkgs.add(pkg)
             del to_install[pkg]
             continue

--- a/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/libraries/scanner.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/libraries/scanner.py
@@ -10,7 +10,7 @@ def load_tasks_file(path, logger):
             with open(path, 'r') as f:
                 return list(set([entry.strip() for entry in f.read().split() if entry.strip()]))
         except IOError as e:
-            logger.warn('Failed to open %s to load additional transaction data. Error: %s', path, e.message)
+            logger.warn('Failed to open %s to load additional transaction data. Error: %s', path, str(e))
     return []
 
 

--- a/repos/system_upgrade/el7toel8/actors/setuptargetrepos/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/setuptargetrepos/actor.py
@@ -62,7 +62,7 @@ class SetupTargetRepos(Actor):
                 for repo in repo_file.data:
                     enabled_repos.add(repo.repoid)
 
-        skipped_repos = skipped_repos.intersection(used.keys())
+        skipped_repos = skipped_repos.intersection(set(used.keys()))
 
         if skipped_repos:
             pkgs = set()

--- a/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
+++ b/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
@@ -27,7 +27,7 @@ def install(target_basedir):
     except EnvironmentError as e:
         api.current_logger().debug('Failed to install DNF plugin', exc_info=True)
         raise StopActorExecutionError(
-            message='Failed to install DNF plugin. Error: {}'.format(e.message)
+            message='Failed to install DNF plugin. Error: {}'.format(str(e))
         )
 
 
@@ -86,7 +86,7 @@ def backup_debug_data(context):
         try:
             context.copytree_from('/debugdata', DNF_DEBUG_DATA_PATH)
         except OSError as e:
-            api.current_logger().warn('Failed to copy debugdata. Message: {}'.format(e.message), exc_info=True)
+            api.current_logger().warn('Failed to copy debugdata. Message: {}'.format(str(e)), exc_info=True)
 
 
 def _transaction(context, stage, target_repoids, tasks, test=False):
@@ -109,9 +109,9 @@ def _transaction(context, stage, target_repoids, tasks, test=False):
                 callback_raw=utils.logging_handler
             )
         except OSError as e:
-            api.current_logger().error('Could not call dnf command: Message: %s', e.message, exc_info=True)
+            api.current_logger().error('Could not call dnf command: Message: %s', str(e), exc_info=True)
             raise StopActorExecutionError(
-                message='Failed to execute dnf. Reason: {}'.format(e.message)
+                message='Failed to execute dnf. Reason: {}'.format(str(e))
             )
         except CalledProcessError as e:
             api.current_logger().error('DNF execution failed: ')

--- a/repos/system_upgrade/el7toel8/libraries/guards.py
+++ b/repos/system_upgrade/el7toel8/libraries/guards.py
@@ -26,7 +26,7 @@ def guarded_execution(*guards):
                 'hint': 'Possible spurious failure: {cause}'.format(cause=' '.join(guard_errors))
             }
         raise StopActorExecutionError(
-            message=e.message,
+            message=str(e),
             details=details
         )
 

--- a/repos/system_upgrade/el7toel8/libraries/mounting.py
+++ b/repos/system_upgrade/el7toel8/libraries/mounting.py
@@ -284,12 +284,12 @@ class MountingBase(object):
             try:
                 run(['umount', '-fl', self.target], split=False)
             except (OSError, CalledProcessError) as e:
-                api.current_logger().warn('Unmounting %s failed with: %s', self.target, e.message)
+                api.current_logger().warn('Unmounting %s failed with: %s', self.target, str(e))
         for directory in itertools.chain(self.additional_directories, (self.target,)):
             try:
                 run(['rm', '-rf', directory], split=False)
             except (OSError, CalledProcessError):
-                api.current_logger().warn('Removing mount directory %s failed with: %s', directory, e.message)
+                api.current_logger().warn('Removing mount directory %s failed with: %s', directory, str(e))
 
     def mount(self):
         """ Performs the mount if MountConfig.should_create = True """
@@ -306,7 +306,7 @@ class MountingBase(object):
         try:
             run(['mount'] + self._mount_options() + [self.target], split=False)
         except (OSError, CalledProcessError) as e:
-            api.current_logger().warn('Mounting %s failed with: %s', self.target, e.message, exc_info=True)
+            api.current_logger().warn('Mounting %s failed with: %s', self.target, str(e), exc_info=True)
             raise MountError(
                 message='Mount operation with mode {} from {} to {} failed: {}'.format(
                     self._mode, self.source, self.target, str(e)),

--- a/repos/system_upgrade/el7toel8/libraries/overlaygen.py
+++ b/repos/system_upgrade/el7toel8/libraries/overlaygen.py
@@ -33,7 +33,7 @@ def cleanup_scratch(scratch_dir, mounts_dir):
             run(['/bin/umount', '-fl', mounts_dir])
             api.current_logger().debug('Unmounted mounted disk image.')
         except (OSError, CalledProcessError) as e:
-            api.current_logger().warn('Failed to umount %s - message: %s', mounts_dir, e.message)
+            api.current_logger().warn('Failed to umount %s - message: %s', mounts_dir, str(e))
     api.current_logger().debug('Recursively removing scratch directory %s.', scratch_dir)
     shutil.rmtree(scratch_dir, onerror=utils.report_and_ignore_shutil_rmtree_error)
     api.current_logger().debug('Recursively removed scratch directory %s.', scratch_dir)
@@ -60,7 +60,7 @@ def _create_mount_disk_image(scratch_dir, mounts_dir):
     except CalledProcessError as e:
         api.current_logger().error('Failed to create ext4 filesystem %s', exc_info=True)
         raise StopActorExecutionError(
-            message=e.message
+            message=str(e)
         )
 
     return diskimage_path

--- a/repos/system_upgrade/el7toel8/libraries/rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/rhsm.py
@@ -23,7 +23,7 @@ def _handle_rhsm_exceptions(hint=None):
     except OSError as e:
         api.current_logger().error('Failed to execute subscription-manager executable')
         raise StopActorExecutionError(
-            message='Unable to execute subscription-manager executable. Message: {}'.format(e.message),
+            message='Unable to execute subscription-manager executable. Message: {}'.format(str(e)),
             details={
                 'hint': 'Please ensure subscription-manager is installed and exceutable.'
             }

--- a/repos/system_upgrade/el7toel8/libraries/utils.py
+++ b/repos/system_upgrade/el7toel8/libraries/utils.py
@@ -27,11 +27,11 @@ def apply_yum_workaround(context=None):
         context.call(cmd)
     except OSError as e:
         raise StopActorExecutionError(
-            message='Failed to exceute script to apply yum adjustment. Message: {}'.format(e.message)
+            message='Failed to exceute script to apply yum adjustment. Message: {}'.format(str(e))
         )
     except CalledProcessError as e:
         raise StopActorExecutionError(
-            message='Failed to apply yum adjustment. Message: {}'.format(e.message)
+            message='Failed to apply yum adjustment. Message: {}'.format(str(e))
         )
 
 
@@ -77,7 +77,7 @@ def call_with_oserror_handled(cmd):
     except OSError as e:
         if cmd:
             raise StopActorExecutionError(
-                message=e.message,
+                message=str(e),
                 details={
                     'hint': 'Please ensure that {} is installed and executable.'.format(cmd[0])
                 }
@@ -97,7 +97,7 @@ def call_with_failure_hint(cmd, hint):
         call_with_oserror_handled(cmd)
     except CalledProcessError as e:
         raise StopActorExecutionError(
-            message='Failed to execute command `{}`. Error: {}'.format(' '.join(cmd), e.message),
+            message='Failed to execute command `{}`. Error: {}'.format(' '.join(cmd), str(e)),
             details={hint: hint}
         )
 


### PR DESCRIPTION
Previously we only verified with Python2 compatibility, however our
codebase needs to be running also on Python 3, therefore we will enable
the compatibility checks for Python 3.