### PR TITLE
Warn about removed pam_tally2 module

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkremovedpammodules/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkremovedpammodules/actor.py
@@ -1,0 +1,60 @@
+from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.models import Report, PamConfiguration
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.libraries.stdlib import api
+from leapp.libraries.common.reporting import report_with_remediation
+
+
+class CheckRemovedPamModules(Actor):
+    """
+    Check for modules that are not available in RHEL 8 anymore
+
+    At this moment, we check only for pam_tally2. Few more modules
+    are alredy covered in RemoveOldPAMModulesApply actor
+    """
+
+    name = 'removed_pam_modules'
+    consumes = (PamConfiguration, )
+    produces = (Report, )
+    tags = (ChecksPhaseTag, IPUWorkflowTag, )
+
+    def process(self):
+        messages = self.consume(PamConfiguration)
+        config = next(messages, None)
+        if list(messages):
+            api.current_logger().warning('Unexpectedly received more than one PamConfiguration message.')
+        if not config:
+            raise StopActorExecutionError(
+                'Could not check pam configuration', details={'details': 'No PamConfiguration facts found.'}
+            )
+
+        # This list contain tupples of removed modules and their recommended replacements
+        removed_modules = [
+            ('pam_tally2', 'pam_faillock'),
+            ]
+        found_services = set()
+        found_modules = set()
+        replacements = set()
+        for service in config.services:
+            for module in removed_modules:
+                removed = module[0]
+                replacement = module[1]
+                if removed in service.modules:
+                    found_services.add(service.service)
+                    found_modules.add(removed)
+                    replacements.add(replacement)
+
+        if found_modules:
+            report_with_remediation(
+                title='The {} pam module(s) no longer available'.format(', '.join(found_modules)),
+                summary='The services {} using PAM are configured to '
+                        'use {} module(s), which is no longer available '
+                        'in Red Hat Enterprise Linux 8.'.format(
+                        ', '.join(found_services), ', '.join(found_modules)),
+                remediation='If you depend on its functionality, it is '
+                            'recommended to migrate to {}. Otherwise '
+                            'please remove the pam module(s) from all the files '
+                            'under /etc/pam.d/.'.format(', '.join(replacements)),
+                severity='high',
+                flags=['inhibitor'])

--- a/repos/system_upgrade/el7toel8/actors/opensshalgorithmscheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshalgorithmscheck/actor.py
@@ -1,4 +1,5 @@
 from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
 from leapp.models import Report, OpenSshConfig
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import api
@@ -31,9 +32,13 @@ class OpenSshAlgorithmsCheck(Actor):
         found_ciphers = []
         found_macs = []
         openssh_messages = self.consume(OpenSshConfig)
-        config = next(openssh_messages)
+        config = next(openssh_messages, None)
         if list(openssh_messages):
             api.current_logger().warning('Unexpectedly received more than one OpenSshConfig message.')
+        if not config:
+            raise StopActorExecutionError(
+                'Could not check openssh configuration', details={'details': 'No OpenSshConfig facts found.'}
+            )
 
         for cipher in removed_ciphers:
             if config.ciphers and cipher in config.ciphers:

--- a/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
@@ -1,4 +1,5 @@
 from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor.library import semantics_changes
 from leapp.models import Report, OpenSshConfig
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
@@ -20,9 +21,13 @@ class OpenSshPermitRootLoginCheck(Actor):
 
     def process(self):
         openssh_messages = self.consume(OpenSshConfig)
-        config = next(openssh_messages)
+        config = next(openssh_messages, None)
         if list(openssh_messages):
             api.current_logger().warning('Unexpectedly received more than one OpenSshConfig message.')
+        if not config:
+            raise StopActorExecutionError(
+                'Could not check openssh configuration', details={'details': 'No OpenSshConfig facts found.'}
+            )
 
         if not config.permit_root_login:
             # TODO find out whether the file was modified and will be

--- a/repos/system_upgrade/el7toel8/actors/opensshuseprivilegeseparationcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshuseprivilegeseparationcheck/actor.py
@@ -1,4 +1,5 @@
 from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
 from leapp.models import Report, OpenSshConfig
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import api
@@ -19,9 +20,13 @@ class OpenSshUsePrivilegeSeparationCheck(Actor):
 
     def process(self):
         openssh_messages = self.consume(OpenSshConfig)
-        config = next(openssh_messages)
+        config = next(openssh_messages, None)
         if list(openssh_messages):
             api.current_logger().warning('Unexpectedly received more than one OpenSshConfig message.')
+        if not config:
+            raise StopActorExecutionError(
+                'Could not check openssh configuration', details={'details': 'No OpenSshConfig facts found.'}
+            )
 
         if config.use_privilege_separation is not None and \
            config.use_privilege_separation != "sandbox":

--- a/repos/system_upgrade/el7toel8/actors/pammodulesscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/pammodulesscanner/actor.py
@@ -1,0 +1,43 @@
+import os
+
+from leapp.actors import Actor
+from leapp.models import PamConfiguration, PamService
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+from leapp.libraries.stdlib import api
+from leapp.libraries.common.pam import PAM
+
+
+class PamModulesScanner(Actor):
+    """
+    Scan the pam directory for services and modules used in them
+
+    This produces a PAMConfiguration message containing the whole
+    list of configured PAM services and what modules they contain.
+    """
+
+    name = 'pam_modules_scanner'
+    consumes = ()
+    produces = (PamConfiguration, )
+    tags = (FactsPhaseTag, IPUWorkflowTag, )
+
+    def process(self):
+        conf = []
+        path = "/etc/pam.d/"
+        for f in os.listdir(path):
+            pam_file = os.path.join(path, f)
+            # Ignore symlinks (usually handled by authconfig)
+            if not os.path.isfile(pam_file) or os.path.islink(pam_file):
+                continue
+
+            # Use the existing PAM library to parse the files, but unpack it to our model
+            try:
+                content = PAM.read_file(pam_file)
+                modules = PAM(content)
+                service = PamService(service=f, modules=modules.modules)
+                conf.append(service)
+            except OSError as err:
+                # if leapp can not read that file it will probably not be important
+                api.current_logger().warning('Failed to read file {}: {}'.format(pam_file, err.strerror))
+
+        pam = PamConfiguration(services=conf)
+        self.produce(pam)

--- a/repos/system_upgrade/el7toel8/models/pamconfiguration.py
+++ b/repos/system_upgrade/el7toel8/models/pamconfiguration.py
@@ -1,0 +1,29 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class PamService(Model):
+    """
+    Pam service description
+
+    This model contains information about pam modules used by specific PAM
+    service/filename
+    """
+    topic = SystemInfoTopic
+
+    service = fields.String()
+    modules = fields.List(fields.String())
+    # Should this also list includes?
+
+
+class PamConfiguration(Model):
+    """
+    Global PAM configuration
+
+    This model describes separate services using PAM and what pam modules are
+    used in each of them. Consumer can select just the pam services he is
+    interested in or scan for specific configuration throughout all the services.
+    """
+    topic = SystemInfoTopic
+
+    services = fields.List(fields.Model(PamService))


### PR DESCRIPTION
The RHEL 8 does not come with `pam_tally2` module anymore and if the pam stacks of some services used to be configured with this module, they can very simply prevent login on the upgraded systems.

This patch set is using the PAM library from #102 (not merged at the time of writing) to generate `PamConfiguration` messages, which are then consumed by another actor, verifying that none of the services depend on this removed pam module. It is written in a way that it can check for more modules, but we did not identify any other module (that would not be handled by #102) that was removed.

I will also have to figure out the final wording of the reports before merging, whether the removal is documented somewhere and whether we have some migration steps.

~~**Edit:** I cherry-picked part of the #102 which my pull request is using to be able to move on, since the original PR is blocked on the dialogs.~~

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1713645