### PR TITLE
Add ip6tables to firewall facts

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
@@ -267,4 +267,5 @@ def get_firewalls_status():
     return FirewallsFacts(
         firewalld=_get_firewall_status('firewalld'),
         iptables=_get_firewall_status('iptables'),
+        ip6tables=_get_firewall_status('ip6tables'),
     )

--- a/repos/system_upgrade/el7toel8/models/firewallsfacts.py
+++ b/repos/system_upgrade/el7toel8/models/firewallsfacts.py
@@ -14,3 +14,4 @@ class FirewallsFacts(Model):
 
     firewalld = fields.Model(FirewallStatus)
     iptables = fields.Model(FirewallStatus)
+    ip6tables = fields.Model(FirewallStatus)


### PR DESCRIPTION
ip6tables is part of iptables so it should be treated respectfully.