### PR TITLE
Add support for fstab entries that do not have optional fields

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/storagescanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/storagescanner/actor.py
@@ -1,6 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import library
 from leapp.models import StorageInfo
+from leapp.reporting import Report
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 
@@ -14,8 +15,8 @@ class StorageScanner(Actor):
 
     name = 'storage_scanner'
     consumes = ()
-    produces = (StorageInfo,)
-    tags = (IPUWorkflowTag, FactsPhaseTag,)
+    produces = (Report, StorageInfo)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
 
     def process(self):
         self.produce(library.get_storage_info())

--- a/repos/system_upgrade/el7toel8/actors/storagescanner/tests/files/fstab
+++ b/repos/system_upgrade/el7toel8/actors/storagescanner/tests/files/fstab
@@ -7,5 +7,8 @@
 # See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info
 #
 /dev/mapper/rhel_ibm--p8--kvm--03--guest--02-root /                       xfs     defaults        0 0
-UUID=0a5215ef-1fb4-4b1b-8860-be4baa9e624c /boot                   xfs     defaults        0 0
+UUID=0a5215ef-1fb4-4b1b-8860-be4baa9e624c /boot                   xfs     defaults        0 1
+UUID=acf9f525-3691-429f-96d7-3f8530227062 /var                   xfs     defaults
+# Testing comment at the middle of valid lines
+UUID=d74186c9-21d5-4549-ae26-91ca9ed36f56 /tmp                   ext4     defaults,nodev,nosuid,noexec        1
 /dev/mapper/rhel_ibm--p8--kvm--03--guest--02-swap swap                    swap    defaults        0 0

--- a/repos/system_upgrade/el7toel8/actors/storagescanner/tests/files/invalid_fstab
+++ b/repos/system_upgrade/el7toel8/actors/storagescanner/tests/files/invalid_fstab
@@ -1,0 +1,11 @@
+
+#
+# /etc/fstab
+# Created by anaconda on Thu Nov 15 16:05:33 2018
+#
+# Accessible filesystems, by reference, are maintained under '/dev/disk'
+# See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info
+#
+
+/dev/mapper/rhel_ibm--p8--kvm--03--guest--02-root /               xfs     defaults        0 0
+UUID=0a5215ef-1fb4-4b1b-8860-be4baa9e624c /boot                   xfs


### PR DESCRIPTION
- the last two fstab fields are optional and may be missing.
- the default values were added based on the fstab man page.
- update unit tests.
- add warning for comments at end of valid lines.

This PR aims to fix issue #263 