### PR TITLE
Force new target kernel to be default boot entry

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import forcedefaultboot
+from leapp.models import InstalledTargetKernelVersion
+from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
+
+
+class ForceDefaultBootToTargetKernelVersion(Actor):
+    """
+    Ensure the default boot entry is set to the new target kernel
+
+    This Actor ensure that the default entry in the boot loader is set to the newly installed kernel version.
+    There have been cases when the default boot entry was not set to the default kernel version. In this case the
+    actor will log a warning for debugging purposes.
+    """
+
+    name = 'force_default_boot_to_target_kernel_version'
+    consumes = (InstalledTargetKernelVersion,)
+    produces = ()
+    tags = (FinalizationPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        forcedefaultboot.process()

--- a/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/libraries/forcedefaultboot.py
+++ b/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/libraries/forcedefaultboot.py
@@ -1,0 +1,68 @@
+import os
+from collections import namedtuple
+
+from leapp.libraries import stdlib
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledTargetKernelVersion
+
+KernelInfo = namedtuple('KernelInfo', ('kernel_path', 'initrd_path'))
+
+
+def get_kernel_info(message):
+    kernel_name = 'vmlinuz-{}'.format(message.version)
+    initrd_name = 'initramfs-{}.img'.format(message.version)
+    kernel_path = os.path.join('/boot', kernel_name)
+    initrd_path = os.path.join('/boot', initrd_name)
+
+    target_version_bootable = True
+    if not os.path.exists(kernel_path):
+        target_version_bootable = False
+        api.current_logger().warning('Mandatory kernel %s does not exist', kernel_path)
+    if not os.path.exists(initrd_path):
+        target_version_bootable = False
+        api.current_logger().warning('Mandatory initrd %s does not exist', initrd_path)
+
+    if target_version_bootable:
+        return KernelInfo(kernel_path=kernel_path, initrd_path=initrd_path)
+
+    api.current_logger().warning('Skipping check due to missing mandatory files')
+    return None
+
+
+def update_default_kernel(kernel_info):
+    try:
+        stdlib.run(['grubby', '--info', kernel_info.kernel_path])
+    except stdlib.CalledProcessError:
+        api.current_logger().error('Expected kernel %s to be installed at the boot loader but cannot be found.',
+                                   kernel_info.kernel_path)
+    except OSError:
+        api.current_logger().error('Could not check for kernel existence in boot loader. Is grubby installed?')
+    else:
+        try:
+            stdlib.run(['grubby', '--set-default', kernel_info.kernel_path])
+        except (OSError, stdlib.CalledProcessError):
+            api.current_logger().error('Failed to set default kernel to: %s', kernel_info.kernel_path, exc_info=True)
+
+
+def process():
+    message = next(api.consume(InstalledTargetKernelVersion), None)
+    if not message:
+        api.current_logger().warning(('Skipped - Forcing checking and setting default boot entry to target kernel'
+                                      ' version due to missing message'))
+        return
+
+    try:
+        current_default_kernel = stdlib.run(['grubby', '--default-kernel'])['stdout'].strip()
+    except (OSError, stdlib.CalledProcessError):
+        api.current_logger().warning('Failed to query grubby for default kernel', exc_info=True)
+        return
+
+    kernel_info = get_kernel_info(message)
+    if not kernel_info:
+        return
+
+    if current_default_kernel != kernel_info.kernel_path:
+        api.current_logger().warning(('Current default boot entry not target kernel version: Current default: %s.'
+                                      'Forcing default kernel to %s'),
+                                     current_default_kernel, kernel_info.kernel_path)
+        update_default_kernel(kernel_info)

--- a/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/tests/test_forcedefaultboot.py
+++ b/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/tests/test_forcedefaultboot.py
@@ -1,0 +1,120 @@
+import os.path
+from collections import namedtuple
+
+import pytest
+
+from leapp.libraries import stdlib
+from leapp.libraries.actor import forcedefaultboot
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledTargetKernelVersion
+
+Expected = namedtuple(
+    'Expected', (
+     'grubby_setdefault'
+    )
+)
+
+Case = namedtuple(
+    'Case',
+    ('initrd_exists',
+     'kernel_exists',
+     'entry_default',
+     'entry_exists',
+     'message_available'
+     )
+)
+
+TARGET_KERNEL_VERSION = '1.2.3.4.el8.x86_64'
+TARGET_KERNEL_PATH = '/boot/vmlinuz-{}'.format(TARGET_KERNEL_VERSION)
+TARGET_INITRD_PATH = '/boot/initramfs-{}.img'.format(TARGET_KERNEL_VERSION)
+
+OLD_KERNEL_VERSION = '0.1.2.3.el7.x86_64'
+OLD_KERNEL_PATH = '/boot/vmlinuz-{}'.format(OLD_KERNEL_VERSION)
+
+CASES = (
+    (Case(initrd_exists=True, kernel_exists=True, entry_default=True, entry_exists=True, message_available=True),
+     Expected(grubby_setdefault=False)),
+    (Case(initrd_exists=False, kernel_exists=True, entry_default=False, entry_exists=True, message_available=True),
+     Expected(grubby_setdefault=False)),
+    (Case(initrd_exists=True, kernel_exists=False, entry_default=False, entry_exists=True, message_available=True),
+     Expected(grubby_setdefault=False)),
+    (Case(initrd_exists=False, kernel_exists=False, entry_default=False, entry_exists=True, message_available=True),
+     Expected(grubby_setdefault=False)),
+    (Case(initrd_exists=True, kernel_exists=True, entry_default=False, entry_exists=True, message_available=False),
+     Expected(grubby_setdefault=False)),
+    (Case(initrd_exists=True, kernel_exists=True, entry_default=False, entry_exists=False, message_available=False),
+     Expected(grubby_setdefault=False)),
+    (Case(initrd_exists=True, kernel_exists=True, entry_default=False, entry_exists=True, message_available=True),
+     Expected(grubby_setdefault=True))
+)
+
+_GRUBBY_INFO_TEMPLATE = '''index={entry_index}
+kernel=/boot/vmlinuz-{kernel_version}
+args="ro rd.lvm.lv=testing/root rd.lvm.lv=testing/swap rhgb quiet LANG=en_US.UTF-8"
+root=/dev/mapper/testing-root
+initrd=/boot/initramfs-{kernel_version}.img
+'''
+
+
+class MockedRun(object):
+    def __init__(self, case):
+        self.case = case
+        self.called_setdefault = False
+
+    def __call__(self, cmd, *args, **kwargs):
+        if cmd and cmd[0] == 'grubby':
+            target = getattr(self, 'grubby_{}'.format(cmd[1].strip('--').replace('-', '_')), None)
+            assert target and 'Unsupport grubby command called'
+            return target(cmd)  # pylint: disable=not-callable
+        return None
+
+    def grubby_info(self, cmd):
+        assert len(cmd) == 3
+        if not self.case.entry_exists:
+            raise stdlib.CalledProcessError('A leapp command failed', cmd, {})
+        else:
+            return {
+                'stdout': _GRUBBY_INFO_TEMPLATE.format(
+                    entry_index=0 if self.case.entry_default else 1,
+                    kernel_version=TARGET_KERNEL_VERSION)
+                }
+
+    def grubby_default_kernel(self, cmd):
+        assert len(cmd) == 2
+        if self.case.entry_default:
+            return {'stdout': '{}\n'.format(TARGET_KERNEL_PATH)}
+        return {'stdout': '{}\n'.format(OLD_KERNEL_PATH)}
+
+    def grubby_set_default(self, cmd):
+        assert len(cmd) == 3
+        assert cmd[2] == TARGET_KERNEL_PATH
+        self.called_setdefault = True
+
+
+def mocked_consume(case):
+    def impl(*args):
+        if case.message_available:
+            return iter((InstalledTargetKernelVersion(version=TARGET_KERNEL_VERSION),))
+        return iter(())
+    return impl
+
+
+def mocked_exists(case, orig_path_exists):
+    def impl(path):
+        if path == TARGET_KERNEL_PATH:
+            return case.kernel_exists
+        if path == TARGET_INITRD_PATH:
+            return case.initrd_exists
+        return orig_path_exists(path)
+    return impl
+
+
+@pytest.mark.parametrize('case_result', CASES)
+def test_force_default_boot_target_scenario(case_result, monkeypatch):
+    case, result = case_result
+    mocked_run = MockedRun(case)
+    monkeypatch.setattr(api, 'consume', mocked_consume(case))
+    monkeypatch.setattr(stdlib, 'run', mocked_run)
+    monkeypatch.setattr(os.path, 'exists', mocked_exists(case, os.path.exists))
+    forcedefaultboot.process()
+    assert result.grubby_setdefault == mocked_run.called_setdefault

--- a/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scankernel
+from leapp.models import InstalledTargetKernelVersion, TransactionCompleted
+from leapp.tags import IPUWorkflowTag, RPMUpgradePhaseTag
+
+
+class ScanInstalledTargetKernelVersion(Actor):
+    """
+    Scan for the version of the newly installed kernel
+
+    This actor will query rpm for all kernel packages and reports the first matching el8 kernel RPM version.
+    """
+
+    name = 'scan_installed_target_kernel_version'
+    consumes = (TransactionCompleted,)
+    produces = (InstalledTargetKernelVersion,)
+    tags = (RPMUpgradePhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        scankernel.process()

--- a/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/libraries/scankernel.py
+++ b/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/libraries/scankernel.py
@@ -1,0 +1,12 @@
+from leapp.libraries import stdlib
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledTargetKernelVersion
+
+
+def process():
+    kernels = stdlib.run(["rpm", "-q", "kernel"], split=True)["stdout"]
+    for kernel in kernels:
+        version = kernel.split("-", 1)[1]
+        if "el8" in version:
+            api.produce(InstalledTargetKernelVersion(version=version))
+            break

--- a/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/tests/test_scaninstalledkernel.py
+++ b/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/tests/test_scaninstalledkernel.py
@@ -1,0 +1,31 @@
+from leapp.libraries import stdlib
+from leapp.libraries.actor import scankernel
+from leapp.libraries.stdlib import api
+
+TARGET_KERNEL_VERSION = '1.2.3-4.el8.x86_64'
+TARGET_KERNEL = 'kernel-{}'.format(TARGET_KERNEL_VERSION)
+OLD_KERNEL = 'kernel-0.1.2-3.el7.x86_64'
+
+
+def mocked_run_with_target_kernel(*args, **kwargs):
+    return {'stdout': [TARGET_KERNEL, OLD_KERNEL]}
+
+
+def mocked_run_without_target_kernel(*args, **kwargs):
+    return {'stdout': [OLD_KERNEL]}
+
+
+def test_scaninstalledkernel(monkeypatch):
+    result = []
+    monkeypatch.setattr(stdlib, 'run', mocked_run_with_target_kernel)
+    monkeypatch.setattr(api, 'produce', result.append)
+    scankernel.process()
+    assert result and result[0].version == TARGET_KERNEL_VERSION
+
+
+def test_scaninstalledkernel_missing(monkeypatch):
+    result = []
+    monkeypatch.setattr(stdlib, 'run', mocked_run_without_target_kernel)
+    monkeypatch.setattr(api, 'produce', result.append)
+    scankernel.process()
+    assert not result

--- a/repos/system_upgrade/el7toel8/models/installedtargetkernelversion.py
+++ b/repos/system_upgrade/el7toel8/models/installedtargetkernelversion.py
@@ -1,0 +1,12 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class InstalledTargetKernelVersion(Model):
+    """
+    This message is used to propagate the version of the kernel that has been installed during the upgrade process.
+
+    The version value is mainly used for boot loader entry manipulations, to know which boot entry to manipulate.
+    """
+    topic = SystemInfoTopic
+    version = fields.String()


### PR DESCRIPTION
During the upgrade, in some yet unknown cases, it happens that the
default boot entry is not being updated to the newly installed kernel,
but the previous kernel version is set as default. With this patch we
are forcing grubby to make the newly installed kernel the default.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>