### PR TITLE
Clean "to_remove" transaction file

### DIFF
--- a/etc/leapp/transaction/to_install
+++ b/etc/leapp/transaction/to_install
@@ -1,0 +1,1 @@
+### List of packages (each on new line) to be added to the upgrade transaction

--- a/etc/leapp/transaction/to_keep
+++ b/etc/leapp/transaction/to_keep
@@ -1,3 +1,5 @@
+### List of packages (each on new line) to be kept in the upgrade transaction
+
 leapp
 python2-leapp
 python3-leapp

--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -1,51 +1,14 @@
-redhat-rpm-config
+### List of packages (each on new line) to be removed from the upgrade transaction
+
+# python2-devel - https://bugzilla.redhat.com/show_bug.cgi?id=1703600
 python2-devel
+# packages that depends on python2-devel
 pygobject2-devel
-pygtk2-devel
 python2-cairo-devel
 python2-debug
-python2-psycopg2-debug
 python2-numpy-f2py
-python2-scipy
 python2-virtualenv
-kernel-rpm-macros
-multilib-rpm-config
-nodejs-packaging
-nodejs-devel
-perl-devel
-net-snmp-devel
-perl-App-cpanminus
-perl-tests
-perl-ExtUtils-CBuilder
-perl-CPAN
-perl-ExtUtils-Embed
-perl-ExtUtils-MakeMaker
-perl-ExtUtils-Install
-perl-Module-Build
-perl-libnetcfg
-perl-inc-latest
-redhat-lsb-languages
-redhat-lsb
-perl-ExtUtils-Miniperl
-perl
-platform-python-devel
-platform-python-debug
-python36-debug
-python3-numpy-f2py
-python3-scipy
-python36-devel
-python3-virtualenv
-unbound-devel
-rpm-build
-openscap-utils
-oscap-anaconda-addon
-scap-workbench
-rpmdevtools
-supermin-devel
-scl-utils-build
-varnish
-varnish-devel
-varnish-modules
-tpm2-abrmd
+# squid - https://bugzilla.redhat.com/show_bug.cgi?id=1703117
 squid
+# python-docs - https://bugzilla.redhat.com/show_bug.cgi?id=1703605
 python-docs

--- a/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/libraries/scanner.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/libraries/scanner.py
@@ -8,7 +8,10 @@ def load_tasks_file(path, logger):
     if os.path.isfile(path):
         try:
             with open(path, 'r') as f:
-                return list(set([entry.strip() for entry in f.read().split() if entry.strip()]))
+                return list(
+                    {entry.strip() for entry in f.read().split('\n') if entry.strip() and
+                        not entry.strip().startswith('#')}
+                )
         except IOError as e:
             logger.warn('Failed to open %s to load additional transaction data. Error: %s', path, str(e))
     return []


### PR DESCRIPTION
After we started using RHEL8 rpm userspace, we should not hit
richdeps issues anymore. As a result we are removing:

"tpm2-abrmd"
"redhat-rpm-config"

And packages that depend on "redhat-rpm-config".