### PR TITLE
Refactor kernelcmdlineconfig to use InstalledKernelVersion message

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/actor.py
@@ -1,8 +1,7 @@
 from leapp.actors import Actor
-from leapp.models import KernelCmdlineArg
-from leapp.tags import IPUWorkflowTag, FinalizationPhaseTag
-from leapp.libraries.stdlib import run, CalledProcessError
-from leapp.exceptions import StopActorExecutionError
+from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg
+from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
+from leapp.libraries.actor import kernelcmdlineconfig
 
 
 class KernelCmdlineConfig(Actor):
@@ -11,28 +10,9 @@ class KernelCmdlineConfig(Actor):
     """
 
     name = 'kernelcmdlineconfig'
-    consumes = (KernelCmdlineArg,)
+    consumes = (KernelCmdlineArg, InstalledTargetKernelVersion)
     produces = ()
     tags = (FinalizationPhaseTag, IPUWorkflowTag)
 
-    def get_rhel8_kernel_version(self):
-        kernels = run(["rpm", "-q", "kernel"], split=True)["stdout"]
-        for kernel in kernels:
-            version = kernel.split("-", 1)[1]
-            if "el8" in version:
-                return version
-        raise StopActorExecutionError(
-            "Cannot get version of the installed RHEL-8 kernel",
-            details={"details": "\n".join(kernels)})
-
     def process(self):
-        kernel_version = self.get_rhel8_kernel_version()
-        for arg in self.consume(KernelCmdlineArg):
-            cmd = ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(kernel_version),
-                   '--args={}={}'.format(arg.key, arg.value)]
-            try:
-                run(cmd)
-            except CalledProcessError as e:
-                raise StopActorExecutionError(
-                    "Failed to append extra arguments to kernel command line.",
-                    details={"details": str(e)})
+        kernelcmdlineconfig.process()

--- a/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
+++ b/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
@@ -1,0 +1,18 @@
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries import stdlib
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg
+
+
+def process():
+    kernel_version = next(api.consume(InstalledTargetKernelVersion), None)
+    if kernel_version:
+        for arg in api.consume(KernelCmdlineArg):
+            cmd = ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(kernel_version.version),
+                   '--args={}={}'.format(arg.key, arg.value)]
+            try:
+                stdlib.run(cmd)
+            except (OSError, stdlib.CalledProcessError) as e:
+                raise StopActorExecutionError(
+                    "Failed to append extra arguments to kernel command line.",
+                    details={"details": str(e)})

--- a/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
+++ b/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
@@ -1,0 +1,65 @@
+from leapp.libraries import stdlib
+from leapp.libraries.actor import kernelcmdlineconfig
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg
+
+KERNEL_VERSION = '1.2.3-4.x86_64.el8'
+
+
+class MockedRun(object):
+    def __init__(self):
+        self.commands = []
+
+    def __call__(self, cmd, *args, **kwargs):
+        self.commands.append(cmd)
+        return {}
+
+
+def mocked_consume(*models):
+    if InstalledTargetKernelVersion in models:
+        return iter((InstalledTargetKernelVersion(version=KERNEL_VERSION),))
+    return iter((
+        KernelCmdlineArg(key='some_key1', value='some_value1'),
+        KernelCmdlineArg(key='some_key2', value='some_value2')
+    ))
+
+
+def mocked_consume_no_args(*models):
+    if InstalledTargetKernelVersion in models:
+        return iter((InstalledTargetKernelVersion(version=KERNEL_VERSION),))
+    return iter(())
+
+
+def mocked_consume_no_version(*models):
+    if InstalledTargetKernelVersion in models:
+        return iter(())
+    assert False and 'this should not be called'
+    return iter(())
+
+
+def test_kernelcmdline_config(monkeypatch):
+    mocked_run = MockedRun()
+    monkeypatch.setattr(stdlib, 'run', mocked_run)
+    monkeypatch.setattr(api, 'consume', mocked_consume)
+    kernelcmdlineconfig.process()
+    assert mocked_run.commands and len(mocked_run.commands) == 2
+    assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
+        KERNEL_VERSION), '--args=some_key2=some_value2'] == mocked_run.commands.pop()
+    assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
+        KERNEL_VERSION), '--args=some_key1=some_value1'] == mocked_run.commands.pop()
+
+
+def test_kernelcmdline_config_no_args(monkeypatch):
+    mocked_run = MockedRun()
+    monkeypatch.setattr(stdlib, 'run', mocked_run)
+    monkeypatch.setattr(api, 'consume', mocked_consume_no_args)
+    kernelcmdlineconfig.process()
+    assert not mocked_run.commands
+
+
+def test_kernelcmdline_config_no_version(monkeypatch):
+    mocked_run = MockedRun()
+    monkeypatch.setattr(stdlib, 'run', mocked_run)
+    monkeypatch.setattr(api, 'consume', mocked_consume_no_version)
+    kernelcmdlineconfig.process()
+    assert not mocked_run.commands


### PR DESCRIPTION
In a previous patch we introduced a new actor that produces a message
that provides the version of the newly installed kernel.
In this patch kernelcmdlineconfig makes use of that message instead of
scanning itself for the version.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>