### PR TITLE
Enable crb <=> the Optional repo is enabled

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/enablecrbrepo/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/enablecrbrepo/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import UsedTargetRepositories
+from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
+
+
+class EnableCRBrepo(Actor):
+    """
+    Enable CRB repository when used during the upgrade.
+    """
+    # TODO: replace this actor by more robust one which will enable repositories
+    # based on msg; be careful about the solution as there is similar thing
+    # for the upgrade process already - see the RepositoriesSetupTasks model
+
+    name = 'enable_crb_repo'
+    consumes = (UsedTargetRepositories,)
+    produces = ()
+    tags = (IPUWorkflowTag, FirstBootPhaseTag)
+
+    def process(self):
+        library.process()

--- a/repos/system_upgrade/el7toel8/actors/enablecrbrepo/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/enablecrbrepo/libraries/library.py
@@ -1,0 +1,22 @@
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import UsedTargetRepositories
+
+
+CRB_REPOID = 'codeready-builder-for-rhel-8-x86_64-rpms'
+
+
+def _is_crb_used():
+    # the UsedTargetRepositories has to be set always, by design of IPU
+    used_repos = next(api.consume(UsedTargetRepositories), None)
+    for repo in used_repos.repos:
+        if repo.repoid == CRB_REPOID:
+            return True
+    return False
+
+
+def process():
+    if _is_crb_used():
+        try:
+            run(['subscription-manager', 'repos', '--enable', CRB_REPOID])
+        except CalledProcessError as e:
+            api.current_logger().error('Cannot enable CRB repository: %s', str(e))

--- a/repos/system_upgrade/el7toel8/actors/enablecrbrepo/tests/test_enablecrbrepo.py
+++ b/repos/system_upgrade/el7toel8/actors/enablecrbrepo/tests/test_enablecrbrepo.py
@@ -1,0 +1,75 @@
+from leapp.libraries.actor import library
+from leapp.libraries.stdlib import api, CalledProcessError
+from leapp.models import UsedTargetRepositories, UsedTargetRepository
+
+
+class run_mocked(object):
+    def __init__(self, raise_err=False):
+        self.called = 0
+        self.args = []
+        self.raise_err = raise_err
+
+    def __call__(self, *args):
+        self.called += 1
+        self.args.append(args)
+        if self.raise_err:
+            raise CalledProcessError(
+                message='A Leapp Command Error occured.',
+                command=args,
+                result={'signal': None, 'exit_code': 1, 'pid': 0, 'stdout': 'fake', 'stderr': 'fake'}
+            )
+
+
+class logger_mocked(object):
+    def __init__(self):
+        self.errmsg = None
+
+    def error(self, *args):
+        self.errmsg = args
+
+    def __call__(self):
+        return self
+
+
+def construct_UTRepo_consume(repoids):
+    repos = [UsedTargetRepository(repoid=repoid) for repoid in repoids]
+    return lambda *x: (x for x in (UsedTargetRepositories(repos=repos),))
+
+
+def test_is_crb_used_false(monkeypatch):
+    inputs = ([], ['some-name'], ['some-name', 'another-repo'])
+    for i in inputs:
+        monkeypatch.setattr(api, 'consume', construct_UTRepo_consume(i))
+        assert not library._is_crb_used()
+
+
+def test_is_crb_used_true(monkeypatch):
+    inputs = ([library.CRB_REPOID], ['some-name', library.CRB_REPOID])
+    for i in inputs:
+        monkeypatch.setattr(api, 'consume', construct_UTRepo_consume(i))
+        assert library._is_crb_used()
+
+
+def test_process_setrepo(monkeypatch):
+    monkeypatch.setattr(library, 'run', run_mocked())
+    monkeypatch.setattr(library, '_is_crb_used', lambda: True)
+    library.process()
+    assert library.run.called
+    assert 'subscription-manager' in library.run.args[0][0]
+    assert library.CRB_REPOID in library.run.args[0][0]
+
+
+def test_process_donothing(monkeypatch):
+    monkeypatch.setattr(library, 'run', run_mocked())
+    monkeypatch.setattr(library, '_is_crb_used', lambda: False)
+    library.process()
+    assert not library.run.called
+
+
+def test_process_fail(monkeypatch):
+    monkeypatch.setattr(library, 'run', run_mocked(raise_err=True))
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(library, '_is_crb_used', lambda: True)
+    library.process()
+    assert library.run.called
+    assert api.current_logger.errmsg

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -12,7 +12,8 @@ from leapp.models import (InstalledRedHatSignedRPM, PESRpmTransactionTasks,
 # FIXME: this mapping is not complete and will need to be manually updated frequently
 REPOSITORIES_MAPPING = {
     'rhel8-appstream': 'rhel-8-for-x86_64-appstream-rpms',
-    'rhel8-baseos': 'rhel-8-for-x86_64-baseos-rpms'}
+    'rhel8-baseos': 'rhel-8-for-x86_64-baseos-rpms',
+    'rhel8-crb': 'codeready-builder-for-rhel-8-x86_64-rpms'}
 
 Event = namedtuple('Event', ['action',   # A string representing an event type (see EVENT_TYPES)
                              'in_pkgs',  # A dictionary with packages in format {<pkg_name>: <repository>}
@@ -217,8 +218,8 @@ def process_events(events, installed_pkgs):
         if event.action in ('Renamed', 'Replaced', 'Removed'):
             to_remove.update(event.in_pkgs)
 
-    filter_out_pkgs_in_blacklisted_repos(to_install)
     map_repositories(to_install)
+    filter_out_pkgs_in_blacklisted_repos(to_install)
 
     return to_install, to_remove
 

--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/actor.py
@@ -1,5 +1,5 @@
 from leapp.actors import Actor
-from leapp.models import RepositoriesBlacklisted
+from leapp.models import RepositoriesBlacklisted, RepositoriesFacts
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 
@@ -9,13 +9,21 @@ class RepositoriesBlacklist(Actor):
     """
 
     name = 'repositories_blacklist'
-    consumes = ()
+    consumes = (RepositoriesFacts,)
     produces = (RepositoriesBlacklisted,)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
+    def _is_repo_enabled(self, repoid):
+        for repos in self.consume(RepositoriesFacts):
+            for repo_file in repos.repositories:
+                for repo in repo_file.data:
+                    if repo.repoid == repoid and repo.enabled:
+                        return True
+        return False
+
     def process(self):
-        self.produce(RepositoriesBlacklisted(
-            repoids=[
-                'rhel8-buildroot',  # As seem at PES Events
-                'rhel8-crb',  # As seem at PES Events
-                'codeready-builder-for-rhel-8-x86_64-rpms']))
+        # blacklist crb repo <=> optional repo is not enabled
+        if not self._is_repo_enabled('rhel-7-server-optional-rpms'):
+            self.log.info("The optional repository is not enabled. Add the CRB repository to the blacklist.")
+            self.produce(RepositoriesBlacklisted(
+                repoids=['codeready-builder-for-rhel-8-x86_64-rpms']))


### PR DESCRIPTION
Blacklist the CRB repository (as before) iff the Optional repository is not enabled. Otherwise keep the rest on other actors that will handle it as other repositories. In case that the CRB repository is used during the upgrade (can be only when it is not blacklisted), enable the repo on the target system as well during the `FirstBoot` phase.

*Note*: Planned todo in future: the actor is working with this one repo now, but would be nice to make it more robust to be used for any repository task in future. See the TODO msg in code.

