### PR TITLE
linter: fix py3 compatibility test

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,3 @@
-[MASTER]
-py3k=
-
 [MESSAGES CONTROL]
 disable=
 # "F" Fatal errors that prevent further processing

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,8 @@ lint:
 	bash -c "[[ ! -z $${SEARCH_PATH} ]] && find $${SEARCH_PATH} -name '*.py' | sort -u | xargs pylint" && \
 	echo "--- Running flake8 ---" && \
 	bash -c "[[ ! -z $${SEARCH_PATH} ]] && flake8 $${SEARCH_PATH}" && \
+	echo "--- Checking py3 compatibility ---" && \
+	bash -c "[[ ! -z $${SEARCH_PATH} ]] && find $${SEARCH_PATH} -name '*.py' | sort -u | xargs pylint --py3k" && \
 	echo "--- Linting done. ---"
 
 test_no_lint:


### PR DESCRIPTION
According to [1] --py3k option will run only
py3 compatibility testing ignoring standard py2
linting checks specified in .pylintrc.
This commit fixes the problem by running py3
compatibility tests separately from basic linter
checks.

[1] https://github.com/PyCQA/pylint/issues/761