### PR TITLE
linter: enable invalid-name check

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,6 @@ disable=
  unused-import,
 # "C" Coding convention violations
  bad-continuation,
- invalid-name,
  missing-docstring,
  wrong-import-order,
 # "R" Refactor recommendations
@@ -49,3 +48,15 @@ max-attributes=21  # 4x + 1 from default
 
 [REPORTS]
 msg-template='[{msg_id} {symbol}] {msg} File: {path}, line {line}, in {obj}'
+
+[BASIC]
+# In order to make a check more strict add proper regex http://pylint-messages.wikidot.com/messages:c0103
+argument-rgx=.*
+attr-rgx=.*
+class-rgx=.*
+const-rgx=.*
+function-rgx=.*
+method-rgx=.*
+module-rgx=.*
+variable-rgx=.*
+inlinevar-rgx=.*


### PR DESCRIPTION
This removes invalid-name check from disabled
by defaut checks. Currently regexes are super
relaxed and any name is allowed, to fix this
consult [1].
Not making them strict by default as it will
require plenty of time and effort to fix existing
codebase, though in the long perspective that's
a nive thing to do.

[1] http://pylint-messages.wikidot.com/messages:c0103