### PR TITLE
WIP: Remove python-tools before transaction

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -12,3 +12,5 @@ python2-virtualenv
 squid
 # python-docs - https://bugzilla.redhat.com/show_bug.cgi?id=1703605
 python-docs
+
+python-tools


### PR DESCRIPTION
Unfortunately I don't have valid reference URL for this.  During
downstream testing, we've found that presence of this package prevents
leapp from creating a valid transaction.

At some point @pirat89 mentioned that this was known already (@bocekm
should also know) but I haven't found Bugzilla or Github issue.