### PR TITLE
Mount also "/boot/efi" if system is EFI

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.library import remove_boot_entry
-from leapp.models import BootContent
+from leapp.models import BootContent, FirmwareFacts
 from leapp.tags import InitRamStartPhaseTag, IPUWorkflowTag
 
 
@@ -12,7 +12,7 @@ class RemoveUpgradeBootEntry(Actor):
     """
 
     name = 'remove_upgrade_boot_entry'
-    consumes = (BootContent,)
+    consumes = (BootContent, FirmwareFacts)
     produces = ()
     tags = (IPUWorkflowTag, InitRamStartPhaseTag)
 

--- a/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/tests/unit_test.py
@@ -3,7 +3,7 @@ import pytest
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.stdlib import api
 from leapp.libraries.actor import library
-from leapp.models import BootContent
+from leapp.models import BootContent, FirmwareFacts
 
 
 class run_mocked(object):
@@ -13,16 +13,30 @@ class run_mocked(object):
         self.args.append(args)
 
 
-def test_remove_boot_entry(monkeypatch):
+@pytest.mark.parametrize('firmware', ['bios', 'efi'])
+def test_remove_boot_entry(firmware, monkeypatch):
     def get_upgrade_kernel_filepath_mocked():
         return '/abc'
+
+    def consume_systemfacts_mocked(*models):
+        yield FirmwareFacts(firmware=firmware)
+
     monkeypatch.setattr(library, 'get_upgrade_kernel_filepath', get_upgrade_kernel_filepath_mocked)
+    monkeypatch.setattr(api, 'consume', consume_systemfacts_mocked)
     monkeypatch.setattr(library, 'run', run_mocked())
 
     library.remove_boot_entry()
 
-    assert library.run.args == [['/bin/mount', '/boot'],
-                                ['/usr/sbin/grubby', '--remove-kernel=/abc'], ['/bin/mount', '-a']]
+    boot_mounts = [['/bin/mount', '/boot']]
+    if firmware == 'efi':
+        boot_mounts.append(['/bin/mount', '/boot/efi'])
+
+    calls = boot_mounts + [['/usr/sbin/grubby', '--remove-kernel=/abc'], ['/bin/mount', '-a']]
+
+    assert library.run.args == calls
+
+    # clear args for next run
+    del library.run.args[:]
 
 
 def test_get_upgrade_kernel_filepath(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/systemfacts/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/actor.py
@@ -1,7 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import systemfacts
 from leapp.models import SysctlVariablesFacts, ActiveKernelModulesFacts, UsersFacts, GroupsFacts, RepositoriesFacts, \
-    SELinuxFacts, FirewallsFacts
+    SELinuxFacts, FirewallsFacts, FirmwareFacts
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 
@@ -28,7 +28,8 @@ class SystemFactsActor(Actor):
                 GroupsFacts,
                 RepositoriesFacts,
                 SELinuxFacts,
-                FirewallsFacts)
+                FirewallsFacts,
+                FirmwareFacts)
     tags = (IPUWorkflowTag, FactsPhaseTag,)
 
     def process(self):
@@ -39,3 +40,4 @@ class SystemFactsActor(Actor):
         self.produce(systemfacts.get_repositories_status())
         self.produce(systemfacts.get_selinux_status())
         self.produce(systemfacts.get_firewalls_status())
+        self.produce(systemfacts.get_firmware())

--- a/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
@@ -13,7 +13,7 @@ import six
 from leapp.libraries.stdlib import CalledProcessError, api, run
 from leapp.models import SysctlVariablesFacts, SysctlVariable, ActiveKernelModulesFacts, ActiveKernelModule, \
     KernelModuleParameter, UsersFacts, User, GroupsFacts, Group, RepositoriesFacts, RepositoryFile, RepositoryData, \
-    SELinuxFacts, fields, FirewallStatus, FirewallsFacts
+    SELinuxFacts, fields, FirewallStatus, FirewallsFacts, FirmwareFacts
 
 
 def aslist(f):
@@ -269,3 +269,8 @@ def get_firewalls_status():
         iptables=_get_firewall_status('iptables'),
         ip6tables=_get_firewall_status('ip6tables'),
     )
+
+
+def get_firmware():
+    firmware = 'efi' if os.path.isdir('/sys/firmware/efi') else 'bios'
+    return FirmwareFacts(firmware=firmware)

--- a/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
+++ b/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
@@ -168,8 +168,13 @@ def perform_transaction_install(target_userspace_info, used_repos, tasks):
         '/proc:/installroot/proc',
         '/run/udev:/installroot/run/udev'
     ]
+
     if os.path.ismount('/boot'):
         bind_mounts.append('/boot:/installroot/boot')
+
+    if os.path.ismount('/boot/efi'):
+        bind_mounts.append('/boot/efi:/installroot/boot/efi')
+
     with _prepare_transaction(used_repos=used_repos,
                               target_userspace_info=target_userspace_info,
                               binds=bind_mounts

--- a/repos/system_upgrade/el7toel8/models/firmwarefacts.py
+++ b/repos/system_upgrade/el7toel8/models/firmwarefacts.py
@@ -1,0 +1,8 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemFactsTopic
+
+
+class FirmwareFacts(Model):
+    topic = SystemFactsTopic
+
+    firmware = fields.StringEnum(['bios', 'efi'])


### PR DESCRIPTION
Currently, when removing our upgrade boot entry, we try to
mount only "/boot", but when the system is EFI, we fails
as "grubby" see only "/boot" as try to update "/boot/grub/grub.cfg"
instead of "/boot/efi/EFI/redhat/grub.cfg".