### PR TITLE
Do not install python2-tools

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -2,6 +2,8 @@
 
 # python2-devel - https://bugzilla.redhat.com/show_bug.cgi?id=1703600
 python2-devel
+# python2-tools - same reason as python2-devel
+python2-tools
 # packages that depends on python2-devel
 pygobject2-devel
 python2-cairo-devel


### PR DESCRIPTION
The same issue as we have with python-docs, python-2devel. The python-tools RPM provides and obsoletes python2-tools. Especially the problematic is unversioned Obsoletes of python2-tools.