### PR TITLE
Allow to override the target version for devel

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/actor.py
@@ -18,7 +18,7 @@ class IPUWorkflowConfig(Actor):
     tags = (IPUWorkflowTag,)
 
     def process(self):
-        target_version = '8.0'
+        target_version = library.get_target_version()
         os_release = library.get_os_release('/etc/os-release')
         self.produce(IPUConfig(
             leapp_env_vars=library.get_env_vars(),

--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
@@ -3,6 +3,7 @@ import os
 from leapp.libraries.common import reporting
 from leapp.models import EnvVar, OSRelease
 
+CURRENT_TARGET_VERSION = '8.0'
 
 ENV_IGNORE = ('LEAPP_CURRENT_PHASE', 'LEAPP_CURRENT_ACTOR', 'LEAPP_VERBOSE',
               'LEAPP_DEBUG')
@@ -37,3 +38,7 @@ def get_os_release(path):
             severity='high',
             flags=['inhibitor'])
         return None
+
+
+def get_target_version():
+    return os.getenv('LEAPP_DEVEL_TARGET_RELEASE', None) or CURRENT_TARGET_VERSION

--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/tests/test_ipuworkflowconfig.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/tests/test_ipuworkflowconfig.py
@@ -31,6 +31,16 @@ def test_leapp_env_vars(monkeypatch):
     assert len(library.get_env_vars()) == 1
 
 
+def test_get_target_version(monkeypatch):
+    monkeypatch.delenv('LEAPP_DEVEL_TARGET_RELEASE', raising=False)
+    assert library.get_target_version() == library.CURRENT_TARGET_VERSION
+    monkeypatch.setenv('LEAPP_DEVEL_TARGET_RELEASE', '')
+    assert library.get_target_version() == library.CURRENT_TARGET_VERSION
+    monkeypatch.setenv('LEAPP_DEVEL_TARGET_RELEASE', '1.2.3')
+    assert library.get_target_version() == '1.2.3'
+    monkeypatch.delenv('LEAPP_DEVEL_TARGET_RELEASE', raising=True)
+
+
 def test_get_os_release_info(monkeypatch):
     monkeypatch.setattr('leapp.libraries.stdlib.api.produce', produce_mocked())
     monkeypatch.setattr(reporting, 'report_generic', report_generic_mocked())

--- a/repos/system_upgrade/el7toel8/files/rhel_upgrade.py
+++ b/repos/system_upgrade/el7toel8/files/rhel_upgrade.py
@@ -95,7 +95,10 @@ class RhelUpgradeCommand(dnf.cli.Command):
             # We are doing this to avoid downloading the packages in the check phase
             self.base.download_packages = _do_not_download_packages
             try:
-                self.base.do_transaction()
+                displays = []
+                if self.cli.demands.transaction_display is not None:
+                    displays.append(self.cli.demands.transaction_display)
+                self.base.do_transaction(display=displays)
             except DoNotDownload:
                 print('Check completed.')
 


### PR DESCRIPTION
This PR introduces to use the LEAPP_DEVEL_TARGET_VERSION environment
variable which allows to override the targeted version.
This value will then be used to set a target version for RHSM.

As requested by @AloisMahdal 