### PR TITLE
remove_old_pam_modules_check: change dialogs scope

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulescheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulescheck/actor.py
@@ -21,7 +21,7 @@ class RemoveOldPAMModulesCheck(Actor):
     tags = (IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag)
     dialogs = (
         Dialog(
-            scope='remove_old_pam_modules_check',
+            scope='remove_pam_pkcs11_module_check',
             reason='Confirmation',
             components=(
                 BooleanComponent(
@@ -37,7 +37,7 @@ class RemoveOldPAMModulesCheck(Actor):
             )
         ),
         Dialog(
-            scope='remove_old_pam_modules_check',
+            scope='remove_pam_krb5_module_check',
             reason='Confirmation',
             components=(
                 BooleanComponent(


### PR DESCRIPTION
Changed key of each of the 2 dialogs under the same scope
remove_old_pam_modules_check to reflect the module they
are infering about (pam_krb5 and pam_pkcs11 respectively).

Note that it isn't enough to generate different confirm values
as the resulting value will be set identical to the last question
asked about remove_old_pam_modules_check scope (which might be
actually a bug).

```
[remove_old_pam_modules_check]
# Title:              None
# Reason:             Confirmation
# ==================== remove_old_pam_modules_check.confirm ===================
# Label:              Disable pam_pkcs11 module in PAM configuration? If no, the upgrade process will be interrupted.
# Description:        PAM module pam_pkcs11 is no longer available in RHEL-8 since it was replaced by SSSD.
# Type:               bool
# Default:            False
confirm = True

[remove_old_pam_modules_check]
# Title:              None
# Reason:             Confirmation
# ==================== remove_old_pam_modules_check.confirm ===================
# Label:              Disable pam_krb5 module in PAM configuration? If no, the upgrade process will be interrupted.
# Description:        PAM module pam_krb5 is no longer available in RHEL-8 since it was replaced by SSSD.
# Type:               bool
# Default:            False
confirm = True
```