### PR TITLE
Clean to_remove transaction customization file

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -1,14 +1,1 @@
 ### List of packages (each on new line) to be removed from the upgrade transaction
-
-# python2-devel - https://bugzilla.redhat.com/show_bug.cgi?id=1703600
-python2-devel
-# python2-tools - same reason as python2-devel
-python2-tools
-# packages that depends on python2-devel
-pygobject2-devel
-python2-cairo-devel
-python2-debug
-python2-numpy-f2py
-python2-virtualenv
-# python-docs - https://bugzilla.redhat.com/show_bug.cgi?id=1703605
-python-docs


### PR DESCRIPTION
- this is another round of removing packages from the to_remove file
  as some of them have been fixed and are being released to the RHEL 7.6
  z-stream
- related:
  - https://github.com/oamg/leapp-repository/pull/276
  - https://bugzilla.redhat.com/show_bug.cgi?id=1703600
  - https://bugzilla.redhat.com/show_bug.cgi?id=1703605
  - https://bugzilla.redhat.com/show_bug.cgi?id=1734086