### PR TITLE
Enable RHEL 8 CRB when RHEL 7 EUS Optional enabled

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/actor.py
@@ -5,7 +5,7 @@ from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 class RepositoriesBlacklist(Actor):
     """
-    Generate list of Repositories ID that should be ignored by Leapp during upgrade process
+    Generate list of repository IDs that should be ignored by Leapp during upgrade process
     """
 
     name = 'repositories_blacklist'
@@ -22,8 +22,9 @@ class RepositoriesBlacklist(Actor):
         return False
 
     def process(self):
-        # blacklist crb repo <=> optional repo is not enabled
-        if not self._is_repo_enabled('rhel-7-server-optional-rpms'):
-            self.log.info("The optional repository is not enabled. Add the CRB repository to the blacklist.")
+        # blacklist CRB repo if optional repo is not enabled
+        if not (self._is_repo_enabled('rhel-7-server-optional-rpms') or
+                self._is_repo_enabled('rhel-7-server-eus-optional-rpms')):
+            self.log.info("The optional repository is not enabled. Blacklisting the CRB repository.")
             self.produce(RepositoriesBlacklisted(
                 repoids=['codeready-builder-for-rhel-8-x86_64-rpms']))


### PR DESCRIPTION
So far we've been enabling RHEL 8 CRB when RHEL 7 Optional was enabled but with the release of RHEL 7.7 customers will start enabling the EUS Optional instead.