### PR TITLE
Fix migratentp actor to extract configs to root directory

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
@@ -10,7 +10,7 @@ from leapp.libraries.stdlib import CalledProcessError, run
 def extract_tgz64(s):
     stream = io.BytesIO(base64.b64decode(s))
     tar = tarfile.open(fileobj=stream, mode='r:gz')
-    tar.extractall()
+    tar.extractall('/')
     tar.close()
 
 


### PR DESCRIPTION
The files saved in the checkntp actor should be extracted to the same place.