### PR TITLE
No size limit on leapp.db in sosreport

### DIFF
--- a/sources/sos-report/leapp.py
+++ b/sources/sos-report/leapp.py
@@ -12,9 +12,11 @@ class Leapp(Plugin, RedHatPlugin):
 
     def setup(self):
         self.add_copy_spec([
-            '/var/lib/leapp/leapp.db',
             '/var/log/leapp/dnf-debugdata/',
             '/var/log/leapp/leapp-upgrade.log',
             '/var/log/leapp/leapp-report.txt',
             '/var/log/leapp/dnf-plugin-data.txt'
         ])
+
+        # capture DB without sizelimit
+        self.add_copy_spec('/var/lib/leapp/leapp.db', sizelimit=0)


### PR DESCRIPTION
- mirroring upstream https://github.com/sosreport/sos/pull/1753

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1741321