### PR TITLE
Add actor checking KDE and GNOME

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkkdeapps/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdeapps/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+from leapp.models import InstalledKdeAppsFacts, InstalledRPM
+from leapp.libraries.actor.library import get_kde_apps_info
+
+
+class CheckKdeApps(Actor):
+    """
+    Actor checks which KDE apps are installed.
+    """
+
+    name = 'check_kde_apps'
+    consumes = (InstalledRPM,)
+    produces = (InstalledKdeAppsFacts,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        app_facts = get_kde_apps_info()
+        self.produce(InstalledKdeAppsFacts(
+            installed_apps=app_facts))

--- a/repos/system_upgrade/el7toel8/actors/checkkdeapps/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdeapps/libraries/library.py
@@ -1,0 +1,25 @@
+from leapp.libraries.stdlib import api
+from leapp.libraries.common.rpms import has_package
+from leapp.models import InstalledRPM
+
+
+def get_kde_apps_info():
+    installed = list()
+    base_kde_apps = ("kde-baseapps",
+                     "okular",
+                     "ark",
+                     "kdepim",
+                     "konsole",
+                     "gwenview",
+                     "kdenetwork",
+                     "kate",
+                     "kwrite")
+
+    api.current_logger().info("  Detecting installed KDE apps  ")
+    api.current_logger().info("================================")
+    for app in [application for application in base_kde_apps if has_package(InstalledRPM, application)]:
+        api.current_logger().info("Application {0} is installed.".format(app))
+        installed.append(app)
+    api.current_logger().info("----------------------------------")
+
+    return installed

--- a/repos/system_upgrade/el7toel8/actors/checkkdeapps/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdeapps/tests/unit_test.py
@@ -1,0 +1,47 @@
+from leapp.snactor.fixture import current_actor_context
+from leapp.models import InstalledRPM, RPM, InstalledKdeAppsFacts
+
+
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+
+#  KDE apps (only name matters, other values are irrelevant)
+okular_RPM = RPM(name='okular', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+                 pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
+kdenetwork_RPM = RPM(name='kdenetwork', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER,
+                     arch='noarch', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
+kate_RPM = RPM(name='kate', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+               pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
+
+# Some other apps to check false detection (only name matters, other values are irrelevant)
+epiphany_PRM = RPM(name='epiphany', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+                   pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
+polari_RPM = RPM(name='polari', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+                 pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
+
+
+def test_no_app_present(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[]))
+    current_actor_context.run()
+    message = current_actor_context.consume(InstalledKdeAppsFacts)[0]
+    assert not message.installed_apps
+
+
+def test_no_KDE_app_present(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[epiphany_PRM, polari_RPM]))
+    current_actor_context.run()
+    message = current_actor_context.consume(InstalledKdeAppsFacts)[0]
+    assert not message.installed_apps
+
+
+def test_only_KDE_apps_present(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[okular_RPM, kdenetwork_RPM, kate_RPM]))
+    current_actor_context.run()
+    message = current_actor_context.consume(InstalledKdeAppsFacts)[0]
+    assert len(message.installed_apps) == 3
+
+
+def test_many_apps_present(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[okular_RPM, kdenetwork_RPM, kate_RPM, epiphany_PRM, polari_RPM]))
+    current_actor_context.run()
+    message = current_actor_context.consume(InstalledKdeAppsFacts)[0]
+    assert len(message.installed_apps) == 3

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/actor.py
@@ -1,0 +1,28 @@
+"""
+Actor to check if KDE and/or GNOME are installed
+Author: Jan Beran
+Email: jaberan@redhat.com
+"""
+
+from leapp.actors import Actor
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+from leapp.reporting import Report
+from leapp.libraries.actor.library import check_kde_gnome
+
+
+class CheckKdeGnome(Actor):
+    """
+    Actor will check whether KDE is installed together with GNOME desktop to inform whether we can
+    inhibit the upgrade process. When both are installed, we need to inform the user that KDE will
+    be removed and GNOME will be used instead. If only KDE is installed, we want to inhibit
+    the upgrade process otherwise the user will end up without a desktop.
+    Also if both are installed, but KDE is not used as default desktop, we further check most common
+    KDE apps to inform the user that those will be removed in case the user is using them.
+    """
+    name = 'check_kde_gnome'
+    consumes = ()
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        check_kde_gnome()

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/actor.py
@@ -5,9 +5,11 @@ Email: jaberan@redhat.com
 """
 
 from leapp.actors import Actor
-from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
 from leapp.reporting import Report
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
 from leapp.libraries.actor.library import check_kde_gnome
+from leapp.models import (InstalledRPM, InstalledDesktopsFacts,
+                          InstalledKdeAppsFacts)
 
 
 class CheckKdeGnome(Actor):
@@ -18,11 +20,9 @@ class CheckKdeGnome(Actor):
     inhibit the upgrade process. When both are installed, we need to inform the user that KDE will
     be removed and GNOME will be used instead. If only KDE is installed, we want to inhibit
     the upgrade process otherwise the user will end up without a desktop.
-    Also if both are installed, but KDE is not used as default desktop, we further check most common
-    KDE apps to inform the user that those will be removed in case the user is using them.
     """
     name = 'check_kde_gnome'
-    consumes = ()
+    consumes = (InstalledRPM, InstalledDesktopsFacts, InstalledKdeAppsFacts)
     produces = (Report,)
     tags = (IPUWorkflowTag, ChecksPhaseTag)
 

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/actor.py
@@ -12,6 +12,8 @@ from leapp.libraries.actor.library import check_kde_gnome
 
 class CheckKdeGnome(Actor):
     """
+    Checks whether KDE is installed
+
     Actor will check whether KDE is installed together with GNOME desktop to inform whether we can
     inhibit the upgrade process. When both are installed, we need to inform the user that KDE will
     be removed and GNOME will be used instead. If only KDE is installed, we want to inhibit

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/actor.py
@@ -20,6 +20,8 @@ class CheckKdeGnome(Actor):
     inhibit the upgrade process. When both are installed, we need to inform the user that KDE will
     be removed and GNOME will be used instead. If only KDE is installed, we want to inhibit
     the upgrade process otherwise the user will end up without a desktop.
+    Note: The Package Evolution Service data makes sure the KDE-related packages are removed in the
+    dnf upgrade transaction.
     """
     name = 'check_kde_gnome'
     consumes = (InstalledRPM, InstalledDesktopsFacts, InstalledKdeAppsFacts)

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/libraries/library.py
@@ -113,7 +113,7 @@ def check_kde_gnome():
                     reporting.Severity(reporting.Severity.MEDIUM),
                     reporting.Tags([
                         reporting.Tags.UPGRADE_PROCESS
-                    ])
+                    ])])
             else:
                 api.current_logger().info("GNOME used as default session. Continuing with the upgrade.")
         api.current_logger().info("----------------------------------")

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/libraries/library.py
@@ -1,74 +1,12 @@
-import os
-import subprocess
-import time
-
 from leapp import reporting
 from leapp.libraries.stdlib import api
-
-ONE_MONTH = 2592000  # Number of seconds in one month
-
-
-def is_executable(path):
-    """
-    Checks if path exists, if it is file and if is executable.
-    """
-    return os.path.exists(path) and os.path.isfile(path) and os.access(path, os.X_OK)
-
-
-def get_xsession(path):
-    """
-    Gets current XSession.
-
-    If there is more than one definition of xsession for some reason,
-    function returns last definition. Return empty string if no XSession found in file given
-    by path (any reason including bad path etc.)
-    """
-    default_xsession = ""
-    if not isinstance(path, str):
-        return default_xsession
-    if not (os.path.exists(path) and os.path.isfile(path)):  # Bad path - in container for example
-        return default_xsession
-    with open(path, "r") as f:
-        for line in f.readlines():
-            if "xsession" in line.lower():
-                default_xsession = line.split("=")[1].lower()
-    return default_xsession
-
-
-def check_app_in_use(app):
-    """
-    Method return True if application was used in last month, False in other cases.
-    """
-    path = "{0}/.kde/share/config/{1}rc".format(os.environ.get("HOME"), app)
-    if os.path.isfile(path):
-        last_modified = os.stat(path).st_mtime
-        # Application is considered actively used, if it has been used in last month.
-        return last_modified >= int(time.time() - ONE_MONTH)
-    return False
-
-
-def is_installed(app):
-    """
-    Wrapper for "rpm -q <app>" command
-
-    Return value: True if application is found,
-    False in other cases.
-    Output of rpm command is not supressed.
-    """
-    return True if subprocess.call(["rpm", "-q", app]) == 0 else False
+from leapp.models import InstalledDesktopsFacts, InstalledKdeAppsFacts
 
 
 def check_kde_gnome():
-    apps_in_use = 0
-    api.current_logger().info("  Detecting desktop environments  ")
-    api.current_logger().info("==================================")
-
-    # Detect installed desktops by their startup files
-    kde_desktop_installed = is_executable("/usr/bin/startkde")
-    gnome_desktop_installed = is_executable("/usr/bin/gnome-session")
-    api.current_logger().info("* KDE installed: {0}".format(kde_desktop_installed))
-    api.current_logger().info("* Gnome installed: {0}".format(gnome_desktop_installed))
-    api.current_logger().info("----------------------------------")
+    desktopFacts = next(api.consume(InstalledDesktopsFacts))
+    kde_desktop_installed = desktopFacts.kde_installed
+    gnome_desktop_installed = desktopFacts.gnome_installed
 
     # No desktop installed, we don't even care about apps as they are most likely not used or even installed
     if not kde_desktop_installed and not gnome_desktop_installed:
@@ -83,7 +21,7 @@ def check_kde_gnome():
             # We cannot continue with the upgrade process
             reporting.create_report([
                 reporting.Title("Cannot upgrade because there is no other desktop than KDE installed."),
-                reporting.Summary("With only KDE installed, there would be no other desktop after upgrade."),
+                reporting.Summary("With only KDE installed, there would be no other desktop env. after upgrade."),
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Tags([
                     reporting.Tags.UPGRADE_PROCESS
@@ -95,66 +33,35 @@ def check_kde_gnome():
                     hint="Install GNOME desktop to be able to upgrade.")
                 ])
             return
-
-        # Assume GNOME is installed in this state
-
-        user = os.environ.get("USER")
-        default_xsession = get_xsession("/var/lib/AccountsService/users/{0}".format(user))
-        if not default_xsession:
-            api.current_logger().warn("Unable to detect default session.")
         else:
-            if "plasma" in default_xsession:  # using in because there can be some white spaces
-                api.current_logger().info("KDE used as default session.")
-                api.current_logger().info("Upgrade can be performed, but KDE desktop will"
-                                          " be removed in favor of GNOME")
-                reporting.create_report([
-                    reporting.Title("Upgrade can be performed, but KDE will be uninstalled."),
-                    reporting.Summary("KDE has to be uninstalled in favor of GNOME to perform the upgrade."),
-                    reporting.Severity(reporting.Severity.MEDIUM),
-                    reporting.Tags([
-                        reporting.Tags.UPGRADE_PROCESS
-                    ])])
-            else:
-                api.current_logger().info("GNOME used as default session. Continuing with the upgrade.")
+            # Assume both GNOME and KDE are installed in this state
+            api.current_logger().info("Upgrade can be performed, but KDE desktop will"
+                                      " be removed in favor of GNOME")
+            reporting.create_report([
+                reporting.Title("Upgrade can be performed, but KDE will be uninstalled."),
+                reporting.Summary("KDE has to be uninstalled in favor of GNOME to perform the upgrade."),
+                reporting.Severity(reporting.Severity.MEDIUM),
+                reporting.Tags([
+                    reporting.Tags.UPGRADE_PROCESS
+                ])])
         api.current_logger().info("----------------------------------")
 
-    # At this state we can assume that KDE desktop as such is not installed or used and we just need to
-    # detect whether any KDE/Qt app is actively used to inform user that the application will be removed
-    # during the upgrade process
+    # At this state we just need to detect whether any KDE/Qt app is installed to inform user
+    # that the application will be removed during the upgrade process. No matter if KDE is installed
+    # or not.
 
-    base_kde_apps = ("kde-baseapps",
-                     "okular",
-                     "ark",
-                     "kdepim",
-                     "konsole",
-                     "gwenview",
-                     "kdenetwork",
-                     "kate", "kwrite")
-    api.current_logger().info("  Detecting installed KDE apps  ")
-    api.current_logger().info("================================")
-
-    for app in base_kde_apps:
-        if is_installed(app):
-            if check_app_in_use(app):
-                api.current_logger().info("Application {0} is actively used".format(app))
-                apps_in_use += 1
-        api.current_logger().info("* {0} {1} installed.".format(app, "is" if is_installed(app) else "is not"))
-
-    api.current_logger().info("----------------------------------")
-
-    if apps_in_use > 0:
-        api.current_logger().info("KDE apps in use detected.")
+    KDEAppsFacts = next(api.consume(InstalledKdeAppsFacts))
+    apps_in_use = KDEAppsFacts.installed_apps
+    if apps_in_use:
+        # upgrade can be performed, but user will loose KDE apps
+        api.current_logger().info("Installed KDE/Qt apps detected.")
         reporting.create_report([
-            reporting.Title("Upgrade can be performed, but KDE apps will be uninstalled."),
-            reporting.Summary("KDE apps will be removed to perform the upgrade."),
+            reporting.Title("Upgrade can be performed, but KDE/Qt apps will be uninstalled."),
+            reporting.Summary("KDE/Qt apps will be removed to perform the upgrade."),
             reporting.Severity(reporting.Severity.MEDIUM),
             reporting.Tags([
                 reporting.Tags.UPGRADE_PROCESS
-            ]),
-            reporting.Remediation(
-                hint="KDE apps has to be removed, no other solution is possible.")
-            ])
-        # upgrade can be performed, but user will loose KDE desktop in favor of GNOME desktop
+            ])])
     else:
         api.current_logger().info("No KDE app in use detected.")
-    # upgrade can be performed
+        # upgrade can be performed

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/libraries/library.py
@@ -1,0 +1,158 @@
+import os
+import subprocess
+import time
+
+from leapp import reporting
+from leapp.libraries.stdlib import api
+
+ONE_MONTH = 2592000  # Number of seconds in one month
+
+
+def is_executable(path):
+    """
+    Checks if path exists, if it is file and if is executable.
+    """
+    return os.path.exists(path) and os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def get_xsession(path):
+    """
+    Gets current XSession. If there is more than one definition of xsession for some reason,
+     function returns last definition. Return empty string if no XSession found in file given
+     by path (any reason including bad path etc.)
+    """
+    default_xsession = ""
+    if not isinstance(path, str):
+        return default_xsession
+    if not (os.path.exists(path) and os.path.isfile(path)):  # Bad path - in container for example
+        return default_xsession
+    with open(path, "r") as f:
+        for line in f.readlines():
+            if "xsession" in line.lower():
+                default_xsession = line.split("=")[1].lower()
+    return default_xsession
+
+
+def check_app_in_use(app):
+    """
+    Method return True if application was used in last month, False in other cases.
+    """
+    path = "{0}/.kde/share/config/{1}rc".format(os.environ.get("HOME"), app)
+    if os.path.isfile(path):
+        last_modified = os.stat(path).st_mtime
+        # Application is considered actively used, if it has been used in last month.
+        return last_modified >= int(time.time() - ONE_MONTH)
+    return False
+
+
+def is_installed(app):
+    """
+    Wrapper for "rpm -q <app>" command, returns True if application is found,
+    False in other cases. Output of rpm command is not supressed.
+    """
+    return True if subprocess.call(["rpm", "-q", app]) == 0 else False
+
+
+def check_kde_gnome():
+    apps_in_use = 0
+    api.current_logger().info("  Detecting desktop environments  ")
+    api.current_logger().info("==================================")
+
+    # Detect installed desktops by their startup files
+    kde_desktop_installed = is_executable("/usr/bin/startkde")
+    gnome_desktop_installed = is_executable("/usr/bin/gnome-session")
+    api.current_logger().info("* KDE installed: {0}".format(kde_desktop_installed))
+    api.current_logger().info("* Gnome installed: {0}".format(gnome_desktop_installed))
+    api.current_logger().info("----------------------------------")
+
+    # No desktop installed, we don't even care about apps as they are most likely not used or even installed
+    if not kde_desktop_installed and not gnome_desktop_installed:
+        api.current_logger().info("No desktop installed. Continuing with the upgrade.")
+        return
+
+    if kde_desktop_installed:
+        api.current_logger().info("KDE desktop is installed. Checking what we can do about it.")
+        if not gnome_desktop_installed:
+            api.current_logger().error("Cannot perform the upgrade because there is\
+             no other desktop than KDE installed.")
+            # We cannot continue with the upgrade process
+            reporting.create_report([
+                reporting.Title("Cannot upgrade because there is no other desktop than KDE installed."),
+                reporting.Summary("With only KDE installed, there would be no other desktop after upgrade."),
+                reporting.Severity(reporting.Severity.HIGH),
+                reporting.Tags([
+                    reporting.Tags.UPGRADE_PROCESS
+                ]),
+                reporting.Flags([
+                    reporting.Flags.INHIBITOR
+                ]),
+                reporting.Remediation(
+                    hint="Install GNOME desktop to be able to upgrade.")
+                ])
+            return
+
+        # Assume GNOME is installed in this state
+
+        user = os.environ.get("USER")
+        default_xsession = get_xsession("/var/lib/AccountsService/users/{0}".format(user))
+        if not default_xsession:
+            api.current_logger().warn("Unable to detect default session.")
+        else:
+            if "plasma" in default_xsession:  # using in because there can be some white spaces
+                api.current_logger().info("KDE used as default session.")
+                api.current_logger().info("Upgrade can be performed, but KDE desktop will\
+                 be removed in favor of GNOME")
+                reporting.create_report([
+                    reporting.Title("Upgrade can be performed, but KDE will be uninstalled."),
+                    reporting.Summary("KDE has to be uninstalled in favor of GNOME to perform the upgrade."),
+                    reporting.Severity(reporting.Severity.MEDIUM),
+                    reporting.Tags([
+                        reporting.Tags.UPGRADE_PROCESS
+                    ]),
+                    reporting.Remediation(
+                        hint="KDE has to be removed, no other solution is possible.")
+                    ])
+            else:
+                api.current_logger().info("GNOME used as default session. Continuing with the upgrade.")
+        api.current_logger().info("----------------------------------")
+
+    # At this state we can assume that KDE desktop as such is not installed or used and we just need to
+    # detect whether any KDE/Qt app is actively used to inform user that the application will be removed
+    # during the upgrade process
+
+    base_kde_apps = ("kde-baseapps",
+                     "okular",
+                     "ark",
+                     "kdepim",
+                     "konsole",
+                     "gwenview",
+                     "kdenetwork",
+                     "kate", "kwrite")
+    api.current_logger().info("  Detecting installed KDE apps  ")
+    api.current_logger().info("================================")
+
+    for app in base_kde_apps:
+        if is_installed(app):
+            if check_app_in_use(app):
+                api.current_logger().info("Application {0} is actively used".format(app))
+                apps_in_use += 1
+        api.current_logger().info("* {0} {1} installed.".format(app, "is" if is_installed(app) else "is not"))
+
+    api.current_logger().info("----------------------------------")
+
+    if apps_in_use > 0:
+        api.current_logger().info("KDE apps in use detected.")
+        reporting.create_report([
+            reporting.Title("Upgrade can be performed, but KDE apps will be uninstalled."),
+            reporting.Summary("KDE apps will be removed to perform the upgrade."),
+            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Tags([
+                reporting.Tags.UPGRADE_PROCESS
+            ]),
+            reporting.Remediation(
+                hint="KDE apps has to be removed, no other solution is possible.")
+            ])
+        # upgrade can be performed, but user will loose KDE desktop in favor of GNOME desktop
+    else:
+        api.current_logger().info("No KDE app in use detected.")
+    # upgrade can be performed

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/libraries/library.py
@@ -17,9 +17,11 @@ def is_executable(path):
 
 def get_xsession(path):
     """
-    Gets current XSession. If there is more than one definition of xsession for some reason,
-     function returns last definition. Return empty string if no XSession found in file given
-     by path (any reason including bad path etc.)
+    Gets current XSession.
+
+    If there is more than one definition of xsession for some reason,
+    function returns last definition. Return empty string if no XSession found in file given
+    by path (any reason including bad path etc.)
     """
     default_xsession = ""
     if not isinstance(path, str):
@@ -47,8 +49,11 @@ def check_app_in_use(app):
 
 def is_installed(app):
     """
-    Wrapper for "rpm -q <app>" command, returns True if application is found,
-    False in other cases. Output of rpm command is not supressed.
+    Wrapper for "rpm -q <app>" command
+
+    Return value: True if application is found,
+    False in other cases.
+    Output of rpm command is not supressed.
     """
     return True if subprocess.call(["rpm", "-q", app]) == 0 else False
 
@@ -73,8 +78,8 @@ def check_kde_gnome():
     if kde_desktop_installed:
         api.current_logger().info("KDE desktop is installed. Checking what we can do about it.")
         if not gnome_desktop_installed:
-            api.current_logger().error("Cannot perform the upgrade because there is\
-             no other desktop than KDE installed.")
+            api.current_logger().error("Cannot perform the upgrade because there is"
+                                       " no other desktop than KDE installed.")
             # We cannot continue with the upgrade process
             reporting.create_report([
                 reporting.Title("Cannot upgrade because there is no other desktop than KDE installed."),
@@ -100,17 +105,14 @@ def check_kde_gnome():
         else:
             if "plasma" in default_xsession:  # using in because there can be some white spaces
                 api.current_logger().info("KDE used as default session.")
-                api.current_logger().info("Upgrade can be performed, but KDE desktop will\
-                 be removed in favor of GNOME")
+                api.current_logger().info("Upgrade can be performed, but KDE desktop will"
+                                          " be removed in favor of GNOME")
                 reporting.create_report([
                     reporting.Title("Upgrade can be performed, but KDE will be uninstalled."),
                     reporting.Summary("KDE has to be uninstalled in favor of GNOME to perform the upgrade."),
                     reporting.Severity(reporting.Severity.MEDIUM),
                     reporting.Tags([
                         reporting.Tags.UPGRADE_PROCESS
-                    ]),
-                    reporting.Remediation(
-                        hint="KDE has to be removed, no other solution is possible.")
                     ])
             else:
                 api.current_logger().info("GNOME used as default session. Continuing with the upgrade.")

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/tests/unit_test.py
@@ -1,0 +1,175 @@
+from leapp.libraries.actor import library
+from leapp.libraries.common.testutils import create_report_mocked
+from leapp import reporting
+
+
+def is_executable_only_gnome(path):
+    return path == "/usr/bin/gnome-session"
+
+
+def is_executable_only_kde(path):
+    return path == "/usr/bin/startkde"
+
+
+def check_app_in_use_mocked(app):
+    #  Only one app in use
+    return app == "okular"
+
+
+def get_xsession_gnome(path):
+    return "gnome"
+
+
+def get_xsession_kde(path):
+    return "plasma"
+
+
+def test_no_desktop(monkeypatch):
+    """
+    Scenario: There is no desktop.
+    Expected behavior: No report
+    """
+    #  Desktop presence is found by trying to execute gnome-session or startkde
+    monkeypatch.setattr(library, "is_executable", lambda x: False)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    library.check_kde_gnome()
+
+    assert reporting.create_report.called == 0
+
+
+def test_only_gnome_without_apps(monkeypatch):
+    """
+    Scenario: KDE and KDE apps are NOT installed
+    Expected behavior: No report
+    """
+
+    monkeypatch.setattr(library, "is_executable", is_executable_only_gnome)
+    monkeypatch.setattr(library, "is_installed", lambda x: False)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    library.check_kde_gnome()
+
+    assert reporting.create_report.called == 0
+
+
+def test_only_gnome_without_active_apps(monkeypatch):
+    """
+    Scenatio: no KDE desktop is installed, but there are some KDE apps, which are not active
+    Expected behavior: No report (unused app is not considered to be important)
+
+    """
+    monkeypatch.setattr(library, "is_executable", is_executable_only_gnome)
+    monkeypatch.setattr(library, "is_installed", lambda x: True)
+    monkeypatch.setattr(library, "check_app_in_use", lambda x: False)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    library.check_kde_gnome()
+
+    assert reporting.create_report.called == 0
+
+
+def test_only_gnome_with_active_apps(monkeypatch):
+    """
+    Scenatio: no KDE desktop is installed, but there are some KDE apps, which are actively used
+    Expected behavior: Report is made (severity = MEDIUM)
+
+    """
+    monkeypatch.setattr(library, "is_executable", is_executable_only_gnome)
+    monkeypatch.setattr(library, "is_installed", lambda x: True)
+    monkeypatch.setattr(library, "check_app_in_use", check_app_in_use_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    library.check_kde_gnome()
+
+    assert reporting.create_report.called == 1
+    #  Do not even touch the string! It is ugly, but because of max line lenght it has to
+    #  be written on two lines.
+    assert reporting.create_report.report_fields["title"] == "Upgrade can be\
+ performed, but KDE apps will be uninstalled."
+
+
+def test_only_kde(monkeypatch):
+    """
+    Scenario: There is only KDE installed.
+    Expected behavior: Report is generated with HIGH severity and inhibitor tag.
+    """
+    monkeypatch.setattr(library, "is_executable", is_executable_only_kde)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    library.check_kde_gnome()
+
+    assert reporting.create_report.called == 1
+    assert "inhibitor" in reporting.create_report.report_fields["flags"]
+
+
+def test_both_gnome_main_without_active_apps(monkeypatch):
+    """
+    Scenario: There are both KDE and GNOME installed, GNOME is the main desktop
+    and there are no KDE apps
+    Expected behavior: No report is generated.
+    """
+    monkeypatch.setattr(library, "is_executable", lambda x: True)
+    monkeypatch.setattr(library, "is_installed", lambda x: False)
+    monkeypatch.setattr(library, "get_xsession", get_xsession_gnome)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    library.check_kde_gnome()
+
+    assert reporting.create_report.called == 0
+
+
+def test_both_gnome_main_with_active_apps(monkeypatch):
+    """
+    Scenario: There are both KDE and GNOME installed, GNOME is the main desktop
+    and there are some KDE apps
+    Expected behavior: Report is generated about deleting KDE apps
+    """
+    monkeypatch.setattr(library, "is_executable", lambda x: True)
+    monkeypatch.setattr(library, "is_installed", lambda x: True)
+    monkeypatch.setattr(library, "get_xsession", get_xsession_gnome)
+    monkeypatch.setattr(library, "check_app_in_use", check_app_in_use_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    library.check_kde_gnome()
+
+    assert reporting.create_report.called == 1
+    #  Do not even touch the string! It is ugly, but because of max line lenght it has to
+    #  be written on two lines.
+    assert reporting.create_report.report_fields["title"] == "Upgrade can be\
+ performed, but KDE apps will be uninstalled."
+
+
+def test_both_kde_main_without_active_apps(monkeypatch):
+    """
+    Scenario: There are both KDE and GNOME installed, KDE is the main desktop
+    and there are no KDE apps
+    Expected behavior: There is a report generated.
+    """
+    monkeypatch.setattr(library, "is_executable", lambda x: True)
+    monkeypatch.setattr(library, "is_installed", lambda x: False)
+    monkeypatch.setattr(library, "get_xsession", get_xsession_kde)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    library.check_kde_gnome()
+
+    assert reporting.create_report.called == 1
+    assert reporting.create_report.report_fields["title"] == "Upgrade can be\
+ performed, but KDE will be uninstalled."
+
+
+def test_both_kde_main_with_active_apps(monkeypatch):
+    """
+    Scenario: There are both KDE and GNOME installed, KDE is the main desktop
+    and there are some KDE apps
+    Expected behavior: Two reports are generated: one about KDE and one about KDE apps.
+    """
+    monkeypatch.setattr(library, "is_executable", lambda x: True)
+    monkeypatch.setattr(library, "is_installed", lambda x: True)
+    monkeypatch.setattr(library, "get_xsession", get_xsession_kde)
+    monkeypatch.setattr(library, "check_app_in_use", check_app_in_use_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    library.check_kde_gnome()
+
+    assert reporting.create_report.called == 2

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/tests/unit_test.py
@@ -68,7 +68,6 @@ def test_KDE_desktop_KDE_apps(current_actor_context):
     current_actor_context.run()
     message = current_actor_context.consume(Report)[0]
     assert "inhibitor" in message.report["flags"]
-    # assert [True for message in messages if "inhibitor" in message.report["flags"]]
 
 
 def test_both_desktops_no_apps(current_actor_context):

--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/tests/unit_test.py
@@ -29,6 +29,7 @@ def test_no_desktop(monkeypatch):
     Scenario: There is no desktop.
     Expected behavior: No report
     """
+
     #  Desktop presence is found by trying to execute gnome-session or startkde
     monkeypatch.setattr(library, "is_executable", lambda x: False)
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
@@ -57,8 +58,8 @@ def test_only_gnome_without_active_apps(monkeypatch):
     """
     Scenatio: no KDE desktop is installed, but there are some KDE apps, which are not active
     Expected behavior: No report (unused app is not considered to be important)
-
     """
+
     monkeypatch.setattr(library, "is_executable", is_executable_only_gnome)
     monkeypatch.setattr(library, "is_installed", lambda x: True)
     monkeypatch.setattr(library, "check_app_in_use", lambda x: False)
@@ -73,8 +74,8 @@ def test_only_gnome_with_active_apps(monkeypatch):
     """
     Scenatio: no KDE desktop is installed, but there are some KDE apps, which are actively used
     Expected behavior: Report is made (severity = MEDIUM)
-
     """
+
     monkeypatch.setattr(library, "is_executable", is_executable_only_gnome)
     monkeypatch.setattr(library, "is_installed", lambda x: True)
     monkeypatch.setattr(library, "check_app_in_use", check_app_in_use_mocked)
@@ -83,10 +84,8 @@ def test_only_gnome_with_active_apps(monkeypatch):
     library.check_kde_gnome()
 
     assert reporting.create_report.called == 1
-    #  Do not even touch the string! It is ugly, but because of max line lenght it has to
-    #  be written on two lines.
-    assert reporting.create_report.report_fields["title"] == "Upgrade can be\
- performed, but KDE apps will be uninstalled."
+    title_KDE_apps = "Upgrade can be performed, but KDE apps will be uninstalled."
+    assert reporting.create_report.report_fields["title"] == title_KDE_apps
 
 
 def test_only_kde(monkeypatch):
@@ -94,6 +93,7 @@ def test_only_kde(monkeypatch):
     Scenario: There is only KDE installed.
     Expected behavior: Report is generated with HIGH severity and inhibitor tag.
     """
+
     monkeypatch.setattr(library, "is_executable", is_executable_only_kde)
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
 
@@ -109,6 +109,7 @@ def test_both_gnome_main_without_active_apps(monkeypatch):
     and there are no KDE apps
     Expected behavior: No report is generated.
     """
+
     monkeypatch.setattr(library, "is_executable", lambda x: True)
     monkeypatch.setattr(library, "is_installed", lambda x: False)
     monkeypatch.setattr(library, "get_xsession", get_xsession_gnome)
@@ -125,6 +126,7 @@ def test_both_gnome_main_with_active_apps(monkeypatch):
     and there are some KDE apps
     Expected behavior: Report is generated about deleting KDE apps
     """
+
     monkeypatch.setattr(library, "is_executable", lambda x: True)
     monkeypatch.setattr(library, "is_installed", lambda x: True)
     monkeypatch.setattr(library, "get_xsession", get_xsession_gnome)
@@ -134,10 +136,8 @@ def test_both_gnome_main_with_active_apps(monkeypatch):
     library.check_kde_gnome()
 
     assert reporting.create_report.called == 1
-    #  Do not even touch the string! It is ugly, but because of max line lenght it has to
-    #  be written on two lines.
-    assert reporting.create_report.report_fields["title"] == "Upgrade can be\
- performed, but KDE apps will be uninstalled."
+    title_KDE_apps = "Upgrade can be performed, but KDE apps will be uninstalled."
+    assert reporting.create_report.report_fields["title"] == title_KDE_apps
 
 
 def test_both_kde_main_without_active_apps(monkeypatch):
@@ -146,6 +146,7 @@ def test_both_kde_main_without_active_apps(monkeypatch):
     and there are no KDE apps
     Expected behavior: There is a report generated.
     """
+
     monkeypatch.setattr(library, "is_executable", lambda x: True)
     monkeypatch.setattr(library, "is_installed", lambda x: False)
     monkeypatch.setattr(library, "get_xsession", get_xsession_kde)
@@ -154,8 +155,8 @@ def test_both_kde_main_without_active_apps(monkeypatch):
     library.check_kde_gnome()
 
     assert reporting.create_report.called == 1
-    assert reporting.create_report.report_fields["title"] == "Upgrade can be\
- performed, but KDE will be uninstalled."
+    title_KDE = "Upgrade can be performed, but KDE will be uninstalled."
+    assert reporting.create_report.report_fields["title"] == title_KDE
 
 
 def test_both_kde_main_with_active_apps(monkeypatch):
@@ -164,6 +165,7 @@ def test_both_kde_main_with_active_apps(monkeypatch):
     and there are some KDE apps
     Expected behavior: Two reports are generated: one about KDE and one about KDE apps.
     """
+
     monkeypatch.setattr(library, "is_executable", lambda x: True)
     monkeypatch.setattr(library, "is_installed", lambda x: True)
     monkeypatch.setattr(library, "get_xsession", get_xsession_kde)

--- a/repos/system_upgrade/el7toel8/actors/getinstalleddesktops/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/getinstalleddesktops/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+from leapp.models import InstalledDesktopsFacts, InstalledRPM
+from leapp.libraries.actor.library import get_installed_desktops
+
+
+class GetInstalledDesktops(Actor):
+    """
+    Actor checks if kde or gnome desktop environments
+    are installed and what desktop is default.
+    """
+
+    name = 'get_installed_desktops'
+    consumes = (InstalledRPM,)
+    produces = (InstalledDesktopsFacts,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        facts = get_installed_desktops()
+        self.produce(InstalledDesktopsFacts(
+            gnome_installed=facts["gnome_installed"],
+            kde_installed=facts["kde_installed"]))

--- a/repos/system_upgrade/el7toel8/actors/getinstalleddesktops/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/getinstalleddesktops/libraries/library.py
@@ -1,0 +1,17 @@
+from leapp.libraries.stdlib import api
+from leapp.libraries.common.rpms import has_package
+from leapp.models import InstalledRPM
+
+
+def get_installed_desktops():
+    api.current_logger().info("  Detecting desktop environments  ")
+    api.current_logger().info("==================================")
+
+    # Detect installed desktops by one of the base rpm packages
+    kde_desktop_installed = has_package(InstalledRPM, "plasma-workspace")
+    gnome_desktop_installed = has_package(InstalledRPM, "gnome-session")
+    api.current_logger().info("* KDE installed: {0}".format(kde_desktop_installed))
+    api.current_logger().info("* Gnome installed: {0}".format(gnome_desktop_installed))
+    api.current_logger().info("----------------------------------")
+
+    return {"gnome_installed": gnome_desktop_installed, "kde_installed": kde_desktop_installed}

--- a/repos/system_upgrade/el7toel8/actors/getinstalleddesktops/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/getinstalleddesktops/libraries/library.py
@@ -8,7 +8,7 @@ def get_installed_desktops():
     api.current_logger().info("==================================")
 
     # Detect installed desktops by one of the base rpm packages
-    kde_desktop_installed = has_package(InstalledRPM, "plasma-workspace")
+    kde_desktop_installed = has_package(InstalledRPM, "kde-workspace")
     gnome_desktop_installed = has_package(InstalledRPM, "gnome-session")
     api.current_logger().info("* KDE installed: {0}".format(kde_desktop_installed))
     api.current_logger().info("* Gnome installed: {0}".format(gnome_desktop_installed))

--- a/repos/system_upgrade/el7toel8/actors/getinstalleddesktops/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/getinstalleddesktops/tests/unit_test.py
@@ -1,0 +1,36 @@
+from leapp.snactor.fixture import current_actor_context
+from leapp.models import InstalledRPM, RPM, InstalledDesktopsFacts
+
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+Gnome_RPM = RPM(name='gnome-session', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+                pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
+KDE_RPM = RPM(name='plasma-workspace', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+              pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
+
+
+def test_Gnome_present(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[Gnome_RPM, ]))
+    current_actor_context.run()
+    message = current_actor_context.consume(InstalledDesktopsFacts)[0]
+    assert message.gnome_installed
+
+
+def test_KDE_present(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[KDE_RPM, ]))
+    current_actor_context.run()
+    message = current_actor_context.consume(InstalledDesktopsFacts)[0]
+    assert message.kde_installed
+
+
+def test_KDE_Gnome_present(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[Gnome_RPM, KDE_RPM]))
+    current_actor_context.run()
+    message = current_actor_context.consume(InstalledDesktopsFacts)[0]
+    assert message.gnome_installed and message.kde_installed
+
+
+def test_no_desktop_present(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[]))
+    current_actor_context.run()
+    message = current_actor_context.consume(InstalledDesktopsFacts)[0]
+    assert not message.gnome_installed and not message.kde_installed

--- a/repos/system_upgrade/el7toel8/actors/getinstalleddesktops/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/getinstalleddesktops/tests/unit_test.py
@@ -4,7 +4,7 @@ from leapp.models import InstalledRPM, RPM, InstalledDesktopsFacts
 RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
 Gnome_RPM = RPM(name='gnome-session', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
                 pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
-KDE_RPM = RPM(name='plasma-workspace', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
+KDE_RPM = RPM(name='kde-workspace', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
               pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51')
 
 

--- a/repos/system_upgrade/el7toel8/models/installeddesktopsfacts.py
+++ b/repos/system_upgrade/el7toel8/models/installeddesktopsfacts.py
@@ -1,0 +1,11 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemFactsTopic
+
+
+class InstalledDesktopsFacts(Model):
+    """
+    The model includes fact about installe
+    """
+    topic = SystemFactsTopic
+    gnome_installed = fields.Boolean(default=False)
+    kde_installed = fields.Boolean(default=False)

--- a/repos/system_upgrade/el7toel8/models/installedkdeappsfacts.py
+++ b/repos/system_upgrade/el7toel8/models/installedkdeappsfacts.py
@@ -1,0 +1,7 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemFactsTopic
+
+
+class InstalledKdeAppsFacts(Model):
+    topic = SystemFactsTopic
+    installed_apps = fields.List(fields.String(), default=[])


### PR DESCRIPTION
A simple script detecting installed KDE desktop environment and its apps,
written in leapp framework. When started, the script will check whether
KDE is installed together with GNOME desktop to inform whether we can
inhibit the upgrade process. When both are installed, we need to inform
the user that KDE will be removed and GNOME will be used instead. If only
KDE is installed, we want to inhibit the upgrade process otherwise the
user will end up without a desktop. Also if both are installed,
but KDE is not used as default desktop, we further check most common
KDE apps to inform the user that those will be removed in case the user is using them.

Possible values in message CanUpgrade:

* 0: we can safely continue with the upgrade process
* 1: we cannot continue with the upgrade process
* 2: we can continue with the upgrade process, but KDE desktop will be removed
together with KDE apps in favor of GNOME desktop

Original script in bash written by jgrulich [0].
[0] https://gitlab.cee.redhat.com/jgrulich/rhel-upgrade