### PR TITLE
Make Report.to_dict a method, not a property

### DIFF
--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -21,7 +21,7 @@ class create_report_mocked(object):
         # iterate list of report primitives (classes)
         for report in report_fields:
             # last element of path is our field name
-            self.report_fields.update(report.to_dict)
+            self.report_fields.update(report.to_dict())
 
 
 def make_IOError(error):


### PR DESCRIPTION
In spite of changes in leapp PR546 this will
make more sense.