### PR TITLE
Remove squid as BZ#1703117 is fixed

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -10,7 +10,5 @@ python2-cairo-devel
 python2-debug
 python2-numpy-f2py
 python2-virtualenv
-# squid - https://bugzilla.redhat.com/show_bug.cgi?id=1703117
-squid
 # python-docs - https://bugzilla.redhat.com/show_bug.cgi?id=1703605
 python-docs


### PR DESCRIPTION
note on WIP status
===============

This actually only applies only when upgrading to RHEL-8.1 I'm not sure yet how do we make it possible without forcing leapp to support *only* 8.1 now.

For now, AFAICS, all we can do is just not merge this until the moment when we switch to supporting exclusively 8.1.

We (downstream QE) do need the PR build to be able to verify the change, though.

Also there's possible bug in 8.1 support in master (not filed yet) so this PR will need to be rebased once that is sorted out.