### PR TITLE
Add removed verify_check_results actor

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/verifycheckresults/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/verifycheckresults/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.reporting import Report
+from leapp.tags import ReportPhaseTag, IPUWorkflowTag
+
+
+class VerifyCheckResults(Actor):
+    """
+    Check all generated results messages and notify user about them.
+
+    A report file containing all messages will be generated, together with log messages displayed
+    to the user.
+    """
+
+    name = 'verify_check_results'
+    consumes = (Report,)
+    produces = ()
+    tags = (ReportPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        results = list(self.consume(Report))
+        for error in [msg for msg in results if 'inhibitor' in msg.report.get('flags', [])]:
+            self.report_error(error.report['title'])


### PR DESCRIPTION
During report refactoring this actor has
been removed which led to no errors being
registered for workflow, which in it's turn
caused the upgrade not to be inhibited when
necessary.
This patch should solve that pitiful error.