### PR TITLE
Add RelatedResource fields to reports

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/authselectapply/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectapply/actor.py
@@ -6,6 +6,13 @@ from leapp.reporting import Report, create_report
 from leapp.tags import IPUWorkflowTag, ApplicationsPhaseTag, ExperimentalTag
 
 
+resources = [
+    reporting.RelatedResource('package', 'authselect'),
+    reporting.RelatedResource('package', 'authconfig'),
+    reporting.RelatedResource('file', '/etc/nsswitch.conf')
+]
+
+
 class AuthselectApply(Actor):
     """
     Apply changes suggested by AuthselectScanner.
@@ -43,7 +50,7 @@ class AuthselectApply(Actor):
                 reporting.Flags([
                     reporting.Flags.FAILURE
                 ])
-            ])  # pylint: disable-msg=too-many-arguments
+            ] + resources)  # pylint: disable-msg=too-many-arguments
             return
 
         create_report([  # pylint: disable-msg=too-many-arguments
@@ -57,4 +64,4 @@ class AuthselectApply(Actor):
                     reporting.Tags.SECURITY,
                     reporting.Tags.TOOLS
                 ])
-        ])  # pylint: disable-msg=too-many-arguments
+        ] + resources)  # pylint: disable-msg=too-many-arguments

--- a/repos/system_upgrade/el7toel8/actors/authselectcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectcheck/actor.py
@@ -7,6 +7,13 @@ from leapp import reporting
 from leapp.tags import IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag
 
 
+resources = [
+    reporting.RelatedResource('package', 'authselect'),
+    reporting.RelatedResource('package', 'authconfig'),
+    reporting.RelatedResource('file', '/etc/nsswitch.conf')
+]
+
+
 class AuthselectCheck(Actor):
     """
     Confirm suggested authselect call from AuthselectScanner.
@@ -99,7 +106,7 @@ class AuthselectCheck(Actor):
                 reporting.Tags.SECURITY,
                 reporting.Tags.TOOLS
             ])
-        ])
+        ] + resources)
 
     def produce_current_configuration(self, model):
         self.produce(
@@ -125,7 +132,7 @@ class AuthselectCheck(Actor):
                 reporting.Tags.TOOLS
             ]),
             reporting.Severity(reporting.Severity.INFO)
-        ])
+        ] + resources)
 
     def produce_suggested_configuration(self, model, confirmed, command):
         self.produce(
@@ -150,7 +157,7 @@ class AuthselectCheck(Actor):
                     reporting.Tags.SECURITY,
                     reporting.Tags.TOOLS
                 ])
-            ])
+            ] + resources)
 
         else:
             create_report([
@@ -172,4 +179,4 @@ class AuthselectCheck(Actor):
                 ]),
                 reporting.Remediation(commands=[[command]]),
                 reporting.Severity(reporting.Severity.MEDIUM)
-            ])
+            ] + resources)

--- a/repos/system_upgrade/el7toel8/actors/checkacpid/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkacpid/actor.py
@@ -25,5 +25,6 @@ class CheckAcpid(Actor):
                 reporting.Remediation(
                     hint='You must now use both options (\'-df\') for the same behavior. Please update '
                          'your scripts to be compatible with the changes.'),
-                reporting.Tags([reporting.Tags.KERNEL, reporting.Tags.SERVICES])
+                reporting.Tags([reporting.Tags.KERNEL, reporting.Tags.SERVICES]),
+                reporting.RelatedResource('package', 'acpid')
             ])

--- a/repos/system_upgrade/el7toel8/actors/checkbootavailspace/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkbootavailspace/libraries/library.py
@@ -34,5 +34,6 @@ def inhibit_upgrade(avail_bytes):
         ),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Tags([reporting.Tags.FILESYSTEM]),
-        reporting.Flags([reporting.Flags.INHIBITOR])
+        reporting.Flags([reporting.Flags.INHIBITOR]),
+        reporting.RelatedResource('directory', '/boot')
     ])

--- a/repos/system_upgrade/el7toel8/actors/checkbrltty/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkbrltty/actor.py
@@ -7,6 +7,9 @@ from leapp import reporting
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
+related = [reporting.RelatedResource('package', 'brltty')]
+
+
 class CheckBrltty(Actor):
     """
     Check if brltty is installed, check whether configuration update is needed.
@@ -30,7 +33,7 @@ class CheckBrltty(Actor):
                 reporting.Remediation(
                     hint='Please update your scripts to be compatible with the changes.'
                 )
-            ])
+            ] + related)
 
             (migrate_file, migrate_bt, migrate_espeak) = library.check_for_unsupported_cfg()
             report_summary = ''
@@ -47,7 +50,7 @@ class CheckBrltty(Actor):
                     reporting.Summary(report_summary),
                     reporting.Severity(reporting.Severity.LOW),
                     reporting.Tags([reporting.Tags.ACCESSIBILITY]),
-                ])
+                ] + related)
 
                 self.produce(BrlttyMigrationDecision(migrate_file=migrate_file, migrate_bt=migrate_bt,
                                                      migrate_espeak=migrate_espeak))
@@ -57,4 +60,4 @@ class CheckBrltty(Actor):
                     reporting.Summary('brltty configuration seems to be compatible'),
                     reporting.Severity(reporting.Severity.LOW),
                     reporting.Tags([reporting.Tags.ACCESSIBILITY]),
-                ])
+                ] + related)

--- a/repos/system_upgrade/el7toel8/actors/checkbtrfs/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkbtrfs/actor.py
@@ -33,6 +33,7 @@ class CheckBtrfs(Actor):
                         ),
                         reporting.Severity(reporting.Severity.HIGH),
                         reporting.Flags([reporting.Flags.INHIBITOR]),
-                        reporting.Tags([reporting.Tags.FILESYSTEM])
+                        reporting.Tags([reporting.Tags.FILESYSTEM]),
+                        reporting.RelatedResource('kernel-driver', 'btrfs')
                     ])
                     break

--- a/repos/system_upgrade/el7toel8/actors/checkchrony/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkchrony/libraries/library.py
@@ -2,6 +2,13 @@ from leapp import reporting
 from leapp.libraries.stdlib import api, run
 
 
+related = [
+    reporting.RelatedResource('package', 'ntpd'),
+    reporting.RelatedResource('package', 'chrony'),
+    reporting.RelatedResource('file', '/etc/chrony.conf'),
+]
+
+
 def is_config_default():
     """Check if the chrony config file was not modified since installation."""
     try:
@@ -30,7 +37,7 @@ def check_chrony(chrony_installed):
                     reporting.Tags.SERVICES,
                     reporting.Tags.TIME_MANAGEMENT
             ])
-        ])
+        ] + related)
 
     else:
         reporting.create_report([
@@ -41,4 +48,4 @@ def check_chrony(chrony_installed):
                     reporting.Tags.SERVICES,
                     reporting.Tags.TIME_MANAGEMENT
             ])
-        ])
+        ] + related)

--- a/repos/system_upgrade/el7toel8/actors/checkdosfstools/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkdosfstools/actor.py
@@ -33,5 +33,6 @@ class CheckDosfstools(Actor):
                         reporting.Tags.FILESYSTEM,
                         reporting.Tags.TOOLS
                 ]),
-                reporting.Remediation(hint='Please update your scripts to be compatible with the changes.')
+                reporting.Remediation(hint='Please update your scripts to be compatible with the changes.'),
+                reporting.RelatedResource('package', 'dosfstools')
             ])

--- a/repos/system_upgrade/el7toel8/actors/checkfirewalld/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfirewalld/actor.py
@@ -6,6 +6,9 @@ from leapp import reporting
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
+related = [reporting.RelatedResource('package', 'firewalld')]
+
+
 class CheckFirewalld(Actor):
     """
     Check for certain firewalld configuration that may prevent an upgrade.
@@ -47,7 +50,7 @@ class CheckFirewalld(Actor):
                 reporting.Remediation(
                     hint='Remove firewalld direct rules that use these ebtables tables:{}{}'.format(*format_tuple)
                 )
-            ])
+            ] + related)
 
         if unsupported_ipset_types:
             format_tuple = (
@@ -70,4 +73,4 @@ class CheckFirewalld(Actor):
                 reporting.Remediation(
                     hint='Remove ipsets of these types from firewalld:{}{}'.format(*format_tuple)
                 )
-            ])
+            ] + related)

--- a/repos/system_upgrade/el7toel8/actors/checkgrep/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkgrep/actor.py
@@ -37,5 +37,6 @@ class CheckGrep(Actor):
                 ),
                 reporting.Severity(reporting.Severity.LOW),
                 reporting.Tags([reporting.Tags.TOOLS]),
-                reporting.Remediation(hint='Please update your scripts to be compatible with the changes.')
+                reporting.Remediation(hint='Please update your scripts to be compatible with the changes.'),
+                reporting.RelatedResource('package', 'grep')
             ])

--- a/repos/system_upgrade/el7toel8/actors/checkhacluster/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkhacluster/libraries/library.py
@@ -17,7 +17,9 @@ def inhibit(node_type):
         ),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Tags([reporting.Tags.HIGH_AVAILABILITY]),
-        reporting.Flags([reporting.Flags.INHIBITOR])
+        reporting.Flags([reporting.Flags.INHIBITOR]),
+        reporting.RelatedResource('file', COROSYNC_CONF_LOCATION),
+        reporting.RelatedResource('file', CIB_LOCATION)
     ])
 
 

--- a/repos/system_upgrade/el7toel8/actors/checkirssi/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkirssi/actor.py
@@ -31,5 +31,6 @@ class CheckIrssi(Actor):
                         reporting.Tags.COMMUNICATION,
                         reporting.Tags.TOOLS
                 ]),
-                reporting.Remediation(hint='Please update your scripts to be compatible with the changes.')
+                reporting.Remediation(hint='Please update your scripts to be compatible with the changes.'),
+                reporting.RelatedResource('package', 'irssi')
             ])

--- a/repos/system_upgrade/el7toel8/actors/checkmemcached/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmemcached/libraries/library.py
@@ -9,6 +9,11 @@ COMMON_REPORT_TAGS = [reporting.Tags.SERVICES]
 
 sysconfig_path = '/etc/sysconfig/memcached'
 
+related = [
+    reporting.RelatedResource('package', 'memcached'),
+    reporting.RelatedResource('file', sysconfig_path)
+]
+
 
 def is_sysconfig_default():
     """Check if the memcached sysconfig file was not modified since installation."""
@@ -44,7 +49,7 @@ def check_memcached(memcached_installed):
             reporting.Summary('memcached in RHEL8 listens on loopback only and has UDP port disabled by default'),
             reporting.Severity(reporting.Severity.MEDIUM),
             reporting.Tags(COMMON_REPORT_TAGS),
-        ])
+        ] + related)
 
     elif not disabled_udp_port:
         reporting.create_report([
@@ -54,7 +59,7 @@ def check_memcached(memcached_installed):
             ),
             reporting.Severity(reporting.Severity.MEDIUM),
             reporting.Tags(COMMON_REPORT_TAGS),
-        ])
+        ] + related)
 
     else:
         reporting.create_report([
@@ -62,4 +67,4 @@ def check_memcached(memcached_installed):
             reporting.Summary('memcached in RHEL8 has UDP port disabled by default'),
             reporting.Severity(reporting.Severity.LOW),
             reporting.Tags(COMMON_REPORT_TAGS),
-        ])
+        ] + related)

--- a/repos/system_upgrade/el7toel8/actors/checknfs/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checknfs/actor.py
@@ -54,5 +54,6 @@ class CheckNfs(Actor):
                         reporting.Tags.NETWORK
                 ]),
                 reporting.Remediation(hint='Disable NFS temporarily for the upgrade if possible.'),
-                reporting.Flags([reporting.Flags.INHIBITOR])
+                reporting.Flags([reporting.Flags.INHIBITOR]),
+                reporting.RelatedResource('file', '/etc/fstab')
             ])

--- a/repos/system_upgrade/el7toel8/actors/checkntp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkntp/libraries/library.py
@@ -8,6 +8,17 @@ from leapp.libraries.stdlib import CalledProcessError, api, run
 from leapp.models import NtpMigrationDecision
 
 
+files = [
+    '/etc/ntp.conf', '/etc/ntp/keys',
+    '/etc/ntp/crypto/pw', '/etc/ntp/step-tickers'
+]
+
+related = [
+    reporting.RelatedResource('package', 'ntpd'),
+    reporting.RelatedResource('package', 'chrony'),
+] + [reporting.RelatedResource('file', f) for f in files]
+
+
 # Check if a service is active and enabled
 def check_service(name):
     for state in ['active', 'enabled']:
@@ -60,11 +71,10 @@ def check_ntp(installed_packages):
             reporting.Summary('{} service(s) detected to be enabled and active'.format(', '.join(migrate_services))),
             reporting.Severity(reporting.Severity.LOW),
             reporting.Tags([reporting.Tags.SERVICES, reporting.Tags.TIME_MANAGEMENT]),
-        ])
+        ] + related)
 
         # Save configuration files that will be renamed in the upgrade
-        config_tgz64 = get_tgz64(['/etc/ntp.conf', '/etc/ntp/keys',
-                                  '/etc/ntp/crypto/pw', '/etc/ntp/step-tickers'])
+        config_tgz64 = get_tgz64(files)
     else:
         api.current_logger().info('ntpd/ntpdate configuration will not be migrated')
         migrate_services = []

--- a/repos/system_upgrade/el7toel8/actors/checkosrelease/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkosrelease/libraries/library.py
@@ -8,6 +8,8 @@ from leapp.models import OSReleaseFacts
 
 COMMON_REPORT_TAGS = [reporting.Tags.SANITY]
 
+related = [reporting.RelatedResource('file', '/etc/os-release')]
+
 
 def skip_check():
     """ Check if an environment variable was used to skip this actor """
@@ -17,7 +19,7 @@ def skip_check():
             reporting.Summary('Source RHEL release check skipped via LEAPP_SKIP_CHECK_OS_RELEASE env var.'),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags(COMMON_REPORT_TAGS)
-        ])
+        ] + related)
 
         return True
     return False
@@ -45,7 +47,7 @@ def check_os_version(supported_version):
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags(COMMON_REPORT_TAGS),
             reporting.Flags([reporting.Flags.INHIBITOR])
-        ])
+        ] + related)
 
         return
 
@@ -66,4 +68,4 @@ def check_os_version(supported_version):
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags(COMMON_REPORT_TAGS),
             reporting.Flags([reporting.Flags.INHIBITOR])
-        ])
+        ] + related)

--- a/repos/system_upgrade/el7toel8/actors/checkpostfix/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkpostfix/actor.py
@@ -57,5 +57,6 @@ class CheckPostfix(Actor):
                         ),
                         reporting.Severity(reporting.Severity.LOW),
                         reporting.Tags([reporting.Tags.SERVICES, reporting.Tags.EMAIL]),
+                        reporting.RelatedResource('package', 'postfix')
                     ])
                     return

--- a/repos/system_upgrade/el7toel8/actors/checkremovedpammodules/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkremovedpammodules/actor.py
@@ -60,5 +60,5 @@ class CheckRemovedPamModules(Actor):
                          'under /etc/pam.d/.'.format(', '.join(replacements))
                 ),
                 reporting.Severity(reporting.Severity.HIGH),
-                reporting.Flags([reporting.Flags.INHIBITOR])
-            ])
+                reporting.Flags([reporting.Flags.INHIBITOR]),
+            ] + [reporting.RelatedResource('pam', r) for r in replacements | found_modules])

--- a/repos/system_upgrade/el7toel8/actors/checkrhsmsku/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrhsmsku/actor.py
@@ -33,5 +33,6 @@ class CheckRedHatSubscriptionManagerSKU(Actor):
                         reporting.Flags([reporting.Flags.INHIBITOR]),
                         reporting.Remediation(
                             hint='Register your system with the subscription-manager tool and attach it to proper SKUs'
-                                 ' to be able to proceed the upgrade.')
+                                 ' to be able to proceed the upgrade.'),
+                        reporting.RelatedResource('package', 'subscription-manager')
                     ])

--- a/repos/system_upgrade/el7toel8/actors/checksendmail/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checksendmail/actor.py
@@ -10,6 +10,10 @@ from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 COMMON_REPORT_TAGS = [reporting.Tags.SERVICES, reporting.Tags.EMAIL]
 
+related = [
+    reporting.RelatedResource('file', f) for f in library.get_conf_files()
+] + [reporting.RelatedResource('package', 'sendmail')]
+
 
 class CheckSendmail(Actor):
     """
@@ -40,7 +44,7 @@ class CheckSendmail(Actor):
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Tags(COMMON_REPORT_TAGS + [reporting.Tags.NETWORK]),
                 reporting.Flags([reporting.Flags.INHIBITOR])
-            ])
+            ] + related)
 
             return
         migrate_files = library.check_files_for_compressed_ipv6()
@@ -53,7 +57,7 @@ class CheckSendmail(Actor):
                 ),
                 reporting.Severity(reporting.Severity.LOW),
                 reporting.Tags(COMMON_REPORT_TAGS)
-            ])
+            ] + related)
 
             self.produce(SendmailMigrationDecision(migrate_files=migrate_files))
         else:

--- a/repos/system_upgrade/el7toel8/actors/checkskippedrepositories/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkskippedrepositories/actor.py
@@ -36,6 +36,9 @@ class CheckSkippedRepositories(Actor):
             summary_data.extend(['- {}'.format(p) for p in packages])
             summary = '\n'.join(summary_data)
 
+            packages_related = [reporting.RelatedResource('package', str(p)) for p in packages]
+            repos_related = [reporting.RelatedResource('repository', str(r)) for r in repos]
+
             create_report([
                 reporting.Title(title),
                 reporting.Summary(summary),
@@ -44,7 +47,7 @@ class CheckSkippedRepositories(Actor):
                 reporting.Remediation(
                     hint='You can file a request to add this repository to the scope of in-place upgrades '
                          'by filing a support ticket')
-            ])
+            ] + packages_related + repos_related)
 
             if config.is_verbose():
                 self.log.info('\n'.join([title, summary]))

--- a/repos/system_upgrade/el7toel8/actors/createresumeservice/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/createresumeservice/actor.py
@@ -42,5 +42,8 @@ class CreateSystemdResumeService(Actor):
                 'after reboot.'.format(service_name)
             ),
             reporting.Severity(reporting.Severity.INFO),
-            reporting.Tags([reporting.Tags.UPGRADE_PROCESS])
+            reporting.Tags([reporting.Tags.UPGRADE_PROCESS]),
+            reporting.RelatedResource('file', service_path),
+            reporting.RelatedResource('file', symlink_path),
+            reporting.RelatedResource('service', service_name)
         ])

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/actor.py
@@ -17,7 +17,8 @@ class DetectGrubConfigError(Actor):
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 
     def process(self):
-        error_detected = detect_config_error('/etc/default/grub')
+        config = '/etc/default/grub'
+        error_detected = detect_config_error(config)
         if error_detected:
             create_report([
                 reporting.Title('Syntax error detected in grub configuration'),
@@ -27,7 +28,8 @@ class DetectGrubConfigError(Actor):
                     'Error is automatically fixed by add_upgrade_boot_entry actor.'
                 ),
                 reporting.Severity(reporting.Severity.LOW),
-                reporting.Tags([reporting.Tags.BOOT])
+                reporting.Tags([reporting.Tags.BOOT]),
+                reporting.RelatedResource('file', config)
             ])
 
         self.produce(GrubConfigError(error_detected=error_detected))

--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
@@ -37,7 +37,8 @@ def get_os_release(path):
             reporting.Summary(str(e)),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags([reporting.Tags.OS_FACTS, reporting.Tags.SANITY]),
-            reporting.Flags([reporting.Flags.INHIBITOR])
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.RelatedResource('file', path)
         ])
         return None
 

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkkerneldrivers/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkkerneldrivers/actor.py
@@ -84,4 +84,4 @@ class CheckKernelDrivers(Actor):
                     reporting.Tags([reporting.Tags.KERNEL, reporting.Tags.DRIVERS]),
                     reporting.Flags([reporting.Flags.INHIBITOR]),
                     reporting.Remediation(hint=remediation)
-                ])
+                ] + [reporting.RelatedResource('kernel-driver', km) for km in drivers_to_report])

--- a/repos/system_upgrade/el7toel8/actors/migratebrltty/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/migratebrltty/actor.py
@@ -34,5 +34,6 @@ class MigrateBrltty(Actor):
                     reporting.Title('brltty configuration files migrated'),
                     reporting.Summary(report_summary),
                     reporting.Severity(reporting.Severity.LOW),
-                    reporting.Tags([reporting.Tags.TOOLS, reporting.Tags.ACCESSIBILITY])
+                    reporting.Tags([reporting.Tags.TOOLS, reporting.Tags.ACCESSIBILITY]),
+                    reporting.RelatedResource('package', 'brltty')
                 ])

--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/library.py
@@ -82,13 +82,16 @@ def migrate_ntp(migrate_services, config_tgz64):
 
     ignored_lines = ntp2chrony('/', ntp_conf, step_tickers)
 
+    config_resources = [reporting.RelatedResource('file', mc) for mc in migrate_configs + [ntp_conf]]
+    package_resources = [reporting.RelatedResource('package', p) for p in ['ntpd', 'chrony']]
+
     if not ignored_lines:
         reporting.create_report([
             reporting.Title('{} configuration migrated to chrony'.format(' and '.join(migrate_configs))),
             reporting.Summary('ntp2chrony executed successfully'),
             reporting.Severity(reporting.Severity.INFO),
             reporting.Tags(COMMON_REPORT_TAGS)
-        ])
+        ] + config_resources + package_resources)
 
     else:
         reporting.create_report([
@@ -96,4 +99,4 @@ def migrate_ntp(migrate_services, config_tgz64):
             reporting.Summary('Some lines in /etc/ntp.conf were ignored in migration (check /etc/chrony.conf)'),
             reporting.Severity(reporting.Severity.MEDIUM),
             reporting.Tags(COMMON_REPORT_TAGS)
-        ])
+        ] + config_resources + package_resources)

--- a/repos/system_upgrade/el7toel8/actors/opensshalgorithmscheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshalgorithmscheck/actor.py
@@ -48,6 +48,10 @@ class OpenSshAlgorithmsCheck(Actor):
             if config.macs and mac in config.macs:
                 found_macs.append(mac)
 
+        resources = [
+            reporting.RelatedResource('package', 'openssh-server'),
+            reporting.RelatedResource('file', '/etc/ssh/sshd_config')
+        ]
         if found_ciphers:
             create_report([
                 reporting.Title('OpenSSH configured to use removed ciphers'),
@@ -69,7 +73,7 @@ class OpenSshAlgorithmsCheck(Actor):
                          '{}'.format(','.join(found_ciphers))
                 ),
                 reporting.Flags([reporting.Flags.INHIBITOR])
-            ])
+            ] + resources)
 
         if found_macs:
             create_report([
@@ -91,4 +95,4 @@ class OpenSshAlgorithmsCheck(Actor):
                     hint='Remove the following MACs from sshd_config: {}'.format(','.join(found_macs))
                 ),
                 reporting.Flags([reporting.Flags.INHIBITOR])
-            ])
+            ] + resources)

--- a/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
@@ -38,6 +38,10 @@ class OpenSshPermitRootLoginCheck(Actor):
                 'Could not check openssh configuration', details={'details': 'No OpenSshConfig facts found.'}
             )
 
+        resources = [
+            reporting.RelatedResource('package', 'openssh-server'),
+            reporting.RelatedResource('file', '/etc/ssh/sshd_config')
+        ]
         if not config.permit_root_login:
             # TODO find out whether the file was modified and will be
             # replaced by the update. If so, this message is bogus
@@ -57,7 +61,7 @@ class OpenSshPermitRootLoginCheck(Actor):
                          '"PermitRootLogin yes" to sshd_config.'
                 ),
                 reporting.Flags([reporting.Flags.INHIBITOR])
-            ])
+            ] + resources)
 
         # Check if there is at least one PermitRootLogin other than "no"
         # in match blocks (other than Match All).
@@ -83,4 +87,4 @@ class OpenSshPermitRootLoginCheck(Actor):
                          'in global context if desired.'
                 ),
                 reporting.Flags([reporting.Flags.INHIBITOR])
-            ])
+            ] + resources)

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -88,7 +88,8 @@ def get_events(pes_events_filepath):
             reporting.Summary(summary),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags([reporting.Tags.SANITY]),
-            reporting.Flags([reporting.Flags.INHIBITOR])
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.RelatedResource('file', pes_events_filepath)
         ])
         raise StopActorExecution()
 
@@ -294,7 +295,7 @@ def report_skipped_packages(message, packages):
         reporting.Summary(summary),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Tags([reporting.Tags.REPOSITORY]),
-    ])
+    ] + [reporting.RelatedResource('package', p) for p in packages])
     if is_verbose():
         api.show_message(summary)
 

--- a/repos/system_upgrade/el7toel8/actors/powertop/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/powertop/actor.py
@@ -30,5 +30,6 @@ class PowerTop(Actor):
                 ),
                 reporting.Severity(reporting.Severity.LOW),
                 reporting.Tags([reporting.Tags.TOOLS, reporting.Tags.MONITORING]),
-                reporting.Remediation(hint='Please remove the dropped options from your scripts.')
+                reporting.Remediation(hint='Please remove the dropped options from your scripts.'),
+                reporting.RelatedResource('package', 'powertop')
             ])

--- a/repos/system_upgrade/el7toel8/actors/pythoninformuser/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/pythoninformuser/actor.py
@@ -24,5 +24,9 @@ class PythonInformUser(Actor):
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags([reporting.Tags.PYTHON]),
             reporting.Audience('developer'),
-            reporting.Remediation(commands=[['alternatives', '--set', 'python', '/usr/bin/python3']])
+            reporting.ExternalLink(url, title),
+            reporting.Remediation(commands=[['alternatives', '--set', 'python', '/usr/bin/python3']]),
+            reporting.RelatedResource('package', 'python'),
+            reporting.RelatedResource('package', 'python2'),
+            reporting.RelatedResource('package', 'python3')
         ])

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/libraries/library.py
@@ -37,8 +37,8 @@ def generate_report(packages):
         reporting.Summary(summary),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Tags(COMMON_REPORT_TAGS),
-        reporting.Remediation(commands=[remediation])
-    ])
+        reporting.Remediation(commands=[remediation]),
+    ] + [reporting.RelatedResource('package', p) for p in packages])
 
     if is_verbose():
         api.show_message(summary)

--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulescheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulescheck/actor.py
@@ -91,7 +91,8 @@ class RemoveOldPAMModulesCheck(Actor):
                     reporting.Tags.SECURITY,
                     reporting.Tags.TOOLS
             ]),
-            reporting.Remediation(hint='Configure SSSD to replace {0}'.format(module))
+            reporting.Remediation(hint='Configure SSSD to replace {0}'.format(module)),
+            reporting.RelatedResource('package', 'sssd')
         ])
 
     def produce_inhibitor(self, module):
@@ -114,5 +115,6 @@ class RemoveOldPAMModulesCheck(Actor):
             ]),
             reporting.Flags([reporting.Flags.INHIBITOR]),
             reporting.Remediation(
-                hint='Disable {0} module and switch to SSSD to recover its functionality.'.format(module))
+                hint='Disable {0} module and switch to SSSD to recover its functionality.'.format(module)),
+            reporting.RelatedResource('package', 'sssd')
         ])

--- a/repos/system_upgrade/el7toel8/actors/reportleftoverpackages/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/reportleftoverpackages/actor.py
@@ -33,7 +33,7 @@ class ReportLeftoverPackages(Actor):
                     reporting.Summary('Following packages have been removed:\n{}'.format('\n'.join(removed))),
                     reporting.Severity(reporting.Severity.HIGH),
                     reporting.Tags([reporting.Tags.SANITY]),
-                ])
+                ] + [reporting.RelatedResource('package', pkg.name) for pkg in removed_packages.items])
             else:
                 summary = ('Following packages have been removed:\n'
                            '{}\n'
@@ -45,7 +45,7 @@ class ReportLeftoverPackages(Actor):
                     reporting.Summary(summary),
                     reporting.Severity(reporting.Severity.HIGH),
                     reporting.Tags([reporting.Tags.SANITY]),
-                ])
+                ] + [reporting.RelatedResource('package', pkg.name) for pkg in leftover_packages.items])
             return
 
         if not leftover_packages.items:
@@ -59,4 +59,4 @@ class ReportLeftoverPackages(Actor):
             reporting.Summary(summary),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags([reporting.Tags.SANITY]),
-        ])
+        ] + [reporting.RelatedResource('package', pkg.name) for pkg in leftover_packages.items])

--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/actor.py
@@ -27,5 +27,6 @@ class ReportSetTargetRelease(Actor):
                     format(release=info.release)
                 ),
                 reporting.Severity(reporting.Severity.LOW),
-                reporting.Tags([reporting.Tags.UPGRADE_PROCESS])
+                reporting.Tags([reporting.Tags.UPGRADE_PROCESS]),
+                reporting.RelatedResource('package', 'subscription-manager')
             ])

--- a/repos/system_upgrade/el7toel8/actors/scheduleselinuxrelabeling/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scheduleselinuxrelabeling/actor.py
@@ -7,6 +7,8 @@ from leapp import reporting
 
 COMMON_REPORT_TAGS = [reporting.Tags.SELINUX]
 
+related = [reporting.RelatedResource('file', '/.autorelabel')]
+
 
 class ScheduleSeLinuxRelabeling(Actor):
     """
@@ -32,18 +34,18 @@ class ScheduleSeLinuxRelabeling(Actor):
                             '/.autorelabel file touched on root in order to schedule SElinux relabelling.'),
                         reporting.Severity(reporting.Severity.INFO),
                         reporting.Tags(COMMON_REPORT_TAGS),
-                    ])
+                    ] + related)
 
                 except OSError as e:
                     # FIXME: add an "action required" flag later
                     create_report([
                         reporting.Title('Could not schedule SElinux for relabelling'),
-                        reporting.Summary('./autorelabel file could not be created: {}.'.format(e)),
+                        reporting.Summary('/.autorelabel file could not be created: {}.'.format(e)),
                         reporting.Severity(reporting.Severity.HIGH),
                         reporting.Tags(COMMON_REPORT_TAGS),
                         reporting.Remediation(
                             hint='Please set autorelabelling manually after the upgrade.'
                         ),
                         reporting.Flags([reporting.Flags.FAILURE])
-                    ])
+                    ] + related)
                     self.log.critical('Could not schedule SElinux for relabelling: %s.' % e)

--- a/repos/system_upgrade/el7toel8/actors/setpermissiveselinux/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/setpermissiveselinux/actor.py
@@ -30,6 +30,7 @@ class SetPermissiveSelinux(Actor):
                         reporting.Summary('{}'.format(err_msg)),
                         reporting.Severity(reporting.Severity.HIGH),
                         reporting.Tags([reporting.Tags.SELINUX, reporting.Tags.SECURITY]),
-                        reporting.Flags([reporting.Flags.FAILURE])
+                        reporting.Flags([reporting.Flags.FAILURE]),
+                        reporting.RelatedResource('file', '/etc/selinux/config')
                     ])
                     self.log.critical('Could not set SElinux into permissive mode: %s.' % err_msg)

--- a/repos/system_upgrade/el7toel8/actors/sssdcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sssdcheck/actor.py
@@ -7,6 +7,11 @@ from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
 
 COMMON_REPORT_TAGS = [reporting.Tags.AUTHENTICATION, reporting.Tags.SECURITY]
 
+related = [
+    reporting.RelatedResource('package', 'sssd'),
+    reporting.RelatedResource('file', '/etc/sssd/sssd.conf')
+]
+
 
 class SSSDCheck(Actor):
     '''
@@ -49,7 +54,7 @@ class SSSDCheck(Actor):
             reporting.Summary('Local provider is no longer supported.'),
             reporting.Tags(COMMON_REPORT_TAGS),
             reporting.Severity(reporting.Severity.MEDIUM)
-            ])
+        ] + related)
 
     def reportRemovedOption(self, domain, option):
         create_report([
@@ -58,7 +63,7 @@ class SSSDCheck(Actor):
             reporting.Summary('Option %s was removed and it will be ignored.' % option),
             reporting.Tags(COMMON_REPORT_TAGS),
             reporting.Severity(reporting.Severity.MEDIUM)
-        ])
+        ] + related)
 
     def reportSudoRegexp(self, domain):
         create_report([
@@ -71,4 +76,4 @@ class SSSDCheck(Actor):
                 hint='If you use sudo rules with wildcards, set this option to true explicitly.'
             ),
             reporting.Severity(reporting.Severity.HIGH)
-        ])
+        ] + related)

--- a/repos/system_upgrade/el7toel8/actors/storagescanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/storagescanner/libraries/library.py
@@ -119,7 +119,8 @@ def _get_fstab_info(fstab_path):
                         reporting.Severity(reporting.Severity.HIGH),
                         reporting.Tags([reporting.Tags.FILESYSTEM]),
                         reporting.Flags([reporting.Flags.INHIBITOR]),
-                        reporting.Remediation(hint=remediation)
+                        reporting.Remediation(hint=remediation),
+                        reporting.RelatedResource('file', '/etc/fstab')
                     ])
 
                     api.current_logger().error(summary)

--- a/repos/system_upgrade/el7toel8/actors/tcpwrapperscheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/tcpwrapperscheck/actor.py
@@ -74,5 +74,8 @@ class TcpWrappersCheck(Actor):
                     url='https://access.redhat.com/solutions/3906701'
                 ),
                 reporting.Tags([reporting.Tags.SECURITY, reporting.Tags.NETWORK]),
-                reporting.Flags([reporting.Flags.INHIBITOR])
-            ])
+                reporting.Flags([reporting.Flags.INHIBITOR]),
+                reporting.RelatedResource('file', '/etc/hosts.allow'),
+                reporting.RelatedResource('file', '/etc/hosts.deny'),
+                reporting.RelatedResource('package', 'tcp_wrappers')
+            ] + [reporting.RelatedResource('package', fp) for fp in found_packages])

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigcheck/libraries/library.py
@@ -26,5 +26,7 @@ def check_config_supported(tcpwrap_facts, vsftpd_facts):
             reporting.ExternalLink(
                 title='Replacing TCP Wrappers in RHEL 8',
                 url='https://access.redhat.com/solutions/3906701'
-            )
-        ])
+            ),
+            reporting.RelatedResource('package', 'tcp_wrappers'),
+            reporting.RelatedResource('package', 'vsftpd'),
+        ] + [reporting.RelatedResource('file', str(bc)) for bc in bad_configs])


### PR DESCRIPTION
Report entries can have various `RelatedResources`, currently
we recognize the following 6 types of resources:
- file
- package
- directory
- repository
- kernel-driver
- pam