### PR TITLE
Fix traceback in dnfupgradetransaction if RHSM is skipped

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/dnfupgradetransaction/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/dnfupgradetransaction/actor.py
@@ -31,8 +31,9 @@ class DnfUpgradeTransaction(Actor):
         # run(cmd)
 
         src_rhsm_info = next(self.consume(SourceRHSMInfo), None)
-        for prod_cert in src_rhsm_info.existing_product_certificates:
-            run(['rm', '-f', prod_cert])
+        if src_rhsm_info:
+            for prod_cert in src_rhsm_info.existing_product_certificates:
+                run(['rm', '-f', prod_cert])
 
         used_repos = self.consume(UsedTargetRepositories)
         tasks = next(self.consume(FilteredRpmTransactionTasks), FilteredRpmTransactionTasks())


### PR DESCRIPTION
Previously some change introduced removing certificates as specified by
the SourceRHSMInfo message.
However this message might not be available if RHSM is skipped.
In that case a None object will be returned by the next() call.
While trying to access the existing_product_certificates member of the
message, which actually is a None object, an AttributeError exception
happens.

This patch fixes this issue.

Fixes Rabbit: OAMG-515
Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>