### PR TITLE
Add a comment to a shady Makefile line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ source: prepare
 		COPR_REPO=$(_COPR_REPO_TMP) COPR_PACKAGE=$(DEPS_PKGNAME) \
 		$(_USE_PYTHON_INTERPRETER) ./utils/get_latest_copr_build > packaging/tmp/deps_build_id
 	@copr --config $(_COPR_CONFIG) download-build -d packaging/tmp `cat packaging/tmp/deps_build_id`
+	# Move rpms from any subfolder of packaging/tmp/, like packaging/tmp/rhel-8.dev-x86_64/, to packaging/tmp/
 	@mv `find packaging/tmp/ | grep "rpm$$" | grep -v "src"` packaging/tmp
 	@tar -czf packaging/sources/deps-pkgs.tar.gz -C packaging/tmp/ `ls packaging/tmp | grep -o "[^/]*rpm$$"`
 	@rm -rf packaging/tmp


### PR DESCRIPTION
This line seems to be useless - to move rpms from where they are to the same location - but it actually moves them from subfolders.