### PR TITLE
initramdisk generator: respect sys architecture

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/initramdiskgenerator/libraries/initramgen.py
+++ b/repos/system_upgrade/el7toel8/actors/initramdiskgenerator/libraries/initramgen.py
@@ -70,8 +70,9 @@ def generate_initram_disk(context):
     install_initram_deps(context)
     context.call([
         '/bin/sh', '-c',
-        'LEAPP_ADD_DRACUT_MODULES={modules} {cmd}'.format(
+        'LEAPP_ADD_DRACUT_MODULES={modules} LEAPP_KERNEL_ARCH={arch} {cmd}'.format(
             modules=','.join([mod.name for mod in modules]),
+            arch=api.current_actor().configuration.architecture,
             cmd=os.path.join('/', INITRAM_GEN_SCRIPT_NAME))
     ])
     copy_boot_files(context)
@@ -82,8 +83,9 @@ def copy_boot_files(context):
     Function to copy the generated initram and corresponding kernel to /boot - Additionally produces a BootContent
     message with their location.
     """
-    kernel = 'vmlinuz-upgrade.x86_64'
-    initram = 'initramfs-upgrade.x86_64.img'
+    curr_arch = api.current_actor().configuration.architecture
+    kernel = 'vmlinuz-upgrade.{}'.format(curr_arch)
+    initram = 'initramfs-upgrade.{}.img'.format(curr_arch)
     content = BootContent(
         kernel_path=os.path.join('/boot', kernel),
         initram_path=os.path.join('/boot', initram)


### PR DESCRIPTION
Previously the x86_64 architecture was hardcoded. Now, it should work on other architectures as well (excluding problems with requirements of modules that does not exists - so actor still crashes
in such case in specific cases).