### PR TITLE
Improve message on failed submgr cmd

### DIFF
--- a/repos/system_upgrade/el7toel8/libraries/rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/rhsm.py
@@ -52,15 +52,17 @@ def _handle_rhsm_exceptions(hint=None):
     except OSError as e:
         api.current_logger().error('Failed to execute subscription-manager executable')
         raise StopActorExecutionError(
-            message='Unable to execute subscription-manager executable. Message: {}'.format(str(e)),
+            message='Unable to execute subscription-manager executable: {}'.format(str(e)),
             details={
-                'hint': 'Please ensure subscription-manager is installed and exceutable.'
+                'hint': 'Please ensure subscription-manager is installed and executable.'
             }
         )
     except CalledProcessError as e:
         raise StopActorExecutionError(
             message='A subscription-manager command failed to execute',
             details={
+                'details': str(e),
+                'stderr': e.stderr,
                 'hint': hint or 'Please ensure you have a valid RHEL subscription and your network is up.'
             }
         )


### PR DESCRIPTION
Till now the error message was not very descriptive about the reason why a subscription-manager call failed:
```
[ERROR] Actor: target_userspace_creator Message: A subscription-manager command failed to execute
Detail: {u'hint': u'Please ensure you have a valid RHEL subscription and your network is up.'}
```

After this and the related https://github.com/oamg/leapp/pull/552 changes:
```
[ERROR]  Actor: target_userspace_creator Message: A subscription-manager command failed to execute
Detail: {u'details': u"Command ['subscription-manager', 'release', '--unset'] failed with exit code 70.",
 u'hint': u'Please ensure you have a valid RHEL subscription and your network is up.',
 u'stderr': u'Host and machine ids are equal (d924fee74944427ab8e3868bf1625817): refusing to link journals\nSystem certificates corrupted. Please reregister.\n'}
```

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1746956