### PR TITLE
Makefile: use release 100 for master branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ MASTER_BRANCH=master
 
 # In case the PR or MR is defined or in case build is not comming from the
 # MATER_BRANCH branch, N_REL=0; (so build is not update of the approved
-# upstream solution). For upstream builds N_REL=1;
-N_REL=`_NR=$${PR:+0}; if test "$${_NR:-1}" == "1"; then _NR=$${MR:+0}; fi; git rev-parse --abbrev-ref HEAD | grep -qE "^($(MASTER_BRANCH)|stable)$$" || _NR=0;  echo $${_NR:-1}`
+# upstream solution). For upstream builds N_REL=100;
+N_REL=`_NR=$${PR:+0}; if test "$${_NR:-100}" == "100"; then _NR=$${MR:+0}; fi; git rev-parse --abbrev-ref HEAD | grep -qE "^($(MASTER_BRANCH)|stable)$$" || _NR=0;  echo $${_NR:-100}`
 
 TIMESTAMP:=$${__TIMESTAMP:-$(shell /bin/date -u "+%Y%m%d%H%MZ")}
 SHORT_SHA=`git rev-parse --short HEAD`


### PR DESCRIPTION
We had some issues with rpms in downstream when people installed
mix of upstream and downstream rpms by default because of higher
release there. After some discussions we will rather use release
100 instead of 1 for upstream builds by default.