### PR TITLE
CheckBrltty: remove confusing report message

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkbrltty/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkbrltty/actor.py
@@ -54,10 +54,3 @@ class CheckBrltty(Actor):
 
                 self.produce(BrlttyMigrationDecision(migrate_file=migrate_file, migrate_bt=migrate_bt,
                                                      migrate_espeak=migrate_espeak))
-            else:
-                create_report([
-                    reporting.Title('brltty configuration will be not migrated'),
-                    reporting.Summary('brltty configuration seems to be compatible'),
-                    reporting.Severity(reporting.Severity.LOW),
-                    reporting.Tags([reporting.Tags.ACCESSIBILITY]),
-                ] + related)


### PR DESCRIPTION
Previously the report with low priority would be
created if the brltty configuration appeared to be
compatible.