### PR TITLE
mock_configs: add disclaimer about testing purposes

### DIFF
--- a/repos/system_upgrade/el7toel8/libraries/config/mock_configs.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/mock_configs.py
@@ -1,3 +1,11 @@
+
+"""
+This is not regular library.
+
+The library is supposed to be used only for testing purposes. Import of the
+library is expected only inside test files.
+"""
+
 from leapp.models import IPUConfig, EnvVar, OSRelease, Version
 
 CONFIG = IPUConfig(


### PR DESCRIPTION
Not so required to have. But I think it's more safe to add there something like that. Whad do you think?