### PR TITLE
packaging: drop dnf from deps on RHEL-7 system

### DIFF
--- a/packaging/leapp-el7toel8-deps.spec
+++ b/packaging/leapp-el7toel8-deps.spec
@@ -18,7 +18,7 @@ URL:        https://oamg.github.io/leapp/
 ##################################################
 %package -n %{lrdname}
 Summary:    Meta-package with system dependencies for leapp repository
-Provides:   leapp-repository-dependencies = 5
+Provides:   leapp-repository-dependencies = 6
 Obsoletes:  leapp-repository-deps
 
 Requires:   dnf >= 4

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -56,11 +56,10 @@ Summary:    Meta-package with system dependencies of %{name} package
 
 # IMPORTANT: everytime the requirements are changed, increment number by one
 # - same for Requires in main package
-Provides:  leapp-repository-dependencies = 5
+Provides:  leapp-repository-dependencies = 6
 ##################################################
 # Real requirements for the leapp-repository HERE
 ##################################################
-Requires:   dnf >= 4
 Requires:   pciutils
 %if 0%{?rhel} && 0%{?rhel} == 7
 # Required to gather system facts about SELinux


### PR DESCRIPTION
Since we are using DNF from RHEL-8 userspace, we haven't need to
depend on DNF anymore on RHEL-7 system. Keeping the dependency on
RHEL-8 even when I am not sure whether we need it.