### PR TITLE
Fix a broken assertion in a test

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
@@ -50,4 +50,7 @@ def test_actor_execution_with_unsigned_data(monkeypatch):
     library.generate_report(packages)
     assert reporting.create_report.called == 1
     assert 'Packages not signed by Red Hat found' in reporting.create_report.report_fields['title']
-    assert ['yum remove sample' in r for r in reporting.create_report.report_fields['remediations']]
+    assert all(r['remediations']['context'][0] == 'yum' and
+               r['remediations']['context'][1] == 'remove' and
+               'sample' in r['remediations']['context'][2]
+               for r in reporting.create_report.report_fields['remediations'])


### PR DESCRIPTION
While researching how to unit test that remediation is correctly set, I noticed that
an assertion in a test was incorrectly rewritten in commit 548a3b83909c4. The
assertion is not looking for the expected data where it should. To
test the actual data, we need to reach far deeper into the object hierarchy.

As it is now, the assertion effectively checks that the list [False]
is True (which it is, because a non-zero length list is True). So the
assertion passes even though we don't want it to.