### PR TITLE
Multi partition overlayfs support

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -40,7 +40,7 @@ do_upgrade() {
     # TODO: update: systemd-nspawn
     nspawn_opts="--capability=all --bind=/sys --bind=/dev --bind=/dev/pts --bind=/run/systemd --bind=/proc"
     nspawn_opts="$nspawn_opts  --bind=/run/udev --keep-unit --register=no --timezone=off --resolv-conf=off"
-    /bin/systemd-nspawn $nspawn_opts -D $NEWROOT $LEAPPBIN upgrade --resume $args
+    /bin/systemd-nspawn $nspawn_opts -D /usr/bin/bash -c "mount -a; $NEWROOT $LEAPPBIN upgrade --resume $args"
     rv=$?
 
     # NOTE: flush the cached content to disk to ensure everything is written

--- a/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -29,18 +29,13 @@ do_upgrade() {
         getargbool 0 enforcing || echo 0 > /sys/fs/selinux/enforce
     fi
 
-    # Incase we have the LVM command available try make it activate all partitions
-    if command -v lvm 2>/dev/null 1>/dev/null; then
-        lvm vgchange -a y
-    fi
-
     # and off we go...
     # NOTE: in case we would need to run leapp before pivot, we would need to
     #       specify where the root is, e.g. --root=/sysroot
     # TODO: update: systemd-nspawn
     nspawn_opts="--capability=all --bind=/sys --bind=/dev --bind=/dev/pts --bind=/run/systemd --bind=/proc"
     nspawn_opts="$nspawn_opts  --bind=/run/udev --keep-unit --register=no --timezone=off --resolv-conf=off"
-    /bin/systemd-nspawn $nspawn_opts -D /usr/bin/bash -c "mount -a; $NEWROOT $LEAPPBIN upgrade --resume $args"
+    /bin/systemd-nspawn $nspawn_opts -D $NEWROOT /usr/bin/bash -c "mount -a; $LEAPPBIN upgrade --resume $args"
     rv=$?
 
     # NOTE: flush the cached content to disk to ensure everything is written

--- a/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/module-setup.sh
+++ b/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/module-setup.sh
@@ -75,6 +75,7 @@ install() {
     inst_binary sync
 
     # script to actually run the upgrader binary
+    inst_hook upgrade 49 "$moddir/mount_usr.sh"
     inst_hook upgrade 50 "$moddir/do-upgrade.sh"
 
     #NOTE: some clean up?.. ideally, everything should be inside the leapp*

--- a/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/mount_usr.sh
+++ b/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/mount_usr.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+type info >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+export NEWROOT=${NEWROOT:-"/sysroot"}
+
+filtersubvol() {
+    local _oldifs
+    _oldifs="$IFS"
+    IFS=","
+    set $*
+    IFS="$_oldifs"
+    while [ $# -gt 0 ]; do
+        case $1 in
+            subvol\=*) :;;
+            *) printf '%s' "${1}," ;;
+        esac
+        shift
+    done
+}
+
+mount_usr()
+{
+    local _dev _mp _fs _opts _rest _usr_found _ret _freq _passno
+    # check, if we have to mount the /usr filesystem
+    while read _dev _mp _fs _opts _freq _passno; do
+        [ "${_dev%%#*}" != "$_dev" ] && continue
+        if [ "$_mp" = "/usr" ]; then
+            case "$_dev" in
+                LABEL=*)
+                    _dev="$(echo $_dev | sed 's,/,\\x2f,g')"
+                    _dev="/dev/disk/by-label/${_dev#LABEL=}"
+                    ;;
+                UUID=*)
+                    _dev="${_dev#block:}"
+                    _dev="/dev/disk/by-uuid/${_dev#UUID=}"
+                    ;;
+            esac
+            if strstr "$_opts" "subvol=" && \
+                [ "${root#block:}" -ef $_dev ] && \
+                [ -n "$rflags" ]; then
+                # for btrfs subvolumes we have to mount /usr with the same rflags
+                rflags=$(filtersubvol "$rflags")
+                rflags=${rflags%%,}
+                _opts="${_opts:+${_opts},}${rflags}"
+            elif getargbool 0 ro; then
+                # if "ro" is specified, we want /usr to be mounted read-only
+                _opts="${_opts:+${_opts},}ro"
+            elif getargbool 0 rw; then
+                # if "rw" is specified, we want /usr to be mounted read-write
+                _opts="${_opts:+${_opts},}rw"
+            fi
+            echo "$_dev ${NEWROOT}${_mp} $_fs ${_opts} $_freq $_passno"
+            _usr_found="1"
+            break
+        fi
+    done < "$NEWROOT/etc/fstab" >> /etc/fstab
+
+    if [ "$_usr_found" != "" ]; then
+        info "Mounting /usr with -o $_opts"
+        mount "$NEWROOT/usr" 2>&1 | vinfo
+        mount -o remount,rw "$NEWROOT/usr"
+
+        if ! ismounted "$NEWROOT/usr"; then
+            warn "Mounting /usr to $NEWROOT/usr failed"
+            warn "*** Dropping you to a shell; the system will continue"
+            warn "*** when you leave the shell."
+            action_on_fail
+        fi
+    fi
+}
+
+if [ -f "$NEWROOT/etc/fstab" ]; then
+    # Incase we have the LVM command available try make it activate all partitions
+    if command -v lvm 2>/dev/null 1>/dev/null; then
+        lvm vgchange -a y
+    fi
+
+    mount_usr
+fi

--- a/repos/system_upgrade/el7toel8/actors/dnfpackagedownload/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/dnfpackagedownload/actor.py
@@ -1,6 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.common import dnfplugin
-from leapp.models import FilteredRpmTransactionTasks, TargetUserSpaceInfo, UsedTargetRepositories, XFSPresence
+from leapp.models import (FilteredRpmTransactionTasks, StorageInfo, TargetUserSpaceInfo, UsedTargetRepositories,
+                          XFSPresence)
 from leapp.tags import DownloadPhaseTag, IPUWorkflowTag
 
 
@@ -13,16 +14,16 @@ class DnfPackageDownload(Actor):
     """
 
     name = 'dnf_package_download'
-    consumes = (UsedTargetRepositories, FilteredRpmTransactionTasks, TargetUserSpaceInfo, XFSPresence)
+    consumes = (UsedTargetRepositories, FilteredRpmTransactionTasks, StorageInfo, TargetUserSpaceInfo, XFSPresence)
     produces = ()
     tags = (IPUWorkflowTag, DownloadPhaseTag)
 
     def process(self):
-        presence = next(self.consume(XFSPresence), XFSPresence())
-        xfs_present = presence.present and presence.without_ftype
+        xfs_info = next(self.consume(XFSPresence), XFSPresence())
+        storage_info = next(self.consume(StorageInfo), StorageInfo())
         used_repos = self.consume(UsedTargetRepositories)
         tasks = next(self.consume(FilteredRpmTransactionTasks), FilteredRpmTransactionTasks())
         target_userspace_info = next(self.consume(TargetUserSpaceInfo), None)
 
         dnfplugin.perform_rpm_download(tasks=tasks, used_repos=used_repos, target_userspace_info=target_userspace_info,
-                                       xfs_present=xfs_present)
+                                       xfs_info=xfs_info, storage_info=storage_info)

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
@@ -2,7 +2,8 @@ from leapp.actors import Actor
 from leapp.libraries.actor import userspacegen
 from leapp.libraries.common.config import version
 from leapp.models import (OSReleaseFacts, RepositoriesMap, RequiredTargetUserspacePackages, SourceRHSMInfo,
-                          TargetRepositories, TargetRHSMInfo, TargetUserSpaceInfo, UsedTargetRepositories, XFSPresence)
+                          StorageInfo, TargetRepositories, TargetRHSMInfo, TargetUserSpaceInfo, UsedTargetRepositories,
+                          XFSPresence)
 from leapp.tags import TargetTransactionFactsPhaseTag, IPUWorkflowTag
 
 
@@ -19,7 +20,7 @@ class TargetUserspaceCreator(Actor):
 
     name = 'target_userspace_creator'
     consumes = (OSReleaseFacts, RepositoriesMap, RequiredTargetUserspacePackages,
-                SourceRHSMInfo, TargetRepositories, XFSPresence)
+                StorageInfo, SourceRHSMInfo, TargetRepositories, XFSPresence)
     produces = (TargetRHSMInfo, TargetUserSpaceInfo, UsedTargetRepositories)
     tags = (IPUWorkflowTag, TargetTransactionFactsPhaseTag)
 

--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -7,8 +7,8 @@ class produce_mocked(object):
         self.model_instances = []
 
     def __call__(self, *model_instances):
-        self.called += 1
-        self.model_instances.append(model_instances[0])
+        self.called += len(model_instances)
+        self.model_instances.extend(list(model_instances))
 
 
 class create_report_mocked(object):


### PR DESCRIPTION
Previously leapp did not support more than /boot, /home and the / (root)
partitions. The problem lies in the way how overlay mounts work. This
patch introduces changes to the code base to allow for any partition
that is configured in /etc/fstab. Other parititions are not being
considered and currently expected to be irrelevant to the system's
upgrade.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>

This PR depends on https://github.com/oamg/leapp-repository/pull/331