### PR TITLE
Switch target release from 8.0 to 8.1

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
@@ -3,7 +3,7 @@ import os
 from leapp import reporting
 from leapp.models import EnvVar, OSRelease
 
-CURRENT_TARGET_VERSION = '8.0'
+CURRENT_TARGET_VERSION = '8.1'
 
 ENV_IGNORE = ('LEAPP_CURRENT_PHASE', 'LEAPP_CURRENT_ACTOR', 'LEAPP_VERBOSE',
               'LEAPP_DEBUG')

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -28,7 +28,7 @@ def prepare_target_userspace(context, userspace_dir, enabled_repos, packages):
                '--nogpgcheck',
                '--setopt=module_platform_id=platform:el8',
                '--setopt=keepcache=1',
-               '--releasever', '8',
+               '--releasever', api.current_actor().configuration.version.target,
                '--installroot', '/el8target',
                '--disablerepo', '*'
                ] + repos_opt + packages

--- a/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
+++ b/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
@@ -51,7 +51,7 @@ def build_plugin_data(target_repoids, debug, test, tasks):
             'enable_repos': target_repoids,
             'gpgcheck': False,
             'platform_id': 'platform:el8',
-            'releasever': '8',
+            'releasever': api.current_actor().configuration.version.target,
             'installroot': '/installroot',
             'test_flag': test
         }


### PR DESCRIPTION
Make sure the dnf calls respect this target version.

Since CDN does not contain 8.1 content yet, after this PR is merged, we'll need to test with custom repos only, using the LEAPP_DEVEL_SKIP_RHSM=1.