### PR TITLE
Fix bug when adding remote rpms

### DIFF
--- a/repos/system_upgrade/el7toel8/files/rhel_upgrade.py
+++ b/repos/system_upgrade/el7toel8/files/rhel_upgrade.py
@@ -67,7 +67,11 @@ class RhelUpgradeCommand(dnf.cli.Command):
                 repo.enable()
 
     def run(self):
-        self.base.add_remote_rpms(self.plugin_data['pkgs_info']['local_rpms'])
+        # takes local rpms, creates Package objects from them, and then adds them to the sack as virtual repository
+        local_rpm_objects = self.base.add_remote_rpms(self.plugin_data['pkgs_info']['local_rpms'])
+
+        for pkg in local_rpm_objects:
+            self.base.package_install(pkg)
 
         for pkg_spec in self.plugin_data['pkgs_info']['to_remove']:
             try:


### PR DESCRIPTION
Currently, when adding remote rpms, we added them only to the
sack as rpm objects, however never to the transaction itself.

It was working for us only because the rpms we added to the
sack was brought to the transaction by another package.