### PR TITLE
Check s390x

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkcpu/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkcpu/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import cpu
+from leapp.models import CPUInfo, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckCPU(Actor):
+    """
+    Check whether the CPU is supported by the target system. Inhibit upgrade if not.
+
+    Currently we know just about cases with s390x where the set of CPUs supported
+    by RHEL 8 is subset of CPUs supported on RHEL 7. We can detect such cases based
+    on the machine field inside the /proc/cpuinfo file. expected values of the
+    field on supported machines are: 2964, 2965, 3906, 3907.
+    """
+
+    name = "checkcpu"
+    consumes = (CPUInfo,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        cpu.process()

--- a/repos/system_upgrade/el7toel8/actors/checkcpu/libraries/cpu.py
+++ b/repos/system_upgrade/el7toel8/actors/checkcpu/libraries/cpu.py
@@ -1,0 +1,43 @@
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+from leapp.models import CPUInfo
+
+SUPPORTED_MACHINE_TYPES = [2964, 2965, 3906, 3907]
+
+
+def process():
+    if not architecture.matches_architecture(architecture.ARCH_S390X):
+        return
+    cpuinfo = next(api.consume(CPUInfo), None)
+    if cpuinfo is None:
+        raise StopActorExecutionError(message=("Missing information about CPU."))
+
+    if not cpuinfo.machine_type:
+        # this is not expected to happen, but in case...
+        api.curernt_logger().warning("The machine (CPU) type is empty.")
+
+    if cpuinfo.machine_type not in SUPPORTED_MACHINE_TYPES:
+        summary = ("The machine is not possible to upgrade because of unsupported"
+                   " type of the processor. Regarding the official documentation,"
+                   " z13 and z14 processors are supported on the Red Had Enterprise"
+                   " Linux 8 system for the IBM Z architecture. If you have one of"
+                   " the supported processors, you should see provided the machine"
+                   " type in the /proc/cpuinfo file with one of those values: {}."
+                   " Detected machine type of the CPU is '{}'."
+                   .format(", ".join([str(i) for i in SUPPORTED_MACHINE_TYPES]), cpuinfo.machine_type))
+        report = [
+            reporting.Title("The processor is not supported by the target system."),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.SANITY]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.ExternalLink(
+                title="Considerations in adopting RHEL 8",
+                url=("https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/"
+                     "html-single/considerations_in_adopting_rhel_8/"
+                     "index#changes-in-gcc-in-rhel-8_changes-in-toolchain-since-rhel-7"))
+        ]
+        reporting.create_report(report)

--- a/repos/system_upgrade/el7toel8/actors/checkcpu/tests/test_check_cpu.py
+++ b/repos/system_upgrade/el7toel8/actors/checkcpu/tests/test_check_cpu.py
@@ -1,0 +1,55 @@
+from collections import namedtuple
+
+import pytest
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import cpu
+from leapp.libraries.common import testutils
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+from leapp.models import CPUInfo
+
+
+class CurrentActorMocked(object):
+    def __init__(self, arch):
+        self.configuration = namedtuple('configuration', ['architecture'])(arch)
+
+    def __call__(self):
+        return self
+
+
+def test_non_ibmz_arch(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+    monkeypatch.setattr(reporting, "create_report", testutils.create_report_mocked())
+    cpu.process()
+    assert not reporting.create_report.called
+
+
+def test_ibmz_arch_missing_cpuinfo(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
+    monkeypatch.setattr(reporting, "create_report", testutils.create_report_mocked())
+    monkeypatch.setattr(api, 'consume', lambda x: iter([]))
+    with pytest.raises(StopActorExecutionError):
+        cpu.process()
+    assert not reporting.create_report.called
+
+
+def test_ibmz_cpu_supported(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
+    monkeypatch.setattr(reporting, "create_report", testutils.create_report_mocked())
+    for sup_arch in cpu.SUPPORTED_MACHINE_TYPES:
+        monkeypatch.setattr(api, 'consume', lambda x: iter([CPUInfo(machine_type=sup_arch)]))
+        cpu.process()
+        assert not reporting.create_report.called
+
+
+def test_ibmz_cpu_unsupported(monkeypatch):
+    title_msg = 'The processor is not supported by the target system.'
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
+    monkeypatch.setattr(api, 'consume', lambda x: iter([CPUInfo(machine_type=666)]))
+    monkeypatch.setattr(reporting, "create_report", testutils.create_report_mocked())
+    cpu.process()
+    assert reporting.create_report.called
+    assert title_msg == reporting.create_report.report_fields['title']
+    assert reporting.Flags.INHIBITOR in reporting.create_report.report_fields['flags']

--- a/repos/system_upgrade/el7toel8/actors/scancpu/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scancpu/actor.py
@@ -1,0 +1,16 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import cpu
+from leapp.models import CPUInfo
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+
+
+class ScanCPU(Actor):
+    """Scan CPUs of the machine."""
+
+    name = 'scancpu'
+    consumes = ()
+    produces = (CPUInfo)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        cpu.process()

--- a/repos/system_upgrade/el7toel8/actors/scancpu/libraries/cpu.py
+++ b/repos/system_upgrade/el7toel8/actors/scancpu/libraries/cpu.py
@@ -1,0 +1,24 @@
+import re
+
+from leapp.libraries.stdlib import api
+from leapp.models import CPUInfo
+
+RE_MACHINE_TYPE = re.compile(r'^processor.*\smachine\s*=\s*([0-9]+)')
+
+
+def _get_cpuinfo():
+    """Return lines from /proc/cpuinfo."""
+    # Expecting the file exists on earch system, skipping any check
+    with open('/proc/cpuinfo', 'rb') as fp:
+        return fp.readlines()
+
+
+def process():
+    cpuinfo = CPUInfo()
+
+    machine_types = [RE_MACHINE_TYPE.findall(line) for line in _get_cpuinfo()]
+    machine_types = [i[0] for i in machine_types if i]
+    if machine_types:
+        # machine type should be same for all found cpus
+        cpuinfo.machine_type = int(machine_types[0])
+    api.produce(cpuinfo)

--- a/repos/system_upgrade/el7toel8/actors/scancpu/tests/files/cpuinfo_s390x
+++ b/repos/system_upgrade/el7toel8/actors/scancpu/tests/files/cpuinfo_s390x
@@ -1,0 +1,22 @@
+vendor_id       : IBM/S390
+# processors    : 2
+bogomips per cpu: 2913.00
+max thread id   : 0
+features	: esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te sie 
+facilities      : 0 1 2 3 4 6 7 8 9 10 12 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 40 41 42 43 44 45 46 47 48 49 50 51 52 57 73 74 75 76 77 81 82
+cache0          : level=1 type=Data scope=Private size=96K line_size=256 associativity=6
+cache1          : level=1 type=Instruction scope=Private size=64K line_size=256 associativity=4
+cache2          : level=2 type=Data scope=Private size=1024K line_size=256 associativity=8
+cache3          : level=2 type=Instruction scope=Private size=1024K line_size=256 associativity=8
+cache4          : level=3 type=Unified scope=Shared size=49152K line_size=256 associativity=12
+cache5          : level=4 type=Unified scope=Shared size=393216K line_size=256 associativity=24
+processor 0: version = FF,  identification = 32C047,  machine = 2827
+processor 1: version = FF,  identification = 32C047,  machine = 2827
+
+cpu number      : 0
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504
+
+cpu number      : 1
+cpu MHz dynamic : 5504
+cpu MHz static  : 5504

--- a/repos/system_upgrade/el7toel8/actors/scancpu/tests/test_scancpu.py
+++ b/repos/system_upgrade/el7toel8/actors/scancpu/tests/test_scancpu.py
@@ -1,0 +1,38 @@
+import os
+
+from leapp.libraries.actor import cpu
+from leapp.libraries.common import testutils
+from leapp.libraries.stdlib import api
+from leapp.models import CPUInfo
+
+
+class mocked_get_cpuinfo(object):
+    def __init__(self, filename):
+        self.filename = filename
+
+    def __call__(self):
+        """
+        Return lines of the self.filename test file located in the files directory.
+
+        Those files contain /proc/cpuinfo content from several machines.
+        """
+        with open(os.path.join('tests/files', self.filename), 'rb') as fp:
+            return fp.readlines()
+
+
+def test_machine_type(monkeypatch):
+    # cpuinfo doesn't contain a machine field
+    mocked_cpuinfo = mocked_get_cpuinfo('cpuinfo_x86_64')
+    monkeypatch.setattr(cpu, '_get_cpuinfo', mocked_cpuinfo)
+    monkeypatch.setattr(api, 'produce', testutils.produce_mocked())
+    cpu.process()
+    assert api.produce.called == 1
+    assert CPUInfo() == api.produce.model_instances[0]
+
+    # cpuinfo contains a machine field
+    api.produce.called = 0
+    api.produce.model_instances = []
+    mocked_cpuinfo.filename = 'cpuinfo_s390x'
+    cpu.process()
+    assert api.produce.called == 1
+    assert CPUInfo(machine_type=2827) == api.produce.model_instances[0]

--- a/repos/system_upgrade/el7toel8/models/cpuinfo.py
+++ b/repos/system_upgrade/el7toel8/models/cpuinfo.py
@@ -1,0 +1,48 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemFactsTopic
+
+
+class CPUInfo(Model):
+    """
+    The model represents information about CPUs.
+
+    The model currently doesn't represent all information about cpus could
+    provide on the machine. Just part of them, in case any other attributes
+    will be neded, the model can be extended.
+
+    The provided info is aggregated - like from lscpu command. Expecting all
+    CPUs are same on the machine (at least for now).
+    """
+
+    topic = SystemFactsTopic
+
+    machine_type = fields.Nullable(fields.Integer())
+    """
+    Specifies machine type if provided.
+
+    This is important for the check of s390x, whether the HW is supported
+    by RHEL 8.
+    """
+
+    # TODO: regarding possible problems with LOCALE, I am keeping most of
+    # parts commented out and focus just on the one particular needed info.
+    # architecture = fields.String()
+    # """ Architecture of the CPU (e.g. x86_64) """
+
+    # byte_order = fields.StringEnum(['Little Endian', 'Big Endian'])
+    # """ Byte order of the CPU: 'Little Endian' or 'Big Endian' """
+
+    # flags = fields.List(fields.String(), default=[])
+    # """ Specifies flags/features of the CPU. """
+
+    # hypervisor = fields.Nullable(fields.String())
+    # hypervisor_vendor = fields.Nullable(fields.String())
+
+    # number = fields.Integer()
+    # """ Number of CPUs. """
+
+    # vendor_id = fields.Nullable(fields.String())
+    # """ ID of vendor of the CPU. """
+
+    # virtualization = fields.Nullable(fields.String())
+    # virtualization_type = fields.Nullable(fields.String())


### PR DESCRIPTION
Add two new actors to get information about CPU (in this case, we are interested just about the machine field for now) and check whether the machine's CPU is supported on RHEL 8. Currently we need this now just for the s390x architecture.