### PR TITLE
Add spamassassin migration actors

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigcheck/actor.py
@@ -1,0 +1,33 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import Report, SpamassassinFacts
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class SpamassassinConfigCheck(Actor):
+    """
+    Reports changes in spamassassin between RHEL-7 and RHEL-8
+
+    Reports backward-incompatible changes that have been made in spamassassin
+    between RHEL-7 and RHEL-8 (spamc no longer accepts an argument with the --ssl
+    option; spamd no longer accepts the --ssl-version; SSLv3 is no longer supported;
+    the type of spamassassin.service has been changed from "forking" to "simple";
+    sa-update no longer supports SHA1 validation of rule files).
+
+    The migration of the configuration files will be mostly handled by the
+    SpamassassinConfigUpdate actor, however the admin still needs to know about
+    the changes so that they can do any necessary migration in places that we cannot
+    reach (e.g. scripts).
+    """
+
+    name = 'spamassassin_config_check'
+    consumes = (SpamassassinFacts,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        facts = next(self.consume(SpamassassinFacts), None)
+        if facts:
+            library.produce_reports(facts)
+        else:
+            self.log.debug('Skipping execution - no SpamassassinFacts message has been produced.')

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigcheck/libraries/library.py
@@ -1,0 +1,104 @@
+from leapp import reporting
+from leapp.libraries.common.spamassassinutils import \
+    SPAMC_CONFIG_FILE, SPAMASSASSIN_SERVICE_OVERRIDE, SYSCONFIG_SPAMASSASSIN
+
+
+def _check_spamc_config(facts, report_func):
+    title = ('spamc no longer allows specifying the TLS version and no longer '
+             'supports SSLv3')
+    summary_generic = ('spamc no longer allows using the "--ssl" option with an '
+                       'argument specifying the TLS version - the option can only '
+                       'be used without an argument. Also, spamc no longer supports '
+                       'SSLv3.')
+    if facts.spamc_ssl_argument:
+        summary_detail = ('The spamc configuration file uses "--ssl %s", it will '
+                          'be updated during the upgrade.'
+                          % facts.spamc_ssl_argument)
+        summary = reporting.Summary('%s %s' % (summary_generic, summary_detail))
+        resource = reporting.RelatedResource('file', SPAMC_CONFIG_FILE)
+    else:
+        summary = reporting.Summary(summary_generic)
+        resource = None
+    severity = (reporting.Severity.HIGH if facts.spamc_ssl_argument == 'sslv3'
+                else reporting.Severity.MEDIUM)
+    hint = 'Please update your scripts and configuration, if there are any.'
+
+    args = [
+        reporting.Title(title),
+        summary,
+        reporting.Tags([reporting.Tags.ENCRYPTION]),
+        reporting.Severity(severity),
+        reporting.Remediation(hint=hint),
+    ]
+    if resource:
+        args.append(resource)
+    report_func(args)
+
+
+def _check_spamd_config_ssl(facts, report_func):
+    title = ('spamd no longer allows specifying the TLS version and no longer '
+             'supports SSLv3')
+    summary_generic = ('spamd no longer accepts the --ssl-version option and '
+                       'no longer supports SSLv3.')
+    if facts.spamd_ssl_version:
+        summary_detail = ('The spamd sysconfig file uses "--ssl-version %s", '
+                          'it will be updated during the upgrade.'
+                          % facts.spamd_ssl_version)
+        summary = reporting.Summary('%s %s' % (summary_generic, summary_detail))
+        resource = reporting.RelatedResource('file', SYSCONFIG_SPAMASSASSIN)
+    else:
+        summary = reporting.Summary(summary_generic)
+        resource = None
+    severity = (reporting.Severity.HIGH if facts.spamd_ssl_version == 'sslv3'
+                else reporting.Severity.MEDIUM)
+    hint = 'Please update your scripts and configuration, if there are any.'
+
+    args = [
+        reporting.Title(title),
+        summary,
+        reporting.Tags([reporting.Tags.ENCRYPTION, reporting.Tags.SERVICES]),
+        reporting.Severity(severity),
+        reporting.Remediation(hint=hint)
+    ]
+    if resource:
+        args.append(resource)
+    report_func(args)
+
+
+def _check_spamd_config_service_type(facts, report_func):
+    title = 'The type of the spamassassin systemd service has changed'
+    summary_generic = 'The type of spamassassin.service has been changed from "forking" to "simple".'
+    if facts.service_overriden:
+        summary_detail = 'However, the service appears to be overriden; no migration action will occur.'
+        resource = reporting.RelatedResource('file', SPAMASSASSIN_SERVICE_OVERRIDE)
+    else:
+        summary_detail = 'The spamassassin sysconfig file will be updated.'
+        resource = reporting.RelatedResource('file', SYSCONFIG_SPAMASSASSIN)
+    report_func([
+        reporting.Title(title),
+        reporting.Summary('%s %s' % (summary_generic, summary_detail)),
+        reporting.Tags([reporting.Tags.SERVICES]),
+        reporting.Severity(reporting.Severity.MEDIUM),
+        resource
+    ])
+
+
+def _report_sa_update_change(report_func):
+    summary = ('sa-update no longer supports SHA1 validation of filtering rules, '
+               'SHA256/SHA512 validation is done instead. This may affect you if '
+               'you are using an alternative update channel (sa-update used with '
+               'option --channel or --channelfile), or if you install filtering '
+               'rule updates directly from files (sa-update --install).')
+    report_func([reporting.Title('sa-update no longer supports SHA1 validation'),
+                 reporting.Summary(summary),
+                 reporting.Severity(reporting.Severity.LOW)])
+
+
+def produce_reports(facts):
+    """
+    Checks spamassassin configuration and produces reports.
+    """
+    _check_spamc_config(facts, reporting.create_report)
+    _check_spamd_config_ssl(facts, reporting.create_report)
+    _check_spamd_config_service_type(facts, reporting.create_report)
+    _report_sa_update_change(reporting.create_report)

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigcheck/tests/test_actor.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigcheck/tests/test_actor.py
@@ -1,0 +1,28 @@
+from leapp.models import SpamassassinFacts
+from leapp.reporting import Report
+from leapp.snactor.fixture import current_actor_context
+
+
+def test_actor_basic(current_actor_context):
+    facts = SpamassassinFacts(service_overriden=False)
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    reports = current_actor_context.consume(Report)
+
+    assert len(reports) == 4
+    report = reports[0]
+    assert '--ssl' in report.report['summary']
+    assert 'spamc' in report.report['summary']
+    report = reports[1]
+    assert '--ssl-version' in report.report['summary']
+    assert 'spamd' in report.report['summary']
+    report = reports[2]
+    assert 'spamassassin.service' in report.report['summary']
+    report = reports[3]
+    assert 'sa-update no longer supports SHA1' in report.report['summary']
+
+
+def test_actor_no_message(current_actor_context):
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigcheck/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigcheck/tests/test_library.py
@@ -1,0 +1,158 @@
+from leapp.libraries.actor import library
+from leapp.libraries.common.testutils import create_report_mocked
+from leapp.models import SpamassassinFacts
+
+
+def test_check_spamc_config_tlsv1():
+    facts = SpamassassinFacts(spamc_ssl_argument='tlsv1', service_overriden=False)
+    report_func = create_report_mocked()
+
+    library._check_spamc_config(facts, report_func)
+
+    assert report_func.called == 1
+    report_fields = report_func.report_fields
+    assert 'specifying the TLS version' in report_fields['title']
+    assert 'SSLv3' in report_fields['title']
+    assert '--ssl' in report_fields['summary']
+    assert 'SSLv3' in report_fields['summary']
+    assert 'spamc configuration file' in report_fields['summary']
+    assert '--ssl tlsv1' in report_fields['summary']
+    assert all('update your scripts' in r['remediations']['context']
+               for r in report_fields['remediations'])
+    assert report_fields['severity'] == 'medium'
+
+
+def test_check_spamc_config_sslv3():
+    facts = SpamassassinFacts(spamc_ssl_argument='sslv3', service_overriden=False)
+    report_func = create_report_mocked()
+
+    library._check_spamc_config(facts, report_func)
+
+    assert report_func.called == 1
+    report_fields = report_func.report_fields
+    assert 'specifying the TLS version' in report_fields['title']
+    assert 'SSLv3' in report_fields['title']
+    assert '--ssl' in report_fields['summary']
+    assert 'SSLv3' in report_fields['summary']
+    assert 'spamc configuration file' in report_fields['summary']
+    assert '--ssl sslv3' in report_fields['summary']
+    assert all('update your scripts' in r['remediations']['context']
+               for r in report_fields['remediations'])
+    assert report_fields['severity'] == 'high'
+
+
+def test_check_spamc_config_correct_config():
+    facts = SpamassassinFacts(spamc_ssl_argument=None, service_overriden=False)
+    report_func = create_report_mocked()
+
+    library._check_spamc_config(facts, report_func)
+
+    assert report_func.called == 1
+    report_fields = report_func.report_fields
+    assert 'specifying the TLS version' in report_fields['title']
+    assert 'SSLv3' in report_fields['title']
+    assert '--ssl' in report_fields['summary']
+    assert 'SSLv3' in report_fields['summary']
+    assert 'spamc configuration file' not in report_fields['summary']
+    assert all('update your scripts' in r['remediations']['context']
+               for r in report_fields['remediations'])
+    assert report_fields['severity'] == 'medium'
+
+
+def test_check_spamd_config_ssl_tlsv1():
+    facts = SpamassassinFacts(spamd_ssl_version='tlsv1', service_overriden=False)
+    report_func = create_report_mocked()
+
+    library._check_spamd_config_ssl(facts, report_func)
+
+    assert report_func.called == 1
+    report_fields = report_func.report_fields
+    assert 'specifying the TLS version' in report_fields['title']
+    assert 'SSLv3' in report_fields['title']
+    assert '--ssl-version' in report_fields['summary']
+    assert 'SSLv3' in report_fields['summary']
+    assert 'sysconfig' in report_fields['summary']
+    assert '--ssl-version tlsv1' in report_fields['summary']
+    assert all('update your scripts' in r['remediations']['context']
+               for r in report_fields['remediations'])
+    assert report_fields['severity'] == 'medium'
+
+
+def test_check_spamd_config_ssl_sslv3():
+    facts = SpamassassinFacts(spamd_ssl_version='sslv3', service_overriden=False)
+    report_func = create_report_mocked()
+
+    library._check_spamd_config_ssl(facts, report_func)
+
+    assert report_func.called == 1
+    report_fields = report_func.report_fields
+    assert 'specifying the TLS version' in report_fields['title']
+    assert 'SSLv3' in report_fields['title']
+    assert '--ssl-version' in report_fields['summary']
+    assert 'SSLv3' in report_fields['summary']
+    assert 'sysconfig' in report_fields['summary']
+    assert '--ssl-version sslv3' in report_fields['summary']
+    assert all('update your scripts' in r['remediations']['context']
+               for r in report_fields['remediations'])
+    assert report_fields['severity'] == 'high'
+
+
+def test_check_spamd_config_ssl_correct_config():
+    facts = SpamassassinFacts(spamd_ssl_version=None, service_overriden=False)
+    report_func = create_report_mocked()
+
+    library._check_spamd_config_ssl(facts, report_func)
+
+    assert report_func.called == 1
+    report_fields = report_func.report_fields
+    assert 'specifying the TLS version' in report_fields['title']
+    assert 'SSLv3' in report_fields['title']
+    assert '--ssl-version' in report_fields['summary']
+    assert 'SSLv3' in report_fields['summary']
+    assert 'sysconfig' not in report_fields['summary']
+    assert all('update your scripts' in r['remediations']['context']
+               for r in report_fields['remediations'])
+    assert report_fields['severity'] == 'medium'
+
+
+def test_check_spamd_config_service_type_service_overriden():
+    facts = SpamassassinFacts(service_overriden=True)
+    report_func = create_report_mocked()
+
+    library._check_spamd_config_service_type(facts, report_func)
+
+    assert report_func.called == 1
+    report_fields = report_func.report_fields
+    assert 'type of the spamassassin systemd service' in report_fields['title']
+    assert 'The type of spamassassin.service' in report_fields['summary']
+    assert 'overriden' in report_fields['summary']
+    assert report_fields['severity'] == 'medium'
+
+
+def test_check_spamd_config_service_type_service_not_overriden():
+    facts = SpamassassinFacts(service_overriden=False)
+    report_func = create_report_mocked()
+
+    library._check_spamd_config_service_type(facts, report_func)
+
+    assert report_func.called == 1
+    report_fields = report_func.report_fields
+    assert 'type of the spamassassin systemd service' in report_fields['title']
+    assert 'The type of spamassassin.service' in report_fields['summary']
+    assert 'will be updated' in report_fields['summary']
+    assert report_fields['severity'] == 'medium'
+
+
+def test_report_sa_update_change():
+    report_func = create_report_mocked()
+
+    library._report_sa_update_change(report_func)
+
+    assert report_func.called == 1
+    report_fields = report_func.report_fields
+    assert 'sa-update no longer supports SHA1' in report_fields['title']
+    assert 'no longer supports SHA1' in report_fields['summary']
+    assert 'SHA256/SHA512' in report_fields['summary']
+    assert '--channel or --channelfile' in report_fields['summary']
+    assert '--install' in report_fields['summary']
+    assert report_fields['severity'] == 'low'

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/actor.py
@@ -1,0 +1,26 @@
+import os
+
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.libraries.common.utils import read_file
+from leapp.models import InstalledRedHatSignedRPM, SpamassassinFacts
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class SpamassassinConfigRead(Actor):
+    """
+    Reads spamc configuration (/etc/mail/spamassassin/spamc.conf), the
+    spamassassin sysconfig file (/etc/sysconfig/spamassassin) and checks
+    whether the spamassassin service has been overriden. Produces
+    SpamassassinFacts containing the extracted information.
+    """
+
+    name = 'spamassassin_config_read'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (SpamassassinFacts,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        if library.is_processable():
+            self.produce(library.get_spamassassin_facts(read_func=read_file,
+                                                        listdir=os.listdir))

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/libraries/lib_spamc.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/libraries/lib_spamc.py
@@ -1,0 +1,35 @@
+import errno
+import re
+
+from leapp.libraries.common.spamassassinutils import SPAMC_CONFIG_FILE
+from leapp.libraries.stdlib import api
+
+
+def _remove_comments(content):
+    return re.sub(r'^#.*$', '', content, flags=re.MULTILINE)
+
+
+def _parse_spamc_ssl_argument(content):
+    content = _remove_comments(content)
+    res = None
+    for match in re.finditer(r'(?<!\S)--ssl(\s+|=)(sslv3|tlsv1)(?!\S)', content):
+        arg = match.group(2)
+        if arg == 'tlsv1' or (arg == 'sslv3' and res is None):
+            res = arg
+    return res
+
+
+def get_spamc_ssl_argument(read_func):
+    """
+    Extracts and returns the argument given to the --ssl option from the spamc
+    configuration file. Returns None if the option is not specified or the config
+    file does not exist.
+    """
+    try:
+        content = read_func(SPAMC_CONFIG_FILE)
+        return _parse_spamc_ssl_argument(content)
+    except (IOError, OSError) as e:
+        if e.errno != errno.ENOENT:
+            api.current_logger().warning(
+                'Failed to read spamc configuration file: %s' % e)
+        return None

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/libraries/lib_spamd.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/libraries/lib_spamd.py
@@ -1,0 +1,40 @@
+import errno
+import os
+import re
+
+import leapp.libraries.common.spamassassinutils as lib
+from leapp.libraries.stdlib import api
+
+
+def spamassassin_service_overriden(listdir):
+    file_name = os.path.basename(lib.SPAMASSASSIN_SERVICE_OVERRIDE)
+    dir_path = os.path.dirname(lib.SPAMASSASSIN_SERVICE_OVERRIDE)
+    try:
+        return file_name in listdir(dir_path)
+    except OSError as e:
+        return e.errno != errno.ENOENT
+
+
+def _parse_ssl_version(content):
+    _, assignment, _ = lib.parse_sysconfig_spamassassin(content)
+    if re.search(r'(?<![\w-])--ssl-version(=|\s+)sslv3(?![\w-])', assignment):
+        return 'sslv3'
+    elif re.search(r'(?<![\w-])--ssl-version(=|\s+)tlsv1(?![\w-])', assignment):
+        return 'tlsv1'
+    return None
+
+
+def get_spamd_ssl_version(read_func):
+    """
+    Extracts and returns the argument given to the --ssl-version option from
+    the spamassassin sysconfig file. Returns None if the option is not specified
+    or the file does not exist.
+    """
+    try:
+        content = read_func(lib.SYSCONFIG_SPAMASSASSIN)
+    except (IOError, OSError) as e:
+        if e.errno != errno.ENOENT:
+            api.current_logger().warning(
+                'Failed to read spamassassin sysconfig file: %s' % e)
+        return None
+    return _parse_ssl_version(content)

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/libraries/library.py
@@ -1,0 +1,27 @@
+from leapp.libraries.actor import lib_spamc, lib_spamd
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM, SpamassassinFacts
+
+
+def is_processable():
+    """
+    Checks whether the spamassassin package is installed.
+    """
+    res = has_package(InstalledRedHatSignedRPM, 'spamassassin')
+    if not res:
+        api.current_logger().debug('spamassassin is not installed.')
+    return res
+
+
+def get_spamassassin_facts(read_func, listdir):
+    """
+    Reads the spamc configuration file, the spamassassin sysconfig file and checks
+    whether the spamassassin service is overriden. Returns SpamassassinFacts.
+    """
+    spamc_ssl_argument = lib_spamc.get_spamc_ssl_argument(read_func)
+    service_overriden = lib_spamd.spamassassin_service_overriden(listdir)
+    spamd_ssl_version = lib_spamd.get_spamd_ssl_version(read_func)
+    return SpamassassinFacts(spamc_ssl_argument=spamc_ssl_argument,
+                             service_overriden=service_overriden,
+                             spamd_ssl_version=spamd_ssl_version)

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/tests/test_lib_spamc.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/tests/test_lib_spamc.py
@@ -1,0 +1,139 @@
+import errno
+
+from leapp.libraries.actor import lib_spamc
+from leapp.libraries.common.testutils import make_IOError
+
+
+class MockFileOperations(object):
+    def __init__(self, to_raise=None):
+        self.files = {}
+        self.files_read = {}
+        self.read_called = 0
+        self.to_raise = to_raise
+
+    def _increment_read_counters(self, path):
+        self.read_called += 1
+        self.files_read.setdefault(path, 0)
+        self.files_read[path] += 1
+
+    def read(self, path):
+        self._increment_read_counters(path)
+        if self.to_raise is not None:
+            raise self.to_raise
+        try:
+            return self.files[path]
+        except KeyError:
+            raise make_IOError(errno.ENOENT)
+
+
+def test_parse_spamc_ssl_argument():
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl sslv3')
+    assert value == 'sslv3'
+
+    # equal sign format
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl=tlsv1')
+    assert value == 'tlsv1'
+
+
+def test_parse_spamc_ssl_argument_without_valid_argument():
+    # unknown argument
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl foo')
+    assert value is None
+
+    # --ssl followed by another option
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl -B')
+    assert value is None
+
+    # space surrounding the equal sign. This amounts to an unrecognized
+    # argument (empty string)
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl= tlsv1')
+    assert value is None
+
+    # space surrounding the equal sign. This amounts to an unrecognized
+    # argument ("=tlsv1")
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl =tlsv1')
+    assert value is None
+
+
+def test_parse_spamc_ssl_argument_multiline():
+    value = lib_spamc._parse_spamc_ssl_argument('-B --ssl \n sslv3 -c\n-H')
+    assert value == 'sslv3'
+
+
+def test_parse_spamc_ssl_argument_tls_supersedes_ssl():
+    # Due to the way the spamc cmdline parser works, if '--ssl tlsv1' is
+    # specified, all other --ssl options are effectively ignored and tlsv1 is
+    # used.
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl sslv3 --ssl tlsv1')
+    assert value == 'tlsv1'
+
+    # reverse order
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl tlsv1 --ssl sslv3')
+    assert value == 'tlsv1'
+
+
+def test_parse_spamc_ssl_argument_comment():
+    value = lib_spamc._parse_spamc_ssl_argument('# --ssl tlsv1')
+    assert value is None
+
+    # comment mixed with actual option
+    value = lib_spamc._parse_spamc_ssl_argument('# --ssl tlsv1\n--ssl sslv3')
+    assert value == 'sslv3'
+
+    # comment mixed with actual option
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl tlsv1\n# --ssl sslv3')
+    assert value == 'tlsv1'
+
+
+def test_parse_spamc_ssl_argument_crazy_corner_cases():
+    # The option and value can have a comment in between
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl\n# foo\ntlsv1')
+    assert value == 'tlsv1'
+
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl\n# foo\n# bar\nsslv3')
+    assert value == 'sslv3'
+
+    value = lib_spamc._parse_spamc_ssl_argument('--ssl\n# foo\n# tlsv1\nsslv3')
+    assert value == 'sslv3'
+
+
+def test_get_spamc_ssl_argument():
+    path = '/etc/mail/spamassassin/spamc.conf'
+    fileops = MockFileOperations()
+    fileops.files[path] = '--ssl sslv3'
+
+    value = lib_spamc.get_spamc_ssl_argument(fileops.read)
+
+    assert fileops.files_read == {path: 1}
+    assert value == 'sslv3'
+
+
+def test_get_spamc_ssl_argument_empty():
+    path = '/etc/mail/spamassassin/spamc.conf'
+    fileops = MockFileOperations()
+    fileops.files[path] = ''
+
+    value = lib_spamc.get_spamc_ssl_argument(fileops.read)
+
+    assert fileops.files_read == {path: 1}
+    assert value is None
+
+
+def test_get_spamc_ssl_argument_nonexistent():
+    path = '/etc/mail/spamassassin/spamc.conf'
+    fileops = MockFileOperations()
+
+    value = lib_spamc.get_spamc_ssl_argument(fileops.read)
+
+    assert fileops.files_read == {path: 1}
+    assert value is None
+
+
+def test_get_spamc_ssl_argument_inaccessible():
+    path = '/etc/mail/spamassassin/spamc.conf'
+    fileops = MockFileOperations(to_raise=make_IOError(errno.EACCES))
+
+    value = lib_spamc.get_spamc_ssl_argument(fileops.read)
+
+    assert fileops.files_read == {path: 1}
+    assert value is None

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/tests/test_lib_spamd.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/tests/test_lib_spamd.py
@@ -1,0 +1,175 @@
+import errno
+import os
+
+from leapp.libraries.actor import lib_spamd
+from leapp.libraries.common.testutils import make_IOError, make_OSError
+
+
+class MockFileOperations(object):
+    def __init__(self, to_raise=None):
+        self.files = {}
+        self.files_read = {}
+        self.read_called = 0
+        self.to_raise = to_raise
+
+    def _increment_read_counters(self, path):
+        self.read_called += 1
+        self.files_read.setdefault(path, 0)
+        self.files_read[path] += 1
+
+    def read(self, path):
+        self._increment_read_counters(path)
+        if self.to_raise is not None:
+            raise self.to_raise
+        try:
+            return self.files[path]
+        except KeyError:
+            raise make_IOError(errno.ENOENT)
+
+
+class MockListDir(object):
+    def __init__(self, path=None, file_names=None, to_raise=None):
+        self.path = None if path is None else os.path.normpath(path)
+        self.file_names = file_names
+        self.to_raise = to_raise
+        self.error = False
+
+    def listdir(self, path):
+        if self.to_raise:
+            raise self.to_raise
+        if os.path.normpath(path) == self.path:
+            return self.file_names
+        else:
+            self.error = True
+            raise make_OSError(errno.ENOENT)
+
+
+def test_spamassassin_service_overriden():
+    listdir = MockListDir(path='/etc/systemd/system', file_names=['spamassassin.service'])
+    overriden = lib_spamd.spamassassin_service_overriden(listdir.listdir)
+    assert overriden is True
+
+    listdir = MockListDir(path='/etc/systemd/system',
+                          file_names=['foo.service', 'spamassassin.service', 'bar.service'])
+    overriden = lib_spamd.spamassassin_service_overriden(listdir.listdir)
+    assert overriden is True
+    assert not listdir.error
+
+
+def test_spamassassin_service_overriden_nonexistent():
+    listdir = MockListDir(path='/etc/systemd/system', file_names=[])
+    overriden = lib_spamd.spamassassin_service_overriden(listdir.listdir)
+    assert overriden is False
+
+    listdir = MockListDir(path='/etc/systemd/system',
+                          file_names=['foo.service', 'bar.service'])
+    overriden = lib_spamd.spamassassin_service_overriden(listdir.listdir)
+    assert overriden is False
+    assert not listdir.error
+
+
+def test_spamassassin_service_overriden_nonexistent_dir():
+    listdir = MockListDir(to_raise=make_OSError(errno.ENOENT))
+    overriden = lib_spamd.spamassassin_service_overriden(listdir.listdir)
+    assert overriden is False
+
+
+def test_spamassassin_service_overriden_nonexistent_inaccessible():
+    # If we can't check if the file is there, we treat it as if it was there,
+    # so that the SpamassassinConfigUpdate actor doesn't make changes to
+    # /etc/sysconfig/spamassassin that may not be justified.
+    listdir = MockListDir(to_raise=make_OSError(errno.EACCES))
+    overriden = lib_spamd.spamassassin_service_overriden(listdir.listdir)
+    assert overriden is True
+
+
+def test_parse_ssl_version_sslv3():
+    content = 'SPAMDOPTIONS="--ssl-version sslv3"'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'sslv3'
+
+    content = 'SPAMDOPTIONS="-cd -m5 --ssl-version sslv3 -H"'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'sslv3'
+
+
+def test_parse_ssl_version_tlsv1():
+    content = 'SPAMDOPTIONS="--ssl-version tlsv1"'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'tlsv1'
+
+    content = 'SPAMDOPTIONS="-cd -m5 --ssl-version tlsv1 -H"'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'tlsv1'
+
+
+def test_parse_ssl_version_invalid_argument():
+    # If an invalid argument is used, we treat it as if the option was not
+    # specified at all, so that the config update actor doesn't touch it. We
+    # don't want to break the config even more.
+    content = 'SPAMDOPTIONS="--ssl-version foo"\n'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value is None
+
+
+def test_parse_ssl_version_comments():
+    content = '# foo\nSPAMDOPTIONS="--ssl-version tlsv1"\n# bar\n'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'tlsv1'
+
+
+def test_parse_ssl_version_repeated():
+    # The last --ssl-version option takes effect
+    content = 'SPAMDOPTIONS="--ssl-version tlsv1 --ssl-version sslv3"\n'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'sslv3'
+
+    content = 'SPAMDOPTIONS="--ssl-version sslv3 --ssl-version tlsv1"\n'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'sslv3'
+
+
+def test_parse_ssl_version_last_assignment_takes_effect():
+    # The last assignment to SPAMDOPTIONS takes effect
+    content = 'SPAMDOPTIONS="--ssl-version tlsv1"\nSPAMDOPTIONS="--ssl-version sslv3"\n'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'sslv3'
+
+
+def test_parse_ssl_version_multiline():
+    content = 'SPAMDOPTIONS="--ssl \\\n --ssl-version tlsv1"\n'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'tlsv1'
+
+    content = 'SPAMDOPTIONS="--ssl-version \\\n sslv3"\n'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'sslv3'
+
+
+def test_parse_ssl_version_multiline_comment():
+    content = 'SPAMDOPTIONS="--ssl-version tlsv1"\n' \
+              '# foo \\\nSPAMDOPTIONS="--ssl-version sslv3" \\\n still a comment'
+    value = lib_spamd._parse_ssl_version(content)
+    assert value == 'tlsv1'
+
+
+def test_get_spamd_ssl_version():
+    path = '/etc/sysconfig/spamassassin'
+    fileops = MockFileOperations()
+    fileops.files[path] = '# foo\nSPAMDOPTIONS="--ssl-version tlsv1"\n# bar\n'
+
+    value = lib_spamd.get_spamd_ssl_version(fileops.read)
+
+    assert value == 'tlsv1'
+
+
+def test_get_spamd_ssl_version_nonexistent():
+    fileops = MockFileOperations()
+    value = lib_spamd.get_spamd_ssl_version(fileops.read)
+    assert value is None
+
+
+def test_get_spamd_ssl_version_inaccessible():
+    fileops = MockFileOperations(to_raise=make_IOError(errno.EACCES))
+    value = lib_spamd.get_spamd_ssl_version(fileops.read)
+    assert value is None

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigread/tests/test_library.py
@@ -1,0 +1,74 @@
+import errno
+import os
+
+from leapp.libraries.actor import library
+from leapp.libraries.common.testutils import make_IOError, make_OSError
+
+
+class MockFileOperations(object):
+    def __init__(self):
+        self.files = {}
+        self.files_read = {}
+        self.read_called = 0
+
+    def _increment_read_counters(self, path):
+        self.read_called += 1
+        self.files_read.setdefault(path, 0)
+        self.files_read[path] += 1
+
+    def read(self, path):
+        self._increment_read_counters(path)
+        try:
+            return self.files[path]
+        except KeyError:
+            raise make_IOError(errno.ENOENT)
+
+
+class MockListDir(object):
+    def __init__(self, path=None, file_names=None):
+        self.path = None if path is None else os.path.normpath(path)
+        self.file_names = file_names
+        self.error = False
+
+    def listdir(self, path):
+        if os.path.normpath(path) == self.path:
+            return self.file_names
+        else:
+            self.error = True
+            raise make_OSError(errno.ENOENT)
+
+
+def test_get_spamassassin_facts():
+    spamc_path = '/etc/mail/spamassassin/spamc.conf'
+    spamd_path = '/etc/sysconfig/spamassassin'
+    fileops = MockFileOperations()
+    fileops.files[spamc_path] = '--ssl sslv3'
+    fileops.files[spamd_path] = 'SPAMDOPTIONS="--ssl-version tlsv1"'
+    listdir = MockListDir(path='/etc/systemd/system', file_names=['spamassassin.service'])
+
+    facts = library.get_spamassassin_facts(read_func=fileops.read, listdir=listdir.listdir)
+
+    assert len(fileops.files_read) == 2
+    assert spamc_path in fileops.files_read
+    assert spamd_path in fileops.files_read
+    assert facts.spamc_ssl_argument == 'sslv3'
+    assert facts.spamd_ssl_version == 'tlsv1'
+    assert facts.service_overriden is True
+    assert not listdir.error
+
+
+def test_get_spamassassin_facts_nonexistent_config():
+    spamc_path = '/etc/mail/spamassassin/spamc.conf'
+    spamd_path = '/etc/sysconfig/spamassassin'
+    fileops = MockFileOperations()
+    listdir = MockListDir(path='/etc/systemd/system', file_names=[])
+
+    facts = library.get_spamassassin_facts(read_func=fileops.read, listdir=listdir.listdir)
+
+    assert len(fileops.files_read) == 2
+    assert spamc_path in fileops.files_read
+    assert spamd_path in fileops.files_read
+    assert facts.spamc_ssl_argument is None
+    assert facts.spamd_ssl_version is None
+    assert facts.service_overriden is False
+    assert not listdir.error

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/actor.py
@@ -1,0 +1,31 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import SpamassassinFacts
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class SpamassassinConfigUpdate(Actor):
+    """
+    This actor performs several modifications to spamassassin configuration
+    so that spamc and the spamassassin systemd service can be run without error
+    on the target system:
+    1. Remove arguments given to the --ssl option in spamc configuration
+       (/etc/mail/spamassassin/spamc.conf).
+    2. Remove --ssl-version options from the spamassassin sysconfig file
+       (/etc/sysconfig/spamassassin), or replace them with --ssl, if needed.
+    3. Remove the -d/--daemonize option from the spamassassin sysconfig file.
+
+    All files are backed up before they are modified.
+    """
+
+    name = 'spamassassin_config_update'
+    consumes = (SpamassassinFacts,)
+    produces = ()
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        facts = next(self.consume(SpamassassinFacts), None)
+        if facts:
+            library.migrate_configs(facts)
+        else:
+            self.log.debug('Skipping execution - no SpamassassinFacts message has been produced.')

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/lib_backup.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/lib_backup.py
@@ -1,0 +1,22 @@
+import errno
+import os
+import shutil
+import tempfile
+
+
+def backup_file(path):
+    """ Backup the file specified by path and return the path to the backup file. """
+    backup_path = '%s.leapp-backup' % path
+    try:
+        fd = os.open(backup_path, os.O_CREAT | os.O_EXCL, 0o600)
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            file_name = os.path.basename(backup_path)
+            fd, backup_path = tempfile.mkstemp(prefix=file_name + '.',
+                                               dir=os.path.dirname(backup_path))
+        else:
+            raise
+    os.close(fd)
+
+    shutil.copyfile(path, backup_path)
+    return backup_path

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/lib_spamc.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/lib_spamc.py
@@ -1,0 +1,46 @@
+import re
+
+from leapp.libraries.common.spamassassinutils import SPAMC_CONFIG_FILE
+from leapp.libraries.stdlib import api
+
+
+def _rewrite_spamc_config(content):
+    res_lines = []
+    read_ssl_option = False
+    for line in content.split('\n'):
+        if line.startswith('#'):
+            res_lines.append(line)
+            continue
+        if read_ssl_option:
+            line = re.sub(r'^\s*(sslv3|tlsv1)', '', line)
+            read_ssl_option = False
+        if re.search(r'(?<!\S)--ssl\s*$', line):
+            read_ssl_option = True
+        line = re.sub(r'(?<!\S)--ssl(\s+|=)(sslv3|tlsv1)(?!\S)', '--ssl', line)
+        res_lines.append(line)
+    res = '\n'.join(res_lines)
+    return res
+
+
+def migrate_spamc_config(facts, fileops, backup_func):
+    """
+    Removes arguments given to the --ssl option in the spamc config file.
+    The file is backed up beforehand.
+    """
+    if facts.spamc_ssl_argument is None:
+        api.current_logger().info('There is nothing to migrate in the spamc configuration file')
+        return
+    try:
+        backup_path = backup_func(SPAMC_CONFIG_FILE)
+        api.current_logger().info('spamc configuration file backup created at %s.'
+                                  % backup_path)
+    except (OSError, IOError) as e:
+        api.current_logger().warn(
+            'spamc configuration file migration will not be performed. Failed to create backup: %s' % e)
+        return
+    try:
+        content = fileops.read(SPAMC_CONFIG_FILE)
+        new_content = _rewrite_spamc_config(content)
+        fileops.write(SPAMC_CONFIG_FILE, new_content)
+    except (OSError, IOError) as e:
+        api.current_logger().warn('Failed to migrate spamc configuration file: %s' % e)

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/lib_spamd.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/lib_spamd.py
@@ -1,0 +1,83 @@
+import errno
+import re
+
+import leapp.libraries.common.spamassassinutils as utils
+from leapp.libraries.stdlib import api
+
+
+def _drop_ssl_version(value):
+    regex = r'(?<![\w-])--ssl-version(=|\s+)(sslv3|tlsv1)(?![\w-])'
+    if not re.search(r'(?<![\w-])--ssl(?![\w-])', value):
+        value = re.sub(regex, '--ssl', value, count=1)
+    return re.sub(regex, '', value)
+
+
+def _drop_daemonize_option(value):
+    shortopts = utils.SPAMD_SHORTOPTS_NOARG
+    value = re.sub(r'(?<![\w-])-d+(?![\w-])',
+                   r'', value)
+    while True:
+        value, nsubs = re.subn(r'(?<![\w-])(-[' + shortopts + ']*)d',
+                               r'\1', value)
+        if nsubs == 0:
+            break
+    return re.sub(r'(?<![\w-])--daemonize(?![\w-])', '', value)
+
+
+def _rewrite_spamd_option(content, ops):
+    pre_assignment, assignment, post_assignment = \
+        utils.parse_sysconfig_spamassassin(content)
+    if assignment:
+        value = re.sub(r'^\s*' + utils.SYSCONFIG_VARIABLE + r'\s*=(.*)$',
+                       r'\1', assignment)
+        for op in ops:
+            value = op(value)
+        assignment = utils.SYSCONFIG_VARIABLE + '=' + value
+    res = '\n'.join(filter(None, (pre_assignment, assignment, post_assignment)))
+    if res and not res.endswith('\n'):
+        res += '\n'
+    return res
+
+
+def _rewrite_spamd_config(facts, content):
+    ops = []
+    if facts.spamd_ssl_version:
+        ops.append(_drop_ssl_version)
+    if not facts.service_overriden:
+        ops.append(_drop_daemonize_option)
+    return _rewrite_spamd_option(content, ops) if ops else content
+
+
+def migrate_spamd_config(facts, fileops, backup_func):
+    """
+    Removes --ssl-version and -d/--daemonize options from the spamassassin
+    sysconfig file. The file is backed up beforehand.
+    """
+    nothing_to_migrate_msg = 'There is nothing to migrate in the spamd configuration file'
+    if facts.service_overriden and not facts.spamd_ssl_version:
+        api.current_logger().info(nothing_to_migrate_msg)
+        return
+    try:
+        content = fileops.read(utils.SYSCONFIG_SPAMASSASSIN)
+    except (OSError, IOError) as e:
+        if e.errno == errno.ENOENT:
+            api.current_logger().info(nothing_to_migrate_msg)
+        else:
+            api.current_logger().warn('Failed to read spamd configuration file: %s' % e)
+        return
+    new_content = _rewrite_spamd_config(facts, content)
+    if new_content == content:
+        api.current_logger().info('There is nothing to migrate in the spamd configuration file')
+        return
+    try:
+        backup_path = backup_func(utils.SYSCONFIG_SPAMASSASSIN)
+        api.current_logger().info('spamd configuration file backup created at %s.'
+                                  % backup_path)
+    except (OSError, IOError) as e:
+        api.current_logger().warn(
+            'spamd configuration file migration will not be performed. Failed to create backup: %s' % e)
+        return
+    try:
+        fileops.write(utils.SYSCONFIG_SPAMASSASSIN, new_content)
+    except (OSError, IOError) as e:
+        api.current_logger().warn('Failed to rewrite the spamd configuration file: %s' % e)

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/library.py
@@ -1,0 +1,21 @@
+from leapp.libraries.actor import lib_backup, lib_spamc, lib_spamd
+
+
+class FileOperations(object):
+    def read(self, path):
+        with open(path, 'r') as f:
+            return f.read()
+
+    def write(self, path, content):
+        with open(path, 'w') as f:
+            f.write(content)
+
+
+def migrate_configs(facts, fileops=FileOperations(),
+                    backup_func=lib_backup.backup_file):
+    """
+    Perform necessary changes in spamassassin configuration. See
+    lib_spamc.migrate_spamc_config() and lib_spamd.migrate_spamd_config for details.
+    """
+    lib_spamc.migrate_spamc_config(facts, fileops, backup_func)
+    lib_spamd.migrate_spamd_config(facts, fileops, backup_func)

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/tests/test_lib_backup.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/tests/test_lib_backup.py
@@ -1,0 +1,58 @@
+import os
+import shutil
+import stat
+import tempfile
+
+from leapp.libraries.actor.lib_backup import backup_file
+
+
+def test_backup_file():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        file_path = os.path.join(tmpdir, 'foo-bar')
+        content = 'test content\n'
+        with open(file_path, 'w') as f:
+            f.write(content)
+
+        backup_path = backup_file(file_path)
+
+        assert os.path.basename(backup_path) == 'foo-bar.leapp-backup'
+        assert os.path.dirname(backup_path) == tmpdir
+        assert len(os.listdir(tmpdir)) == 2
+        st = os.stat(backup_path)
+        assert stat.S_IMODE(st.st_mode) == (stat.S_IRUSR | stat.S_IWUSR)
+        with open(backup_path, 'r') as f:
+            backup_content = f.read()
+        assert backup_content == content
+        with open(file_path, 'r') as f:
+            orig_content = f.read()
+        assert orig_content == content
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_backup_file_target_exists():
+    tmpdir = tempfile.mkdtemp()
+    try:
+        file_path = os.path.join(tmpdir, 'foo-bar')
+        primary_target_path = '%s.leapp-backup' % file_path
+        primary_target_content = 'do not overwrite me'
+        content = 'test_content\n'
+        with open(file_path, 'w') as f:
+            f.write(content)
+        with open(primary_target_path, 'w') as f:
+            f.write(primary_target_content)
+
+        backup_path = backup_file(file_path)
+
+        assert os.path.basename(backup_path).startswith('foo-bar.leapp-backup.')
+        assert os.path.dirname(backup_path) == tmpdir
+        assert len(os.listdir(tmpdir)) == 3
+        st = os.stat(backup_path)
+        assert stat.S_IMODE(st.st_mode) == (stat.S_IRUSR | stat.S_IWUSR)
+        with open(backup_path, 'r') as f:
+            assert f.read() == content
+        with open(primary_target_path, 'r') as f:
+            assert f.read() == primary_target_content
+    finally:
+        shutil.rmtree(tmpdir)

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/tests/test_lib_spamc.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/tests/test_lib_spamc.py
@@ -1,0 +1,239 @@
+import errno
+
+from leapp.libraries.actor import lib_spamc
+from leapp.libraries.common.spamassassinutils import SPAMC_CONFIG_FILE
+from leapp.libraries.common.testutils import make_IOError, make_OSError
+from leapp.models.spamassassinfacts import SpamassassinFacts
+
+
+# The test cases reuse values from the SpamassassinConfigRead test cases
+
+def test_rewrite_spamc_config():
+    new_content = lib_spamc._rewrite_spamc_config('--ssl sslv3\n')
+    assert new_content == '--ssl\n'
+
+    # equal sign format
+    new_content = lib_spamc._rewrite_spamc_config('--ssl=tlsv1\n')
+    assert new_content == '--ssl\n'
+
+    # no argument
+    new_content = lib_spamc._rewrite_spamc_config('--ssl\n')
+    assert new_content == '--ssl\n'
+
+
+def test_rewrite_spamc_config_without_valid_argument():
+    # If we encounter an unrecognized parameter, we leave it be - the
+    # configuration is invalid anyway, so let's not mess it up even more.
+    new_content = lib_spamc._rewrite_spamc_config('--ssl foo\n')
+    assert new_content == '--ssl foo\n'
+
+    # --ssl followed by another option
+    new_content = lib_spamc._rewrite_spamc_config('--ssl -B\n')
+    assert new_content == '--ssl -B\n'
+
+    # space surrounding the equal sign. This amounts to an unrecognized
+    # argument (empty string)
+    new_content = lib_spamc._rewrite_spamc_config('--ssl= tlsv1\n')
+    assert new_content == '--ssl= tlsv1\n'
+
+    # space surrounding the equal sign. This amounts to an unrecognized
+    # argument ("=tlsv1")
+    new_content = lib_spamc._rewrite_spamc_config('--ssl =tlsv1\n')
+    assert new_content == '--ssl =tlsv1\n'
+
+
+def test_rewrite_spamc_config_multiline():
+    new_content = lib_spamc._rewrite_spamc_config('-B --ssl \n sslv3 -c\n-H\n')
+    assert new_content == '-B --ssl \n -c\n-H\n'
+
+    new_content = lib_spamc._rewrite_spamc_config('--ssl\n-B\n')
+    assert new_content == '--ssl\n-B\n'
+
+
+def test_rewrite_spamc_config_tls_supersedes_ssl():
+    # Ideally, the result would be a single '--ssl' option. However for
+    # simplicity, we allow the option to be output twice. It's not nice, but
+    # there's nothing technically wrong with it. And it's really a corner case
+    # anyway.  If someone fixes it, this test case can be updated to expect
+    # '--ssl' as output.
+    new_content = lib_spamc._rewrite_spamc_config('--ssl sslv3 --ssl tlsv1\n')
+    assert new_content == '--ssl --ssl\n'
+
+    # reverse order
+    new_content = lib_spamc._rewrite_spamc_config('--ssl tlsv1 --ssl sslv3\n')
+    assert new_content == '--ssl --ssl\n'
+
+
+def test_rewrite_spamc_config_comment():
+    new_content = lib_spamc._rewrite_spamc_config('# --ssl tlsv1\n')
+    assert new_content == '# --ssl tlsv1\n'
+
+    # comment mixed with actual option
+    new_content = lib_spamc._rewrite_spamc_config('# --ssl tlsv1\n--ssl sslv3\n')
+    assert new_content == '# --ssl tlsv1\n--ssl\n'
+
+    # comment mixed with actual option
+    new_content = lib_spamc._rewrite_spamc_config('--ssl tlsv1\n# --ssl sslv3\n')
+    assert new_content == '--ssl\n# --ssl sslv3\n'
+
+
+def test_rewrite_spamc_config_crazy_corner_cases():
+    # The option and new_content can have a comment in between
+    new_content = lib_spamc._rewrite_spamc_config('--ssl\n# foo\ntlsv1\n')
+    assert new_content == '--ssl\n# foo\n\n'
+
+    new_content = lib_spamc._rewrite_spamc_config('--ssl\n# foo\n# bar\nsslv3\n')
+    assert new_content == '--ssl\n# foo\n# bar\n\n'
+
+    new_content = lib_spamc._rewrite_spamc_config('--ssl\n# foo\n# tlsv1\nsslv3\n')
+    assert new_content == '--ssl\n# foo\n# tlsv1\n\n'
+
+    # --ssl followed by another option
+    new_content = lib_spamc._rewrite_spamc_config('--ssl\n# foo\n-B\n')
+    assert new_content == '--ssl\n# foo\n-B\n'
+
+
+class MockBackup(object):
+    def __init__(self, to_raise=None):
+        self.to_raise = to_raise
+        self.called = 0
+        self.paths = []
+
+    def __call__(self, path):
+        self.called += 1
+        self.paths.append(path)
+        if self.to_raise:
+            raise self.to_raise
+        return '/path/to/backup'
+
+
+class MockFileOperations(object):
+    def __init__(self, read_error=None, write_error=None):
+        self.files = {}
+        self.files_read = {}
+        self.files_written = {}
+        self.read_called = 0
+        self.write_called = 0
+        self.read_error = read_error
+        self.write_error = write_error
+
+    def _increment_read_counters(self, path):
+        self.read_called += 1
+        self.files_read.setdefault(path, 0)
+        self.files_read[path] += 1
+
+    def read(self, path):
+        self._increment_read_counters(path)
+        if self.read_error:
+            raise self.read_error
+        return self.files[path]
+
+    def _increment_write_counters(self, path):
+        self.write_called += 1
+        self.files_written.setdefault(path, 0)
+        self.files_written[path] += 1
+
+    def write(self, path, content):
+        self._increment_write_counters(path)
+        if self.write_error:
+            raise self.write_error
+        self.files[path] = content
+
+
+def test_migrate_spamc_config():
+    facts = SpamassassinFacts(spamc_ssl_argument='sslv3', service_overriden=False)
+    fileops = MockFileOperations()
+    fileops.files[SPAMC_CONFIG_FILE] = '--ssl sslv3\n# foo\n-B\n'
+    backup_func = MockBackup()
+
+    lib_spamc.migrate_spamc_config(facts, fileops, backup_func)
+
+    assert backup_func.called == 1
+    assert backup_func.paths[0] == SPAMC_CONFIG_FILE
+    assert fileops.files[SPAMC_CONFIG_FILE] == '--ssl\n# foo\n-B\n'
+    assert fileops.read_called == 1
+    assert fileops.files_read[SPAMC_CONFIG_FILE] == 1
+    assert fileops.write_called == 1
+    assert fileops.files_written[SPAMC_CONFIG_FILE] == 1
+
+
+def test_migrate_spamc_config_no_ssl_option():
+    facts = SpamassassinFacts(spamc_ssl_argument=None, service_overriden=False)
+    fileops = MockFileOperations()
+    backup_func = MockBackup()
+
+    lib_spamc.migrate_spamc_config(facts, fileops, backup_func)
+
+    assert backup_func.called == 0
+    assert fileops.read_called == 0
+    assert fileops.write_called == 0
+
+
+def test_migrate_spamc_config_no_write_if_backup_fails():
+    # OSError (e.g. os.open)
+    facts = SpamassassinFacts(spamc_ssl_argument='sslv3', service_overriden=False)
+    fileops = MockFileOperations()
+    backup_func = MockBackup(to_raise=make_OSError(errno.EACCES))
+
+    lib_spamc.migrate_spamc_config(facts, fileops, backup_func)
+
+    assert fileops.write_called == 0
+
+    # IOError (e.g. file.read)
+    facts = SpamassassinFacts(spamc_ssl_argument='sslv3', service_overriden=False)
+    fileops = MockFileOperations()
+    backup_func = MockBackup(to_raise=make_IOError(errno.EACCES))
+
+    lib_spamc.migrate_spamc_config(facts, fileops, backup_func)
+
+    assert fileops.write_called == 0
+
+
+def test_migrate_spamc_config_read_failure():
+    # OSError (e.g. os.open)
+    facts = SpamassassinFacts(spamc_ssl_argument='sslv3', service_overriden=False)
+    fileops = MockFileOperations(read_error=make_OSError(errno.EACCES))
+    backup_func = MockBackup()
+
+    lib_spamc.migrate_spamc_config(facts, fileops, backup_func)
+
+    # The main purpose of this test is to check that exceptions are handled
+    # properly. The following assertions are supplementary.
+    assert fileops.read_called == 1
+    assert fileops.write_called == 0
+
+    # IOError (e.g. builtin open)
+    facts = SpamassassinFacts(spamc_ssl_argument='sslv3', service_overriden=False)
+    fileops = MockFileOperations(read_error=make_IOError(errno.EACCES))
+    backup_func = MockBackup()
+
+    lib_spamc.migrate_spamc_config(facts, fileops, backup_func)
+
+    assert fileops.read_called == 1
+    assert fileops.write_called == 0
+
+
+def test_migrate_spamc_config_write_failure():
+    # OSError (e.g. os.open)
+    facts = SpamassassinFacts(spamc_ssl_argument='sslv3', service_overriden=False)
+    fileops = MockFileOperations(write_error=make_OSError(errno.EACCES))
+    fileops.files[SPAMC_CONFIG_FILE] = '--ssl sslv3\n# foo\n-B\n'
+    backup_func = MockBackup()
+
+    lib_spamc.migrate_spamc_config(facts, fileops, backup_func)
+
+    # The main purpose of this test is to check that exceptions are handled
+    # properly. The following assertions are supplementary.
+    assert fileops.read_called == 1
+    assert fileops.write_called == 1
+
+    # IOError (e.g. builtin open)
+    facts = SpamassassinFacts(spamc_ssl_argument='sslv3', service_overriden=False)
+    fileops = MockFileOperations(write_error=make_IOError(errno.EACCES))
+    fileops.files[SPAMC_CONFIG_FILE] = '--ssl sslv3\n# foo\n-B\n'
+    backup_func = MockBackup()
+
+    lib_spamc.migrate_spamc_config(facts, fileops, backup_func)
+
+    assert fileops.read_called == 1
+    assert fileops.write_called == 1

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/tests/test_lib_spamd.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/tests/test_lib_spamd.py
@@ -1,0 +1,449 @@
+import errno
+
+from leapp.libraries.actor import lib_spamd
+from leapp.libraries.common.spamassassinutils import SYSCONFIG_SPAMASSASSIN, SYSCONFIG_VARIABLE
+from leapp.libraries.common.testutils import make_IOError, make_OSError
+from leapp.models import SpamassassinFacts
+
+
+# The tests for _drop_ssl_version and _drop_daemonize_option are overly
+# restrictive in what output they accept - namely regarding whitespace and
+# order of the options; don't be afraid to change the tests if they start
+# failing due to whitespace or the order of options. It's done this way for
+# simplicity - regular expressions accepting all acceptable outputs would be
+# too complex.
+
+def test_drop_ssl_version_double_quotes():
+    value = '"--ssl --ssl-version tlsv1"'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '"--ssl "'
+
+    value = '"--ssl --ssl-version=tlsv1"'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '"--ssl "'
+
+    value = '"--ssl --ssl-version sslv3"'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '"--ssl "'
+
+    value = '"-d -c -m5 -H --ssl --ssl-version tlsv1"'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '"-d -c -m5 -H --ssl "'
+
+    value = '"-d -c -m5 -H --ssl --ssl-version sslv3"'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '"-d -c -m5 -H --ssl "'
+
+    value = '"-d --ssl -c -m5 --ssl-version tlsv1 -H"'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '"-d --ssl -c -m5  -H"'
+
+    value = '"-d --ssl -c -m5 --ssl-version sslv3 -H"'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '"-d --ssl -c -m5  -H"'
+
+    value = '"-d --ssl -c -m5 --ssl-version=sslv3 -H"'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '"-d --ssl -c -m5  -H"'
+
+
+def test_drop_ssl_version_no_quotes():
+    value = '-d --ssl -c -m5 --ssl-version sslv3 -H'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '-d --ssl -c -m5  -H'
+
+    value = '-d --ssl -c -m5 --ssl-version=sslv3 -H'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '-d --ssl -c -m5  -H'
+
+
+def test_drop_ssl_version_single_quotes():
+    value = "'-d --ssl -c -m5 --ssl-version sslv3 -H'"
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == "'-d --ssl -c -m5  -H'"
+
+    value = "'-d --ssl -c -m5 --ssl-version=sslv3 -H'"
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == "'-d --ssl -c -m5  -H'"
+
+
+def test_drop_ssl_version_ssl_version_implies_ssl():
+    # If --ssl-version is used and --ssl is missing, we need to add --ssl
+    # because --ssl-version implies --ssl
+    value = '--ssl-version tlsv1'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '--ssl'
+
+    value = '--ssl-version=tlsv1'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '--ssl'
+
+    value = '"--ssl-version tlsv1"'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '"--ssl"'
+
+    value = ' --ssl-version tlsv1 '
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == ' --ssl '
+
+    value = '-d -c -m5 --ssl-version sslv3 -H'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '-d -c -m5 --ssl -H'
+
+    value = '-d -c -m5 --ssl-version=sslv3 -H'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '-d -c -m5 --ssl -H'
+
+    value = '-d -c -m5 -H --ssl-version sslv3'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == '-d -c -m5 -H --ssl'
+
+
+def test_drop_ssl_version_invalid_argument():
+    # If the argument of --ssl-version is invalid, we don't touch it because
+    # the configuration is invalid and the user needs to fix it up anyway.
+    value = '--ssl-version foo'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == value
+
+    value = '--ssl-version=foo'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == value
+
+    value = '-d --ssl -c --ssl-version foo -H'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == value
+
+    value = '-d --ssl -c --ssl-version=foo -H'
+    rewritten = lib_spamd._drop_ssl_version(value)
+    assert rewritten == value
+
+
+def test_drop_daemonize_option_double_quotes():
+    value = '"-d -c -m5 -H"'
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == '" -c -m5 -H"'
+
+    value = '"-c -d -m5 -H"'
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == '"-c  -m5 -H"'
+
+
+def test_drop_daemonize_option_no_quotes():
+    value = '-d -c -m5 -H'
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == ' -c -m5 -H'
+
+    value = '-c -d -m5 -H'
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == '-c  -m5 -H'
+
+
+def test_drop_daemonize_option_single_quotes():
+    value = "'-d -c -m5 -H'"
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == "' -c -m5 -H'"
+
+    value = "'-c -d -m5 -H'"
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == "'-c  -m5 -H'"
+
+
+def test_drop_daemonize_option_longopt():
+    value = '--daemonize -c -m5 -H'
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == ' -c -m5 -H'
+
+    value = '-c --daemonize -m5 -H'
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == '-c  -m5 -H'
+
+
+def test_drop_daemonize_short_form():
+    value = '-cdL -m5'
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == '-cL -m5'
+
+    value = '-dcL -m5'
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == '-cL -m5'
+
+    value = '-cLd -m5'
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == '-cL -m5'
+
+
+def test_drop_daemonize_option_repeated():
+    value = '--daemonize -cdd -m5 -dcd --daemonize -H -ddd'
+    rewritten = lib_spamd._drop_daemonize_option(value)
+    assert rewritten == ' -c -m5 -c  -H '
+
+
+def test_rewrite_spamd_option_no_assignment():
+    content = '# foo\nbar=foobar\n'
+    ops = [lib_spamd._drop_ssl_version, lib_spamd._drop_daemonize_option]
+    rewritten = lib_spamd._rewrite_spamd_option(content, ops)
+    assert rewritten == content
+
+
+def test_rewrite_spamd_option_comments():
+    ops = [lib_spamd._drop_ssl_version, lib_spamd._drop_daemonize_option]
+
+    # Leave comments be
+    content = '# foo\n# bar\nSPAMDOPTIONS="--ssl-version tlsv1 -d --ssl"\n# foobar\n'
+    rewritten = lib_spamd._rewrite_spamd_option(content, ops)
+    assert rewritten == '# foo\n# bar\nSPAMDOPTIONS="  --ssl"\n# foobar\n'
+
+    content = '# foo\n# bar\n# SPAMDOPTIONS="--ssl-version tlsv1 -d --ssl"\n# foobar\n'
+    rewritten = lib_spamd._rewrite_spamd_option(content, ops)
+    assert rewritten == content
+
+    content = '# foo\\\n' \
+              'SPAMDOPTIONS="--ssl-version tlsv1 -d --ssl"\n'  # still a comment
+    rewritten = lib_spamd._rewrite_spamd_option(content, ops)
+    assert rewritten == content
+
+
+def test_rewrite_spamd_option_last_assignment_takes_effect():
+    ops = [lib_spamd._drop_ssl_version, lib_spamd._drop_daemonize_option]
+
+    # Only the last assignment to a variable takes effect, so that's the only
+    # assignment that we need to take care of
+    content = 'SPAMDOPTIONS="-c -d"\n' \
+              'SPAMDOPTIONS="-c -d -H"\n'
+    rewritten = lib_spamd._rewrite_spamd_option(content, ops)
+    assert rewritten == '%s\nSPAMDOPTIONS="-c  -H"\n' % content.split('\n')[0]
+
+    content = 'SPAMDOPTIONS="--ssl-version tlsv1 --ssl"\n' \
+              'SPAMDOPTIONS="-c --ssl --ssl-version sslv3 -H"\n'
+    rewritten = lib_spamd._rewrite_spamd_option(content, ops)
+    assert rewritten == '%s\nSPAMDOPTIONS="-c --ssl  -H"\n' % content.split('\n')[0]
+
+
+def test_rewrite_spamd_option_multiline_value():
+    ops = [lib_spamd._drop_ssl_version, lib_spamd._drop_daemonize_option]
+    content = 'SPAMDOPTIONS="--ssl \\\n--ssl-version sslv3"\n'
+    rewritten = lib_spamd._rewrite_spamd_option(content, ops)
+    assert rewritten == 'SPAMDOPTIONS="--ssl "\n'
+
+
+def test_rewrite_spamd_config():
+    facts = SpamassassinFacts(spamd_ssl_version='tlsv1', service_overriden=False)
+    content = '# Options passed to spamd\n' \
+              'SPAMDOPTIONS="-c -d -m5 --ssl -H --ssl-version tlsv1"\n'
+
+    rewritten = lib_spamd._rewrite_spamd_config(facts, content)
+
+    assert rewritten == '# Options passed to spamd\n' \
+                        'SPAMDOPTIONS="-c  -m5 --ssl -H "\n'
+
+
+def test_rewrite_spamd_config_service_overriden():
+    # If the service is overriden, the service type (simple/forking) remains
+    # the same after upgrade. So we must not remove the -d option.
+    facts = SpamassassinFacts(spamd_ssl_version='sslv3', service_overriden=True)
+    content = '# Options to spamd\n' \
+              'SPAMDOPTIONS="-c -d -m5 --ssl -H --ssl-version sslv3"\n'
+
+    rewritten = lib_spamd._rewrite_spamd_config(facts, content)
+
+    assert rewritten == '# Options to spamd\n' \
+                        'SPAMDOPTIONS="-c -d -m5 --ssl -H "\n'
+
+
+class MockBackup(object):
+    def __init__(self, to_raise=None):
+        self.to_raise = to_raise
+        self.called = 0
+        self.paths = []
+
+    def __call__(self, path):
+        self.called += 1
+        self.paths.append(path)
+        if self.to_raise:
+            raise self.to_raise
+        return '/path/to/backup'
+
+
+class MockFileOperations(object):
+    def __init__(self, read_error=None, write_error=None):
+        self.files = {}
+        self.files_read = {}
+        self.files_written = {}
+        self.read_called = 0
+        self.write_called = 0
+        self.read_error = read_error
+        self.write_error = write_error
+
+    def _increment_read_counters(self, path):
+        self.read_called += 1
+        self.files_read.setdefault(path, 0)
+        self.files_read[path] += 1
+
+    def read(self, path):
+        self._increment_read_counters(path)
+        if self.read_error:
+            raise self.read_error
+        return self.files[path]
+
+    def _increment_write_counters(self, path):
+        self.write_called += 1
+        self.files_written.setdefault(path, 0)
+        self.files_written[path] += 1
+
+    def write(self, path, content):
+        self._increment_write_counters(path)
+        if self.write_error:
+            raise self.write_error
+        self.files[path] = content
+
+
+def test_migrate_spamd_config():
+    facts = SpamassassinFacts(service_overriden=False, spamd_ssl_version='tlsv1')
+    fileops = MockFileOperations()
+    content = ('# foo\n' +
+               SYSCONFIG_VARIABLE + '="-c --ssl-version tlsv1 -hdx"\n' +
+               '# bar \n')
+    fileops.files[SYSCONFIG_SPAMASSASSIN] = content
+    backup_func = MockBackup()
+
+    lib_spamd.migrate_spamd_config(facts, fileops, backup_func)
+
+    assert backup_func.called == 1
+    assert backup_func.paths[0] == SYSCONFIG_SPAMASSASSIN
+    expected_content = ('# foo\n' +
+                        SYSCONFIG_VARIABLE + '="-c --ssl -hx"\n' +
+                        '# bar \n')
+    assert fileops.files[SYSCONFIG_SPAMASSASSIN] == expected_content
+    assert fileops.read_called == 1
+    assert fileops.files_read[SYSCONFIG_SPAMASSASSIN] == 1
+    assert fileops.write_called == 1
+    assert fileops.files_written[SYSCONFIG_SPAMASSASSIN] == 1
+
+
+def test_migrate_spamd_config_nothing_to_migrate():
+    facts = SpamassassinFacts(service_overriden=True, spamd_ssl_version=None)
+    fileops = MockFileOperations()
+    content = ('# foo\n' +
+               SYSCONFIG_VARIABLE + '="-c -hdx"\n' +
+               '# bar \n')
+    fileops.files[SYSCONFIG_SPAMASSASSIN] = content
+    backup_func = MockBackup()
+
+    lib_spamd.migrate_spamd_config(facts, fileops, backup_func)
+
+    assert fileops.read_called == 0
+    assert fileops.write_called == 0
+    assert backup_func.called == 0
+
+
+def test_migrate_spamd_config_no_write_if_backup_fails():
+    # OSError (e.g. os.open)
+    facts = SpamassassinFacts(service_overriden=False, spamd_ssl_version='tlsv1')
+    fileops = MockFileOperations()
+    content = ('# foo\n' +
+               SYSCONFIG_VARIABLE + '="-c --ssl-version tlsv1 -hdx"\n' +
+               '# bar \n')
+    fileops.files[SYSCONFIG_SPAMASSASSIN] = content
+    backup_func = MockBackup(to_raise=make_OSError(errno.EACCES))
+
+    lib_spamd.migrate_spamd_config(facts, fileops, backup_func)
+
+    assert backup_func.called == 1
+    assert fileops.write_called == 0
+
+    # IOError (e.g. file.read)
+    facts = SpamassassinFacts(service_overriden=False, spamd_ssl_version='tlsv1')
+    fileops = MockFileOperations()
+    content = ('# foo\n' +
+               SYSCONFIG_VARIABLE + '="-c --ssl-version tlsv1 -hdx"\n' +
+               '# bar \n')
+    fileops.files[SYSCONFIG_SPAMASSASSIN] = content
+    backup_func = MockBackup(to_raise=make_IOError(errno.EACCES))
+
+    lib_spamd.migrate_spamd_config(facts, fileops, backup_func)
+
+    assert backup_func.called == 1
+    assert fileops.write_called == 0
+
+
+def test_migrate_spamd_config_read_failure():
+    # OSError (e.g. os.open)
+    facts = SpamassassinFacts(service_overriden=False, spamd_ssl_version='tlsv1')
+    fileops = MockFileOperations(read_error=make_OSError(errno.EACCES))
+    content = ('# foo\n' +
+               SYSCONFIG_VARIABLE + '="-c --ssl-version tlsv1 -hdx"\n' +
+               '# bar \n')
+    fileops.files[SYSCONFIG_SPAMASSASSIN] = content
+    backup_func = MockBackup()
+
+    lib_spamd.migrate_spamd_config(facts, fileops, backup_func)
+
+    # The main purpose of this test is to check that exceptions are handled
+    # properly. The following assertions are supplementary.
+    assert fileops.read_called == 1
+    assert fileops.write_called == 0
+
+    # IOError (e.g. builtin open)
+    facts = SpamassassinFacts(service_overriden=False, spamd_ssl_version='tlsv1')
+    fileops = MockFileOperations(read_error=make_IOError(errno.EACCES))
+    content = ('# foo\n' +
+               SYSCONFIG_VARIABLE + '="-c --ssl-version tlsv1 -hdx"\n' +
+               '# bar \n')
+    fileops.files[SYSCONFIG_SPAMASSASSIN] = content
+    backup_func = MockBackup()
+
+    lib_spamd.migrate_spamd_config(facts, fileops, backup_func)
+
+    assert fileops.read_called == 1
+    assert fileops.write_called == 0
+
+
+def test_migrate_spamd_config_write_failure():
+    # OSError (e.g. os.open)
+    facts = SpamassassinFacts(service_overriden=False, spamd_ssl_version='tlsv1')
+    fileops = MockFileOperations(write_error=make_OSError(errno.EACCES))
+    content = ('# foo\n' +
+               SYSCONFIG_VARIABLE + '="-c --ssl-version tlsv1 -hdx"\n' +
+               '# bar \n')
+    fileops.files[SYSCONFIG_SPAMASSASSIN] = content
+    backup_func = MockBackup()
+
+    lib_spamd.migrate_spamd_config(facts, fileops, backup_func)
+
+    # The main purpose of this test is to check that exceptions are handled
+    # properly. The following assertions are supplementary.
+    assert fileops.read_called == 1
+    assert fileops.write_called == 1
+
+    # IOError (e.g. builtin open)
+    facts = SpamassassinFacts(service_overriden=False, spamd_ssl_version='tlsv1')
+    fileops = MockFileOperations(write_error=make_IOError(errno.EACCES))
+    content = ('# foo\n' +
+               SYSCONFIG_VARIABLE + '="-c --ssl-version tlsv1 -hdx"\n' +
+               '# bar \n')
+    fileops.files[SYSCONFIG_SPAMASSASSIN] = content
+    backup_func = MockBackup()
+
+    lib_spamd.migrate_spamd_config(facts, fileops, backup_func)
+
+    assert fileops.read_called == 1
+    assert fileops.write_called == 1
+
+
+def test_migrate_spamd_config_no_writes_with_unmodified_config():
+    # Test that no writes are performed if the sysconfig file is in its
+    # default state and thus gets replaced during the RPM upgrade.
+    facts = SpamassassinFacts(service_overriden=False, spamd_ssl_version='tlsv1')
+    # Content of the sysconfig file from RHEL-8
+    content = ('# Options to spamd\n'
+               'SPAMDOPTIONS="-c -m5 -H --razor-home-dir=\'/var/lib/razor/\' --razor-log-file=\'sys-syslog\'"\n')
+    fileops = MockFileOperations()
+    fileops.files[SYSCONFIG_SPAMASSASSIN] = content
+    backup_func = MockBackup()
+
+    lib_spamd.migrate_spamd_config(facts, fileops, backup_func)
+
+    assert backup_func.called == 0
+    assert fileops.read_called == 1
+    assert fileops.write_called == 0

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/tests/test_library.py
@@ -1,0 +1,74 @@
+from leapp.libraries.actor import library
+from leapp.libraries.common.spamassassinutils import SPAMC_CONFIG_FILE, SYSCONFIG_SPAMASSASSIN, SYSCONFIG_VARIABLE
+from leapp.models.spamassassinfacts import SpamassassinFacts
+
+
+class MockBackup(object):
+    def __init__(self, to_raise=None):
+        self.to_raise = to_raise
+        self.called = 0
+        self.paths = []
+
+    def __call__(self, path):
+        self.called += 1
+        self.paths.append(path)
+        if self.to_raise:
+            raise self.to_raise
+        return '/path/to/backup'
+
+
+class MockFileOperations(object):
+    def __init__(self, read_error=None, write_error=None):
+        self.files = {}
+        self.files_read = {}
+        self.files_written = {}
+        self.read_called = 0
+        self.write_called = 0
+        self.read_error = read_error
+        self.write_error = write_error
+
+    def _increment_read_counters(self, path):
+        self.read_called += 1
+        self.files_read.setdefault(path, 0)
+        self.files_read[path] += 1
+
+    def read(self, path):
+        self._increment_read_counters(path)
+        if self.read_error:
+            raise self.read_error
+        return self.files[path]
+
+    def _increment_write_counters(self, path):
+        self.write_called += 1
+        self.files_written.setdefault(path, 0)
+        self.files_written[path] += 1
+
+    def write(self, path, content):
+        self._increment_write_counters(path)
+        if self.write_error:
+            raise self.write_error
+        self.files[path] = content
+
+
+def test_migrate_configs():
+    facts = SpamassassinFacts(spamc_ssl_argument='sslv3',
+                              spamd_ssl_version='sslv3',
+                              service_overriden=False)
+    fileops = MockFileOperations()
+    fileops.files[SPAMC_CONFIG_FILE] = '--ssl sslv3\n# foo\n-B\n'
+    content = ('# foo\n' +
+               SYSCONFIG_VARIABLE + '="-c --ssl-version sslv3 -hdx"\n' +
+               '# bar \n')
+    fileops.files[SYSCONFIG_SPAMASSASSIN] = content
+    backup_func = MockBackup()
+
+    library.migrate_configs(facts, fileops, backup_func)
+
+    assert backup_func.called == 2
+    assert SPAMC_CONFIG_FILE in backup_func.paths
+    assert SYSCONFIG_SPAMASSASSIN in backup_func.paths
+    assert fileops.files[SPAMC_CONFIG_FILE] == '--ssl\n# foo\n-B\n'
+    expected_content = ('# foo\n' +
+                        SYSCONFIG_VARIABLE + '="-c --ssl -hx"\n' +
+                        '# bar \n')
+    assert fileops.files[SYSCONFIG_SPAMASSASSIN] == expected_content

--- a/repos/system_upgrade/el7toel8/libraries/spamassassinutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/spamassassinutils.py
@@ -1,0 +1,45 @@
+import re
+
+
+SPAMC_CONFIG_FILE = '/etc/mail/spamassassin/spamc.conf'
+SPAMASSASSIN_SERVICE_OVERRIDE = '/etc/systemd/system/spamassassin.service'
+SYSCONFIG_SPAMASSASSIN = '/etc/sysconfig/spamassassin'
+SYSCONFIG_VARIABLE = 'SPAMDOPTIONS'
+SPAMD_SHORTOPTS_NOARG = "ch46LlxPQqVv"
+""" All short options in spamd that do not accept an argument, excluding -d. """
+
+
+def parse_sysconfig_spamassassin(content):
+    """
+    Splits up a spamassassin sysconfig file into three parts and returns those parts:
+    1. Beginning of the file up to the SPAMDOPTIONS assignment
+    2. The assignment to the SPAMDOPTIONS variable (this is the assignment
+       that takes effect, i.e. the last assignment to the variable)
+    3. End of the file after the SPAMDOPTIONS assignment
+    """
+    line_continues = False
+    is_assignment = False
+    assignment_start = None
+    assignment_end = None
+    lines = content.split('\n')
+    for ix, line in enumerate(lines):
+        is_assignment = ((is_assignment and line_continues) or
+                         (not (not is_assignment and line_continues) and
+                          re.match(r'\s*' + SYSCONFIG_VARIABLE + '=', line)))
+        if is_assignment:
+            if line_continues:
+                assignment_end += 1
+            else:
+                assignment_start = ix
+                assignment_end = ix + 1
+        line_continues = line.endswith('\\')
+
+    if assignment_start is None:
+        return content, '', ''
+    assignment = ''
+    for line in lines[assignment_start:assignment_end - 1]:
+        assignment += line[:-1]
+    assignment += lines[assignment_end - 1]
+    pre_assignment = '\n'.join(lines[:assignment_start])
+    post_assignment = '\n'.join(lines[assignment_end:])
+    return pre_assignment, assignment, post_assignment

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_spamassassinutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_spamassassinutils.py
@@ -1,0 +1,41 @@
+import leapp.libraries.common.spamassassinutils as lib
+
+
+def test_parse_sysconfig_spamassassin_begins_with_assignment():
+    content = 'SPAMDOPTIONS="foo"\n# bar\n'
+    pre, assignment, post = lib.parse_sysconfig_spamassassin(content)
+    assert pre == ''
+    assert assignment == 'SPAMDOPTIONS="foo"'
+    assert post == '# bar\n'
+
+
+def test_parse_sysconfig_spamassassin_ends_with_assignment():
+    content = '# bar\nSPAMDOPTIONS="foo"\n'
+    pre, assignment, post = lib.parse_sysconfig_spamassassin(content)
+    assert pre == '# bar'
+    assert assignment == 'SPAMDOPTIONS="foo"'
+    assert post == ''
+
+
+def test_parse_sysconfig_spamassassin_only_assignment():
+    content = 'SPAMDOPTIONS="foo"\n'
+    pre, assignment, post = lib.parse_sysconfig_spamassassin(content)
+    assert pre == ''
+    assert assignment == 'SPAMDOPTIONS="foo"'
+    assert post == ''
+
+
+def test_parse_sysconfig_spamassassin_no_assignment():
+    content = '# foo\n'
+    pre, assignment, post = lib.parse_sysconfig_spamassassin(content)
+    assert pre == '# foo\n'
+    assert assignment == ''
+    assert post == ''
+
+
+def test_parse_sysconfig_spamassassin_empty():
+    content = ''
+    pre, assignment, post = lib.parse_sysconfig_spamassassin(content)
+    assert pre == ''
+    assert assignment == ''
+    assert post == ''

--- a/repos/system_upgrade/el7toel8/libraries/utils.py
+++ b/repos/system_upgrade/el7toel8/libraries/utils.py
@@ -123,3 +123,11 @@ def clean_guard(cleanup_function):
                 raise  # rethrow original exception
         return wrapper
     return clean_wrapper
+
+
+def read_file(path):
+    """
+    Reads the file specified by path in text mode and returns the contents.
+    """
+    with open(path, 'r') as f:
+        return f.read()

--- a/repos/system_upgrade/el7toel8/models/spamassassinfacts.py
+++ b/repos/system_upgrade/el7toel8/models/spamassassinfacts.py
@@ -1,0 +1,23 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class SpamassassinFacts(Model):
+    topic = SystemInfoTopic
+
+    spamc_ssl_argument = fields.Nullable(fields.String())
+    """
+    SSL version specified by the --ssl option in the spamc config file, or None
+    if no value is given.
+    """
+
+    spamd_ssl_version = fields.Nullable(fields.String())
+    """
+    SSL version specified by the --ssl-version in the spamassassin sysconfig file,
+    or None if no value is given.
+    """
+
+    service_overriden = fields.Boolean()
+    """
+    True if spamassassin.service is overriden, else False.
+    """


### PR DESCRIPTION
This PR adds three new actors to handle the following backward-incompatible changes in spamassassin:
1. spamc no longer accepts an argument with the --ssl option - the --ssl option can now only be used without an argument
2. spamd no longer accepts the --ssl-version option
3. SSLv3 is no longer supported
4. the type of spamassassin.service has been changed from "forking" to "simple"
5. sa-update no longer supports SHA1 validation of filtering rule files)
   
The SpamassassinConfigCheck actor reports all these changes. The SpamassassinConfigUpdate actor updates spamassassin configuration in order to compensate for changes 1-4 (it modifies `/etc/sysconfig/spamassassin` and `/etc/mail/spamassassin/spamc.conf`).