### PR TITLE
Change the title of the boot entry

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
@@ -14,7 +14,7 @@ def add_boot_entry():
         '/usr/sbin/grubby',
         '--add-kernel', '{0}'.format(kernel_dst_path),
         '--initrd', '{0}'.format(initram_dst_path),
-        '--title', 'RHEL Upgrade Initramfs',
+        '--title', 'RHEL-Upgrade-Initramfs',
         '--copy-default',
         '--make-default',
         '--args', '{DEBUG} enforcing=0 rd.plymouth=0 plymouth.enable=0'.format(DEBUG=debug)

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
@@ -33,7 +33,7 @@ def test_add_boot_entry(monkeypatch):
     assert library.run.args == ['/usr/sbin/grubby',
                                 '--add-kernel', '/abc',
                                 '--initrd', '/def',
-                                '--title', 'RHEL Upgrade Initramfs',
+                                '--title', 'RHEL-Upgrade-Initramfs',
                                 '--copy-default',
                                 '--make-default',
                                 '--args',


### PR DESCRIPTION
The previous title contained white spaces:
 - `RHEL Upgrade Initramfs`

Whitespaces are not valid characters in title in case of the ZIPL
bootloader. To be consistent everywhere, replaces spaces by dashes:
- `RHEL-Upgrade-Initramfs`