### PR TITLE
Little fix on ScanCPU actor produces field.

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/scancpu/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scancpu/actor.py
@@ -9,7 +9,7 @@ class ScanCPU(Actor):
 
     name = 'scancpu'
     consumes = ()
-    produces = (CPUInfo)
+    produces = (CPUInfo,)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
     def process(self):


### PR DESCRIPTION
- Just a little fix to avoid warning in leapp linter.

```console
2019-09-27 13:55:20.970 WARNING  PID: 24859 leapp.linter: Actor <class 'actor.ScanCPU'> field produces should be a tuple of Models
```