### PR TITLE
Blacklisting enabling crb

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/actor.py
@@ -1,5 +1,6 @@
 from leapp.actors import Actor
-from leapp.models import RepositoriesBlacklisted, RepositoriesFacts
+from leapp.libraries.actor.library import process
+from leapp.models import RepositoriesBlacklisted, RepositoriesFacts, RepositoriesMap
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 
@@ -9,22 +10,9 @@ class RepositoriesBlacklist(Actor):
     """
 
     name = 'repositories_blacklist'
-    consumes = (RepositoriesFacts,)
+    consumes = (RepositoriesFacts, RepositoriesMap, )
     produces = (RepositoriesBlacklisted,)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
-    def _is_repo_enabled(self, repoid):
-        for repos in self.consume(RepositoriesFacts):
-            for repo_file in repos.repositories:
-                for repo in repo_file.data:
-                    if repo.repoid == repoid and repo.enabled:
-                        return True
-        return False
-
     def process(self):
-        # blacklist CRB repo if optional repo is not enabled
-        if not (self._is_repo_enabled('rhel-7-server-optional-rpms') or
-                self._is_repo_enabled('rhel-7-server-eus-optional-rpms')):
-            self.log.info("The optional repository is not enabled. Blacklisting the CRB repository.")
-            self.produce(RepositoriesBlacklisted(
-                repoids=['codeready-builder-for-rhel-8-x86_64-rpms']))
+        process()

--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/libraries/library.py
@@ -1,0 +1,40 @@
+from leapp.libraries.stdlib import api
+from leapp.models import RepositoriesBlacklisted, RepositoriesFacts, RepositoriesMap
+
+
+def _get_list_of_optional_repos():
+    """
+    Return a dict of optional repositories based on RepositoriesMap: { 'from_id' : 'to_id'}
+
+    It consumes RepositoriesMap messages and create map (dict) of optional repositories
+    on RHEL 7 system to CRB repositories on RHEL 8. See the RepositoriesMap model..
+    """
+    opt_repo = {}
+    repo_map = next(api.consume(RepositoriesMap), None)
+    if repo_map:
+        for repo in repo_map.repositories:
+            if repo.from_id.endswith('optional-rpms'):
+                opt_repo[repo.from_id] = repo.to_id
+    return opt_repo
+
+
+def _get_disabled_optional_repo():
+    """
+    Return a list of disabled optional repositories available on the system.
+    """
+    opt_repos = _get_list_of_optional_repos()
+    repos_blacklist = []
+    repo_map = next(api.consume(RepositoriesFacts), None)
+    for repo_file in repo_map.repositories:
+        for repo in repo_file.data:
+            if repo.repoid in opt_repos and not repo.enabled:
+                repos_blacklist.append(opt_repos[repo.repoid])
+    return repos_blacklist
+
+
+def process():
+    # blacklist CRB repo if optional repo is not enabled
+    reposid_blacklist = _get_disabled_optional_repo()
+    if reposid_blacklist:
+        api.current_logger().info("The optional repository is not enabled. Blacklisting the CRB repository.")
+        api.produce(RepositoriesBlacklisted(repoids=reposid_blacklist))


### PR DESCRIPTION
The  purpose of these PR is to change hardcoded blacklisting of optional repos to dynamic one, using RepositoriesMap data and information about available RH repositories, so the CRB repositories are blacklisted dynamically based on gathered information and data