### PR TITLE
Workflow change

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkskipphase/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkskipphase/actor.py
@@ -1,0 +1,35 @@
+from leapp.actors import Actor
+from leapp.messaging.commands import SkipPhasesUntilCommand
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckSkipPhase(Actor):
+    """
+    Skip all the subsequent phases until the report phase.
+
+    The phases that follow after the Checks phase work with the target (RHEL 8)
+    user space - stuff around preparing and checking the rpm transaction.
+    We do not want to process those phases in case of inhibition - e.g. for
+    a specific HW unsupported by the target system we cannot do anything - we
+    can just see some unclear errors in such case. So we want to instead skip
+    to the Reports phase to provide clear report to user without confusing
+    errors.
+
+    The actor is processed after all actors in the phase (that provides Report
+    messages) are processed.
+    """
+
+    name = 'check_skip_phase'
+    consumes = (Report,)
+    produces = ()
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        results = list(self.consume(Report))
+        inhibitors = [msg for msg in results if 'inhibitor' in msg.report.get('flags', [])]
+        if inhibitors:
+            self.log.info("An upgrade inhibitor detected. Skipping to the Report phase.")
+            # until_phase='targettransactioncheck'  === phase after this phase will be processed
+            # === the Reports phase
+            self._messaging.command(SkipPhasesUntilCommand(until_phase='targettransactioncheck'))

--- a/repos/system_upgrade/el7toel8/actors/dnftransactioncheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/dnftransactioncheck/actor.py
@@ -1,7 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.common import dnfplugin
 from leapp.models import FilteredRpmTransactionTasks, TargetUserSpaceInfo, UsedTargetRepositories, XFSPresence
-from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.tags import TargetTransactionChecksPhaseTag, IPUWorkflowTag
 
 
 class DnfTransactionCheck(Actor):
@@ -12,10 +12,9 @@ class DnfTransactionCheck(Actor):
     name = 'dnf_transaction_check'
     consumes = (UsedTargetRepositories, FilteredRpmTransactionTasks, TargetUserSpaceInfo, XFSPresence)
     produces = ()
-    tags = (IPUWorkflowTag, ChecksPhaseTag)
+    tags = (IPUWorkflowTag, TargetTransactionChecksPhaseTag)
 
     def process(self):
-
         presence = next(self.consume(XFSPresence), XFSPresence())
         xfs_present = presence.present and presence.without_ftype
         used_repos = self.consume(UsedTargetRepositories)

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
@@ -3,7 +3,7 @@ from leapp.libraries.actor import userspacegen
 from leapp.libraries.common.config import version
 from leapp.models import (OSReleaseFacts, RepositoriesMap, RequiredTargetUserspacePackages, SourceRHSMInfo,
                           TargetRepositories, TargetRHSMInfo, TargetUserSpaceInfo, UsedTargetRepositories, XFSPresence)
-from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+from leapp.tags import TargetTransactionFactsPhaseTag, IPUWorkflowTag
 
 
 class TargetUserspaceCreator(Actor):
@@ -21,7 +21,7 @@ class TargetUserspaceCreator(Actor):
     consumes = (OSReleaseFacts, RepositoriesMap, RequiredTargetUserspacePackages,
                 SourceRHSMInfo, TargetRepositories, XFSPresence)
     produces = (TargetRHSMInfo, TargetUserSpaceInfo, UsedTargetRepositories)
-    tags = (IPUWorkflowTag, FactsPhaseTag)
+    tags = (IPUWorkflowTag, TargetTransactionFactsPhaseTag)
 
     def process(self):
         if version.is_supported_version() and next(self.consume(RepositoriesMap), None):

--- a/repos/system_upgrade/el7toel8/tags/checks.py
+++ b/repos/system_upgrade/el7toel8/tags/checks.py
@@ -3,3 +3,7 @@ from leapp.tags import Tag
 
 class ChecksPhaseTag(Tag):
     name = 'checks'
+
+
+class TargetTransactionChecksPhaseTag(Tag):
+    name = 'target_checks'

--- a/repos/system_upgrade/el7toel8/tags/facts.py
+++ b/repos/system_upgrade/el7toel8/tags/facts.py
@@ -3,3 +3,7 @@ from leapp.tags import Tag
 
 class FactsPhaseTag(Tag):
     name = 'facts'
+
+
+class TargetTransactionFactsPhaseTag(Tag):
+    name = 'target_transaction_facts'

--- a/repos/system_upgrade/el7toel8/workflows/inplace_upgrade.py
+++ b/repos/system_upgrade/el7toel8/workflows/inplace_upgrade.py
@@ -1,51 +1,85 @@
-from leapp.workflows import Workflow
-from leapp.workflows.phases import Phase
-from leapp.workflows.flags import Flags
-from leapp.workflows.tagfilters import TagFilter
-from leapp.workflows.policies import Policies
+from leapp import tags
 from leapp.models import IPUConfig
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag, ChecksPhaseTag, \
-    DownloadPhaseTag, InterimPreparationPhaseTag, InitRamStartPhaseTag, \
-    LateTestsPhaseTag, PreparationPhaseTag, RPMUpgradePhaseTag, ApplicationsPhaseTag, ThirdPartyApplicationsPhaseTag, \
-    FinalizationPhaseTag, FirstBootPhaseTag, ReportPhaseTag
+from leapp.workflows import Workflow
+from leapp.workflows.flags import Flags
+from leapp.workflows.phases import Phase
+from leapp.workflows.policies import Policies
+from leapp.workflows.tagfilters import TagFilter
 
 
 class IPUWorkflow(Workflow):
+    """In-Place Upgrade workflow used by the leapp utility to process the in-place upgrade."""
+
     name = 'InplaceUpgrade'
-    tag = IPUWorkflowTag
+    tag = tags.IPUWorkflowTag
     short_name = 'ipu'
     configuration = IPUConfig
-    description = '''The IPU workflow takes care of an in-place upgrade (IPU) of RHEL 7 to RHEL 8.'''
+    description = """The IPU workflow takes care of an in-place upgrade (IPU) of RHEL 7 to RHEL 8."""
 
     class FactsCollectionPhase(Phase):
-        '''Get information (facts) about the system (e.g. installed packages, configuration, ...).
+        """
+        Get information (facts) about the system (e.g. installed packages, configuration, ...).
 
         No decision should be done in this phase. Scan the system to get information you need and provide
         it to other actors in the following phases.
-        '''
+        """
+
         name = 'FactsCollection'
-        filter = TagFilter(FactsPhaseTag)
+        filter = TagFilter(tags.FactsPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags()
 
     class ChecksPhase(Phase):
-        '''Check upgradability of the system, produce user question if needed and produce output for the report.
+        """
+        Check upgradability of the system, produce user question if needed and produce output for the report.
 
         Check whether it is possible to upgrade the system and detect potential risks. It is not expected to get
         additional information about the system in this phase, but rather work with data provided by the actors from
         the FactsCollection. When a potential risk is detected for upgrade, produce messages for the Reports phase.
-        '''
+        """
+
         name = 'Checks'
-        filter = TagFilter(ChecksPhaseTag)
+        filter = TagFilter(tags.ChecksPhaseTag)
+        policies = Policies(Policies.Errors.FailPhase,
+                            Policies.Retry.Phase)
+        flags = Flags()
+
+    class TargetTransactionFactsCollectionPhase(Phase):
+        """
+        Get information about target system. Analogy of FactsCollectionPhase for target system.
+
+        Here we can collect information what repositories are available on target system,
+        what is expected calculation of target transaction (what will be instaled, removed, ...
+        """
+
+        name = 'TargetTransactionFactsCollection'
+        filter = TagFilter(tags.TargetTransactionFactsPhaseTag)
+        policies = Policies(Policies.Errors.FailPhase,
+                            Policies.Retry.Phase)
+        flags = Flags()
+
+    class TargetTransactionChecksPhase(Phase):
+        """
+        Checks upgradability regarding the information gathered about the target system.
+
+        Check whether expected repositories and rpms are available, what rpms are planned
+        to install, remove, ...
+
+        IOW, checks related to rpm transaction mainly.
+        """
+
+        name = 'TargetTransactionCheck'
+        filter = TagFilter(tags.TargetTransactionChecksPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags()
 
     class ReportsPhase(Phase):
-        '''Provide user with the result of the checks.'''
+        """Provide user with the result of the checks."""
+
         name = 'Reports'
-        filter = TagFilter(ReportPhaseTag)
+        filter = TagFilter(tags.ReportPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags()
@@ -55,7 +89,7 @@ class IPUWorkflow(Workflow):
     # class AttachPackageReposPhase(Phase):
     #    name = 'AttachPackageRepos'
     #    #NOTE: in case of use the AttachPackageReposPhaseTag tag has to be created
-    #    filter = TagFilter(AttachPackageReposPhaseTag)
+    #    filter = TagFilter(tags.AttachPackageReposPhaseTag)
     #    policies = Policies(Policies.Errors.FailPhase,
     #                        Policies.Retry.Phase)
     #    flags = Flags()
@@ -63,31 +97,34 @@ class IPUWorkflow(Workflow):
     # class PlanningPhase(Phase):
     #    name = 'Planning'
     #    #NOTE: in case of use the PlanningPhaseTag tag has to be created
-    #    filter = TagFilter(PlanningPhaseTag)
+    #    filter = TagFilter(tags.PlanningPhaseTag)
     #    policies = Policies(Policies.Errors.FailPhase,
     #                        Policies.Retry.Phase)
     #    flags = Flags()
 
     class DownloadPhase(Phase):
-        '''Download data needed for the upgrade and prepare RPM transaction for the upgrade.'''
+        """Download data needed for the upgrade and prepare RPM transaction for the upgrade."""
+
         name = 'Download'
-        filter = TagFilter(DownloadPhaseTag)
+        filter = TagFilter(tags.DownloadPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags()
 
     class InterimPreparationPhase(Phase):
-        '''Prepare an initial RAM file system (if required). Setup bootloader.'''
+        """Prepare an initial RAM file system (if required). Setup bootloader."""
+
         name = 'InterimPreparation'
-        filter = TagFilter(InterimPreparationPhaseTag)
+        filter = TagFilter(tags.InterimPreparationPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags(request_restart_after_phase=True)
 
     class InitRamStartPhase(Phase):
-        '''Boot into the upgrade initramfs, mount disks, etc.'''
+        """Boot into the upgrade initramfs, mount disks, etc."""
+
         name = 'InitRamStart'
-        filter = TagFilter(InitRamStartPhaseTag)
+        filter = TagFilter(tags.InitRamStartPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags()
@@ -97,7 +134,7 @@ class IPUWorkflow(Workflow):
     # class NetworkPhase(Phase):
     #    name = 'Network'
     #    #NOTE: in case of use the NetworkPhaseTag tag has to be created
-    #    filter = TagFilter(NetworkPhaseTag)
+    #    filter = TagFilter(tags.NetworkPhaseTag)
     #    policies = Policies(Policies.Errors.FailPhase,
     #                        Policies.Retry.Phase)
     #    flags = Flags()
@@ -105,70 +142,79 @@ class IPUWorkflow(Workflow):
     # class StoragePhase(Phase):
     #    name = 'Storage'
     #    #NOTE: in case of use the StoragePhaseTag tag has to be created
-    #    filter = TagFilter(StoragePhaseTag)
+    #    filter = TagFilter(tags.StoragePhaseTag)
     #    policies = Policies(Policies.Errors.FailPhase,
     #                        Policies.Retry.Phase)
     #    flags = Flags()
 
     class LateTestsPhase(Phase):
-        '''Last tests before the RPM upgrade that have to be done with the new kernel and systemd.'''
+        """Last tests before the RPM upgrade that have to be done with the new kernel and systemd."""
+
         name = 'LateTests'
-        filter = TagFilter(LateTestsPhaseTag)
+        filter = TagFilter(tags.LateTestsPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags()
 
     class PreparationPhase(Phase):
-        '''Prepare the environment to ascertain success of the RPM upgrade transaction.'''
+        """Prepare the environment to ascertain success of the RPM upgrade transaction."""
+
         name = 'Preparation'
-        filter = TagFilter(PreparationPhaseTag)
+        filter = TagFilter(tags.PreparationPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags()
 
     class RPMUpgradePhase(Phase):
-        '''Perform the RPM transaction, i.e. upgrade the RPMs.'''
+        """Perform the RPM transaction, i.e. upgrade the RPMs."""
+
         name = 'RPMUpgrade'
-        filter = TagFilter(RPMUpgradePhaseTag)
+        filter = TagFilter(tags.RPMUpgradePhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags(is_checkpoint=True)
 
     class ApplicationsPhase(Phase):
-        '''Perform the neccessary steps to finish upgrade of applications provided by Red Hat.
+        """
+        Perform the neccessary steps to finish upgrade of applications provided by Red Hat.
 
         This may include moving/renaming of configuration files, modifying configuration of applications to be able
         to run correctly and with as similar behaviour to the original as possible.
-        '''
+        """
+
         name = 'Applications'
-        filter = TagFilter(ApplicationsPhaseTag)
+        filter = TagFilter(tags.ApplicationsPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags()
 
     class ThirdPartyApplicationsPhase(Phase):
-        '''Analogy to the Applications phase, but for third party and custom applications.'''
+        """Analogy to the Applications phase, but for third party and custom applications."""
+
         name = 'ThirdPartyApplications'
-        filter = TagFilter(ThirdPartyApplicationsPhaseTag)
+        filter = TagFilter(tags.ThirdPartyApplicationsPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags()
 
     class FinalizationPhase(Phase):
-        '''Additional actions that should be done before rebooting into the upgraded system.
+        """
+        Additional actions that should be done before rebooting into the upgraded system.
 
         For example SELinux relabeling.
-        '''
+        """
+
         name = 'Finalization'
-        filter = TagFilter(FinalizationPhaseTag)
+        filter = TagFilter(tags.FinalizationPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags(restart_after_phase=True)
 
     class FirstBootPhase(Phase):
-        '''Actions to be done right after booting into the upgraded system.'''
+        """Actions to be done right after booting into the upgraded system."""
+
         name = 'FirstBoot'
-        filter = TagFilter(FirstBootPhaseTag)
+        filter = TagFilter(tags.FirstBootPhaseTag)
         policies = Policies(Policies.Errors.FailPhase,
                             Policies.Retry.Phase)
         flags = Flags()


### PR DESCRIPTION
We realized we cannot properly gather all information and check it just with one scan and check phase when we need to get and process data from target system (e.g. create target userspace). In some cases we cannot even get those information because current HW is not supported on target system, so all such actions fails and we cannot prevent such actors effectively to no fail.
    
To resolve that, add new 'Target*' phases for actors working with with target userspace or data about calculated RPM transaction and move related actors to thodr phases.

Additionally, in case of inhibition from the original checks phase, skip these two phases and continue with reporting phase (requires leapp PR: https://github.com/oamg/leapp/pull/566). This is done by special extra actor in the checks phase.

Note: currently just two
Note2: I am opened to discussion whether to add just one new phase instead of two, but keep in mind we want to do more stuff in future around that. (check transaction output, ...)

Note3: **Failed tests are expected until the merge of the leapp PR.**