### PR TITLE
Import leapp only when environment is set

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,16 +1,27 @@
 import os
 
-from leapp.utils.repository import find_repository_basedir
-from leapp.repository.scan import find_and_scan_repositories
+def load_repo(path):
+    """
+    Load repository on demand.
 
+    Do not require paths initialized if no environment is set.
+    Allows some parts to be tested without working leapp installation.
+    """
+    from leapp.utils.repository import find_repository_basedir
+    from leapp.repository.scan import find_and_scan_repositories
+
+    repo = find_and_scan_repositories(find_repository_basedir(path), include_locals=True)
+    repo.load()
+    return repo
+        
 
 def pytest_sessionstart(session):
+
     actor_path = os.environ.get('LEAPP_TESTED_ACTOR', None)
     library_path = os.environ.get('LEAPP_TESTED_LIBRARY', None)
 
     if actor_path:
-        repo = find_and_scan_repositories(find_repository_basedir(actor_path), include_locals=True)
-        repo.load()
+        repo = load_repo(actor_path)
 
         actor = None
         # find which actor is being tested
@@ -27,6 +38,5 @@ def pytest_sessionstart(session):
         session.actor_context = actor.injected_context()
         session.actor_context.__enter__()
     elif library_path:
-        repo = find_and_scan_repositories(find_repository_basedir(library_path), include_locals=True)
-        repo.load()
+        load_repo(library_path)
         os.chdir(library_path)


### PR DESCRIPTION
Allows using pytest even on not configured system for small parts not
referencing leapp libraries. Would work the same way when environment is
set, but omits fatal failures of pytest in case leapp cannot be imported.

Related to issue #365. Would help local testing of leapp unrelated parts. If environment in not set, scan is not imported.