### PR TITLE
Fix consuming not produced msg

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/actor.py
@@ -1,8 +1,8 @@
-from leapp.actors import Actor
-from leapp.reporting import create_report
 from leapp import reporting
+from leapp.actors import Actor
 from leapp.models import Report, TargetRHSMInfo
-from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.reporting import create_report
+from leapp.tags import IPUWorkflowTag, TargetTransactionChecksPhaseTag
 
 
 class ReportSetTargetRelease(Actor):
@@ -13,7 +13,7 @@ class ReportSetTargetRelease(Actor):
     name = 'report_set_target_release'
     consumes = (TargetRHSMInfo,)
     produces = (Report,)
-    tags = (IPUWorkflowTag, ChecksPhaseTag)
+    tags = (IPUWorkflowTag, TargetTransactionChecksPhaseTag)
 
     def process(self):
         info = next(self.consume(TargetRHSMInfo), None)


### PR DESCRIPTION
Introduction of https://github.com/oamg/leapp-repository/pull/363 caused that reportsettargetrelease actor was consuming TargetRHSMInfo in the Checks phase before this message being produced later in the TargetTransactionFacts phase.

Found by new checks introduced in https://github.com/oamg/leapp-repository/pull/339.