### PR TITLE
s390x fixes

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/library.py
@@ -2,6 +2,7 @@ import os
 import re
 
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api, run
 from leapp.models import BootContent
 
@@ -19,6 +20,12 @@ def add_boot_entry():
         '--make-default',
         '--args', '{DEBUG} enforcing=0 rd.plymouth=0 plymouth.enable=0'.format(DEBUG=debug)
     ])
+
+    if architecture.matches_architecture(architecture.ARCH_S390X):
+        # on s390x we need to call zipl explicitly because of issue in grubby,
+        # otherwise the new boot entry will not be set as default
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=1764306
+        run(['/usr/sbin/zipl'])
 
 
 def get_boot_file_paths():

--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
@@ -43,8 +43,10 @@ def test_add_boot_entry_non_s390x(monkeypatch):
 
     library.add_boot_entry()
 
-    assert len(library.run.args) == 1
+    assert len(library.run.args) == 2
     assert library.run.args[0] == ['/usr/sbin/grubby',
+                                   '--remove-kernel', '/abc']
+    assert library.run.args[1] == ['/usr/sbin/grubby',
                                    '--add-kernel', '/abc',
                                    '--initrd', '/def',
                                    '--title', 'RHEL-Upgrade-Initramfs',
@@ -64,8 +66,10 @@ def test_add_boot_entry_s390x(monkeypatch):
 
     library.add_boot_entry()
 
-    assert len(library.run.args) == 2
+    assert len(library.run.args) == 3
     assert library.run.args[0] == ['/usr/sbin/grubby',
+                                   '--remove-kernel', '/abc']
+    assert library.run.args[1] == ['/usr/sbin/grubby',
                                    '--add-kernel', '/abc',
                                    '--initrd', '/def',
                                    '--title', 'RHEL-Upgrade-Initramfs',
@@ -73,7 +77,7 @@ def test_add_boot_entry_s390x(monkeypatch):
                                    '--make-default',
                                    '--args',
                                    'debug enforcing=0 rd.plymouth=0 plymouth.enable=0']
-    assert library.run.args[1] == ['/usr/sbin/zipl']
+    assert library.run.args[2] == ['/usr/sbin/zipl']
 
 
 def test_get_boot_file_paths(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/libraries/forcedefaultboot.py
+++ b/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/libraries/forcedefaultboot.py
@@ -2,6 +2,7 @@ import os
 from collections import namedtuple
 
 from leapp.libraries import stdlib
+from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 from leapp.models import InstalledTargetKernelVersion
 
@@ -40,6 +41,11 @@ def update_default_kernel(kernel_info):
     else:
         try:
             stdlib.run(['grubby', '--set-default', kernel_info.kernel_path])
+            if architecture.matches_architecture(architecture.ARCH_S390X):
+                # on s390x we need to call zipl explicitly because of issue in grubby,
+                # otherwise the new boot entry will not be set as default
+                # See https://bugzilla.redhat.com/show_bug.cgi?id=1764306
+                stdlib.run(['/usr/sbin/zipl'])
         except (OSError, stdlib.CalledProcessError):
             api.current_logger().error('Failed to set default kernel to: %s', kernel_info.kernel_path, exc_info=True)
 

--- a/repos/system_upgrade/el7toel8/actors/initramdiskgenerator/files/generate-initram.sh
+++ b/repos/system_upgrade/el7toel8/actors/initramdiskgenerator/files/generate-initram.sh
@@ -37,31 +37,36 @@ build() {
     DRACUT_CONF_DIR=${LEAPP_DRACUT_CONF:-/var/empty}
 
     DRACUT_LVMCONF_ARG="--nolvmconf"
-    if [[ ! -z LEAPP_DRACUT_LVMCONF ]]; then
+    if [[ ! -z "$LEAPP_DRACUT_LVMCONF" ]]; then
         DRACUT_LVMCONF_ARG="--lvmconf"
     fi
     DRACUT_MDADMCONF_ARG="--nomdadmconf"
-    if [[ ! -z LEAPP_DRACUT_MDADMCONF ]]; then
+    if [[ ! -z "$LEAPP_DRACUT_MDADMCONF" ]]; then
         # include local /etc/mdadm.conf
         DRACUT_MDADMCONF_ARG="--mdadmconf"
     fi
 
     KERNEL_VERSION=$LEAPP_KERNEL_VERSION
-    if [[ -z $KERNEL_VERSION ]]; then
+    if [[ -z "$KERNEL_VERSION" ]]; then
         KERNEL_VERSION=$(get_kernel_version)
     fi
 
     KERNEL_ARCH='x86_64'
-    if [[ ! -z $LEAPP_KERNEL_ARCH ]]; then
+    if [[ ! -z "$LEAPP_KERNEL_ARCH" ]]; then
         KERNEL_ARCH=$LEAPP_KERNEL_ARCH
     fi
 
     DRACUT_MODULES_ADD=""
-    if [[ -z $LEAPP_ADD_DRACUT_MODULES ]]; then
+    if [[ -z "$LEAPP_ADD_DRACUT_MODULES" ]]; then
         echo 'ERROR: No dracut modules to add'
         exit 1;
     else
         DRACUT_MODULES_ADD=$(echo "--add $LEAPP_ADD_DRACUT_MODULES" | sed 's/,/ --add /g')
+    fi
+
+    DRACUT_INSTALL="systemd-nspawn"
+    if [[ -n "$LEAPP_DRACUT_INSTALL_FILES" ]]; then
+        DRACUT_INSTALL="$DRACUT_INSTALL $LEAPP_DRACUT_INSTALL_FILES"
     fi
 
     pushd /artifacts
@@ -73,7 +78,7 @@ build() {
         --force \
         --conf $DRACUT_CONF \
         --confdir $DRACUT_CONF_DIR \
-        --install systemd-nspawn \
+        --install "$DRACUT_INSTALL" \
         $DRACUT_MODULES_ADD \
         $DRACUT_MDADMCONF_ARG \
         $DRACUT_LVMCONF_ARG \

--- a/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
+++ b/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
@@ -1,5 +1,6 @@
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries import stdlib
+from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg
 
@@ -12,6 +13,12 @@ def process():
                    '--args={}={}'.format(arg.key, arg.value)]
             try:
                 stdlib.run(cmd)
+                if architecture.matches_architecture(architecture.ARCH_S390X):
+                    # on s390x we need to call zipl explicitly because of issue in grubby,
+                    # otherwise the entry is not updated in the ZIPL bootloader
+                    # See https://bugzilla.redhat.com/show_bug.cgi?id=1764306
+                    stdlib.run(['/usr/sbin/zipl'])
+
             except (OSError, stdlib.CalledProcessError) as e:
                 raise StopActorExecutionError(
                     "Failed to append extra arguments to kernel command line.",

--- a/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
+++ b/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
@@ -1,5 +1,8 @@
+from collections import namedtuple
+
 from leapp.libraries import stdlib
 from leapp.libraries.actor import kernelcmdlineconfig
+from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg
 
@@ -13,6 +16,14 @@ class MockedRun(object):
     def __call__(self, cmd, *args, **kwargs):
         self.commands.append(cmd)
         return {}
+
+
+class CurrentActorMocked(object):
+    def __init__(self, arch):
+        self.configuration = namedtuple('configuration', ['architecture'])(arch)
+
+    def __call__(self):
+        return self
 
 
 def mocked_consume(*models):
@@ -37,10 +48,11 @@ def mocked_consume_no_version(*models):
     return iter(())
 
 
-def test_kernelcmdline_config(monkeypatch):
+def test_kernelcmdline_config_intel(monkeypatch):
     mocked_run = MockedRun()
     monkeypatch.setattr(stdlib, 'run', mocked_run)
     monkeypatch.setattr(api, 'consume', mocked_consume)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
     kernelcmdlineconfig.process()
     assert mocked_run.commands and len(mocked_run.commands) == 2
     assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
@@ -49,10 +61,26 @@ def test_kernelcmdline_config(monkeypatch):
         KERNEL_VERSION), '--args=some_key1=some_value1'] == mocked_run.commands.pop()
 
 
+def test_kernelcmdline_config_ibmz(monkeypatch):
+    mocked_run = MockedRun()
+    monkeypatch.setattr(stdlib, 'run', mocked_run)
+    monkeypatch.setattr(api, 'consume', mocked_consume)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
+    kernelcmdlineconfig.process()
+    assert mocked_run.commands and len(mocked_run.commands) == 4
+    assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
+        KERNEL_VERSION), '--args=some_key1=some_value1'] == mocked_run.commands.pop(0)
+    assert ['/usr/sbin/zipl'] == mocked_run.commands.pop(0)
+    assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
+        KERNEL_VERSION), '--args=some_key2=some_value2'] == mocked_run.commands.pop(0)
+    assert ['/usr/sbin/zipl'] == mocked_run.commands.pop(0)
+
+
 def test_kernelcmdline_config_no_args(monkeypatch):
     mocked_run = MockedRun()
     monkeypatch.setattr(stdlib, 'run', mocked_run)
     monkeypatch.setattr(api, 'consume', mocked_consume_no_args)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
     kernelcmdlineconfig.process()
     assert not mocked_run.commands
 
@@ -61,5 +89,6 @@ def test_kernelcmdline_config_no_version(monkeypatch):
     mocked_run = MockedRun()
     monkeypatch.setattr(stdlib, 'run', mocked_run)
     monkeypatch.setattr(api, 'consume', mocked_consume_no_version)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
     kernelcmdlineconfig.process()
     assert not mocked_run.commands

--- a/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/libraries/library.py
@@ -1,4 +1,5 @@
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import CalledProcessError, api, run
 from leapp.models import BootContent, FirmwareFacts
 
@@ -28,6 +29,12 @@ def remove_boot_entry():
         '/usr/sbin/grubby',
         '--remove-kernel={0}'.format(kernel_filepath)
     ])
+    if architecture.matches_architecture(architecture.ARCH_S390X):
+        # on s390x we need to call zipl explicitly because of issue in grubby,
+        # otherwise the new boot entry will not be set as default
+        # See https://bugzilla.redhat.com/show_bug.cgi?id=1764306
+        run(['/usr/sbin/zipl'])
+
     # TODO: Move calling `mount -a` to a separate actor as it is not really related to removing the upgrade boot entry.
     #       It's worth to call it after removing the boot entry to avoid boot loop in case mounting fails.
     run([

--- a/repos/system_upgrade/el7toel8/actors/ziplconverttoblscfg/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/ziplconverttoblscfg/actor.py
@@ -1,0 +1,69 @@
+import os
+import filecmp
+
+from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import mounting
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import CalledProcessError
+from leapp.models import TargetUserSpaceInfo
+from leapp.tags import IPUWorkflowTag, PreparationPhaseTag
+
+
+class ZiplConvertToBLSCFG(Actor):
+    """
+    Convert the zipl boot loader configuration to the the boot loader specification on s390x systems.
+    """
+
+    name = 'zipl_convert_to_blscfg'
+    consumes = (TargetUserSpaceInfo,)
+    produces = ()
+    tags = (IPUWorkflowTag, PreparationPhaseTag)
+
+    def process(self):
+        if not architecture.matches_architecture(architecture.ARCH_S390X):
+            return
+        userspace = next(self.consume(TargetUserSpaceInfo), None)
+        if not userspace:
+            # actually this should not happen, but in such case, we want to still
+            # rather continue even if we boot into the old kernel, but in such
+            # case, people will have to do manual actions.
+            # NOTE: it is really just hypothetical
+            self.log_error(
+                'TargetUserSpaceInfo is missing. Cannot execute zipl-switch-to-blscfg'
+                ' to convert the zipl configuration to BLS.'
+            )
+            raise StopActorExecutionError('GENERAL FAILURE: Input data for the actor are missing.')
+
+        # replace the original boot directory inside the container by the host one
+        # - as we cannot use zipl* pointing anywhere else than default directory
+        # - no, --bls-directory is not solution
+        with mounting.BindMount(source='/boot', target=os.path.join(userspace.path, 'boot')):
+            userspace_zipl_conf = os.path.join(userspace.path, 'etc', 'zipl.conf')
+            if os.path.exists(userspace_zipl_conf):
+                os.remove(userspace_zipl_conf)
+            with mounting.NullMount(target=userspace.path) as userspace:
+                with userspace.nspawn() as context:
+                    context.copy_to('/etc/zipl.conf', '/etc/zipl.conf')
+                    # zipl needs this one as well
+                    context.copy_to('/etc/machine-id', '/etc/machine-id')
+                    try:
+                        context.call(['/usr/sbin/zipl-switch-to-blscfg'])
+                        if filecmp.cmp('/etc/zipl.conf', userspace_zipl_conf):
+                            # When the files are same, zipl failed - see the switch script
+                            raise OSError('Failed to convert the ZIPL configuration to BLS.')
+                        context.copy_from('/etc/zipl.conf', '/etc/zipl.conf')
+                    except (OSError, CalledProcessError):
+                        self.log.error(
+                            'Failed to execute zipl-switch-to-blscfg to convert the zipl configuration to BLS',
+                            exc_info=True
+                        )
+                        raise StopActorExecutionError('Failed to convert the zipl configuration to BLS.')
+
+                        # FIXME: we do not want to continue anymore, but we should clean
+                        # better.
+                        # NOTE: Basically, just removal of the /boot/loader dir content inside
+                        # could be enough, but we cannot remove /boot/loader because of boom
+                        # - - if we remove it, we will remove the snapshot as well
+                        # - - on the other hand, we should't keep it there if zipl
+                        # - - has not been converted to BLS

--- a/repos/system_upgrade/el7toel8/actors/ziplconverttoblscfg/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/ziplconverttoblscfg/tests/unit_test.py
@@ -1,0 +1,2 @@
+def test_actor():
+    pass


### PR DESCRIPTION
For the s390x architecture, we need to call zipl explicitly because of the grubby issue - grubby is not calling zipl when update the bootloader configuration. Add the missing zipl calls on s390x architecture.

Additoinally, to be able to create initrd & bootloader entries for the new kernel, the ZIPL configuration has to be converted to BLS before the upgrade transaction is processed. For this purpose the target userspace is reused (the one that is created before to create the initrd & prepare the rpm transaction).

The last update includes adding the `/etc/dasd.conf` file to the very same target userspace and install it inside the dracut image explicitly to be able to work with storage on s390x arch - where DASD is required to be used. Maybe we will need to copy more files in future (maybe on other architectures as well). This will be investigated later. Currently this is solving the only known problem.

EDIT: Additionally, ensure that we do not create dulicit boot entries, otherwise zipl fails. Should be resolved by the last commit. Now the boot entries reffering to the upgrade initrd should be rmeoved before we add the upgrade entry.

Ref: PR #358 


EDIT2: I had to fix several additional issues but now it is prepared for final review and merge, BUT there are still some limitations and issues (other arches are affected as well with various impacts.

We are not able to handle removal of the old kernel in case it is needed during the upgrade. I mean the situation, when user has installed max limit number of kernels before upgrade (by default, the limit is 3, and if I am right, for upgrade it is always 3 know, as we ignore user setup of yum&dnf  guess). There are several problems:
1. The first is inside s390utils on RHEL 8.1. because of BLS detection - we are breaking it by our kernel-workaround package. The problem is fixed for adding of the new kernels, but it is not fixed for removal of old ones (that's only s390x related).
1. Another one is inside our kernel-workaround rpm that provides `/usr/sbin/new-kernel-pkg`, which is not doing enything, just exists. So kernel is not correctly removed when the scriptlet is processed. This is common for all arches.

EDIT3: Created issue for problem with networking on some s390x machines https://github.com/oamg/leapp-repository/issues/383