### PR TITLE
Add check for installed multiple kernels

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/actor.py
@@ -1,0 +1,32 @@
+from leapp.actors import Actor
+from leapp.models import InstalledRedHatSignedRPM
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+from leapp.reporting import Report
+from leapp.libraries.actor import library
+
+
+class CheckInstalledKernels(Actor):
+    """
+    Inhibit IPU (in-place upgrade) when multiple kernels are installed.
+
+    We are not able to upgrade correctly when any kernel is expected to be
+    uninstalled during the rpm upgrade transaction now. This is especially
+    problematic on s390x architecture.
+
+    We discovered recently that removal of old kernels is not handled
+    correctly during the IPU. In case the maximum number of kernels
+    are installed, the oldest one is automatically uninstalled during
+    the rpm upgrade transaction.
+
+    To prevent any related troubles during the IPU, inhibit the IPU
+    on s390x unless just one kernel is installed, until the issue will
+    be fixed correctly.
+    """
+
+    name = 'check_installed_kernels'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        library.process()

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/libraries/library.py
@@ -1,0 +1,40 @@
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM
+
+
+def _get_kernel_rpms():
+    rpms = next(api.consume(InstalledRedHatSignedRPM), InstalledRedHatSignedRPM())
+    return [pkg for pkg in rpms.items if pkg.name == 'kernel']
+
+
+def process():
+    if not architecture.matches_architecture(architecture.ARCH_S390X):
+        return
+
+    pkgs = _get_kernel_rpms()
+    if not pkgs:
+        # Hypothatical, user is not allowed to install any kernel that is not signed by RH
+        # In case we would like to be cautious, we could check whether there are no other
+        # kernels installed as well.
+        api.current_logger().log.error('Cannot find any installed kernel signed by Red Hat.')
+        raise StopActorExecutionError('Cannot find any installed kernel signed by Red Hat.')
+    if len(pkgs) > 1:
+        # It's temporary solution, so no need to try automatize everything.
+        title = 'Multiple kernels installed'
+        summary = ('The upgrade process does not handle well the case when multiple kernels'
+                   ' are installed on s390x. There is a severe risk of the bootloader configuration'
+                   ' getting corrupted during the upgrade.')
+        remediation = ('Boot into the most up-to-date kernel and remove all older'
+                       ' kernels installed on the machine before running Leapp again.')
+        reporting.create_report([
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.KERNEL, reporting.Tags.BOOT]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.Remediation(hint=remediation),
+            reporting.RelatedResource('package', 'kernel')
+        ])

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/tests/unit_test.py
@@ -1,0 +1,73 @@
+from collections import namedtuple
+
+from leapp import reporting
+from leapp.libraries.actor import library
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM, RPM
+
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+
+
+class CurrentActorMocked(object):
+    def __init__(self, arch):
+        self.configuration = namedtuple('configuration', ['architecture'])(arch)
+
+    def __call__(self):
+        return self
+
+
+class mocked_logger(object):
+    def __init__(self):
+        self.errmsg = None
+
+    def error(self, *args):
+        self.errmsg = args
+
+    def __call__(self):
+        return self
+
+
+def mocked_consume(pkg_names):
+    installed_rpms = []
+    version = 1
+    for pkg in pkg_names:
+        installed_rpms.append(RPM(
+                name=pkg, arch='noarch',
+                version=str(version), release='1.sm01', epoch='0',
+                packager=RH_PACKAGER, pgpsig='SOME_OTHER_SIG_X'))
+        version += 1
+
+    def f(*a):
+        yield InstalledRedHatSignedRPM(items=installed_rpms)
+    return f
+
+
+def test_single_kernel(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, "consume", mocked_consume(['kernel', 'someting', 'kernel-somethin']))
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    library.process()
+    assert not reporting.create_report.called
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
+    monkeypatch.setattr(api, "consume", mocked_consume(['kernel', 'someting', 'kernel-somethin']))
+    library.process()
+    assert not reporting.create_report.called
+
+
+def test_multi_kernel(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, "consume", mocked_consume(['kernel', 'someting', 'kernel']))
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    library.process()
+    assert not reporting.create_report.called
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
+    monkeypatch.setattr(api, "consume", mocked_consume(['kernel', 'someting', 'kernel']))
+    library.process()
+    assert reporting.create_report.called
+    assert reporting.create_report.report_fields['title'] == 'Multiple kernels installed'


### PR DESCRIPTION
We discovered recently that removal of old kernels is not handled
correctly during the IPU. In case the maximum number of kernels
are installed, the oldest one is automatically uninstalled during
the rpm upgrade transaction.

This could lead into unbootable state on some machines, and the
bootloader configuration can be corrupted after the removal as well.
This is problem especially on s390x machines.

To prevent any related troubles during the IPU, inhibit the IPU
on s390x unless just one kernel is installed, until the issue will
be fixed correctly.