### PR TITLE
Handle exception when setting 8.1 release

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/libraries/library.py
@@ -7,7 +7,12 @@ def set_rhsm_release():
     """Set the RHSM release to the target RHEL 8 minor version."""
     info = next(api.consume(TargetRHSMInfo), None)
     if info and info.release:
-        rhsm.set_release(mounting.NotIsolatedActions(base_dir='/'), info.release)
+        try:
+            rhsm.set_release(mounting.NotIsolatedActions(base_dir='/'), info.release)
+        except CalledProcessError as err:
+            api.current_logger().warning('Unable to set the {0} release through subscription-manager. When using dnf,'
+                                         ' content of the latest RHEL 8 minor version will be downloaded.\n{1}'
+                                         .format(info.release, str(err)))
     else:
         api.current_logger().debug('Skipping setting the RHSM release due to the use of LEAPP_DEVEL_SKIP_RHSM.')
 


### PR DESCRIPTION
It prevents the upgrade to get stuck in emergency shell in case it's not possible to set the release through sub-mgr

<details><summary>Fixing the following traceback caught on s390x:</summary>

```
[    8.076746] leapp3[861]: 2019-10-23 07:08:08.814 DEBUG    PID: 1402 leapp.wor 
kflow.FirstBoot.enable_rhsm_repos_on_rhel8: External command has started: ['subs 
cription-manager', 'release', '--set', '8.1']                                    
[    8.831557] leapp3[861]: Traceback (most recent call last):                   
[    8.860004] leapp3[861]:   File "/usr/sbin/subscription-manager", line 11, in 
 <module>                                                                        
[    8.861536] leapp3[861]:     load_entry_point('subscription-manager==1.23.8', 
 'console_scripts', 'subscription-manager')()                                    
[    8.863207] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/subscript 
ion_manager/scripts/subscription_manager.py", line 85, in main                   
[    8.864588] leapp3[861]:     return managercli.ManagerCLI().main()            
[    8.866067] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/subscript 
ion_manager/managercli.py", line 2918, in main                                   
[    8.866114] leapp3[861]:     ret = CLI.main(self)                             
[    8.868605] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/subscript 
ion_manager/cli.py", line 183, in main                                           
[    8.868662] leapp3[861]:     return cmd.main()                                
[    8.871767] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/subscript 
ion_manager/managercli.py", line 506, in main                                    
[    8.874994] leapp3[861]:     return_code = self._do_command()                 
[    8.876399] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/subscript 
ion_manager/managercli.py", line 1642, in _do_command                            
[    8.878097] leapp3[861]:     releases = self.release_backend.get_releases()   
                                                                                 
[    8.879447] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/subscript 
ion_manager/release.py", line 61, in get_releases                                
[    8.879489] leapp3[861]:     provider = self._get_release_version_provider()  
                                                                                 
[    8.882479] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/subscript 
ion_manager/release.py", line 66, in _get_release_version_provider               
[    8.882519] leapp3[861]:     if release_provider.api_supported():             
[    8.886103] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/subscript 
ion_manager/release.py", line 78, in api_supported                               
[    8.887819] leapp3[861]:     return self._conn().supports_resource("available 
_releases")                                                                      
[    8.889155] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/rhsm/conn 
ection.py", line 950, in supports_resource                                       
[    8.889188] leapp3[861]:     self._load_supported_resources()                 
[    8.892224] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/rhsm/conn 
ection.py", line 937, in _load_supported_resources                               
[    8.893609] leapp3[861]:     resources_list = self.conn.request_get("/")      
[    8.896820] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/rhsm/conn 
ection.py", line 746, in request_get                                             
[    8.897131] leapp3[861]:     return self._request("GET", method, headers=head 
ers)                                                                             
[    8.898526] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/rhsm/conn 
ection.py", line 772, in _request                                                
[    8.898559] leapp3[861]:     info=info, headers=headers)                      
[    8.902113] leapp3[861]:   File "/usr/lib64/python3.6/site-packages/rhsm/conn 
ection.py", line 603, in _request                                                
[    8.903480] leapp3[861]:     conn.request(request_type, handler, body=body, h 
eaders=final_headers)                                                            
[    8.904819] leapp3[861]:   File "/usr/lib64/python3.6/http/client.py", line 1 
239, in request                                                                  
[   20.012238] leapp3[861]:     self._send_request(method, url, body, headers, e 
ncode_chunked)                                                                   
[   20.013358] leapp3[861]:   File "/usr/lib64/python3.6/http/client.py", line 1 
285, in _send_request                                                            
[   20.015088] leapp3[861]:     self.endheaders(body, encode_chunked=encode_chun 
ked)                                                                             
[   20.016967] leapp3[861]:   File "/usr/lib64/python3.6/http/client.py", line 1 
234, in endheaders                                                               
[   20.017011] leapp3[861]:     self._send_output(message_body, encode_chunked=e 
ncode_chunked)                                                                   
You are in emergency mode. After logging in, type "journalctl -xb" to view       
system logs, "systemctl reboot" to reboot, "systemctl default" or "exit"         
to boot into default mode.                                                       
[   20.020331] leapp3[861]:   File "/usr/lib64/python3.6/http/client.py", line 1 
026, in _send_output                                                             
[   20.022335] leapp3[861]:     self.send(msg)                                   
[   20.022373] leapp3[861]:   File "/usr/lib64/python3.6/http/client.py", line 9 
64, in send                                                                      
[   20.025175] leapp3[861]:     self.connect()                                   
[   20.025209] leapp3[861]:   File "/usr/lib64/python3.6/http/client.py", line 1 
392, in connect                                                                  
[   20.028448] leapp3[861]:     super().connect()                                
[   20.029814] leapp3[861]:   File "/usr/lib64/python3.6/http/client.py", line 9 
36, in connect                                                                   
[   20.029852] leapp3[861]:     (self.host,self.port), self.timeout, self.source 
_address)                                                                        
[   20.033461] leapp3[861]:   File "/usr/lib64/python3.6/socket.py", line 704, i 
n create_connection                                                              
[   20.034951] leapp3[861]:     for res in getaddrinfo(host, port, 0, SOCK_STREA 
M):                                                                              
[   20.036700] leapp3[861]:   File "/usr/lib64/python3.6/socket.py", line 745, i 
n getaddrinfo                                                                    
[   20.038379] leapp3[861]:     for res in _socket.getaddrinfo(host, port, famil 
y, type, proto, flags):                                                          
[   20.038429] leapp3[861]: socket.gaierror: [Errno -2] Name or service not know 
n                                                                                
[   20.042793] leapp3[861]: 2019-10-23 07:08:20.782 DEBUG    PID: 1402 leapp.wor 
kflow.FirstBoot.enable_rhsm_repos_on_rhel8: Command ['subscription-manager', 're 
lease', '--set', '8.1'] failed with exit code 1.
```

</details>