### PR TITLE
Do not add to "to_install" what is already installed

### DIFF
--- a/etc/leapp/transaction/to_install
+++ b/etc/leapp/transaction/to_install
@@ -1,1 +1,2 @@
 ### List of packages (each on new line) to be added to the upgrade transaction
+### Signed packages which are already installed will be skipped

--- a/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/actor.py
@@ -1,5 +1,5 @@
 from leapp.actors import Actor
-from leapp.models import RpmTransactionTasks
+from leapp.models import RpmTransactionTasks, InstalledRedHatSignedRPM
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 from leapp.libraries.actor.scanner import load_tasks
 
@@ -15,7 +15,7 @@ class RpmTransactionConfigTasksCollector(Actor):
     """
 
     name = 'rpm_transaction_config_tasks_collector'
-    consumes = ()
+    consumes = (InstalledRedHatSignedRPM,)
     produces = (RpmTransactionTasks,)
     tags = (FactsPhaseTag, IPUWorkflowTag)
 

--- a/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/libraries/scanner.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/libraries/scanner.py
@@ -1,6 +1,7 @@
 import os.path
 
-from leapp.models import RpmTransactionTasks
+from leapp.models import RpmTransactionTasks, InstalledRedHatSignedRPM
+from leapp.libraries.stdlib import api
 
 
 def load_tasks_file(path, logger):
@@ -19,7 +20,19 @@ def load_tasks_file(path, logger):
 
 def load_tasks(base_dir, logger):
     # Loads configuration files to_install, to_keep, and to_remove from the given base directory
+    rpms = next(api.consume(InstalledRedHatSignedRPM))
+    rpm_names = [rpm.name for rpm in rpms.items]
+    to_install = load_tasks_file(os.path.join(base_dir, 'to_install'), logger)
+    # we do not want to put into rpm transaction what is already installed (it will go to "to_upgrade" bucket)
+    to_install_filtered = [pkg for pkg in to_install if pkg not in rpm_names]
+
+    filtered = set(to_install) - set(to_install_filtered)
+    if filtered:
+        api.current_logger().debug(
+            'The following packages from "to_install" file will be ignored as they are already installed:'
+            '\n- ' + '\n- '.join(filtered))
+
     return RpmTransactionTasks(
-        to_install=load_tasks_file(os.path.join(base_dir, 'to_install'), logger),
+        to_install=to_install_filtered,
         to_keep=load_tasks_file(os.path.join(base_dir, 'to_keep'), logger),
         to_remove=load_tasks_file(os.path.join(base_dir, 'to_remove'), logger))


### PR DESCRIPTION
This will prevent potential transaction failures when user tries to install packages that are already installed (these should be upgraded).

It is also needed for gating testing where we add packages to "/etc/leapp/transaction/to_install" without knowing whether a package is or is not installed on the system. 