### PR TITLE
Simplify checking supported OS

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkosrelease/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkosrelease/actor.py
@@ -1,6 +1,5 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.library import check_os_version, skip_check
-from leapp.libraries.common.config import version
 from leapp.models import OSReleaseFacts
 from leapp.reporting import Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
@@ -8,11 +7,9 @@ from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 class CheckOSRelease(Actor):
     """
-    Check if a supported release version of system's OS is in use. If not, inhibit upgrade process.
+    Check if the current RHEL minor version is supported. If not, inhibit the upgrade process.
 
-    Based on OS release collected facts, this actor will compare current release with supported
-    versions. If a problem is found an inhibition message will be generated. This check can be
-    skipped by using LEAPP_SKIP_CHECK_OS_RELEASE environment variable.
+    This check can be skipped by using the LEAPP_DEVEL_SKIP_CHECK_OS_RELEASE environment variable.
     """
 
     name = 'check_os_release'
@@ -22,4 +19,4 @@ class CheckOSRelease(Actor):
 
     def process(self):
         if not skip_check():
-            check_os_version(version.SUPPORTED_VERSION)
+            check_os_version()

--- a/repos/system_upgrade/el7toel8/actors/checkosrelease/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkosrelease/libraries/library.py
@@ -1,8 +1,6 @@
 import os
 
-from leapp.exceptions import StopActorExecution, StopActorExecutionError
 from leapp import reporting
-from leapp.libraries.stdlib import api
 from leapp.libraries.common.config import version
 
 
@@ -13,10 +11,10 @@ related = [reporting.RelatedResource('file', '/etc/os-release')]
 
 def skip_check():
     """ Check if an environment variable was used to skip this actor """
-    if os.getenv('LEAPP_SKIP_CHECK_OS_RELEASE'):
+    if os.getenv('LEAPP_DEVEL_SKIP_CHECK_OS_RELEASE'):
         reporting.create_report([
             reporting.Title('Skipped OS release check'),
-            reporting.Summary('Source RHEL release check skipped via LEAPP_SKIP_CHECK_OS_RELEASE env var.'),
+            reporting.Summary('Source RHEL release check skipped via LEAPP_DEVEL_SKIP_CHECK_OS_RELEASE env var.'),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags(COMMON_REPORT_TAGS)
         ] + related)
@@ -25,38 +23,18 @@ def skip_check():
     return False
 
 
-def check_os_version(supported_version):
-    """ Check OS version and inhibit upgrade if not the same as supported ones """
-    if not isinstance(supported_version, dict):
-        api.current_logger().warning('The supported version value is invalid.')
-        raise StopActorExecution()
-
-    release_id, version_id = version.current_version()
-
-    if not version.matches_release(supported_version.keys(), release_id):
+def check_os_version():
+    """ Check the RHEL minor version and inhibit the upgrade if it does not match the supported ones """
+    if not version.is_supported_version():
+        supported_releases = []
+        for rel in version.SUPPORTED_VERSIONS:
+            for ver in version.SUPPORTED_VERSIONS[rel]:
+                supported_releases.append(rel.upper() + ' ' + ver)
         reporting.create_report([
             reporting.Title('Unsupported OS'),
-            reporting.Summary('Only RHEL is supported by the upgrade process'),
-            reporting.Severity(reporting.Severity.HIGH),
-            reporting.Tags(COMMON_REPORT_TAGS),
-            reporting.Flags([reporting.Flags.INHIBITOR])
-        ] + related)
-
-        return
-
-    if not isinstance(supported_version[release_id], list):
-        raise StopActorExecutionError(
-            'Invalid versions',
-            details={'details': 'OS versions are invalid, please provide a valid list.'},
-        )
-
-    if not version.matches_version(supported_version[release_id], version_id):
-        reporting.create_report([
-            reporting.Title('Unsupported OS version'),
             reporting.Summary(
-                'The supported OS versions for the upgrade process: {}'.format(
-                    ', '.join(supported_version[release_id])
-                )
+                'The supported OS releases for the upgrade process:\n'
+                ' {}'.format('\n'.join(supported_releases))
             ),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Tags(COMMON_REPORT_TAGS),

--- a/repos/system_upgrade/el7toel8/actors/checkosrelease/tests/test_checkosrelease.py
+++ b/repos/system_upgrade/el7toel8/actors/checkosrelease/tests/test_checkosrelease.py
@@ -2,14 +2,14 @@ import os
 
 import pytest
 
+from leapp import reporting
 from leapp.exceptions import StopActorExecution, StopActorExecutionError
 from leapp.libraries.actor import library
-from leapp import reporting
-from leapp.libraries.common.testutils import produce_mocked, create_report_mocked
+from leapp.libraries.common.config import version
+from leapp.libraries.common.testutils import (create_report_mocked,
+                                              produce_mocked)
 from leapp.libraries.stdlib import api
 from leapp.models import OSReleaseFacts
-
-SUPPORTED_VERSION = {'rhel': ['7.5', '7.6']}
 
 
 def test_skip_check(monkeypatch):
@@ -31,49 +31,11 @@ def test_no_skip_check(monkeypatch):
     assert reporting.create_report.called == 0
 
 
-def test_no_facts(monkeypatch):
-    def os_release_mocked(*models):
-        yield None
-
-    monkeypatch.setattr(api, "consume", os_release_mocked)
-    with pytest.raises(StopActorExecutionError):
-        library.check_os_version(SUPPORTED_VERSION)
-
-
-def create_os_release(release_id, version_id=7.6):
-    return OSReleaseFacts(
-        release_id=release_id,
-        name='test',
-        pretty_name='test {}'.format(version_id),
-        version='Some Test {}'.format(version_id),
-        version_id=version_id,
-        variant=None,
-        variant_id=None,
-    )
-
-
-def test_not_supported_id(monkeypatch):
-    def os_release_mocked(*models):
-        yield create_os_release('rhel', '7.7')
-
-    monkeypatch.setattr(api, "consume", os_release_mocked)
-    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-
-    library.check_os_version(SUPPORTED_VERSION)
-    assert reporting.create_report.called == 1
-    assert 'Unsupported OS version' in reporting.create_report.report_fields['title']
-    assert 'flags' in reporting.create_report.report_fields
-    assert 'inhibitor' in reporting.create_report.report_fields['flags']
-
-
 def test_not_supported_release(monkeypatch):
-    def os_release_mocked(*models):
-        yield create_os_release('unsupported', SUPPORTED_VERSION['rhel'][0])
-
-    monkeypatch.setattr(api, "consume", os_release_mocked)
+    monkeypatch.setattr(version, "is_supported_version", lambda: False)
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
 
-    library.check_os_version(SUPPORTED_VERSION)
+    library.check_os_version()
     assert reporting.create_report.called == 1
     assert 'Unsupported OS' in reporting.create_report.report_fields['title']
     assert 'flags' in reporting.create_report.report_fields
@@ -81,34 +43,8 @@ def test_not_supported_release(monkeypatch):
 
 
 def test_supported_release(monkeypatch):
-    def os_mocked_first_release(*models):
-        yield create_os_release('rhel', SUPPORTED_VERSION['rhel'][0])
-
-    def os_mocked_second_release(*models):
-        yield create_os_release('rhel', SUPPORTED_VERSION['rhel'][1])
-
-    monkeypatch.setattr(api, "consume", os_mocked_first_release)
+    monkeypatch.setattr(version, "is_supported_version", lambda: True)
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
 
-    library.check_os_version(SUPPORTED_VERSION)
-    monkeypatch.setattr(api, "consume", os_mocked_second_release)
-    library.check_os_version(SUPPORTED_VERSION)
+    library.check_os_version()
     assert reporting.create_report.called == 0
-
-
-def test_invalid_versions(monkeypatch):
-    def os_release_mocked(*models):
-        yield create_os_release('rhel', '7.6')
-
-    monkeypatch.setattr(api, "consume", os_release_mocked)
-    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-
-    with pytest.raises(StopActorExecution):
-        library.check_os_version('string')
-    with pytest.raises(StopActorExecution):
-        library.check_os_version(None)
-
-    library.check_os_version({})
-    assert reporting.create_report.called == 1
-    with pytest.raises(StopActorExecutionError):
-        library.check_os_version({'rhel': None})

--- a/repos/system_upgrade/el7toel8/libraries/config/version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/version.py
@@ -1,5 +1,4 @@
 import operator
-import os
 
 import six
 
@@ -14,7 +13,7 @@ OP_MAP = {
     '<=': operator.le
 }
 
-SUPPORTED_VERSION = {'rhel': ['7.6']}
+SUPPORTED_VERSIONS = {'rhel': ['7.6']}
 
 
 def _version_to_tuple(version):
@@ -132,7 +131,7 @@ def matches_release(allowed_releases, release):
 
 
 def current_version():
-    """Return current Linux release and version running in system.
+    """Return the current Linux release and version.
 
     :raises StopActorExecutionError: this exception will be raised if no facts found to read data.
     :return: The tuple contains release name and version value.
@@ -150,17 +149,14 @@ def current_version():
 
 
 def is_supported_version():
-    """ Verify if current system version is supported to the upgrade.
+    """ Verify if the current system version is supported for the upgrade.
 
-    :return: `True` if current version is supported and `False` otherwise.
+    :return: `True` if the current version is supported and `False` otherwise.
     :rtype: bool
     """
-    if os.getenv('LEAPP_SKIP_CHECK_OS_RELEASE'):
-        return True
-
     release_id, version_id = current_version()
 
-    if not matches_release(SUPPORTED_VERSION, release_id):
+    if not matches_release(SUPPORTED_VERSIONS, release_id):
         return False
 
-    return matches_version(SUPPORTED_VERSION[release_id], version_id)
+    return matches_version(SUPPORTED_VERSIONS[release_id], version_id)


### PR DESCRIPTION
- Use the common library function `is_supported_version()` instead of duplicating its functionality
- Rename LEAPP_SKIP_CHECK_OS_RELEASE to LEAPP\_**DEVEL**\_SKIP_CHECK_OS_RELEASE to make it more clear that using this option is not supported