### PR TITLE
Inhibit upgrade when it is not supported

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
@@ -1,11 +1,10 @@
-import os
 import json
 
+from leapp import reporting
 from leapp.actors import Actor
 from leapp.models import Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 from leapp.utils.audit import get_connection
-from leapp import reporting
 
 
 class UnsupportedUpgradeCheck(Actor):
@@ -34,12 +33,15 @@ class UnsupportedUpgradeCheck(Actor):
                     'These variables are for development purposes only and can interfere with the upgrade '
                     'process in unexpected ways. As such, a successful and safe upgrade process cannot be '
                     'guaranteed and the upgrade is unsupported.\n'
-                    'Found development variables:\n- ' + '\n- '.join([var.name for var in devel_vars]) + '\n'
+                    'You can bypass this error by setting the LEAPP_UNSUPPORTED variable but by doing so, '
+                    'you continue at your own risk.\n'
+                    'Found development variables:\n- {}\n'.format('\n- '.join([v.name for v in devel_vars]))
                 ),
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Flags([reporting.Flags.INHIBITOR]),
                 reporting.Tags([reporting.Tags.UPGRADE_PROCESS, reporting.Tags.SANITY]),
-                reporting.Remediation(hint='Invoke leapp without any LEAPP_DEVEL_* environment variables.')
+                reporting.Remediation(hint=('Invoke leapp without any LEAPP_DEVEL_* environment variables '
+                                            'or set LEAPP_UNSUPPORTED=1.'))
             ])
 
         experimental = []
@@ -57,10 +59,13 @@ class UnsupportedUpgradeCheck(Actor):
                     'These actors are unstable or in development and can interfere with the upgrade '
                     'process in unexpected ways. As such, a successful and safe upgrade process cannot be '
                     'guaranteed and the upgrade is unsupported.\n'
+                    'You can bypass this error by setting the LEAPP_UNSUPPORTED variable but by doing so, '
+                    'you continue at your own risk.\n'
                     'Found enabled experimental actors:\n- ' + '\n- '.join(experimental) + '\n'
                 ),
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Flags([reporting.Flags.INHIBITOR]),
                 reporting.Tags([reporting.Tags.UPGRADE_PROCESS, reporting.Tags.SANITY]),
-                reporting.Remediation(hint='Invoke leapp without any --whitelist-experimental options.')
+                reporting.Remediation(hint=('Invoke leapp without any --whitelist-experimental options '
+                                            'or set LEAPP_UNSUPPORTED=1.'))
             ])

--- a/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
@@ -23,39 +23,52 @@ class UnsupportedUpgradeCheck(Actor):
         experimental = bool([v for v in leapp_vars if v.name == 'LEAPP_EXPERIMENTAL' and v.value == '1'])
         override = bool([v for v in leapp_vars if v.name == 'LEAPP_UNSUPPORTED' and v.value == '1'])
 
-        if devel_vars and not override:
+        if override:
             reporting.create_report([
-                reporting.Title('Upgrade inhibited due to usage of development variables'),
+                reporting.Title('Upgrade is unsupported'),
                 reporting.Summary(
-                    'One or more environment variables in the form of LEAPP_DEVEL_* have been detected.\n'
-                    'These variables are for development purposes only and can interfere with the upgrade '
-                    'process in unexpected ways. As such, a successful and safe upgrade process cannot be '
-                    'guaranteed and the upgrade is unsupported.\n'
-                    'You can bypass this error by setting the LEAPP_UNSUPPORTED variable but by doing so, '
-                    'you continue at your own risk.\n'
-                    'Found development variables:\n- {}\n'.format('\n- '.join([v.name for v in devel_vars]))
+                    'Environment variable LEAPP_UNSUPPORTED has been detected. A successful and safe '
+                    'upgrade process cannot be guaranteed. From now on you are continuing at your own '
+                    'risk.\n'
                 ),
                 reporting.Severity(reporting.Severity.HIGH),
-                reporting.Flags([reporting.Flags.INHIBITOR]),
                 reporting.Tags([reporting.Tags.UPGRADE_PROCESS, reporting.Tags.SANITY]),
-                reporting.Remediation(hint=('Invoke leapp without any LEAPP_DEVEL_* environment variables '
-                                            'or set LEAPP_UNSUPPORTED=1.'))
             ])
 
-        if experimental and not override:
-            reporting.create_report([
-                reporting.Title('Upgrade inhibited due to enabled experimental actors'),
-                reporting.Summary(
-                    'One or more enabled experimental actors have been detected.\n'
-                    'These actors are unstable or in development and can interfere with the upgrade '
-                    'process in unexpected ways. As such, a successful and safe upgrade process cannot be '
-                    'guaranteed and the upgrade is unsupported.\n'
-                    'You can bypass this error by setting the LEAPP_UNSUPPORTED variable but by doing so, '
-                    'you continue at your own risk.\n'
-                ),
-                reporting.Severity(reporting.Severity.HIGH),
-                reporting.Flags([reporting.Flags.INHIBITOR]),
-                reporting.Tags([reporting.Tags.UPGRADE_PROCESS, reporting.Tags.SANITY]),
-                reporting.Remediation(hint=('Invoke leapp without any --whitelist-experimental options '
-                                            'or set LEAPP_UNSUPPORTED=1.'))
-            ])
+        else:
+            if devel_vars:
+                reporting.create_report([
+                    reporting.Title('Upgrade inhibited due to usage of development variables'),
+                    reporting.Summary(
+                        'One or more environment variables in the form of LEAPP_DEVEL_* have been detected.\n'
+                        'These variables are for development purposes only and can interfere with the upgrade '
+                        'process in unexpected ways. As such, a successful and safe upgrade process cannot be '
+                        'guaranteed and the upgrade is unsupported.\n'
+                        'You can bypass this error by setting the LEAPP_UNSUPPORTED variable but by doing so, '
+                        'you continue at your own risk.\n'
+                        'Found development variables:\n- {}\n'.format('\n- '.join([v.name for v in devel_vars]))
+                    ),
+                    reporting.Severity(reporting.Severity.HIGH),
+                    reporting.Flags([reporting.Flags.INHIBITOR]),
+                    reporting.Tags([reporting.Tags.UPGRADE_PROCESS, reporting.Tags.SANITY]),
+                    reporting.Remediation(hint=('Invoke leapp without any LEAPP_DEVEL_* environment variables '
+                                                'or set LEAPP_UNSUPPORTED=1.'))
+                ])
+
+            if experimental:
+                reporting.create_report([
+                    reporting.Title('Upgrade inhibited due to enabled experimental actors'),
+                    reporting.Summary(
+                        'One or more enabled experimental actors have been detected.\n'
+                        'These actors are unstable or in development and can interfere with the upgrade '
+                        'process in unexpected ways. As such, a successful and safe upgrade process cannot be '
+                        'guaranteed and the upgrade is unsupported.\n'
+                        'You can bypass this error by setting the LEAPP_UNSUPPORTED variable but by doing so, '
+                        'you continue at your own risk.\n'
+                    ),
+                    reporting.Severity(reporting.Severity.HIGH),
+                    reporting.Flags([reporting.Flags.INHIBITOR]),
+                    reporting.Tags([reporting.Tags.UPGRADE_PROCESS, reporting.Tags.SANITY]),
+                    reporting.Remediation(hint=('Invoke leapp without any --whitelist-experimental options '
+                                                'or set LEAPP_UNSUPPORTED=1.'))
+                ])

--- a/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
@@ -22,9 +22,9 @@ class UnsupportedUpgradeCheck(Actor):
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 
     def process(self):
-        env = os.environ
-        devel_vars = {k: env[k] for k in env if k.startswith('LEAPP_DEVEL_')}
-        override = 'LEAPP_UNSUPPORTED' in env
+        leapp_vars = self.configuration.leapp_env_vars
+        devel_vars = [var for var in leapp_vars if var.name.startswith('LEAPP_DEVEL_')]
+        override = bool([var for var in leapp_vars if var.name == 'LEAPP_UNSUPPORTED'])
 
         if devel_vars and not override:
             reporting.create_report([
@@ -34,7 +34,7 @@ class UnsupportedUpgradeCheck(Actor):
                     'These variables are for development purposes only and can interfere with the upgrade '
                     'process in unexpected ways. As such, a successful and safe upgrade process cannot be '
                     'guaranteed and the upgrade is unsupported.\n'
-                    'Found development variables:\n- ' + '\n- '.join(devel_vars) + '\n'
+                    'Found development variables:\n- ' + '\n- '.join([var.name for var in devel_vars]) + '\n'
                 ),
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Flags([reporting.Flags.INHIBITOR]),

--- a/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
@@ -18,8 +18,7 @@ class UnsupportedUpgradeCheck(Actor):
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 
     def process(self):
-        conf = self.configuration
-        leapp_vars = conf.leapp_env_vars
+        leapp_vars = self.configuration.leapp_env_vars
         devel_vars = [v for v in leapp_vars if v.name.startswith('LEAPP_DEVEL_')]
         experimental = bool([v for v in leapp_vars if v.name == 'LEAPP_EXPERIMENTAL' and v.value == '1'])
         override = bool([v for v in leapp_vars if v.name == 'LEAPP_UNSUPPORTED' and v.value == '1'])

--- a/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
@@ -21,7 +21,8 @@ class UnsupportedUpgradeCheck(Actor):
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 
     def process(self):
-        leapp_vars = self.configuration.leapp_env_vars
+        conf = self.configuration
+        leapp_vars = conf.leapp_env_vars
         devel_vars = [var for var in leapp_vars if var.name.startswith('LEAPP_DEVEL_')]
         override = bool([var for var in leapp_vars if var.name == 'LEAPP_UNSUPPORTED'])
 
@@ -44,13 +45,7 @@ class UnsupportedUpgradeCheck(Actor):
                                             'or set LEAPP_UNSUPPORTED=1.'))
             ])
 
-        experimental = []
-        with get_connection(None) as db:
-            conf = db.execute("SELECT configuration FROM execution "
-                              "WHERE kind = 'upgrade' OR kind = 'preupgrade' "
-                              "ORDER BY id DESC LIMIT 1").fetchone()
-            if conf:
-                experimental = json.loads(conf[0])["whitelist_experimental"]
+        experimental = json.loads(conf[0])["whitelist_experimental"]
         if experimental and not override:
             reporting.create_report([
                 reporting.Title('Upgrade inhibited due to enabled experimental actors'),

--- a/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/unsupportedupgradecheck/actor.py
@@ -1,0 +1,66 @@
+import os
+import json
+
+from leapp.actors import Actor
+from leapp.models import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.utils.audit import get_connection
+from leapp import reporting
+
+
+class UnsupportedUpgradeCheck(Actor):
+    """
+    Checks enviroment variables and produces a warning report if the upgrade is unsupported.
+
+    Upgrade is unsupported if any LEAPP_DEVEL_* variable is used or an experimental actor is enabled.
+    This can be overridden by setting the variable LEAPP_UNSUPPORTED (at user's own risk).
+    """
+
+    name = 'unsupported_upgrade_check'
+    consumes = ()
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        env = os.environ
+        devel_vars = {k: env[k] for k in env if k.startswith('LEAPP_DEVEL_')}
+        override = 'LEAPP_UNSUPPORTED' in env
+
+        if devel_vars and not override:
+            reporting.create_report([
+                reporting.Title('Upgrade inhibited due to usage of development variables'),
+                reporting.Summary(
+                    'One or more environment variables in the form of LEAPP_DEVEL_* have been detected.\n'
+                    'These variables are for development purposes only and can interfere with the upgrade '
+                    'process in unexpected ways. As such, a successful and safe upgrade process cannot be '
+                    'guaranteed and the upgrade is unsupported.\n'
+                    'Found development variables:\n- ' + '\n- '.join(devel_vars) + '\n'
+                ),
+                reporting.Severity(reporting.Severity.HIGH),
+                reporting.Flags([reporting.Flags.INHIBITOR]),
+                reporting.Tags([reporting.Tags.UPGRADE_PROCESS, reporting.Tags.SANITY]),
+                reporting.Remediation(hint='Invoke leapp without any LEAPP_DEVEL_* environment variables.')
+            ])
+
+        experimental = []
+        with get_connection(None) as db:
+            conf = db.execute("SELECT configuration FROM execution "
+                              "WHERE kind = 'upgrade' OR kind = 'preupgrade' "
+                              "ORDER BY id DESC LIMIT 1").fetchone()
+            if conf:
+                experimental = json.loads(conf[0])["whitelist_experimental"]
+        if experimental and not override:
+            reporting.create_report([
+                reporting.Title('Upgrade inhibited due to enabled experimental actors'),
+                reporting.Summary(
+                    'One or more enabled experimental actors have been detected.\n'
+                    'These actors are unstable or in development and can interfere with the upgrade '
+                    'process in unexpected ways. As such, a successful and safe upgrade process cannot be '
+                    'guaranteed and the upgrade is unsupported.\n'
+                    'Found enabled experimental actors:\n- ' + '\n- '.join(experimental) + '\n'
+                ),
+                reporting.Severity(reporting.Severity.HIGH),
+                reporting.Flags([reporting.Flags.INHIBITOR]),
+                reporting.Tags([reporting.Tags.UPGRADE_PROCESS, reporting.Tags.SANITY]),
+                reporting.Remediation(hint='Invoke leapp without any --whitelist-experimental options.')
+            ])


### PR DESCRIPTION
Current inhibition cases:
- one or more `LEAPP_DEVEL_*` variables are set
- one or more experimental actors are enabled by `--whitelist-experimental`

Requires PR: https://github.com/oamg/leapp/pull/577