### PR TITLE
initrd: have upgrade.target depend on dracut-cmdline.service

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/90sys-upgrade/module-setup.sh
+++ b/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/90sys-upgrade/module-setup.sh
@@ -48,12 +48,12 @@ install() {
     done
 
     # just try : set another services into the wantsdir
-    #        dracut-cmdline   \
     #        sysroot.mount    \
     #        dracut-mount     \
     #        dracut-pre-udev  \
     #         dracut-pre-mount.service
     for s in \
+             dracut-cmdline.service   \
              dracut-initqueue.service \
     ;do
         ln -sf "${systemdsystemunitdir}/$s" $upgrade_wantsdir


### PR DESCRIPTION
On s390, there's a cmdline hook that sets the ccw.conf contents to
what's been specified by rd.znet parameter. Without it, the ccw_init
udev helper doesn't bind the qeth devices.

Without the qeth devices being available in the leapp session, the
target dracut run doesn't detect that it's necessary to install
the qeth_l2/qeth_l3 drivers into the new hostonly initrd and thus the
upgraded systemd ends up without the network devices.

That us just sad. Let's bring up the dracut-cmdline.service. It fixes
the issue in s390 and should do no harm on other platforms.

Fixes: https://github.com/oamg/leapp-repository/issues/383
Signed-off-by: Lubomir Rintel <lkundrak@v3.sk>