### PR TITLE
Check minimum memory requirements to upgrade to RHEL8

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkmemory/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmemory/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import MemoryInfo, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckMemory(Actor):
+    """
+    The actor check the size of RAM against RHEL8 minimal hardware requirements
+
+    Using the following resource: https://access.redhat.com/articles/rhel-limits
+    """
+
+    name = 'checkmemory'
+    consumes = (MemoryInfo,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        library.process()

--- a/repos/system_upgrade/el7toel8/actors/checkmemory/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmemory/libraries/library.py
@@ -1,0 +1,44 @@
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+from leapp.models import MemoryInfo
+
+min_req_memory = {
+    architecture.ARCH_X86_64: 1536,  # 1.5G
+    architecture.ARCH_ARM64: 2048,  # 2Gb
+    architecture.ARCH_PPC64LE: 2048,  # 2Gb
+    architecture.ARCH_S390X: 1024  # 1Gb
+}
+
+
+def _check_memory(mem_info):
+    msg = {}
+
+    for arch, min_req in iter(min_req_memory.items()):
+        if architecture.matches_architecture(arch):
+            is_ok = mem_info.mem_total >= min_req
+            msg = {} if is_ok else {'detected': mem_info.mem_total,
+                                    'minimal_req': min_req}
+
+    return msg
+
+
+def process():
+    memoryinfo = next(api.consume(MemoryInfo), None)
+    if memoryinfo is None:
+        raise StopActorExecutionError(message=("Missing information about Memory."))
+
+    minimum_req_error = _check_memory(memoryinfo)
+
+    if minimum_req_error:
+        title = 'Minimum memory requirements for RHEL 8 are not met'
+        summary = 'Memory detected: {} KiB, required: {} KiB'.format(minimum_req_error['detected'],
+                                                                     minimum_req_error['minimal_req'])
+        reporting.create_report([
+                          reporting.Title(title),
+                          reporting.Summary(summary),
+                          reporting.Severity(reporting.Severity.HIGH),
+                          reporting.Tags([reporting.Tags.SANITY]),
+                          reporting.Flags([reporting.Flags.INHIBITOR]),
+                      ])

--- a/repos/system_upgrade/el7toel8/actors/checkmemory/tests/test_checkmemory.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmemory/tests/test_checkmemory.py
@@ -1,0 +1,44 @@
+from collections import namedtuple
+
+import pytest
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import library
+from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+from leapp.models import MemoryInfo
+
+
+class CurrentActorMocked(object):
+    def __init__(self, arch):
+        self.configuration = namedtuple('configuration', ['architecture'])(arch)
+
+    def __call__(self):
+        return self
+
+
+def test_check_memory_low(monkeypatch):
+    minimum_req_error = []
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+    minimum_req_error = library._check_memory(MemoryInfo(mem_total=1024))
+    assert minimum_req_error
+
+
+def test_check_memory_high(monkeypatch):
+    minimum_req_error = []
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+    minimum_req_error = library._check_memory(MemoryInfo(mem_total=16273492))
+    assert not minimum_req_error
+
+
+def test_report(monkeypatch):
+    title_msg = 'Minimum memory requirements for RHEL 8 are not met'
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+    monkeypatch.setattr(api, 'consume', lambda x: iter([MemoryInfo(mem_total=129)]))
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    library.process()
+    assert reporting.create_report.called
+    assert title_msg == reporting.create_report.report_fields['title']
+    assert reporting.Flags.INHIBITOR in reporting.create_report.report_fields['flags']

--- a/repos/system_upgrade/el7toel8/actors/scanmemory/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scanmemory/actor.py
@@ -1,0 +1,16 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import MemoryInfo
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+
+
+class ScanMemory(Actor):
+    """Scan Memory of the machine."""
+
+    name = 'scanmemory'
+    consumes = ()
+    produces = (MemoryInfo,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        library.process()

--- a/repos/system_upgrade/el7toel8/actors/scanmemory/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/scanmemory/libraries/library.py
@@ -1,0 +1,24 @@
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp.models import MemoryInfo
+
+
+def _get_memoryinfo(filename='/proc/meminfo'):
+    """ Returns dict of all memory information from /proc/meminfo file """
+
+    try:
+        with open(filename) as fp:
+            # format of the lines: Key:  value unit
+            # e.g.:                MemTotal:   1024 kB
+            return dict((i.split()[0].rstrip(':'), int(i.split()[1])) for i in fp.readlines())
+    except IOError:
+        raise StopActorExecutionError(
+            'Could not read memory values',
+            details={'details': 'Error opening file {}'.format(filename)},
+        )
+
+
+def process():
+    mem_info = _get_memoryinfo()
+    if mem_info:
+        api.produce(MemoryInfo(mem_total=mem_info['MemTotal']))

--- a/repos/system_upgrade/el7toel8/actors/scanmemory/tests/test_scanmemory.py
+++ b/repos/system_upgrade/el7toel8/actors/scanmemory/tests/test_scanmemory.py
@@ -1,0 +1,24 @@
+import mock
+
+from leapp.libraries.actor import library
+from leapp.libraries.common import testutils
+from leapp.libraries.stdlib import api
+from leapp.models import MemoryInfo
+
+
+def test_with_low_memory(monkeypatch):
+    with mock.patch("__builtin__.open", mock.mock_open(read_data="MemTotal: 42 kB")) as mock_proc_meminfo:
+        monkeypatch.setattr(api, 'produce', testutils.produce_mocked())
+        library.process()
+        mock_proc_meminfo.assert_called_once_with('/proc/meminfo')
+        assert api.produce.called == 1
+        assert MemoryInfo(mem_total=42) == api.produce.model_instances[0]
+
+
+def test_with_high_memory(monkeypatch):
+    with mock.patch("__builtin__.open", mock.mock_open(read_data="MemTotal: 424242424242 kB")) as mock_proc_meminfo:
+        monkeypatch.setattr(api, 'produce', testutils.produce_mocked())
+        library.process()
+        mock_proc_meminfo.assert_called_once_with('/proc/meminfo')
+        assert api.produce.called == 1
+        assert MemoryInfo(mem_total=424242424242) == api.produce.model_instances[0]

--- a/repos/system_upgrade/el7toel8/models/memoryinfo.py
+++ b/repos/system_upgrade/el7toel8/models/memoryinfo.py
@@ -1,0 +1,15 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemFactsTopic
+
+
+class MemoryInfo(Model):
+    """
+    Represents information about available memory (KiB)
+    """
+
+    topic = SystemFactsTopic
+
+    mem_total = fields.Nullable(fields.Integer())
+    """
+    Total memory in KiB
+    """


### PR DESCRIPTION
These actor will check the minimum memory requirements to upgrade to RHEL8, based on these document: https://access.redhat.com/articles/rhel-limits
