### PR TITLE
Revert "Add "requests" package also to requirements (#410)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ pylint
 # pytest is fixed at 3.6.4 because never version (3.7.*) requires scandir, which depends on gcc
 pytest==3.6.4
 pytest-ordering==0.5
-requests
 git+https://github.com/oamg/leapp


### PR DESCRIPTION
This reverts commit bb7ac2c6d738ee0574171d8b47a3d3db73e49ef4. That commit was an incorrect workaround on the leapp-repository side. It should have been fixed on the leapp framework side.

The 'requests' package was missing when running leapp-repository unit tests. It was caused when leapp framework was being installed as a dependency by leapp-repository makefile, but without this requests' dependency of leapp framework itself. It's fixed by https://github.com/oamg/leapp/pull/587. Merge this PR after that PR is merged.