### PR TITLE
Make unused fields of custom repo msg optional

### DIFF
--- a/repos/system_upgrade/el7toel8/models/targetrepositories.py
+++ b/repos/system_upgrade/el7toel8/models/targetrepositories.py
@@ -16,8 +16,8 @@ class RHELTargetRepository(TargetRepositoryBase):
 
 
 class CustomTargetRepository(TargetRepositoryBase):
-    name = fields.String()
-    baseurl = fields.String()
+    name = fields.Nullable(fields.String())
+    baseurl = fields.Nullable(fields.String())
     enabled = fields.Boolean(default=True)
 
 


### PR DESCRIPTION
We were requiring the 'baseurl' and 'name' fields but they were not being used anywhere. Because the fields were required, people thought they are being used somewhere. But not really, only repoid is being processed.

Task to improve processing custom repo msgs: RHELLEAPP-1990