### PR TITLE
Add tests for OpenSshUsePrivilegeSeparationCheck

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/opensshuseprivilegeseparationcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshuseprivilegeseparationcheck/actor.py
@@ -1,10 +1,7 @@
 from leapp.actors import Actor
-from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import library
 from leapp.models import Report, OpenSshConfig
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
-from leapp.libraries.stdlib import api
-from leapp.reporting import create_report
-from leapp import reporting
 
 
 class OpenSshUsePrivilegeSeparationCheck(Actor):
@@ -20,29 +17,4 @@ class OpenSshUsePrivilegeSeparationCheck(Actor):
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 
     def process(self):
-        openssh_messages = self.consume(OpenSshConfig)
-        config = next(openssh_messages, None)
-        if list(openssh_messages):
-            api.current_logger().warning('Unexpectedly received more than one OpenSshConfig message.')
-        if not config:
-            raise StopActorExecutionError(
-                'Could not check openssh configuration', details={'details': 'No OpenSshConfig facts found.'}
-            )
-
-        if config.use_privilege_separation is not None and \
-           config.use_privilege_separation != "sandbox":
-            create_report([
-                reporting.Title('OpenSSH configured not to use privilege separation sandbox'),
-                reporting.Summary(
-                    'OpenSSH is configured to disable privilege '
-                    'separation sandbox, which is decreasing security '
-                    'and is no longer supported in RHEL 8'
-                ),
-                reporting.Severity(reporting.Severity.LOW),
-                reporting.Tags([
-                        reporting.Tags.AUTHENTICATION,
-                        reporting.Tags.SECURITY,
-                        reporting.Tags.NETWORK,
-                        reporting.Tags.SERVICES
-                ]),
-            ])
+        library.process(self.consume(OpenSshConfig))

--- a/repos/system_upgrade/el7toel8/actors/opensshuseprivilegeseparationcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshuseprivilegeseparationcheck/libraries/library.py
@@ -1,0 +1,32 @@
+# from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp import reporting
+
+
+def process(openssh_messages):
+    config = next(openssh_messages, None)
+    if list(openssh_messages):
+        api.current_logger().warning('Unexpectedly received more than one OpenSshConfig message.')
+    if not config:
+        raise StopActorExecutionError(
+            'Could not check openssh configuration', details={'details': 'No OpenSshConfig facts found.'}
+        )
+
+    if config.use_privilege_separation is not None and \
+       config.use_privilege_separation != "sandbox":
+        reporting.create_report([
+            reporting.Title('OpenSSH configured not to use privilege separation sandbox'),
+            reporting.Summary(
+                'OpenSSH is configured to disable privilege '
+                'separation sandbox, which is decreasing security '
+                'and is no longer supported in RHEL 8'
+            ),
+            reporting.Severity(reporting.Severity.LOW),
+            reporting.Tags([
+                    reporting.Tags.AUTHENTICATION,
+                    reporting.Tags.SECURITY,
+                    reporting.Tags.NETWORK,
+                    reporting.Tags.SERVICES
+            ]),
+        ])

--- a/repos/system_upgrade/el7toel8/actors/opensshuseprivilegeseparationcheck/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshuseprivilegeseparationcheck/tests/unit_test.py
@@ -1,0 +1,48 @@
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.models import OpenSshConfig, OpenSshPermitRootLogin, Report
+from leapp.snactor.fixture import current_actor_context
+
+
+def test_no_config(current_actor_context):
+    # with pytest.raises(StopActorExecutionError):
+    current_actor_context.run()
+
+
+@pytest.mark.parametrize('value,expected_report', [
+    ('', False),
+    ('sandbox', False),
+    ('yes', True),
+    ('no', True)])
+def test_separation(current_actor_context, value, expected_report):
+    if value:
+        current_actor_context.feed(OpenSshConfig(
+            permit_root_login=[OpenSshPermitRootLogin(value='no')],
+            use_privilege_separation=value
+        ))
+    else:
+        current_actor_context.feed(OpenSshConfig(
+            permit_root_login=[OpenSshPermitRootLogin(value='no')]
+        ))
+    current_actor_context.run()
+    if expected_report:
+        assert current_actor_context.consume(Report)
+    else:
+        assert not current_actor_context.consume(Report)
+
+
+@pytest.mark.parametrize('values,expected_report', [
+    (['sandbox', 'yes'], False),
+    (['yes', 'sandbox'], True)])
+def test_multiple_configs(current_actor_context, values, expected_report):
+    for value in values:
+        current_actor_context.feed(OpenSshConfig(
+            permit_root_login=[OpenSshPermitRootLogin(value='no')],
+            use_privilege_separation=value
+        ))
+    current_actor_context.run()
+    if expected_report:
+        assert current_actor_context.consume(Report)
+    else:
+        assert not current_actor_context.consume(Report)

--- a/repos/system_upgrade/el7toel8/actors/opensshuseprivilegeseparationcheck/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshuseprivilegeseparationcheck/tests/unit_test.py
@@ -1,46 +1,34 @@
 import pytest
 
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import library
 from leapp.models import OpenSshConfig, OpenSshPermitRootLogin, Report
 from leapp.snactor.fixture import current_actor_context
 
 
 def test_no_config(current_actor_context):
-    # with pytest.raises(StopActorExecutionError):
-    current_actor_context.run()
-
-
-@pytest.mark.parametrize('value,expected_report', [
-    ('', False),
-    ('sandbox', False),
-    ('yes', True),
-    ('no', True)])
-def test_separation(current_actor_context, value, expected_report):
-    if value:
-        current_actor_context.feed(OpenSshConfig(
-            permit_root_login=[OpenSshPermitRootLogin(value='no')],
-            use_privilege_separation=value
-        ))
-    else:
-        current_actor_context.feed(OpenSshConfig(
-            permit_root_login=[OpenSshPermitRootLogin(value='no')]
-        ))
-    current_actor_context.run()
-    if expected_report:
-        assert current_actor_context.consume(Report)
-    else:
-        assert not current_actor_context.consume(Report)
+    with pytest.raises(StopActorExecutionError):
+        library.process(iter([]))
 
 
 @pytest.mark.parametrize('values,expected_report', [
+    ([''], False),
+    (['sandbox'], False),
+    (['yes'], True),
+    (['no'], True),
     (['sandbox', 'yes'], False),
     (['yes', 'sandbox'], True)])
-def test_multiple_configs(current_actor_context, values, expected_report):
+def test_separation(current_actor_context, values, expected_report):
     for value in values:
-        current_actor_context.feed(OpenSshConfig(
-            permit_root_login=[OpenSshPermitRootLogin(value='no')],
-            use_privilege_separation=value
-        ))
+        if value:
+            current_actor_context.feed(OpenSshConfig(
+                permit_root_login=[OpenSshPermitRootLogin(value='no')],
+                use_privilege_separation=value
+            ))
+        else:
+            current_actor_context.feed(OpenSshConfig(
+                permit_root_login=[OpenSshPermitRootLogin(value='no')]
+            ))
     current_actor_context.run()
     if expected_report:
         assert current_actor_context.consume(Report)

--- a/repos/system_upgrade/el7toel8/models/opensshconfig.py
+++ b/repos/system_upgrade/el7toel8/models/opensshconfig.py
@@ -7,7 +7,9 @@ class OpenSshPermitRootLogin(Model):
 
     value = fields.StringEnum(['yes', 'prohibit-password',
                                'forced-commands-only', 'no'])
+    """ Value of a PermitRootLogin directive. """
     in_match = fields.Nullable(fields.List(fields.String()))
+    """ Criteria of Match blocks the PermitRootLogin directive occured in, if any. """
 
 
 class OpenSshConfig(Model):
@@ -21,11 +23,16 @@ class OpenSshConfig(Model):
     topic = SystemInfoTopic
 
     permit_root_login = fields.List(fields.Model(OpenSshPermitRootLogin))
+    """ All PermitRootLogin directives. """
     use_privilege_separation = fields.Nullable(fields.StringEnum(['sandbox',
                                                                   'yes',
                                                                   'no']))
+    """ Value of the UsePrivilegeSeparation directive, if present. Removed in RHEL 8. """
     protocol = fields.Nullable(fields.String())
+    """ Value of the Protocols directive, if present. Removed in RHEL 8. """
     ciphers = fields.Nullable(fields.String())
+    """ Value of the Ciphers directive, if present. Ciphers separated by comma. """
     macs = fields.Nullable(fields.String())
-
+    """ Value of the MACs directive, if present. """
     modified = fields.Nullable(fields.Boolean())
+    """ True if the configuration file was modified. """

--- a/repos/system_upgrade/el7toel8/models/opensshconfig.py
+++ b/repos/system_upgrade/el7toel8/models/opensshconfig.py
@@ -34,5 +34,5 @@ class OpenSshConfig(Model):
     """ Value of the Ciphers directive, if present. Ciphers separated by comma. """
     macs = fields.Nullable(fields.String())
     """ Value of the MACs directive, if present. """
-    modified = fields.Nullable(fields.Boolean())
+    modified = fields.Boolean(default=False)
     """ True if the configuration file was modified. """


### PR DESCRIPTION
Processing code is split off to a library so that the exception raise could be tested.
Also documented the related `OpenSshConfig` model.