### PR TITLE
enable testing on multiple architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 git:
   depth: 3
 language: python
-env:
+python: "2.7"
+arch:
+  - amd64
+  - ppc64le
+  - arm64
+env: CONTAINER=centos:7
 services:
-python:
-matrix:
-  include:
-    - python: "2.7"
-      env: CONTAINER=centos:7
-      services:
-        - docker
-      sudo: required
+  - docker
 install:
     - docker pull ${CONTAINER}
     - docker build -t leapp-tests -f utils/docker-tests/Dockerfile utils/docker-tests
 
 script:
-    - docker run --rm -ti -v ${PWD}:/payload leapp-tests
+    - docker run --rm -v ${PWD}:/payload leapp-tests


### PR DESCRIPTION
testing on s390x is not included because centos image used doesn't have a build for s390x