### PR TITLE
Add tests for OpenSshProtocolCheck

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/opensshprotocolcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshprotocolcheck/actor.py
@@ -1,10 +1,7 @@
 from leapp.actors import Actor
-from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import library
 from leapp.models import Report, OpenSshConfig
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
-from leapp.libraries.stdlib import api
-from leapp.reporting import create_report
-from leapp import reporting
 
 
 class OpenSshProtocolCheck(Actor):
@@ -22,29 +19,4 @@ class OpenSshProtocolCheck(Actor):
     tags = (ChecksPhaseTag, IPUWorkflowTag, )
 
     def process(self):
-        openssh_messages = self.consume(OpenSshConfig)
-        config = next(openssh_messages, None)
-        if list(openssh_messages):
-            api.current_logger().warning('Unexpectedly received more than one OpenSshConfig message.')
-        if not config:
-            raise StopActorExecutionError(
-                'Could not check openssh configuration', details={'details': 'No OpenSshConfig facts found.'}
-            )
-
-        if config.protocol:
-            create_report([
-                reporting.Title('OpenSSH configured with removed configuration Protocol'),
-                reporting.Summary(
-                    'OpenSSH is configured with removed configuration '
-                    'option Protocol. If this used to be for enabling '
-                    'SSHv1, this is no longer supported in RHEL 8. '
-                    'Otherwise this option can be simply removed.'
-                ),
-                reporting.Severity(reporting.Severity.LOW),
-                reporting.Tags([
-                        reporting.Tags.AUTHENTICATION,
-                        reporting.Tags.SECURITY,
-                        reporting.Tags.NETWORK,
-                        reporting.Tags.SERVICES
-                ]),
-            ])
+        library.process(self.consume(OpenSshConfig))

--- a/repos/system_upgrade/el7toel8/actors/opensshprotocolcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshprotocolcheck/libraries/library.py
@@ -1,0 +1,31 @@
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp import reporting
+
+
+def process(openssh_messages):
+    config = next(openssh_messages, None)
+    if list(openssh_messages):
+        api.current_logger().warning('Unexpectedly received more than one OpenSshConfig message.')
+    if not config:
+        raise StopActorExecutionError(
+            'Could not check openssh configuration', details={'details': 'No OpenSshConfig facts found.'}
+        )
+
+    if config.protocol:
+        reporting.create_report([
+            reporting.Title('OpenSSH configured with removed configuration Protocol'),
+            reporting.Summary(
+                'OpenSSH is configured with removed configuration '
+                'option Protocol. If this used to be for enabling '
+                'SSHv1, this is no longer supported in RHEL 8. '
+                'Otherwise this option can be simply removed.'
+            ),
+            reporting.Severity(reporting.Severity.LOW),
+            reporting.Tags([
+                    reporting.Tags.AUTHENTICATION,
+                    reporting.Tags.SECURITY,
+                    reporting.Tags.NETWORK,
+                    reporting.Tags.SERVICES
+            ]),
+        ])

--- a/repos/system_upgrade/el7toel8/actors/opensshprotocolcheck/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshprotocolcheck/tests/unit_test.py
@@ -1,0 +1,27 @@
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import library
+from leapp.models import OpenSshConfig, OpenSshPermitRootLogin, Report
+from leapp.snactor.fixture import current_actor_context
+
+
+def test_no_config(current_actor_context):
+    with pytest.raises(StopActorExecutionError):
+        library.process(iter([]))
+
+
+osprl = OpenSshPermitRootLogin(value='no')
+
+
+@pytest.mark.parametrize('protocol', [None, '1', '2', '1,2', '2,1', '7'])
+def test_protocol(current_actor_context, protocol):
+    current_actor_context.feed(OpenSshConfig(
+        permit_root_login=[osprl],
+        protocol=protocol
+    ))
+    current_actor_context.run()
+    if protocol:
+        assert current_actor_context.consume(Report)
+    else:
+        assert not current_actor_context.consume(Report)


### PR DESCRIPTION
- split functionality into the library
- add tests

Heavily similar to #424, since they consume the same model.