### PR TITLE
Inhibit upgrade if some links inside / are absolute

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkrootsymlinks/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrootsymlinks/actor.py
@@ -1,0 +1,43 @@
+import os
+
+from leapp import reporting
+from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.models import Report, RootDirectory
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+
+
+class CheckRootSymlinks(Actor):
+    """
+    Check if the symlinks /bin and /lib are relative, not absolute.
+
+    After reboot, dracut fails if the links are absolute.
+    """
+
+    name = 'check_root_symlinks'
+    consumes = (RootDirectory,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        rootdir = next(self.consume(RootDirectory), None)
+        if not rootdir:
+            raise StopActorExecutionError('Cannot check root symlinks',
+                                          details={'Problem': 'Did not receive a message with '
+                                                              'root subdirectories'})
+        absolute_links = [item for item in rootdir.items if item.target and os.path.isabs(item.target)]
+
+        if absolute_links:
+            reporting.create_report([
+                reporting.Title('Upgrade requires links in root directory to be relative'),
+                reporting.Summary(
+                    'After rebooting, parts of the upgrade process can fail if symbolic links in / '
+                    'point to absolute paths.\n'
+                    'Please change these links to relative ones.'
+                ),
+                reporting.Severity(reporting.Severity.HIGH),
+                reporting.Flags([reporting.Flags.INHIBITOR]),
+                reporting.Remediation(commands=[['ln', '-snf',
+                                                 os.path.relpath(item.target, '/'),
+                                                 os.path.join('/', item.name)] for item in absolute_links])
+            ])

--- a/repos/system_upgrade/el7toel8/actors/checkrootsymlinks/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrootsymlinks/tests/unit_test.py
@@ -1,0 +1,42 @@
+import pytest
+
+from leapp.models import Report, RootDirectory, RootSubdirectory
+from leapp.snactor.fixture import current_actor_context
+
+
+@pytest.mark.parametrize('modified,expected_report', [
+    ({}, False),
+    ({'bin': '/usr/bin'}, True),
+    ({'sbin': 'usr/bin'}, False),
+    ({'sbin': '/usr/sbin'}, True),
+    ({'lib': '/usr/lib', 'lib64': 'usr/lib64'}, True)])
+def test_wrong_symlink_inhibitor(current_actor_context, modified, expected_report):
+    subdirs = {
+        'bin': 'usr/bin',
+        'boot': '',
+        'dev': '',
+        'etc': '',
+        'home': '',
+        'lib': 'usr/lib',
+        'lib64': 'usr/lib64',
+        'media': '',
+        'mnt': '',
+        'opt': '',
+        'proc': '',
+        'root': '',
+        'run': '',
+        'sbin': 'usr/sbin',
+        'srv': '',
+        'sys': '',
+        'tmp': '',
+        'usr': '',
+        'var': ''
+    }
+    subdirs.update(modified)
+    items = [RootSubdirectory(name=subdir, target=subdirs[subdir]) for subdir in subdirs]
+    current_actor_context.feed(RootDirectory(items=items))
+    current_actor_context.run()
+    if expected_report:
+        assert current_actor_context.consume(Report)
+    else:
+        assert not current_actor_context.consume(Report)

--- a/repos/system_upgrade/el7toel8/actors/rootscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/rootscanner/actor.py
@@ -1,0 +1,27 @@
+import os
+
+from leapp.actors import Actor
+from leapp.models import RootDirectory, RootSubdirectory
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+
+
+class RootScanner(Actor):
+    """
+    Scan the system root directory and produce a message containing
+    information about its subdirectories.
+    """
+
+    name = 'root_scanner'
+    consumes = ()
+    produces = (RootDirectory,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        subdirs = []
+        for subdir in os.listdir('/'):
+            path = os.path.join('/', subdir)
+            if os.path.islink(path):
+                subdirs.append(RootSubdirectory(name=subdir, target=os.readlink(path)))
+            else:
+                subdirs.append(RootSubdirectory(name=subdir))
+        self.produce(RootDirectory(items=subdirs))

--- a/repos/system_upgrade/el7toel8/models/rootdirectory.py
+++ b/repos/system_upgrade/el7toel8/models/rootdirectory.py
@@ -1,0 +1,16 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemFactsTopic
+
+
+class RootSubdirectory(Model):
+    """
+    Representation of a single root subdirectory. Can be expanded as needed.
+    """
+    topic = SystemFactsTopic
+    name = fields.String()
+    target = fields.Nullable(fields.String())  # if it's a link
+
+
+class RootDirectory(Model):
+    topic = SystemFactsTopic
+    items = fields.List(fields.Model(RootSubdirectory))  # should not be empty


### PR DESCRIPTION
If `/bin` or `/lib` point to a relative path, there's a fair chance of _dracut_ failing during _InitRamStartPhase_, if not earlier.
We're not sure if this also applies to `/lib64` and `/sbin` but after discussing this in person, we've decided to insist on **all** symbolic links inside `/` being relative.