### PR TITLE
verifydialogs: make report message more explicit

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/verifydialogs/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/verifydialogs/libraries/library.py
@@ -6,15 +6,17 @@ from leapp import reporting
 def check_dialogs(inhibit_if_no_userchoice=True):
     results = list(api.consume(DialogModel))
     for dialog in results:
-        sections = dialog.answerfile_sections.split(',')
+        sections = dialog.answerfile_sections
+        summary = ('One or more sections in answerfile are missing user choices: {}\n'
+                   'For more information consult https://leapp.readthedocs.io/en/latest/dialogs.html')
         dialog_resources = [reporting.RelatedResource('dialog', s) for s in sections]
         dialogs_remediation = ('Please register user choices with leapp answer cli command or by manually editing '
                                'the answerfile.')
-        report_data = [reporting.Title('Dialog choice required'),
+        cmd_remediation = [['leapp', 'answer', '--section', "{}={}".format(s, choice)]
+                           for s, choices in dialog.answerfile_sections.items() for choice in choices]
+        report_data = [reporting.Title('Missing required answers in the answer file'),
                        reporting.Severity(reporting.Severity.HIGH),
-                       reporting.Summary(
-                           'One or more sections in answerfile are missing recorded user choices: {}'.format(
-                               '\n'.join(sections))),
+                       reporting.Summary(summary.format('\n'.join(sections))),
                        reporting.Flags([reporting.Flags.INHIBITOR] if inhibit_if_no_userchoice else []),
-                       reporting.Remediation(hint=dialogs_remediation)]
+                       reporting.Remediation(hint=dialogs_remediation, commands=cmd_remediation)]
         reporting.create_report(report_data + dialog_resources)


### PR DESCRIPTION
Previous "Dialog choice required" turned out to be too cryptic.