### PR TITLE
Make authconfig->authselect actors non-experimental

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/authselectapply/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectapply/actor.py
@@ -3,7 +3,7 @@ from leapp.libraries.stdlib import run, CalledProcessError
 from leapp.models import Authselect, AuthselectDecision
 from leapp import reporting
 from leapp.reporting import Report, create_report
-from leapp.tags import IPUWorkflowTag, ApplicationsPhaseTag, ExperimentalTag
+from leapp.tags import IPUWorkflowTag, ApplicationsPhaseTag
 
 
 resources = [
@@ -24,7 +24,7 @@ class AuthselectApply(Actor):
     name = 'authselect_apply'
     consumes = (Authselect, AuthselectDecision,)
     produces = (Report,)
-    tags = (IPUWorkflowTag, ApplicationsPhaseTag, ExperimentalTag)
+    tags = (IPUWorkflowTag, ApplicationsPhaseTag)
 
     def process(self):
         model = next(self.consume(Authselect))

--- a/repos/system_upgrade/el7toel8/actors/authselectcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectcheck/actor.py
@@ -4,7 +4,7 @@ from leapp.dialogs.components import BooleanComponent
 from leapp.models import Authselect, AuthselectDecision
 from leapp.reporting import Report, create_report
 from leapp import reporting
-from leapp.tags import IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
 
 
 resources = [
@@ -26,7 +26,7 @@ class AuthselectCheck(Actor):
     name = 'authselect_check'
     consumes = (Authselect,)
     produces = (AuthselectDecision, Report,)
-    tags = (IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
     dialogs = (
         Dialog(
             scope='authselect_check',

--- a/repos/system_upgrade/el7toel8/actors/authselectscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectscanner/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import AuthselectScannerLibrary, Authconfig, DConf, read_file
 from leapp.libraries.common.pam import PAM
 from leapp.models import Authselect
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag, ExperimentalTag
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 
 class AuthselectScanner(Actor):
@@ -43,7 +43,7 @@ class AuthselectScanner(Actor):
     name = 'authselect_scanner'
     consumes = ()
     produces = (Authselect,)
-    tags = (IPUWorkflowTag, FactsPhaseTag, ExperimentalTag)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
 
     known_modules = [
         'pam_access',

--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulesapply/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulesapply/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import comment_modules, read_file
 from leapp.libraries.common.pam import PAM
 from leapp.models import RemovedPAMModules
-from leapp.tags import IPUWorkflowTag, PreparationPhaseTag, ExperimentalTag
+from leapp.tags import IPUWorkflowTag, PreparationPhaseTag
 
 
 class RemoveOldPAMModulesApply(Actor):
@@ -14,7 +14,7 @@ class RemoveOldPAMModulesApply(Actor):
     name = 'removed_pam_modules_apply'
     consumes = (RemovedPAMModules,)
     produces = ()
-    tags = (IPUWorkflowTag, PreparationPhaseTag, ExperimentalTag)
+    tags = (IPUWorkflowTag, PreparationPhaseTag)
 
     def process(self):
         for model in self.consume(RemovedPAMModules):

--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulescheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulescheck/actor.py
@@ -4,7 +4,7 @@ from leapp.dialogs.components import BooleanComponent
 from leapp.models import RemovedPAMModules
 from leapp.reporting import Report, create_report
 from leapp import reporting
-from leapp.tags import IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
 
 
 class RemoveOldPAMModulesCheck(Actor):
@@ -18,7 +18,7 @@ class RemoveOldPAMModulesCheck(Actor):
     name = 'removed_pam_modules_check'
     consumes = (RemovedPAMModules,)
     produces = (Report,)
-    tags = (IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
     dialogs = (
         Dialog(
             scope='remove_pam_pkcs11_module_check',

--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulesscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulesscanner/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import RemoveOldPAMModulesScannerLibrary
 from leapp.libraries.common.pam import PAM
 from leapp.models import RemovedPAMModules
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag, ExperimentalTag
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 
 class RemoveOldPAMModulesScanner(Actor):
@@ -16,7 +16,7 @@ class RemoveOldPAMModulesScanner(Actor):
     name = 'removed_pam_modules_scanner'
     consumes = ()
     produces = (RemovedPAMModules,)
-    tags = (IPUWorkflowTag, FactsPhaseTag, ExperimentalTag)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
 
     def process(self):
         pam = PAM.from_system_configuration()


### PR DESCRIPTION
With introduction of new dialogs processing mechanism these actors
can finally be included in the workflow.
May cause the need to update upgrade testing automation as in several
cases (openstack rhel 7.6 image) these actors are hit 100% of the time
so adding a call to `leapp answer` will be inevitable.