### PR TITLE
Optimize filter_out_pkgs_in_blacklisted_repos

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -383,8 +383,9 @@ def filter_out_pkgs_in_blacklisted_repos(to_install):
     # FIXME The to_install contains just a limited subset of packages - those that are *not* currently installed and
     # are to be installed. But we should also warn about the packages that *are* installed.
     blacklisted_pkgs = set()
+    blacklisted_repos = get_repositories_blacklisted()
     for pkg, repo in to_install.items():
-        if repo in get_repositories_blacklisted():
+        if repo in blacklisted_repos:
             blacklisted_pkgs.add(pkg)
 
     for pkg in blacklisted_pkgs:


### PR DESCRIPTION
Previously get_repositories_blacklisted has been called for every
package that has been marked to be installed. That call is very
expensive as it creates a temporary set with all blacklisted
repositories even though the data could be only generated once and
reused. This patch ensures it is only done once.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>