### PR TITLE
Chain events of types Removal and Presence + actor refactor

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -113,7 +113,7 @@ def get_transaction_configuration():
 
 def filter_releases_by_target(releases, target):
     return [r for r in releases if version.matches_version(
-        ['<= {}.{}'.format(target[0], target[1])], '{}.{}'.format(r[0], r[1]))]
+        ['<= {}.{}'.format(*target)], '{}.{}'.format(*r))]
 
 
 def get_events(pes_events_filepath):

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -38,11 +38,13 @@ def pes_events_scanner(pes_json_filepath):
     installed_pkgs = get_installed_pkgs()
     transaction_configuration = get_transaction_configuration()
     arch = api.current_actor().configuration.architecture
-    target = version._version_to_tuple(api.current_actor().configuration.version.target)
-    filtered_releases = filter_releases_by_target(RELEASES, target)
 
     events = get_events(pes_json_filepath)
     filtered_events = filter_events_by_releases(events, filtered_releases)
+    releases = get_releases(events) # This where you would get the releases from the data, doesn't exist ofc
+    
+    target = version._version_to_tuple(api.current_actor().configuration.version.target)
+    filtered_releases = filter_releases_by_target(releases, target)
     arch_events = filter_events_by_architecture(filtered_events, arch)
     add_output_pkgs_to_transaction_conf(transaction_configuration, arch_events)
     tasks = process_events(filtered_releases, arch_events, installed_pkgs)

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -21,7 +21,7 @@ Event = namedtuple('Event', ['action',        # A string representing an event t
                              ])
 
 EVENT_TYPES = ('Present', 'Removed', 'Deprecated', 'Replaced', 'Split', 'Merged', 'Moved', 'Renamed')
-RELEASES = ((7, 5), (7, 6), (7, 7), (7, 8), (8, 0), (8, 1))  # TODO: bad, bad hardcode
+RELEASES = ((7, 5), (7, 6), (7, 7), (7, 8), (8, 0), (8, 1), (8, 2))  # TODO: bad, bad hardcode
 
 
 class Task(Enum):

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -245,7 +245,7 @@ def parse_architectures(architectures):
 def is_event_relevant(event, installed_pkgs, tasks):
     """Determine if event is applicable given the installed packages and tasks planned so far."""
     for package in event.in_pkgs.keys():
-        if package in tasks[Task.remove]:
+        if package in tasks[Task.remove] and event.action != 'Present':
             return False
         if package not in installed_pkgs and package not in tasks[Task.install]:
             return False

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -21,7 +21,7 @@ Event = namedtuple('Event', ['action',        # A string representing an event t
                              ])
 
 EVENT_TYPES = ('Present', 'Removed', 'Deprecated', 'Replaced', 'Split', 'Merged', 'Moved', 'Renamed')
-RELEASES = ((7, 5), (7, 6), (7, 7), (7, 8), (8, 0), (8, 1), (8, 2))  # TODO: bad, bad hardcode
+RELEASES = [(7, 5), (7, 6), (7, 7), (7, 8), (8, 0), (8, 1), (8, 2)]  # TODO: bad, bad hardcode
 
 
 class Task(IntEnum):

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -140,11 +140,7 @@ def get_events(pes_events_filepath):
 
 
 def filter_events_by_architecture(events, arch):
-    filtered_events = []
-    for event in events:
-        if not event.architectures or arch in event.architectures:
-            filtered_events.append(event)
-    return filtered_events
+    return [e for e in events if not e.architectures or arch in e.architectures]
 
 
 def filter_events_by_releases(events, releases):

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/library.py
@@ -113,8 +113,8 @@ def get_transaction_configuration():
 
 
 def filter_releases_by_target(releases, target):
-    return [r for r in releases if version.matches_version(
-        ['<= {}.{}'.format(*target)], '{}.{}'.format(*r))]
+    match_list = ['<= {}.{}'.format(*target)]
+    return [r for r in releases if version.matches_version(match_list, '{}.{}'.format(*r))]
 
 
 def get_events(pes_events_filepath):
@@ -338,6 +338,7 @@ def process_events(releases, events, installed_pkgs):
         for package in do_not_remove:
             del current[Task.remove][package]
 
+        do_not_install = set()
         for package in current[Task.install]:
             if package in tasks[Task.remove]:
                 api.current_logger().warning(
@@ -345,7 +346,9 @@ def process_events(releases, events, installed_pkgs):
                         p=package, r=current[Task.install][package]))
                 current[Task.keep][package] = current[Task.install][package]
                 del tasks[Task.remove][package]
-                del current[Task.install][package]
+                do_not_install.add(package)
+        for package in do_not_install:
+            del current[Task.install][package]
 
         for package in current[Task.keep]:
             if package in tasks[Task.remove]:

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
@@ -159,14 +159,14 @@ def test_filter_out_pkgs_in_blacklisted_repos(monkeypatch):
 def test_resolve_conflicting_requests(monkeypatch):
     monkeypatch.setattr(library, 'map_repositories', lambda x: x)
     monkeypatch.setattr(library, 'filter_out_pkgs_in_blacklisted_repos', lambda x: x)
-    monkeypatch.setattr(library, 'RELEASES', ((7, 5), (7, 6), (7, 7), (7, 8), (8, 0), (8, 1)))
+    monkeypatch.setattr(library, 'RELEASES', RELEASES)
 
     events = [
         Event('Split', {'sip-devel': 'repo'}, {'python3-sip-devel': 'repo', 'sip': 'repo'}, (7, 6), (8, 0), []),
         Event('Split', {'sip': 'repo'}, {'python3-pyqt5-sip': 'repo', 'python3-sip': 'repo'}, (7, 6), (8, 0), [])]
     installed_pkgs = {'sip', 'sip-devel'}
 
-    tasks = process_events(events, installed_pkgs)
+    tasks = process_events(RELEASES[-1], events, installed_pkgs)
 
     assert tasks[Task.install] == {'python3-sip-devel': 'repo', 'python3-pyqt5-sip': 'repo', 'python3-sip': 'repo'}
     assert tasks[Task.remove] == {'sip-devel': 'repo'}
@@ -202,7 +202,7 @@ def test_map_repositories(monkeypatch):
 def test_process_events(monkeypatch):
     monkeypatch.setattr(library, '_get_repositories_mapping', lambda: {'rhel8-repo': 'rhel8-mapped'})
     monkeypatch.setattr(library, 'get_repositories_blacklisted', get_repos_blacklisted_mocked(set()))
-    monkeypatch.setattr(library, 'RELEASES', ((7, 5), (7, 6), (7, 7), (7, 8), (8, 0), (8, 1)))
+    monkeypatch.setattr(library, 'RELEASES', RELEASES)
 
     events = [
         Event('Split', {'original': 'rhel7-repo'}, {'split01': 'rhel8-repo', 'split02': 'rhel8-repo'},
@@ -210,7 +210,7 @@ def test_process_events(monkeypatch):
         Event('Removed', {'removed': 'rhel7-repo'}, {}, (7, 6), (8, 0), []),
         Event('Present', {'present': 'rhel8-repo'}, {}, (7, 6), (8, 0), [])]
     installed_pkgs = {'original', 'removed', 'present'}
-    tasks = process_events(events, installed_pkgs)
+    tasks = process_events(RELEASES[-1], events, installed_pkgs)
 
     assert tasks[Task.install] == {'split02': 'rhel8-mapped', 'split01': 'rhel8-mapped'}
     assert tasks[Task.remove] == {'removed': 'rhel7-repo', 'original': 'rhel7-repo'}

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
@@ -10,6 +10,8 @@ from leapp.libraries.actor.library import (Event,
                                            add_output_pkgs_to_transaction_conf,
                                            filter_out_pkgs_in_blacklisted_repos,
                                            filter_events_by_architecture,
+                                           filter_events_by_releases,
+                                           filter_releases_by_target,
                                            get_events,
                                            map_repositories, parse_action,
                                            parse_entry, parse_packageset,
@@ -290,3 +292,26 @@ def test_filter_events_by_architecture():
     assert {'pkg2': 'repo'} in [event.in_pkgs for event in filtered]
     assert {'pkg3': 'repo'} not in [event.in_pkgs for event in filtered]
     assert {'pkg4': 'repo'} in [event.in_pkgs for event in filtered]
+
+
+def test_filter_events_by_releases():
+    events = [
+        Event('Present', {'pkg1': 'repo'}, {}, (7, 6), (7, 7), []),
+        Event('Present', {'pkg2': 'repo'}, {}, (7, 7), (7, 8), []),
+        Event('Present', {'pkg3': 'repo'}, {}, (7, 8), (8, 0), []),
+        Event('Present', {'pkg4': 'repo'}, {}, (8, 0), (8, 1), []),
+        Event('Present', {'pkg5': 'repo'}, {}, (8, 1), (8, 2), [])
+    ]
+
+    filtered = filter_events_by_releases(events, [(7, 6), (7, 7), (8, 0), (8, 3)])
+    assert {'pkg1': 'repo'} in [event.in_pkgs for event in filtered]
+    assert {'pkg2': 'repo'} not in [event.in_pkgs for event in filtered]
+    assert {'pkg3': 'repo'} in [event.in_pkgs for event in filtered]
+    assert {'pkg4': 'repo'} not in [event.in_pkgs for event in filtered]
+    assert {'pkg5': 'repo'} not in [event.in_pkgs for event in filtered]
+
+
+def test_filter_releases_by_target():
+    releases = [(7, 6), (7, 7), (7, 8), (7, 9), (8, 0), (8, 1), (8, 2), (8, 3), (9, 0), (9, 1)]
+    filtered_releases = filter_releases_by_target(releases, (8, 1))
+    assert filtered_releases == [(7, 6), (7, 7), (7, 8), (7, 9), (8, 0), (8, 1)]

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
@@ -161,14 +161,13 @@ def test_filter_out_pkgs_in_blacklisted_repos(monkeypatch):
 def test_resolve_conflicting_requests(monkeypatch):
     monkeypatch.setattr(library, 'map_repositories', lambda x: x)
     monkeypatch.setattr(library, 'filter_out_pkgs_in_blacklisted_repos', lambda x: x)
-    monkeypatch.setattr(library, 'RELEASES', RELEASES)
 
     events = [
         Event('Split', {'sip-devel': 'repo'}, {'python3-sip-devel': 'repo', 'sip': 'repo'}, (7, 6), (8, 0), []),
         Event('Split', {'sip': 'repo'}, {'python3-pyqt5-sip': 'repo', 'python3-sip': 'repo'}, (7, 6), (8, 0), [])]
     installed_pkgs = {'sip', 'sip-devel'}
 
-    tasks = process_events(RELEASES[-1], events, installed_pkgs)
+    tasks = process_events(RELEASES, events, installed_pkgs)
 
     assert tasks[Task.install] == {'python3-sip-devel': 'repo', 'python3-pyqt5-sip': 'repo', 'python3-sip': 'repo'}
     assert tasks[Task.remove] == {'sip-devel': 'repo'}
@@ -204,7 +203,6 @@ def test_map_repositories(monkeypatch):
 def test_process_events(monkeypatch):
     monkeypatch.setattr(library, '_get_repositories_mapping', lambda: {'rhel8-repo': 'rhel8-mapped'})
     monkeypatch.setattr(library, 'get_repositories_blacklisted', get_repos_blacklisted_mocked(set()))
-    monkeypatch.setattr(library, 'RELEASES', RELEASES)
 
     events = [
         Event('Split', {'original': 'rhel7-repo'}, {'split01': 'rhel8-repo', 'split02': 'rhel8-repo'},
@@ -212,7 +210,7 @@ def test_process_events(monkeypatch):
         Event('Removed', {'removed': 'rhel7-repo'}, {}, (7, 6), (8, 0), []),
         Event('Present', {'present': 'rhel8-repo'}, {}, (7, 6), (8, 0), [])]
     installed_pkgs = {'original', 'removed', 'present'}
-    tasks = process_events(RELEASES[-1], events, installed_pkgs)
+    tasks = process_events(RELEASES, events, installed_pkgs)
 
     assert tasks[Task.install] == {'split02': 'rhel8-mapped', 'split01': 'rhel8-mapped'}
     assert tasks[Task.remove] == {'removed': 'rhel7-repo', 'original': 'rhel7-repo'}

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
@@ -5,7 +5,6 @@ import pytest
 from leapp.exceptions import StopActorExecution
 from leapp.libraries.actor import library
 from leapp.libraries.actor.library import (Event,
-                                           RELEASES,
                                            Task,
                                            add_output_pkgs_to_transaction_conf,
                                            filter_out_pkgs_in_blacklisted_repos,
@@ -167,7 +166,7 @@ def test_resolve_conflicting_requests(monkeypatch):
         Event('Split', {'sip': 'repo'}, {'python3-pyqt5-sip': 'repo', 'python3-sip': 'repo'}, (7, 6), (8, 0), [])]
     installed_pkgs = {'sip', 'sip-devel'}
 
-    tasks = process_events(RELEASES, events, installed_pkgs)
+    tasks = process_events([(8, 0)], events, installed_pkgs)
 
     assert tasks[Task.install] == {'python3-sip-devel': 'repo', 'python3-pyqt5-sip': 'repo', 'python3-sip': 'repo'}
     assert tasks[Task.remove] == {'sip-devel': 'repo'}
@@ -210,7 +209,7 @@ def test_process_events(monkeypatch):
         Event('Removed', {'removed': 'rhel7-repo'}, {}, (7, 6), (8, 0), []),
         Event('Present', {'present': 'rhel8-repo'}, {}, (7, 6), (8, 0), [])]
     installed_pkgs = {'original', 'removed', 'present'}
-    tasks = process_events(RELEASES, events, installed_pkgs)
+    tasks = process_events([(8, 0)], events, installed_pkgs)
 
     assert tasks[Task.install] == {'split02': 'rhel8-mapped', 'split01': 'rhel8-mapped'}
     assert tasks[Task.remove] == {'removed': 'rhel7-repo', 'original': 'rhel7-repo'}

--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test.py
@@ -6,6 +6,7 @@ from leapp.exceptions import StopActorExecution
 from leapp.libraries.actor import library
 from leapp.libraries.actor.library import (Event,
                                            RELEASES,
+                                           Task,
                                            add_output_pkgs_to_transaction_conf,
                                            filter_out_pkgs_in_blacklisted_repos,
                                            filter_events_by_architecture,
@@ -167,9 +168,9 @@ def test_resolve_conflicting_requests(monkeypatch):
 
     tasks = process_events(events, installed_pkgs)
 
-    assert tasks['to_install'] == {'python3-sip-devel': 'repo', 'python3-pyqt5-sip': 'repo', 'python3-sip': 'repo'}
-    assert tasks['to_remove'] == {'sip-devel': 'repo'}
-    assert tasks['to_keep'] == {'sip': 'repo'}
+    assert tasks[Task.install] == {'python3-sip-devel': 'repo', 'python3-pyqt5-sip': 'repo', 'python3-sip': 'repo'}
+    assert tasks[Task.remove] == {'sip-devel': 'repo'}
+    assert tasks[Task.keep] == {'sip': 'repo'}
 
 
 def test_map_repositories(monkeypatch):
@@ -211,9 +212,9 @@ def test_process_events(monkeypatch):
     installed_pkgs = {'original', 'removed', 'present'}
     tasks = process_events(events, installed_pkgs)
 
-    assert tasks['to_install'] == {'split02': 'rhel8-mapped', 'split01': 'rhel8-mapped'}
-    assert tasks['to_remove'] == {'removed': 'rhel7-repo', 'original': 'rhel7-repo'}
-    assert tasks['to_keep'] == {'present': 'rhel8-mapped'}
+    assert tasks[Task.install] == {'split02': 'rhel8-mapped', 'split01': 'rhel8-mapped'}
+    assert tasks[Task.remove] == {'removed': 'rhel7-repo', 'original': 'rhel7-repo'}
+    assert tasks[Task.keep] == {'present': 'rhel8-mapped'}
 
 
 def test_get_events(monkeypatch):


### PR DESCRIPTION
There's a peculiar pair of events in PES:

![2020-02-10-191418_824x97_scrot](https://user-images.githubusercontent.com/33783628/74177256-aeef8100-4c39-11ea-929a-b7ada7663886.png)

In RHEL 8.0, `sblim-cmpi-base` gets removed only to get reintroduced in 8.1. A pair of events typed as Removal and Presence is allegedly the best way to represent such changes, but the way events are processed right now, the Presence event doesn't stop the package from being removed. This PR keeps such packages on the target system and upgrades them.

Apart from that, included are some other smaller changes and refactors of the library code, mainly:
* indexing of tasks by enums instead of strings
* recognition of new minor releases
* filtering of events by release before processing
* several one-liners and comprehensions to shorten the code

Also unit tests.