### PR TITLE
Remove sblim-wbemcli from blacklist

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -1,5 +1,1 @@
 ### List of packages (each on new line) to be removed from the upgrade transaction
-
-#OAMG-590
-#https://bugzilla.redhat.com/show_bug.cgi?id=1757855
-sblim-wbemcli


### PR DESCRIPTION
This reverts commit 430ccc2f3ca1728b0f61bd498523af1ca57abc21, merged in #364.

Since the conflict between `python3-pywbem` and `sblim-wbemcli` has been fixed and verified, we can now remove `sblim-wbemcli` from `to_remove`.