### PR TITLE
Do not use RHSM in the nspawn container

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkrhsmsku/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrhsmsku/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries.common import rhsm
-from leapp.models import Report, SourceRHSMInfo
+from leapp.models import Report, RHSMInfo
 from leapp.reporting import create_report
 from leapp import reporting
 from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
@@ -15,13 +15,13 @@ class CheckRedHatSubscriptionManagerSKU(Actor):
     """
 
     name = 'check_rhsmsku'
-    consumes = (SourceRHSMInfo,)
+    consumes = (RHSMInfo,)
     produces = (Report,)
     tags = (IPUWorkflowTag, ChecksPhaseTag)
 
     def process(self):
         if not rhsm.skip_rhsm():
-            for info in self.consume(SourceRHSMInfo):
+            for info in self.consume(RHSMInfo):
                 if not info.attached_skus:
                     create_report([
                         reporting.Title('The system is not registered or subscribed.'),

--- a/repos/system_upgrade/el7toel8/actors/checkrhsmsku/tests/test_rhsmsku.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrhsmsku/tests/test_rhsmsku.py
@@ -1,11 +1,11 @@
 from leapp.libraries.common import rhsm
-from leapp.models import Report, SourceRHSMInfo
+from leapp.models import Report, RHSMInfo
 
 
 def test_sku_report_skipped(monkeypatch, current_actor_context):
     with monkeypatch.context() as context:
         context.setenv('LEAPP_DEVEL_SKIP_RHSM', '1')
-        current_actor_context.feed(SourceRHSMInfo(attached_skus=[]))
+        current_actor_context.feed(RHSMInfo(attached_skus=[]))
         current_actor_context.run()
         assert not list(current_actor_context.consume(Report))
 
@@ -13,7 +13,7 @@ def test_sku_report_skipped(monkeypatch, current_actor_context):
 def test_sku_report_has_skus(monkeypatch, current_actor_context):
     with monkeypatch.context() as context:
         context.setenv('LEAPP_DEVEL_SKIP_RHSM', '0')
-        current_actor_context.feed(SourceRHSMInfo(attached_skus=['testing-sku']))
+        current_actor_context.feed(RHSMInfo(attached_skus=['testing-sku']))
         current_actor_context.run()
         assert not list(current_actor_context.consume(Report))
 
@@ -21,7 +21,7 @@ def test_sku_report_has_skus(monkeypatch, current_actor_context):
 def test_sku_report_has_no_skus(monkeypatch, current_actor_context):
     with monkeypatch.context() as context:
         context.setenv('LEAPP_DEVEL_SKIP_RHSM', '0')
-        current_actor_context.feed(SourceRHSMInfo(attached_skus=[]))
+        current_actor_context.feed(RHSMInfo(attached_skus=[]))
         current_actor_context.run()
         reports = list(current_actor_context.consume(Report))
         assert reports and len(reports) == 1

--- a/repos/system_upgrade/el7toel8/actors/dnfupgradetransaction/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/dnfupgradetransaction/actor.py
@@ -3,7 +3,7 @@ import shutil
 from leapp.actors import Actor
 from leapp.libraries.common import dnfplugin
 from leapp.libraries.stdlib import run
-from leapp.models import (FilteredRpmTransactionTasks, SourceRHSMInfo, StorageInfo, TargetUserSpaceInfo,
+from leapp.models import (FilteredRpmTransactionTasks, RHSMInfo, StorageInfo, TargetUserSpaceInfo,
                           TransactionCompleted, UsedTargetRepositories)
 from leapp.tags import IPUWorkflowTag, RPMUpgradePhaseTag
 
@@ -17,20 +17,12 @@ class DnfUpgradeTransaction(Actor):
     """
 
     name = 'dnf_upgrade_transaction'
-    consumes = (FilteredRpmTransactionTasks, SourceRHSMInfo, StorageInfo, TargetUserSpaceInfo, UsedTargetRepositories)
+    consumes = (FilteredRpmTransactionTasks, RHSMInfo, StorageInfo, TargetUserSpaceInfo, UsedTargetRepositories)
     produces = (TransactionCompleted,)
     tags = (RPMUpgradePhaseTag, IPUWorkflowTag)
 
     def process(self):
-        # FIXME: we hitting issue now because the network is down and rhsm
-        # # is trying to connect to the server. Commenting this out for now
-        # # so people will not be affected in case they do not have set a
-        # # release and we will have time to fix it properly.
-        # Make sure Subscription Manager OS Release is unset
-        # cmd = ['subscription-manager', 'release', '--unset']
-        # run(cmd)
-
-        src_rhsm_info = next(self.consume(SourceRHSMInfo), None)
+        src_rhsm_info = next(self.consume(RHSMInfo), None)
         if src_rhsm_info:
             for prod_cert in src_rhsm_info.existing_product_certificates:
                 run(['rm', '-f', prod_cert])

--- a/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import library
-from leapp.models import UsedTargetRepositories, TargetRHSMInfo
+from leapp.models import UsedTargetRepositories
 from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
 
 
@@ -20,7 +20,7 @@ class EnableRHSMReposOnRHEL8(Actor):
     """
 
     name = 'enable_rhsm_repos_on_rhel8'
-    consumes = (UsedTargetRepositories, TargetRHSMInfo)
+    consumes = (UsedTargetRepositories,)
     produces = ()
     tags = (IPUWorkflowTag, FirstBootPhaseTag)
 

--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/actor.py
@@ -1,7 +1,6 @@
-from leapp import reporting
 from leapp.actors import Actor
-from leapp.models import Report, TargetRHSMInfo
-from leapp.reporting import create_report
+from leapp.libraries.actor import library
+from leapp.models import Report
 from leapp.tags import IPUWorkflowTag, TargetTransactionChecksPhaseTag
 
 
@@ -11,22 +10,9 @@ class ReportSetTargetRelease(Actor):
     """
 
     name = 'report_set_target_release'
-    consumes = (TargetRHSMInfo,)
+    consumes = ()
     produces = (Report,)
     tags = (IPUWorkflowTag, TargetTransactionChecksPhaseTag)
 
     def process(self):
-        info = next(self.consume(TargetRHSMInfo), None)
-        if info and info.release:
-            create_report([
-                reporting.Title(
-                    'The subscription-manager release is going to be set to {release}'.format(release=info.release)),
-                reporting.Summary(
-                    'After the upgrade has completed the release of the subscription-manager will be set to {release}.'
-                    ' This will ensure that you will receive and keep the version you choose to upgrade to.'.
-                    format(release=info.release)
-                ),
-                reporting.Severity(reporting.Severity.LOW),
-                reporting.Tags([reporting.Tags.UPGRADE_PROCESS]),
-                reporting.RelatedResource('package', 'subscription-manager')
-            ])
+        library.process()

--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/libraries/library.py
@@ -1,0 +1,22 @@
+from leapp import reporting
+from leapp.libraries.stdlib import api
+
+
+def process():
+    # TODO: skip if users are not using rhsm at all (RHELLEAPP-201)
+    target_version = api.current_actor().configuration.version.target
+    reporting.create_report([
+        reporting.Title(
+            'The subscription-manager release is going to be set after the upgrade'),
+        reporting.Summary(
+            'After the upgrade has completed the release of the subscription-manager will be set to {release}.'
+            ' This will ensure that you will receive and keep the version you choose to upgrade to.'
+            .format(release=target_version)
+        ),
+        reporting.Severity(reporting.Severity.LOW),
+        reporting.Remediation(
+            hint='If you wish to receive updates for the latest released version of RHEL 8, run `subscription-manager'
+                 ' release --unset` after the upgrade.'),
+        reporting.Tags([reporting.Tags.UPGRADE_PROCESS]),
+        reporting.RelatedResource('package', 'subscription-manager')
+    ])

--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/tests/test_targetreleasereport.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/tests/test_targetreleasereport.py
@@ -1,24 +1,28 @@
-from leapp.models import Report, TargetRHSMInfo
+from collections import namedtuple
+
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import library
+from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.stdlib import api
 
 
-def test_report_target_version(current_actor_context):
-    current_actor_context.feed(TargetRHSMInfo(release='6.6.6'))
-    current_actor_context.run()
-    reports = list(current_actor_context.consume(Report))
-    assert reports and len(reports) == 1
-    report_fields = reports[0].report
-    assert '6.6.6' in report_fields.get('summary', '')
-    assert '6.6.6' in report_fields.get('title', '')
+class CurrentActorMocked(object):
+    def __init__(self, src_ver='7.6', dst_ver='8.1'):
+
+        version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
+        self.configuration = namedtuple('configuration', ['version'])(version)
+
+    def __call__(self):
+        return self
 
 
-def test_report_target_version_notset(current_actor_context):
-    current_actor_context.feed(TargetRHSMInfo(release=''))
-    current_actor_context.run()
-    reports = list(current_actor_context.consume(Report))
-    assert not reports
-
-
-def test_report_target_version_nomessage(current_actor_context):
-    current_actor_context.run()
-    reports = list(current_actor_context.consume(Report))
-    assert not reports
+@pytest.mark.parametrize('version', ['8.{}'.format(i) for i in range(4)])
+def test_report_target_version(monkeypatch, version):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(dst_ver=version))
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    SUMMARY_FMT = 'will be set to {}.'
+    library.process()
+    assert reporting.create_report.called == 1
+    assert SUMMARY_FMT.format(version) in reporting.create_report.report_fields['summary']

--- a/repos/system_upgrade/el7toel8/actors/scansubscriptionmanagerinfo/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scansubscriptionmanagerinfo/actor.py
@@ -1,7 +1,7 @@
 from leapp.actors import Actor
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 from leapp.libraries.actor import scanrhsm
-from leapp.models import SourceRHSMInfo
+from leapp.models import RHSMInfo
 
 
 class ScanSubscriptionManagerInfo(Actor):
@@ -14,7 +14,7 @@ class ScanSubscriptionManagerInfo(Actor):
 
     name = 'scan_subscription_manager_info'
     consumes = ()
-    produces = (SourceRHSMInfo,)
+    produces = (RHSMInfo,)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
     def process(self):

--- a/repos/system_upgrade/el7toel8/actors/scansubscriptionmanagerinfo/libraries/scanrhsm.py
+++ b/repos/system_upgrade/el7toel8/actors/scansubscriptionmanagerinfo/libraries/scanrhsm.py
@@ -1,4 +1,3 @@
-from leapp.models import SourceRHSMInfo
 from leapp.libraries.common import rhsm
 from leapp.libraries.common.mounting import NotIsolatedActions
 from leapp.libraries.stdlib import api
@@ -6,7 +5,6 @@ from leapp.libraries.stdlib import api
 
 @rhsm.with_rhsm
 def scan():
-    info = SourceRHSMInfo()
     context = NotIsolatedActions(base_dir='/')
-    rhsm.scan_rhsm_info(context, info)
+    info = rhsm.scan_rhsm_info(context)
     api.produce(info)

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
@@ -1,10 +1,11 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import userspacegen
 from leapp.libraries.common.config import get_env, version
-from leapp.models import (RepositoriesMap, RequiredTargetUserspacePackages, SourceRHSMInfo,
-                          StorageInfo, TargetRepositories, TargetRHSMInfo, TargetUserSpaceInfo, UsedTargetRepositories,
+from leapp.models import (RepositoriesMap, RequiredTargetUserspacePackages,
+                          RHSMInfo, StorageInfo, TargetRepositories,
+                          TargetUserSpaceInfo, UsedTargetRepositories,
                           XFSPresence)
-from leapp.tags import TargetTransactionFactsPhaseTag, IPUWorkflowTag
+from leapp.tags import IPUWorkflowTag, TargetTransactionFactsPhaseTag
 
 
 class TargetUserspaceCreator(Actor):
@@ -20,8 +21,8 @@ class TargetUserspaceCreator(Actor):
 
     name = 'target_userspace_creator'
     consumes = (RepositoriesMap, RequiredTargetUserspacePackages,
-                StorageInfo, SourceRHSMInfo, TargetRepositories, XFSPresence)
-    produces = (TargetRHSMInfo, TargetUserSpaceInfo, UsedTargetRepositories)
+                StorageInfo, RHSMInfo, TargetRepositories, XFSPresence)
+    produces = (TargetUserSpaceInfo, UsedTargetRepositories)
     tags = (IPUWorkflowTag, TargetTransactionFactsPhaseTag)
 
     def process(self):

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
@@ -1,0 +1,239 @@
+from collections import namedtuple
+import os
+
+import pytest
+
+from leapp.exceptions import StopActorExecutionError, StopActorExecution
+from leapp.libraries.actor import userspacegen
+from leapp.libraries.common import overlaygen, rhsm
+from leapp.libraries.common import testutils
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+from leapp import models
+
+
+_CERTS_PATH = os.path.join('../../files', userspacegen.PROD_CERTS_FOLDER)
+_DEFAULT_CERT_PATH = os.path.join(_CERTS_PATH, '8.1', '479.pem')
+
+
+class CurrentActorMocked(object):
+    def __init__(self, kernel='3.10.0-957.43.1.el7.x86_64', release_id='rhel',
+                 src_ver='7.6', dst_ver='8.1', arch=architecture.ARCH_X86_64,
+                 envars=None):
+
+        if envars:
+            envarsList = [models.EnvVar(name=key, value=value) for key, value in envars.items()]
+        else:
+            envarsList = []
+
+        version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
+        os_release = namedtuple('OS_release', ['release_id', 'version_id'])(release_id, src_ver)
+        args = (version, kernel, os_release, arch, envarsList)
+        conf_fields = ['version', 'kernel', 'os_release', 'architecture', 'leapp_env_vars']
+        self.configuration = namedtuple('configuration', conf_fields)(*args)
+        self._common_folder = '../../files'
+
+    def __call__(self):
+        return self
+
+    def get_common_folder_path(self, folder):
+        return os.path.join(self._common_folder, folder)
+
+
+class MockedMountingBase(object):
+    def __init__(self, **dummy_kwargs):
+        self.called_copytree_from = []
+
+    def copytree_from(self, src, dst):
+        self.called_copytree_from.append((src, dst))
+
+    def __call__(self, **dummy_kwarg):
+        yield self
+
+    def nspawn(self):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        pass
+
+
+@pytest.mark.parametrize('result,dst_ver,arch,prod_type', [
+    (os.path.join(_CERTS_PATH, '8.1', '479.pem'), '8.1', architecture.ARCH_X86_64, 'ga'),
+    (os.path.join(_CERTS_PATH, '8.1', '419.pem'), '8.1', architecture.ARCH_ARM64, 'ga'),
+    (os.path.join(_CERTS_PATH, '8.1', '279.pem'), '8.1', architecture.ARCH_PPC64LE, 'ga'),
+    (os.path.join(_CERTS_PATH, '8.2', '479.pem'), '8.2', architecture.ARCH_X86_64, 'ga'),
+    (os.path.join(_CERTS_PATH, '8.2', '230.pem'), '8.2', architecture.ARCH_X86_64, 'htb'),
+    (os.path.join(_CERTS_PATH, '8.2', '486.pem'), '8.2', architecture.ARCH_X86_64, 'beta'),
+    (os.path.join(_CERTS_PATH, '8.2', '72.pem'), '8.2', architecture.ARCH_S390X, 'ga'),
+    (os.path.join(_CERTS_PATH, '8.2', '232.pem'), '8.2', architecture.ARCH_S390X, 'htb'),
+    (os.path.join(_CERTS_PATH, '8.2', '433.pem'), '8.2', architecture.ARCH_S390X, 'beta'),
+])
+def test_get_product_certificate_path(monkeypatch, result, dst_ver, arch, prod_type):
+    envars = {'LEAPP_DEVEL_TARGET_PRODUCT_TYPE': prod_type}
+    curr_actor_mocked = CurrentActorMocked(dst_ver=dst_ver, arch=arch, envars=envars)
+    monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
+    assert userspacegen._get_product_certificate_path() == result
+
+
+class mocked_logger(object):
+    def __init__(self):
+        self.errmsg = []
+        self.warnmsg = []
+        self.debugmsg = []
+
+    def error(self, msg):
+        self.errmsg.append(msg)
+
+    def warn(self, msg):
+        self.warnmsg.append(msg)
+
+    def debug(self, msg):
+        self.debugmsg.append(msg)
+
+    def __call__(self):
+        return self
+
+
+_PACKAGES_MSGS = [
+    models.RequiredTargetUserspacePackages(),
+    models.RequiredTargetUserspacePackages(packages=['pkgA']),
+    models.RequiredTargetUserspacePackages(packages=['pkgB', 'pkgsC']),
+    models.RequiredTargetUserspacePackages(packages=['pkgD']),
+]
+_RHSMINFO_MSG = models.RHSMInfo(attached_skus=['testing-sku'])
+_XFS_MSG = models.XFSPresence()
+_STORAGEINFO_MSG = models.StorageInfo()
+
+
+class MockedConsume(object):
+    def __init__(self, *args):
+        self._msgs = []
+        for arg in args:
+            if not arg:
+                continue
+            if isinstance(arg, list):
+                self._msgs.extend(arg)
+            else:
+                self._msgs.append(arg)
+
+    def __call__(self, model):
+        return iter([msg for msg in self._msgs if isinstance(msg, model)])
+
+
+# FIXME: the results should be probably different with supported disconnected
+# systems (see rhsm)
+# undefined: (????, _PACKAGES_MSGS, None, _XFS_MSG, None),
+@pytest.mark.parametrize('raised,pkg_msgs,rhsm_info,xfs,storage', [
+    (None, _PACKAGES_MSGS, _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG),
+    (None, _PACKAGES_MSGS[0], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG),
+    (None, [], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG),
+    (None, _PACKAGES_MSGS, _RHSMINFO_MSG, None, _STORAGEINFO_MSG),
+    ((StopActorExecution, 'RHSM information'), _PACKAGES_MSGS, None, _XFS_MSG, _STORAGEINFO_MSG),
+    ((StopActorExecution, 'RHSM information'), _PACKAGES_MSGS, None, None, _STORAGEINFO_MSG),
+    ((StopActorExecution, 'RHSM information'), [], None, _XFS_MSG, _STORAGEINFO_MSG),
+    ((StopActorExecution, 'RHSM information'), [], None, None, _STORAGEINFO_MSG),
+    ((StopActorExecutionError, 'No storage'), _PACKAGES_MSGS, _RHSMINFO_MSG, _XFS_MSG, None),
+    ((StopActorExecutionError, 'No storage'), _PACKAGES_MSGS, _RHSMINFO_MSG, None, None),
+    ((StopActorExecutionError, 'No storage'), [], _RHSMINFO_MSG, _XFS_MSG, None),
+    ((StopActorExecutionError, 'No storage'), [], _RHSMINFO_MSG, None, None),
+])
+def test_consume_data(monkeypatch, raised, pkg_msgs, rhsm_info, xfs, storage):
+    _exp_pkgs = {'dnf'}
+    if isinstance(pkg_msgs, list):
+        for msg in pkg_msgs:
+            _exp_pkgs.update(msg.packages)
+    else:
+        _exp_pkgs.update(pkg_msgs.packages)
+    mocked_consume = MockedConsume(pkg_msgs, rhsm_info, xfs, storage)
+    monkeypatch.setattr(api, 'consume', mocked_consume)
+    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setenv('LEAPP_DEVEL_SKIP_RHSM', '0')
+    if not xfs:
+        xfs = models.XFSPresence()
+    if not raised:
+        assert userspacegen._consume_data() == (_exp_pkgs, rhsm_info, xfs, storage)
+        assert not api.current_logger.warnmsg
+        assert not api.current_logger.errmsg
+    else:
+        with pytest.raises(raised[0]) as err:
+            userspacegen._consume_data()
+        if isinstance(err.value, StopActorExecutionError):
+            assert raised[1] in err.value.message
+        else:
+            assert api.current_logger.warnmsg
+            assert any([raised[1] in x for x in api.current_logger.warnmsg])
+
+
+@pytest.mark.skip(reason="Currently not implemented in the actor. It's TODO.")
+def test_gather_target_repositories(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    # The available RHSM repos
+    monkeypatch.setattr(rhsm, 'get_available_repo_ids', lambda x, releasever: ['repoidX', 'repoidY', 'repoidZ'])
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: False)
+    # The required RHEL repos based on the repo mapping and PES data + custom repos required by third party actors
+    monkeypatch.setattr(api, 'consume', lambda x: iter([models.TargetRepositories(
+        rhel_repos=[models.RHELTargetRepository(repoid='repoidX'),
+                    models.RHELTargetRepository(repoid='repoidY')],
+        custom_repos=[models.CustomTargetRepository(repoid='repoidCustom')])]))
+
+    target_repoids = userspacegen.gather_target_repositories(None)
+
+    assert target_repoids == ['repoidX', 'repoidY', 'repoidCustom']
+
+
+def test_gather_target_repositories_none_available(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(rhsm, 'get_available_repo_ids', lambda x, releasever: [])
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: False)
+    with pytest.raises(StopActorExecutionError) as err:
+        userspacegen.gather_target_repositories(None)
+    assert "Cannot find required basic RHEL 8 repositories" in str(err)
+
+
+@pytest.mark.skip(reason="Currently not implemented in the actor. It's TODO.")
+def test_gather_target_repositories_required_not_available(monkeypatch):
+    # If the repos that Leapp identifies as required for the upgrade (based on the repo mapping and PES data) are not
+    # available, an exception shall be raised
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    # The available RHSM repos
+    monkeypatch.setattr(rhsm, 'get_available_repo_ids', lambda x, releasever: ['repoidA', 'repoidB', 'repoidC'])
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: False)
+    # The required RHEL repos based on the repo mapping and PES data + custom repos required by third party actors
+    monkeypatch.setattr(api, 'consume', lambda x: iter([models.TargetRepositories(
+        rhel_repos=[models.RHELTargetRepository(repoid='repoidX'),
+                    models.RHELTargetRepository(repoid='repoidY')],
+        custom_repos=[models.CustomTargetRepository(repoid='repoidCustom')])]))
+
+    with pytest.raises(StopActorExecutionError) as err:
+        userspacegen.gather_target_repositories(None)
+    assert "Cannot find required basic RHEL 8 repositories" in str(err)
+
+
+def mocked_consume_data():
+    packages = {'dnf', 'pkgA', 'pkgB'}
+    rhsm_info = _RHSMINFO_MSG
+    xfs_info = models.XFSPresence()
+    storage_info = models.StorageInfo()
+    return packages, rhsm_info, xfs_info, storage_info
+
+
+# TODO: come up with additional tests for the main function
+def test_perform_ok(monkeypatch):
+    repoids = ['repoidX', 'repoidY']
+    monkeypatch.setattr(userspacegen, '_consume_data', mocked_consume_data)
+    monkeypatch.setattr(userspacegen, '_get_product_certificate_path', lambda: _DEFAULT_CERT_PATH)
+    monkeypatch.setattr(overlaygen, 'create_source_overlay', MockedMountingBase)
+    monkeypatch.setattr(userspacegen, '_gather_target_repositories', lambda *x: repoids)
+    monkeypatch.setattr(userspacegen, '_create_target_userspace', lambda *x: None)
+    monkeypatch.setattr(api, 'produce', testutils.produce_mocked())
+    userspacegen.perform()
+    msg_target_repos = models.UsedTargetRepositories(
+            repos=[models.UsedTargetRepository(repoid=repo) for repo in repoids])
+    assert api.produce.called == 2
+    assert api.produce.model_instances[0] == msg_target_repos
+    # this one is full of contants, so it's safe to check just the instance
+    assert isinstance(api.produce.model_instances[1], models.TargetUserSpaceInfo)

--- a/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
+++ b/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
@@ -154,6 +154,7 @@ def install_initramdisk_requirements(packages, target_userspace_info, used_repos
             '--nogpgcheck',
             '--setopt=module_platform_id=platform:el8',
             '--setopt=keepcache=1',
+            '--releasever', api.current_actor().configuration.version.target,
             '--disablerepo', '*'
         ] + repos_opt + list(packages)
         if config.is_verbose():

--- a/repos/system_upgrade/el7toel8/libraries/mounting.py
+++ b/repos/system_upgrade/el7toel8/libraries/mounting.py
@@ -120,6 +120,8 @@ class IsolationType(object):
 class IsolatedActions(object):
     """ This class allows to perform actions in a manner as if the given base_dir would be the current root """
 
+    _isolated = True
+
     def __init__(self, base_dir, implementation, **kwargs):
         self.base_dir = base_dir
         self.type = implementation(base_dir, **kwargs)
@@ -216,6 +218,15 @@ class IsolatedActions(object):
         """
         shutil.copy2(self.full_path(src), dst)
 
+    @classmethod
+    def is_isolated(cls):
+        """
+        Tell whether the context is isolated or not.
+
+        All classes except NotIsolatedActions return True.
+        """
+        return cls._isolated
+
 
 class ChrootActions(IsolatedActions):
     """ Isolation with chroot """
@@ -234,6 +245,7 @@ class NspawnActions(IsolatedActions):
 
 class NotIsolatedActions(IsolatedActions):
     """ Non isolated executed. """
+    _isolated = False
 
     def __init__(self, base_dir):
         super(NotIsolatedActions, self).__init__(base_dir=base_dir, implementation=IsolationType.NONE)

--- a/repos/system_upgrade/el7toel8/libraries/rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/rhsm.py
@@ -3,17 +3,19 @@ import functools
 import os
 import re
 import time
+from collections import namedtuple
 
+from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common.config import get_product_type
 from leapp.libraries.stdlib import CalledProcessError, api
-from leapp.models import TargetRHSMInfo
+from leapp.models import RHSMInfo
 
 _RE_REPO_UID = re.compile(r'Repo ID:\s*([^\s]+)')
 _RE_RELEASE = re.compile(r'Release:\s*([^\s]+)')
 _RE_SKU_CONSUMED = re.compile(r'SKU:\s*([^\s]+)')
 _ATTEMPTS = 5
 _RETRY_SLEEP = 5
+_DEFAULT_RHSM_REPOFILE = '/etc/yum.repos.d/redhat.repo'
 
 
 def _rhsm_retry(max_attempts, sleep=None):
@@ -54,7 +56,7 @@ def _rhsm_retry(max_attempts, sleep=None):
 @contextlib.contextmanager
 def _handle_rhsm_exceptions(hint=None):
     """
-    Context manager based function that handles exceptions of `run` for the subscription manager calls.
+    Context manager based function that handles exceptions of `run` for the subscription-manager calls.
     """
     try:
         yield
@@ -78,12 +80,12 @@ def _handle_rhsm_exceptions(hint=None):
 
 
 def skip_rhsm():
-    """ Function to check whether we should skip RHSM related code """
+    """Check whether we should skip RHSM related code."""
     return os.getenv('LEAPP_DEVEL_SKIP_RHSM', '0') == '1'
 
 
 def with_rhsm(f):
-    """ Decorator to allow skipping RHSM functions by executing a no-op """
+    """Decorator to allow skipping RHSM functions by executing a no-op."""
     if skip_rhsm():
         @functools.wraps(f)
         def _no_op(*args, **kwargs):
@@ -93,59 +95,138 @@ def with_rhsm(f):
 
 
 @with_rhsm
-def get_attached_skus(context, rhsm_info):
+def get_attached_skus(context):
     """
-    Retrieves the list of SKU the system is attached to with the subscription manager.
+    Retrieve the list of the SKUs the system is attached to with the subscription-manager.
 
     :param context: An instance of a mounting.IsolatedActions class
     :type context: mounting.IsolatedActions class
-    :param rhsm_info: An instance of a RHSMInfo derived model.
-    :type rhsm_info: RHSMInfo derived model
+    :return: SKUs the current system is attached to.
+    :rtype: List(string)
     """
-    if not rhsm_info.attached_skus:
-        with _handle_rhsm_exceptions():
-            result = context.call(['subscription-manager', 'list', '--consumed'], split=False)
-            rhsm_info.attached_skus = _RE_SKU_CONSUMED.findall(result['stdout'])
+    with _handle_rhsm_exceptions():
+        result = context.call(['subscription-manager', 'list', '--consumed'], split=False)
+        return _RE_SKU_CONSUMED.findall(result['stdout'])
+
+
+def get_available_repo_ids(context, releasever=None):
+    """
+    Retrieve repo ids of all the repositories available through the subscription-manager.
+
+    :param context: An instance of a mounting.IsolatedActions class
+    :type context: mounting.IsolatedActions class
+    :param releasever: Release version to pass to the `yum repoinfo` command
+    :type releasever: string
+    :return: Repositories that are available to the current system through the subscription-manager
+    :rtype: List(string)
+    """
+    cmd = ['yum', 'repoinfo']
+    if releasever:
+        cmd.extend(['--releasever', releasever])
+    try:
+        result = context.call(cmd)
+    except CalledProcessError as exc:
+        raise StopActorExecutionError(
+            'Unable to get list of available yum repositories.',
+            details={'details': str(exc), 'stderr': exc.stderr}
+        )
+    _inhibit_on_duplicate_repos(result['stderr'])
+    available_repos = list(_get_repos(result['stdout']))
+    available_rhsm_repos = [repo.repoid for repo in available_repos if repo.file == _DEFAULT_RHSM_REPOFILE]
+    list_separator_fmt = '\n    - '
+    if available_rhsm_repos:
+        api.current_logger().info('The following repoids are available through RHSM:{0}{1}'
+                                  .format(list_separator_fmt, list_separator_fmt.join(available_rhsm_repos)))
+    else:
+        api.current_logger().info('There are no repos available through RHSM.')
+    return available_rhsm_repos
+
+
+def _inhibit_on_duplicate_repos(repos_raw_stderr):
+    """
+    Inhibit the upgrade if any repoid is defined multiple times.
+
+    When that happens, it not only shows misconfigured system, but then we can't get details of all the available
+    repos as well.
+    """
+    duplicates = []
+    for duplicate in re.findall(
+            r'Repository ([^\s]+) is listed more than once', repos_raw_stderr, re.DOTALL | re.MULTILINE):
+        duplicates.append(duplicate)
+
+    if not duplicates:
+        return
+    list_separator_fmt = '\n    - '
+    api.current_logger().warn('The following repoids are defined multiple times:{0}{1}'
+                              .format(list_separator_fmt, list_separator_fmt.join(duplicates)))
+
+    reporting.create_report([
+        reporting.Title('A YUM/DNF repository defined multiple times'),
+        reporting.Summary(
+            'The `yum repoinfo` command reports that the following repositories are defined multiple times:{0}{1}'.
+            format(list_separator_fmt, list_separator_fmt.join(duplicates))
+        ),
+        reporting.Severity(reporting.Severity.MEDIUM),
+        reporting.Tags([reporting.Tags.REPOSITORY]),
+        reporting.Flags([reporting.Flags.INHIBITOR]),
+        reporting.Remediation(hint='Remove the duplicit repository definitions.')
+    ])
+
+
+def _get_repos(repos_stdout_raw):
+    """
+    Generator providing all the repos available through yum/dnf.
+
+    :rtype: Iterator[:py:class:`leapp.libraries.common.rhsm.Repo`]
+    """
+    # Split all the available repos per one repo
+    for repo_params_raw in re.findall(
+            r"Repo-id.*?Repo-filename.*?\n", repos_stdout_raw, re.DOTALL | re.MULTILINE):
+        yield _parse_repo_params(repo_params_raw)
+
+
+def _parse_repo_params(repo_params_raw):
+    """Parse multiline string holding repo parameters to distill the important ones."""
+    try:
+        repoid = _get_repo_param(r'^Repo-id\s+:\s+([^/]+?)(/.*?)?$', repo_params_raw, 'Repo-id')
+        repofile = _get_repo_param(r'^Repo-filename:\s+(.*?)$', repo_params_raw, 'Repo-filename')
+        return namedtuple('Repository', ['repoid', 'file'])(repoid, repofile)
+    except ValueError as err:
+        err_detail = ("Failed to parse the '{0}' repo parameter within the following part of the"
+                      " `yum repoinfo` output:\n{1}".format(err.args[0], repo_params_raw))
+        raise StopActorExecutionError(
+            message='Failed to parse the `yum repoinfo` output',
+            details={'details': err_detail})
+
+
+def _get_repo_param(pattern, repo_params_raw, param):
+    """Parse a string with all the repo params to get the value of a single repo param."""
+    repo_param = re.search(pattern, repo_params_raw, re.MULTILINE | re.DOTALL)
+    if repo_param:
+        return repo_param.group(1)
+    raise ValueError(param, repo_params_raw)
 
 
 @with_rhsm
-def get_available_repo_uids(context, rhsm_info):
+def get_enabled_repo_ids(context):
     """
-    Retrieves all available repositories names from the subscription manager.
+    Retrieve repo ids of all the repositories enabled through the subscription-manager.
 
     :param context: An instance of a mounting.IsolatedActions class
     :type context: mounting.IsolatedActions class
-    :param rhsm_info: An instance of a RHSMInfo derived model.
-    :type rhsm_info: RHSMInfo derived model
+    :return: Repositories that are enabled on the current system through the subscription-manager.
+    :rtype: List(string)
     """
-    if not rhsm_info.available_repos:
-        with _handle_rhsm_exceptions():
-            result = context.call(['subscription-manager', 'repos'], split=False)
-            rhsm_info.available_repos = _RE_REPO_UID.findall(result['stdout'])
-
-
-@with_rhsm
-def get_enabled_repo_uids(context, rhsm_info):
-    """
-    Retrieves all enabled repositories names from the subscription manager.
-
-    :param context: An instance of a mounting.IsolatedActions class
-    :type context: mounting.IsolatedActions class
-    :param rhsm_info: An instance of a RHSMInfo derived model.
-    :type rhsm_info: RHSMInfo derived model
-    """
-    if not rhsm_info.enabled_repos:
-        with _handle_rhsm_exceptions():
-            result = context.call(['subscription-manager', 'repos', '--list-enabled'], split=False)
-            rhsm_info.enabled_repos = _RE_REPO_UID.findall(result['stdout'])
+    with _handle_rhsm_exceptions():
+        result = context.call(['subscription-manager', 'repos', '--list-enabled'], split=False)
+        return _RE_REPO_UID.findall(result['stdout'])
 
 
 @with_rhsm
 @_rhsm_retry(max_attempts=_ATTEMPTS, sleep=_RETRY_SLEEP)
 def unset_release(context):
     """
-    Unsets the configured release from the subscription manager so we can perform the upgrade.
-    Stores the previous set release in self.info if not already received.
+    Unset the configured release from the subscription-manager.
 
     :param context: An instance of a mounting.IsolatedActions class
     :type context: mounting.IsolatedActions class
@@ -158,11 +239,11 @@ def unset_release(context):
 @_rhsm_retry(max_attempts=_ATTEMPTS, sleep=_RETRY_SLEEP)
 def set_release(context, release):
     """
-    This function will set the version specified.
+    Set the release (RHEL minor version) through the subscription-manager.
 
     :param context: An instance of a mounting.IsolatedActions class
     :type context: mounting.IsolatedActions class
-    :param release: Release to set the subscription manager to.
+    :param release: Release to set the subscription-manager to.
     :type release: str
     """
     with _handle_rhsm_exceptions():
@@ -170,34 +251,19 @@ def set_release(context, release):
 
 
 @with_rhsm
-def restore_release(context, rhsm_info):
+def get_release(context):
     """
-    If a release has been set, this function will restore it from the rhsm_info.release value.
+    Retrieves the release the subscription-manager has been pinned to, if applicable.
 
     :param context: An instance of a mounting.IsolatedActions class
     :type context: mounting.IsolatedActions class
-    :param rhsm_info: An instance of a RHSMInfo derived model.
-    :type rhsm_info: RHSMInfo derived model
+    :return: Release the subscription-manager is set to.
+    :rtype: string
     """
-    if rhsm_info.release:
-        set_release(context, rhsm_info.release)
-
-
-@with_rhsm
-def get_release(context, rhsm_info):
-    """
-    Retrieves the release the subscription manager has been pinned to, if applicable.
-
-    :param context: An instance of a mounting.IsolatedActions class
-    :type context: mounting.IsolatedActions class
-    :param rhsm_info: An instance of a RHSMInfo derived model.
-    :type rhsm_info: RHSMInfo derived model
-    """
-    if rhsm_info.release is None:
-        with _handle_rhsm_exceptions():
-            result = context.call(['subscription-manager', 'release'], split=False)
-            result = _RE_RELEASE.findall(result['stdout'])
-            rhsm_info.release = result[0] if result else ''
+    with _handle_rhsm_exceptions():
+        result = context.call(['subscription-manager', 'release'], split=False)
+        result = _RE_RELEASE.findall(result['stdout'])
+        return result[0] if result else ''
 
 
 @with_rhsm
@@ -214,51 +280,63 @@ def refresh(context):
 
 
 @with_rhsm
-def get_existing_product_certificates(context, rhsm_info):
+def get_existing_product_certificates(context):
     """
     Retrieves information about existing product certificates on the system.
 
     :param context: An instance of a mounting.IsolatedActions class
     :type context: mounting.IsolatedActions class
-    :param rhsm_info: An instance of a RHSMInfo derived model.
-    :type rhsm_info: RHSMInfo derived model
+    :return: Paths to product certificates that are currently installed on the system.
+    :rtype: List(string)
     """
-    if not rhsm_info.existing_product_certificates:
-        for path in ('/etc/pki/product', '/etc/pki/product-default'):
-            if not os.path.isdir(context.full_path(path)):
-                continue
-            certs = [os.path.join(path, f) for f in os.listdir(context.full_path(path))
-                     if os.path.isfile(os.path.join(context.full_path(path), f))]
-            if not certs:
-                continue
-            rhsm_info.existing_product_certificates.extend(certs)
+    certs = []
+    for path in ('/etc/pki/product', '/etc/pki/product-default'):
+        if not os.path.isdir(context.full_path(path)):
+            continue
+        curr_certs = [os.path.join(path, f) for f in os.listdir(context.full_path(path))
+                      if os.path.isfile(os.path.join(context.full_path(path), f))]
+        if curr_certs:
+            certs.extend(curr_certs)
+    return certs
 
 
-@contextlib.contextmanager
-def switched_certificate(context, rhsm_info, cert_path, version):
+def set_container_mode(context):
     """
-    Performs all actions needed to switch the product certificate passed.
+    Put RHSM into the container mode.
 
-    This function will copy the certificate to /etc/pki/product and if necessary /etc/pki/product-default and
-    removes other product certificates from there. Unsets the release and refreshes the subscription-manager.
+    Inside the container, we have to ensure the RHSM is not used AND that host
+    is not affected. If the RHSM is not set into the container mode, the host
+    could be affected and the generated repo file in the container could be
+    affected as well (e.g. when the release is set, using rhsm, on the host).
 
     :param context: An instance of a mounting.IsolatedActions class
     :type context: mounting.IsolatedActions class
-    :param rhsm_info: An instance of a RHSMInfo derived model.
-    :type rhsm_info: RHSMInfo derived model
-    :param cert_path: Path to the product certificate to switch to.
+    """
+    if not context.is_isolated():
+        api.current_logger().error('Trying to set RHSM into the container mode'
+                                   'on host. Skipping the action.')
+        return
+    try:
+        context.call(['ln', '-s', '/etc/rhsm', '/etc/rhsm-host'])
+    except CalledProcessError:
+        raise StopActorExecutionError(
+                message='Cannot set the container mode for the subscription-manager.')
+
+
+def switch_certificate(context, rhsm_info, cert_path):
+    """
+    Perform all actions needed to switch the passed RHSM product certificate.
+
+    This function will copy the certificate to /etc/pki/product, and /etc/pki/product-default if necessary, and
+    remove other product certificates from there.
+
+    :param context: An instance of a mounting.IsolatedActions class
+    :type context: mounting.IsolatedActions class
+    :param rhsm_info: An instance of the RHSMInfo model
+    :type rhsm_info: RHSMInfo model
+    :param cert_path: Path to the product certificate to switch to
     :type cert_path: string
     """
-    if skip_rhsm():
-        yield TargetRHSMInfo()
-        return
-
-    # Make a backup of product certificates
-    pki_path = '/etc/pki'
-    pki_backup_path = '/etc/pki.bak'
-    context.call(['rm', '-rf', pki_backup_path], checked=False)
-    context.call(['cp', '-a', pki_path, pki_backup_path], checked=False)
-
     for existing in rhsm_info.existing_product_certificates:
         try:
             context.remove(existing)
@@ -269,37 +347,23 @@ def switched_certificate(context, rhsm_info, cert_path, version):
         if os.path.isdir(context.full_path(path)):
             context.copy_to(cert_path, os.path.join(path, os.path.basename(cert_path)))
 
-    unset_release(context)
-    try:
-        refresh(context)
-        # only ga has releases in rhsm
-        if get_product_type('target') == 'ga':
-            set_release(context, version)
-        target_rhsm_info = TargetRHSMInfo()
-        scan_rhsm_info(context, target_rhsm_info)
-        yield target_rhsm_info
-    finally:
-        # Restore backup of product certificates
-        context.call(['rm', '-rf', pki_path], checked=False)
-        context.call(['cp', '-a', pki_backup_path, pki_path], checked=False)
-        unset_release(context)
-        # Restore release - only ga has releases in rhsm
-        if get_product_type('source') == 'ga':
-            restore_release(context, rhsm_info)
-
 
 @with_rhsm
-def scan_rhsm_info(context, rhsm_info):
+def scan_rhsm_info(context):
     """
-    Gathers all RHSM information
+    Gather all the RHSM information of the source system.
+
+    It's not intended for gathering RHSM info about the target system within a container.
 
     :param context: An instance of a mounting.IsolatedActions class
     :type context: mounting.IsolatedActions class
-    :param rhsm_info: An instance of a RHSMInfo derived model.
-    :type rhsm_info: RHSMInfo derived model
+    :return: An instance of an RHSMInfo model.
+    :rtype: RHSMInfo model
     """
-    get_attached_skus(context, rhsm_info)
-    get_available_repo_uids(context, rhsm_info)
-    get_enabled_repo_uids(context, rhsm_info)
-    get_release(context, rhsm_info)
-    get_existing_product_certificates(context, rhsm_info)
+    info = RHSMInfo()
+    info.attached_skus = get_attached_skus(context)
+    info.available_repos = get_available_repo_ids(context)
+    info.enabled_repos = get_enabled_repo_ids(context)
+    info.release = get_release(context)
+    info.existing_product_certificates.extend(get_existing_product_certificates(context))
+    return info

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_rhsm.py
@@ -1,0 +1,177 @@
+from collections import namedtuple
+
+import pytest
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import rhsm
+from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.stdlib import CalledProcessError, api
+
+Repository = namedtuple('Repository', ['repoid', 'file'])
+LIST_SEPARATOR = '\n    - '
+
+
+class IsolatedActionsMocked(object):
+    def __init__(self, call_stdout=None, raise_err=False):
+        self.commands_called = []
+        self.call_return = {'stdout': call_stdout, 'stderr': None}
+        self.raise_err = raise_err
+
+    def call(self, cmd, *args):
+        self.commands_called.append(cmd)
+        if self.raise_err:
+            raise_call_error(cmd)
+        return self.call_return
+
+
+def raise_call_error(args=None, exit_code=1):
+    raise CalledProcessError(
+        message='Command {0} failed with exit code {1}.'.format(str(args), exit_code),
+        command=args,
+        result={'signal': None, 'exit_code': exit_code, 'pid': 0, 'stdout': 'fake out', 'stderr': 'fake err'}
+    )
+
+
+class LoggerMocked(object):
+    def __init__(self):
+        self.infomsg = None
+        self.warnmsg = None
+
+    def info(self, msg):
+        self.infomsg = msg
+
+    def warn(self, msg):
+        self.warnmsg = msg
+
+    def __call__(self):
+        return self
+
+
+@pytest.mark.parametrize('releasever', ['8.2', None])
+@pytest.mark.parametrize('available_repos', [
+    [],
+    [Repository(repoid='repoidX', file=rhsm._DEFAULT_RHSM_REPOFILE),
+     Repository(repoid='repoidY', file='random_test_file')]
+])
+def test_get_available_repo_ids(monkeypatch, releasever, available_repos):
+    context_mocked = IsolatedActionsMocked()
+    monkeypatch.setattr(rhsm, '_inhibit_on_duplicate_repos', lambda x: None)
+    monkeypatch.setattr(rhsm, '_get_repos', lambda x: iter(available_repos))
+    monkeypatch.setattr(api, 'current_logger', LoggerMocked())
+
+    available_repos = rhsm.get_available_repo_ids(context_mocked, releasever)
+
+    if releasever:
+        assert context_mocked.commands_called == [['yum', 'repoinfo', '--releasever', '8.2']]
+    else:
+        assert context_mocked.commands_called == [['yum', 'repoinfo']]
+    if available_repos:
+        available_repoid = 'repoidX'
+        assert available_repos == [available_repoid]
+        assert api.current_logger.infomsg == (
+            'The following repoids are available through RHSM:{0}{1}'
+            .format(LIST_SEPARATOR, available_repoid))
+    else:
+        assert available_repos == []
+        assert api.current_logger.infomsg == 'There are no repos available through RHSM.'
+
+
+def test_get_available_repo_ids_error():
+    context_mocked = IsolatedActionsMocked(raise_err=True)
+
+    with pytest.raises(StopActorExecutionError) as err:
+        rhsm.get_available_repo_ids(context_mocked)
+
+    assert 'Unable to get list of available yum repositories.' in str(err)
+    assert "Command ['yum', 'repoinfo'] failed" in err.value.details['details']
+
+
+YUM_REPOINFO_TYPICAL = ("""
+Repo-id      : custom-repo-id
+Repo-name    : Custom repository
+Repo-revision: 1583940534
+Repo-updated : Wed Mar 11 15:28:55 2020
+Repo-pkgs    : 548
+Repo-size    : 1.2 G
+Repo-baseurl : http://custom-repo-url/
+Repo-expire  : 21,600 second(s) (last: Wed Mar 11 16:05:04 2020)
+  Filter     : read-only:present
+Repo-excluded: 205
+Repo-filename: /etc/yum.repos.d/custom-repo.repo
+
+Repo-id      : rhel-7-server-rpms/7Server/x86_64
+Repo-name    : Red Hat Enterprise Linux 7 Server (RPMs)
+Repo-revision: 1583726307
+Repo-updated : Mon Mar  9 03:58:27 2020
+Repo-pkgs    : 5,231
+Repo-size    : 3.6 G
+Repo-baseurl : https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os
+Repo-expire  : 86,400 second(s) (last: Mon Mar  9 21:06:18 2020)
+  Filter     : read-only:present
+Repo-filename: /etc/yum.repos.d/redhat.repo
+
+repolist: 5,779
+""")
+
+
+YUM_REPOINFO_DUPS = ("""
+Repository rhel-7-server-eus-rpms is listed more than once in the configuration
+Repository rhel-7-server-extras-rpms is listed more than once in the configuration
+Repository rhel-7-server-eus-optional-rpms is listed more than once in the configuration
+""")
+
+
+def test_inhibit_on_duplicate_repos(monkeypatch):
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(api, 'current_logger', LoggerMocked())
+
+    rhsm._inhibit_on_duplicate_repos(YUM_REPOINFO_DUPS + YUM_REPOINFO_TYPICAL)
+
+    dups = ['rhel-7-server-eus-rpms', 'rhel-7-server-extras-rpms', 'rhel-7-server-eus-optional-rpms']
+    assert ('The following repoids are defined multiple times:{0}{1}'
+            .format(LIST_SEPARATOR, LIST_SEPARATOR.join(dups))) in api.current_logger.warnmsg
+    assert reporting.create_report.called == 1
+    assert 'inhibitor' in reporting.create_report.report_fields['flags']
+    assert reporting.create_report.report_fields['title'] == 'A YUM/DNF repository defined multiple times'
+    assert ('the following repositories are defined multiple times:{0}{1}'
+            .format(LIST_SEPARATOR, LIST_SEPARATOR.join(dups))) in reporting.create_report.report_fields['summary']
+
+
+def test_inhibit_on_duplicate_repos_no_dups(monkeypatch):
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(api, 'current_logger', LoggerMocked())
+
+    rhsm._inhibit_on_duplicate_repos(YUM_REPOINFO_TYPICAL)
+
+    assert api.current_logger.warnmsg is None
+    assert reporting.create_report.called == 0
+
+
+def test_get_repos():
+    repos = list(rhsm._get_repos(YUM_REPOINFO_TYPICAL))
+
+    assert repos == [Repository(repoid='custom-repo-id', file='/etc/yum.repos.d/custom-repo.repo'),
+                     Repository(repoid='rhel-7-server-rpms', file='/etc/yum.repos.d/redhat.repo')]
+
+
+# There's an additional space between 'Repo-filename' and ':'
+YUM_REPOINFO_ADDITIONAL_SPACE = ("""Repo-id      : rhel-7-server-rpms/7Server/x86_64
+Repo-name    : Red Hat Enterprise Linux 7 Server (RPMs)
+Repo-revision: 1583726307
+Repo-updated : Mon Mar  9 03:58:27 2020
+Repo-pkgs    : 5,231
+Repo-size    : 3.6 G
+Repo-baseurl : https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os
+Repo-expire  : 86,400 second(s) (last: Mon Mar  9 21:06:18 2020)
+  Filter     : read-only:present
+Repo-filename : /etc/yum.repos.d/redhat.repo""")
+
+
+def test_parse_repo_params():
+    with pytest.raises(StopActorExecutionError) as err:
+        rhsm._parse_repo_params(YUM_REPOINFO_ADDITIONAL_SPACE)
+
+    assert 'Failed to parse the `yum repoinfo` output' in str(err)
+    assert ("Failed to parse the 'Repo-filename' repo parameter within the following part of the `yum repoinfo`"
+            " output:\n{0}".format(YUM_REPOINFO_ADDITIONAL_SPACE)) in err.value.details['details']

--- a/repos/system_upgrade/el7toel8/models/rhsminfo.py
+++ b/repos/system_upgrade/el7toel8/models/rhsminfo.py
@@ -4,25 +4,17 @@ from leapp.topics import RHSMTopic
 
 class RHSMInfo(Model):
     """
-    Subscription manager details required for the inplace upgrade.
+    Subscription-manager details required for the inplace upgrade.
     """
     topic = RHSMTopic
 
     release = fields.Nullable(fields.String())
-    """ Release the subscription manager is set to. """
+    """ Release the subscription-manager is set to. """
     attached_skus = fields.List(fields.String(), default=[])
     """ SKUs the current system is attached to. """
     available_repos = fields.List(fields.String(), default=[])
-    """ Repositories that are available to the current system through the subscription manager. """
+    """ Repositories that are available to the current system through the subscription-manager. """
     enabled_repos = fields.List(fields.String(), default=[])
-    """ Repositories that are enabled on the current system through the subscription manager. """
+    """ Repositories that are enabled on the current system through the subscription-manager. """
     existing_product_certificates = fields.List(fields.String(), default=[])
     """ Product certificates that are currently installed on the system. """
-
-
-class SourceRHSMInfo(RHSMInfo):
-    pass
-
-
-class TargetRHSMInfo(RHSMInfo):
-    pass


### PR DESCRIPTION
It is not safe to use subscription-manager in a container: https://bugzilla.redhat.com/show_bug.cgi?id=1702691

From the RHSM team:

> There are many problems with trying to share a consumer between two systems, which we avoid generally by putting subscription-manager into "container mode".

> Only the population of redhat.repo works in this state.

From @vojtechsokol:

> The container mode (i.e. /etc/rhsm-host/ exists) means that rhsm is effectively disabled (see [this](https://github.com/candlepin/subscription-manager/blob/f9381573978f5e62ef3c6c6d1f5594e6380efe60/src/rhsm/config.py#L107) and [this](https://github.com/candlepin/subscription-manager/blob/master/src/subscription_manager/managercli.py#L397), especially the second is interresting because of the TODO line), therefore any call to rhsm command will fail.

From @pirat89:

> The refreshed redhat.repo file is only source we can use in this case to get info about repos provided by RH.