### PR TITLE
Inhibit upgrade if multiple kernel-devel pkgs are installed

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddevelkernels/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddevelkernels/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.models import InstalledRedHatSignedRPM
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+from leapp.reporting import Report
+from leapp.libraries.actor import library
+
+
+class CheckInstalledDevelKernels(Actor):
+    """
+    Inhibit IPU (in-place upgrade) when multiple devel kernels are installed.
+
+    Because of an issue in DNF, the transaction can't be validated if there's
+    more than one package named kernel-devel. Therefore, in this case, we
+    inhibit the upgrade with a clearer remediation.
+    """
+
+    name = 'check_installed_devel_kernels'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        library.process()

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddevelkernels/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddevelkernels/libraries/library.py
@@ -1,0 +1,40 @@
+from leapp import reporting
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM
+
+
+def get_kernel_rpm_release(rpm):
+    """
+    Get the release of a kernel RPM as an integer.
+
+    :param rpm: An instance of an RPM derived model.
+    """
+    return int(rpm.release.split('.')[0])
+
+
+def get_kernel_devel_rpms():
+    """
+    Get all installed kernel-devel packages ordered by release number (ascending).
+    """
+    rpms = next(api.consume(InstalledRedHatSignedRPM), InstalledRedHatSignedRPM())
+    return sorted([pkg for pkg in rpms.items if pkg.name == 'kernel-devel'], key=get_kernel_rpm_release)
+
+
+def process():
+    pkgs = get_kernel_devel_rpms()
+    if len(pkgs) > 1:
+        title = 'Multiple devel kernels installed'
+        summary = ('DNF cannot produce a valid upgrade transaction when'
+                   ' multiple kernel-devel packages are installed.')
+        hint = ('Remove all but one kernel-devel packages before running Leapp again.')
+        commands = ([['yum', '-y', 'remove', '{n}-{v}.{r}'.format(
+            n=pkg.name, v=pkg.version, r=pkg.release)] for pkg in pkgs[:-1]])
+        reporting.create_report([
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.KERNEL]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.Remediation(hint=hint, commands=commands),
+            reporting.RelatedResource('package', 'kernel')
+        ])

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddevelkernels/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddevelkernels/tests/unit_test.py
@@ -1,0 +1,36 @@
+import pytest
+
+from leapp.models import InstalledRedHatSignedRPM, RPM, Report
+from leapp.snactor.fixture import current_actor_context
+
+
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+
+ballast1 = [
+    RPM(name='b1', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='kernel', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='b2', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s')
+]
+ballast2 = [
+    RPM(name='b3', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='kernel', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='b4', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s')
+]
+devel_kernels = [
+    RPM(name='kernel-devel', version='3.10.0', release='957.27.4.el7',
+        epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='kernel-devel', version='3.10.0', release='957.35.1.el7',
+        epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='kernel-devel', version='3.10.0', release='957.43.1.el7',
+        epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s')
+]
+
+
+@pytest.mark.parametrize('n', [0, 1, 2, 3])
+def test_process_devel_kernels(current_actor_context, n):
+    current_actor_context.feed(InstalledRedHatSignedRPM(items=ballast1+devel_kernels[:n]+ballast2))
+    current_actor_context.run()
+    if n < 2:
+        assert not current_actor_context.consume(Report)
+    else:
+        assert current_actor_context.consume(Report)

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/actor.py
@@ -7,20 +7,26 @@ from leapp.libraries.actor import library
 
 class CheckInstalledKernels(Actor):
     """
-    Inhibit IPU (in-place upgrade) when multiple kernels are installed.
+    Inhibit IPU (in-place upgrade) when installed kernels conflict with a safe upgrade.
 
-    We are not able to upgrade correctly when any kernel is expected to be
-    uninstalled during the rpm upgrade transaction now. This is especially
-    problematic on s390x architecture.
+    a) Inhibit when multiple kernels are installed on a s390x machine
 
-    We discovered recently that removal of old kernels is not handled
-    correctly during the IPU. In case the maximum number of kernels
-    are installed, the oldest one is automatically uninstalled during
-    the rpm upgrade transaction.
+    When on s390x architecture, we are not able to upgrade correctly
+    when any kernel is expected to be uninstalled during the rpm
+    upgrade transaction now. We discovered recently that removal of
+    old kernels is not handled correctly during the IPU. In case the
+    maximum number of kernels are installed, the oldest one is
+    automatically uninstalled during the rpm upgrade transaction.
 
     To prevent any related troubles during the IPU, inhibit the IPU
     on s390x unless just one kernel is installed, until the issue will
     be fixed correctly.
+
+    b) Inhibit when machine is not booted into latest installed kernel
+
+    It is strictly required that during the upgrade the machine is
+    booted into the latest installed kernel. Upgrading with older
+    kernels could cause unexpected issues.
     """
 
     name = 'check_installed_kernels'

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/libraries/library.py
@@ -5,23 +5,41 @@ from leapp.libraries.stdlib import api
 from leapp.models import InstalledRedHatSignedRPM
 
 
-def _get_kernel_rpms():
+def get_current_kernel_release():
+    """
+    Get the release of the running kernel as an integer.
+    """
+    kernel = api.current_actor().configuration.kernel
+    return int(kernel.split('-')[1].split('.')[0])
+
+
+def get_kernel_rpm_release(rpm):
+    """
+    Get the release of a kernel RPM as an integer.
+
+    :param rpm: An instance of an RPM derived model.
+    """
+    return int(rpm.release.split('.')[0])
+
+
+def get_kernel_rpms():
+    """
+    Get all installed kernel packages ordered by release number (ascending).
+    """
     rpms = next(api.consume(InstalledRedHatSignedRPM), InstalledRedHatSignedRPM())
-    return [pkg for pkg in rpms.items if pkg.name == 'kernel']
+    return sorted([pkg for pkg in rpms.items if pkg.name == 'kernel'], key=get_kernel_rpm_release)
 
 
 def process():
-    if not architecture.matches_architecture(architecture.ARCH_S390X):
-        return
-
-    pkgs = _get_kernel_rpms()
+    pkgs = get_kernel_rpms()
     if not pkgs:
         # Hypothatical, user is not allowed to install any kernel that is not signed by RH
         # In case we would like to be cautious, we could check whether there are no other
         # kernels installed as well.
         api.current_logger().log.error('Cannot find any installed kernel signed by Red Hat.')
         raise StopActorExecutionError('Cannot find any installed kernel signed by Red Hat.')
-    if len(pkgs) > 1:
+
+    if len(pkgs) > 1 and architecture.matches_architecture(architecture.ARCH_S390X):
         # It's temporary solution, so no need to try automatize everything.
         title = 'Multiple kernels installed'
         summary = ('The upgrade process does not handle well the case when multiple kernels'
@@ -29,6 +47,23 @@ def process():
                    ' getting corrupted during the upgrade.')
         remediation = ('Boot into the most up-to-date kernel and remove all older'
                        ' kernels installed on the machine before running Leapp again.')
+        reporting.create_report([
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.KERNEL, reporting.Tags.BOOT]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.Remediation(hint=remediation),
+            reporting.RelatedResource('package', 'kernel')
+        ])
+
+    current = get_current_kernel_release()
+    if current != get_kernel_rpm_release(pkgs[-1]):
+        title = 'Newest installed kernel not in use'
+        summary = ('To ensure a stable upgrade, the machine needs to be'
+                   ' booted into the latest installed kernel.')
+        remediation = ('Boot into the most up-to-date kernel installed'
+                       ' on the machine before running Leapp again.')
         reporting.create_report([
             reporting.Title(title),
             reporting.Summary(summary),

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/tests/unit_test.py
@@ -11,8 +11,8 @@ RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
 
 
 class CurrentActorMocked(object):
-    def __init__(self, arch):
-        self.configuration = namedtuple('configuration', ['architecture'])(arch)
+    def __init__(self, arch=architecture.ARCH_X86_64, kernel='3.10.0-957.43.1.el7.x86_64'):
+        self.configuration = namedtuple('configuration', ['architecture', 'kernel'])(arch, kernel)
 
     def __call__(self):
         return self
@@ -29,13 +29,13 @@ class mocked_logger(object):
         return self
 
 
-def mocked_consume(pkg_names):
+def mocked_consume(pkgs):  # pkgs = [(name, version-number)]
     installed_rpms = []
     version = 1
-    for pkg in pkg_names:
+    for pkg in pkgs:
         installed_rpms.append(RPM(
-                name=pkg, arch='noarch',
-                version=str(version), release='1.sm01', epoch='0',
+                name=pkg[0], arch='noarch',
+                version=str(version), release='{}.sm01'.format(pkg[1]), epoch='0',
                 packager=RH_PACKAGER, pgpsig='SOME_OTHER_SIG_X'))
         version += 1
 
@@ -44,30 +44,62 @@ def mocked_consume(pkg_names):
     return f
 
 
-def test_single_kernel(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+s390x_pkgs_single = [('kernel', 957), ('something', 957), ('kernel-something', 957)]
+s390x_pkgs_multi = [('kernel', 957), ('something', 957), ('kernel', 956)]
+
+
+def test_single_kernel_s390x(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     monkeypatch.setattr(api, 'current_logger', mocked_logger())
-    monkeypatch.setattr(api, "consume", mocked_consume(['kernel', 'someting', 'kernel-somethin']))
-    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    monkeypatch.setattr(api, 'consume', mocked_consume(s390x_pkgs_single))
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     library.process()
     assert not reporting.create_report.called
 
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
-    monkeypatch.setattr(api, "consume", mocked_consume(['kernel', 'someting', 'kernel-somethin']))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X))
+    monkeypatch.setattr(api, 'consume', mocked_consume(s390x_pkgs_single))
     library.process()
     assert not reporting.create_report.called
 
 
-def test_multi_kernel(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+def test_multi_kernel_s390x(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     monkeypatch.setattr(api, 'current_logger', mocked_logger())
-    monkeypatch.setattr(api, "consume", mocked_consume(['kernel', 'someting', 'kernel']))
-    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    monkeypatch.setattr(api, 'consume', mocked_consume(s390x_pkgs_multi))
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     library.process()
     assert not reporting.create_report.called
 
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
-    monkeypatch.setattr(api, "consume", mocked_consume(['kernel', 'someting', 'kernel']))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X))
+    monkeypatch.setattr(api, 'consume', mocked_consume(s390x_pkgs_multi))
     library.process()
     assert reporting.create_report.called
     assert reporting.create_report.report_fields['title'] == 'Multiple kernels installed'
+
+
+versioned_kernel_pkgs = [('kernel', 456), ('kernel', 789), ('kernel', 1234)]
+
+
+def test_newest_kernel(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='3.10.0-1234.21.1.el7.x86_64'))
+    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    library.process()
+    assert not reporting.create_report.called
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='3.10.0-456.43.1.el7.x86_64'))
+    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    library.process()
+    assert reporting.create_report.called
+    assert reporting.create_report.report_fields['title'] == 'Newest installed kernel not in use'
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='3.10.0-789.35.2.el7.x86_64'))
+    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    library.process()
+    assert reporting.create_report.called
+    assert reporting.create_report.report_fields['title'] == 'Newest installed kernel not in use'

--- a/repos/system_upgrade/el7toel8/models/installedkernelversion.py
+++ b/repos/system_upgrade/el7toel8/models/installedkernelversion.py
@@ -1,0 +1,9 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class CurrentKernel(Model):
+    topic = SystemInfoTopic
+    version = fields.String()
+    release = fields.String()
+    arch = fields.String()


### PR DESCRIPTION
When multiple `kernel-devel` packages are present, leapp attempts to upgrade them, but can't resolve the transaction in most cases. So we've decided to inhibit the upgrade and present the user with hints on removing the surplus devel kernels.

There's also a high chance of unexpected issues occuring on older kernels, so we've decided to inhibit if the machine isn't booted into the latest installed one.