### PR TITLE
New ipu path RHEL-ALT 7.6 -> 8.2, RHEL 7.8 - 8.2

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/actor.py
@@ -24,5 +24,6 @@ class IPUWorkflowConfig(Actor):
             leapp_env_vars=library.get_env_vars(),
             os_release=os_release,
             architecture=platform.machine(),
-            version=Version(source=os_release.version_id, target=target_version)
+            version=Version(source=os_release.version_id, target=target_version),
+            kernel=library.get_booted_kernel()
         ))

--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/libraries/library.py
@@ -4,7 +4,7 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.stdlib import run, CalledProcessError
 from leapp.models import EnvVar, OSRelease
 
-CURRENT_TARGET_VERSION = '8.1'
+CURRENT_TARGET_VERSION = '8.2'
 
 ENV_IGNORE = ('LEAPP_CURRENT_PHASE', 'LEAPP_CURRENT_ACTOR', 'LEAPP_VERBOSE',
               'LEAPP_DEBUG')

--- a/repos/system_upgrade/el7toel8/libraries/config/mock_configs.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/mock_configs.py
@@ -21,7 +21,8 @@ CONFIG = IPUConfig(
         source='7.6',
         target='8.0'
     ),
-    architecture='x86_64'
+    architecture='x86_64',
+    kernel='3.10.0-957.43.1.el7.x86_64',
 )
 
 CONFIG_ALL_SIGNED = IPUConfig(
@@ -37,7 +38,8 @@ CONFIG_ALL_SIGNED = IPUConfig(
         source='7.6',
         target='8.0'
     ),
-    architecture='x86_64'
+    architecture='x86_64',
+    kernel='3.10.0-957.43.1.el7.x86_64',
 )
 
 CONFIG_S390X = IPUConfig(
@@ -52,5 +54,6 @@ CONFIG_S390X = IPUConfig(
         source='7.6',
         target='8.0'
     ),
-    architecture='s390x'
+    architecture='s390x',
+    kernel='3.10.0-957.43.1.el7.x86_64',
 )

--- a/repos/system_upgrade/el7toel8/libraries/config/version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/version.py
@@ -11,7 +11,8 @@ OP_MAP = {
     '<=': operator.le
 }
 
-SUPPORTED_VERSIONS = {'rhel': ['7.6']}
+# Note: 'rhel-alt' is detected when on 'rhel' with kernel 4.x
+SUPPORTED_VERSIONS = {'rhel': ['7.6'], 'rhel-alt': ['7.6']}
 
 
 def _version_to_tuple(version):
@@ -113,7 +114,8 @@ def matches_target_version(*match_list):
 
 
 def matches_release(allowed_releases, release):
-    """Check if the given `release` is allowed to upgrade based in `allowed_releases`.
+    """
+    Check if the given `release` is allowed to upgrade based in `allowed_releases`.
 
     :param allowed_releases: All supported releases
     :type allowed_releases: list or dict
@@ -129,7 +131,8 @@ def matches_release(allowed_releases, release):
 
 
 def current_version():
-    """Return the current Linux release and version.
+    """
+    Return the current Linux release and version.
 
     :return: The tuple contains release name and version value.
     :rtype: (string, string)
@@ -138,13 +141,28 @@ def current_version():
     return release.release_id, release.version_id
 
 
+def is_rhel_alt():
+    """
+    Check if the current system is RHEL-ALT or not.
+
+    :return: `True` if the current system is RHEL-ALT and `False` otherwise.
+    :rtype: bool
+    """
+    conf = api.current_actor().configuration
+    # rhel-alt is rhel with kernel 4.x - there is not better detection...
+    return conf.os_release.release_id == 'rhel' and conf.kernel[0] == '4'
+
+
 def is_supported_version():
-    """ Verify if the current system version is supported for the upgrade.
+    """
+    Verify if the current system version is supported for the upgrade.
 
     :return: `True` if the current version is supported and `False` otherwise.
     :rtype: bool
     """
     release_id, version_id = current_version()
+    if is_rhel_alt():
+        release_id = 'rhel-alt'
 
     if not matches_release(SUPPORTED_VERSIONS, release_id):
         return False

--- a/repos/system_upgrade/el7toel8/libraries/config/version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/version.py
@@ -12,7 +12,7 @@ OP_MAP = {
 }
 
 # Note: 'rhel-alt' is detected when on 'rhel' with kernel 4.x
-SUPPORTED_VERSIONS = {'rhel': ['7.6'], 'rhel-alt': ['7.6']}
+SUPPORTED_VERSIONS = {'rhel': ['7.8'], 'rhel-alt': ['7.6']}
 
 
 def _version_to_tuple(version):

--- a/repos/system_upgrade/el7toel8/models/ipuconfig.py
+++ b/repos/system_upgrade/el7toel8/models/ipuconfig.py
@@ -6,7 +6,10 @@ class EnvVar(Model):
     topic = SystemInfoTopic
 
     name = fields.String()
+    """Name of the environment variable."""
+
     value = fields.String()
+    """Value of the environment variable."""
 
 
 class OSRelease(Model):
@@ -25,7 +28,10 @@ class Version(Model):
     topic = SystemInfoTopic
 
     source = fields.String()
+    """Version of the source (current) system. E.g.: '7.8'."""
+
     target = fields.String()
+    """Version of the target system. E.g. '8.2.'."""
 
 
 class IPUConfig(Model):
@@ -35,6 +41,16 @@ class IPUConfig(Model):
     topic = SystemInfoTopic
 
     leapp_env_vars = fields.List(fields.Model(EnvVar), default=[])
+    """Environment variables related to the leapp."""
+
     os_release = fields.Model(OSRelease)
+    """Data about the OS get from /etc/os-release."""
+
     version = fields.Model(Version)
+    """Version of the current (source) system and expected target system."""
+
     architecture = fields.String()
+    """Architecture of the system. E.g.: 'x86_64'."""
+
+    kernel = fields.String()
+    """Originally booted kernel when on the source system."""


### PR DESCRIPTION
With this PR, we start to new default upgrade paths:
- RHEL 7.8 -> RHEL 8.2
- RHEL-ALT 7.6 -> RHEL 8.2

For the purposes of RHEL-ALT detection, the `IPUConfig` model has been extended by the `kernel` field, which contains `version-release` of the booted kernel on the source system. E.g.: `3.10.0-100.el7.x86_64`. We already have another one usecase, where the `uname -r` should be consumed in the PR #457 (which can be simplified then.

In the related library (`leapp.libraries.common.config.version`) is added new function `is_rhel_alt` and the function `is_supported_version` reflects the new upgrade paths as well.