### PR TITLE
Removed unused consumes in CheckKDEGnome actor

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkkdegnome/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkkdegnome/actor.py
@@ -8,8 +8,7 @@ from leapp.actors import Actor
 from leapp.reporting import Report
 from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
 from leapp.libraries.actor.library import check_kde_gnome
-from leapp.models import (InstalledRPM, InstalledDesktopsFacts,
-                          InstalledKdeAppsFacts)
+from leapp.models import InstalledDesktopsFacts, InstalledKdeAppsFacts
 
 
 class CheckKdeGnome(Actor):
@@ -24,7 +23,7 @@ class CheckKdeGnome(Actor):
     dnf upgrade transaction.
     """
     name = 'check_kde_gnome'
-    consumes = (InstalledRPM, InstalledDesktopsFacts, InstalledKdeAppsFacts)
+    consumes = (InstalledDesktopsFacts, InstalledKdeAppsFacts)
     produces = (Report,)
     tags = (IPUWorkflowTag, ChecksPhaseTag)
 


### PR DESCRIPTION
Currently the CheckKDEGnomeActor consumes InstalledRPM which is not
used at all. Therefore this patch removes the dependency.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>