### PR TITLE
Run the rpmscanner unit test with py2

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/rpmscanner/tests/test_rpmscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmscanner/tests/test_rpmscanner.py
@@ -1,10 +1,14 @@
+import sys
+
 import pytest
 
-from leapp.snactor.fixture import current_actor_context
 from leapp.models import InstalledRPM
+from leapp.snactor.fixture import current_actor_context
 
 
-@pytest.mark.skip(reason="skipping on py3 raise error on snactor")
+@pytest.mark.skipif(sys.version_info.major >= 3,
+                    reason="There's no yum module for py3. The dnf module could have been used instead but there's a"
+                           " bug in dnf preventing us to do so: https://bugzilla.redhat.com/show_bug.cgi?id=1789840")
 def test_actor_execution(current_actor_context):
     current_actor_context.run()
     assert current_actor_context.consume(InstalledRPM)


### PR DESCRIPTION
- we can't run it with py3 as there's no yum module for py3
- dnf module could have been used instead of yum, but there's a bug in
  dnf preventing us to do so:
   https://bugzilla.redhat.com/show_bug.cgi?id=1789840

The test error when running it with py3:
```
----------------------------- Captured stderr call -----------------------------
Process Process-136:1:
Traceback (most recent call last):
  File "/usr/lib64/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/payload/tut/lib/python3.6/site-packages/leapp/repository/actor_definition.py", line 65, in _do_run
    skip_dialogs=skip_dialogs).run(*args, **kwargs)
  File "/payload/tut/lib/python3.6/site-packages/leapp/actors/__init__.py", line 336, in run
    self.process(*args)
  File "/payload/repos/system_upgrade/el7toel8/actors/rpmscanner/actor.py", line 22, in process
    pkg_repos = get_package_repository_data()
  File "/payload/repos/system_upgrade/el7toel8/actors/rpmscanner/libraries/library.py", line 8, in get_package_repository_data
    import yum  # pylint: disable=import-outside-toplevel
ModuleNotFoundError: No module named 'yum'
```
The whole traceback can be seen here: https://travis-ci.org/oamg/leapp-repository/jobs/660597503


Related: https://github.com/oamg/leapp-repository/pull/427