### PR TITLE
Add an actor for modifying the multipath configuration files

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/multipathconfcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfcheck/actor.py
@@ -1,0 +1,28 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import MultipathConfFacts
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class MultipathConfCheck(Actor):
+    '''
+    Checks whether the multipath configuration can be updated to RHEL-8.
+    Specifically, it checks if the path_checker/checker option is set to
+    something other than tur in the defaults section. If so, non-trivial
+    changes may be required in the multipath.conf file, and it is not
+    possible to auto-update it.
+    '''
+
+    name = 'multipath_conf_check'
+    consumes = (MultipathConfFacts,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        facts = next(self.consume(MultipathConfFacts), None)
+        if facts is None:
+            self.log.debug('Skipping execution. No MultipathConfFacts has ' +
+                           'been produced')
+            return
+        library.check_configs(facts)

--- a/repos/system_upgrade/el7toel8/actors/multipathconfcheck/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfcheck/libraries/library.py
@@ -1,0 +1,126 @@
+from leapp.reporting import create_report
+from leapp import reporting
+
+
+def _merge_configs(configs):
+    options = {'default_path_checker': None, 'detect_prio': None,
+               'detect_path_checker': None, 'reassign_maps': None,
+               'retain_attached_hw_handler': None}
+    for config in configs:
+        if config.default_path_checker is not None:
+            options['default_path_checker'] = (config.default_path_checker,
+                                               config.pathname)
+
+        if config.reassign_maps is not None:
+            options['reassign_maps'] = (config.reassign_maps, config.pathname)
+
+        if config.default_detect_checker is not None:
+            options['detect_path_checker'] = (config.default_detect_checker,
+                                              config.pathname)
+
+        if config.default_detect_prio is not None:
+            options['detect_prio'] = (config.default_detect_prio,
+                                      config.pathname)
+
+        if config.default_retain_hwhandler is not None:
+            options['retain_attached_hw_handler'] = (config.default_retain_hwhandler, config.pathname)
+    return options
+
+
+def _check_default_path_checker(options):
+    if not options['default_path_checker']:
+        return
+    value, pathname = options['default_path_checker']
+    if value == 'tur':
+        return
+    create_report([
+        reporting.Title(
+            'Unsupported device-mapper-multipath configuration'
+        ),
+        reporting.Summary(
+            'device-mapper-multipath has changed the default path_checker '
+            'from "directio" to "tur" in RHEL-8. Further, changing the '
+            'default path_checker can cause issues with built-in device '
+            'configurations in RHEL-8. Please remove the "path_checker" '
+            'option from the defaults section of {}, and add it to the '
+            'device configuration of any devices that need it.'.
+            format(pathname)
+        ),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Tags([reporting.Tags.SERVICES]),
+        reporting.Flags([reporting.Flags.INHIBITOR]),
+        reporting.RelatedResource('package', 'device-mapper-multipath'),
+        reporting.RelatedResource('file', pathname),
+        reporting.Remediation(
+            hint='Please remove the "path_checker {}" option from the '
+            'defaults section of {}, and add it to the device configuration '
+            'of any devices that need it.'.format(value, pathname)
+        )
+    ])
+
+
+def _create_paths_str(paths):
+    if len(paths) < 2:
+        return paths[0]
+    return '{} and {}'.format(', '.join(paths[0:-1]), paths[-1])
+
+
+def _check_default_detection(options):
+    bad = []
+    for keyword in ('detect_path_checker', 'detect_prio',
+                    'retain_attached_hw_handler'):
+        if options[keyword] and not options[keyword][0] and \
+                options[keyword][1] not in bad:
+            bad.append(options[keyword][1])
+    if bad == []:
+        return
+    paths = _create_paths_str(bad)
+    create_report([
+        reporting.Title(
+            'device-mapper-multipath now defaults to detecting settings'
+        ),
+        reporting.Summary(
+            'In RHEL-8, the default value for the "detect_path_checker", '
+            '"detect_prio" and "retain_attached_hw_handler" options has '
+            'changed to "yes". Further, changing these default values can '
+            'cause issues with the built-in device configurations in RHEL-8. '
+            'They will be commented out in the defaults section of all '
+            'multipath config files. This is unlikely to cause any issues '
+            'with existing configurations. If it does, please move these '
+            'options from the defaults sections of {} to the device '
+            'configuration sections of any devices that need them.'.
+            format(paths)
+        ),
+        reporting.Severity(reporting.Severity.MEDIUM),
+        reporting.Tags([reporting.Tags.SERVICES]),
+        reporting.RelatedResource('package', 'device-mapper-multipath')
+    ])
+
+
+def _check_reassign_maps(options):
+    if not options['reassign_maps']:
+        return
+    value, pathname = options['reassign_maps']
+    if not value:
+        return
+    create_report([
+        reporting.Title(
+            'device-mapper-multipath now disables reassign_maps by default'
+        ),
+        reporting.Summary(
+            'In RHEL-8, the default value for "reassign_maps" has been '
+            'changed to "no", and it is not recommended to enable it in any '
+            'configuration going forward. This option will be commented out '
+            'in {}.'.format(pathname)
+        ),
+        reporting.Severity(reporting.Severity.MEDIUM),
+        reporting.Tags([reporting.Tags.SERVICES]),
+        reporting.RelatedResource('package', 'device-mapper-multipath')
+    ])
+
+
+def check_configs(facts):
+    options = _merge_configs(facts.configs)
+    _check_default_path_checker(options)
+    _check_default_detection(options)
+    _check_reassign_maps(options)

--- a/repos/system_upgrade/el7toel8/actors/multipathconfcheck/tests/test_actor.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfcheck/tests/test_actor.py
@@ -1,0 +1,200 @@
+from leapp.models import MultipathConfFacts, MultipathConfig, \
+        MultipathConfigOption
+from leapp.reporting import Report
+from leapp.snactor.fixture import current_actor_context
+
+
+def _assert_default_checker_report(report, pathname):
+    assert report['title'] == \
+        'Unsupported device-mapper-multipath configuration'
+    assert report['severity'] == 'high'
+    assert 'inhibitor' in report['flags']
+    assert pathname in report['summary']
+
+
+def _assert_default_detect_report(report, pathname):
+    assert report['title'] == \
+        'device-mapper-multipath now defaults to detecting settings'
+    assert report['severity'] == 'medium'
+    assert pathname in report['summary']
+
+
+def _assert_reassign_maps(report, pathname):
+    assert report['title'] == \
+        'device-mapper-multipath now disables reassign_maps by default'
+    assert report['severity'] == 'medium'
+    assert pathname in report['summary']
+
+
+def test_config_all_bad(current_actor_context):
+    config = MultipathConfig(
+            pathname='all_bad.conf', default_path_checker='directio',
+            reassign_maps=True, default_detect_checker=False,
+            default_detect_prio=False, default_retain_hwhandler=False)
+    facts = MultipathConfFacts(configs=[config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert reports and len(reports) == 3
+    _assert_default_checker_report(reports[0].report, 'all_bad.conf')
+    _assert_default_detect_report(reports[1].report, 'all_bad.conf')
+    _assert_reassign_maps(reports[2].report, 'all_bad.conf')
+
+
+def test_config_all_good(current_actor_context):
+    config = MultipathConfig(
+            pathname='all_good.conf', default_path_checker='tur',
+            reassign_maps=False, default_detect_checker=True,
+            default_detect_prio=True, default_retain_hwhandler=True)
+    facts = MultipathConfFacts(configs=[config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+
+
+def test_config_unimportant(current_actor_context):
+    option = MultipathConfigOption(name='path_checker', value='rdac')
+    config = MultipathConfig(
+            pathname='unimportant.conf', hw_str_match_exists=True,
+            ignore_new_boot_devs_exists=True, new_bindings_in_boot_exists=True,
+            unpriv_sgio_exists=True, detect_path_checker_exists=True,
+            overrides_hwhandler_exists=True, overrides_pg_timeout_exists=True,
+            queue_if_no_path_exists=True, all_devs_section_exists=True,
+            all_devs_options=[option])
+    facts = MultipathConfFacts(configs=[config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+
+
+def test_bad_then_good(current_actor_context):
+    bad_config = MultipathConfig(
+            pathname='all_bad.conf', default_path_checker='directio',
+            reassign_maps=True, default_detect_checker=False,
+            default_detect_prio=False, default_retain_hwhandler=False)
+    good_config = MultipathConfig(
+            pathname='all_good.conf', default_path_checker='tur',
+            reassign_maps=False, default_detect_checker=True,
+            default_detect_prio=True, default_retain_hwhandler=True)
+    facts = MultipathConfFacts(configs=[bad_config, good_config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+
+
+def test_good_then_bad(current_actor_context):
+    good_config = MultipathConfig(
+            pathname='all_good.conf', default_path_checker='tur',
+            reassign_maps=False, default_detect_checker=True,
+            default_detect_prio=True, default_retain_hwhandler=True)
+    bad_config = MultipathConfig(
+            pathname='all_bad.conf', default_path_checker='directio',
+            reassign_maps=True, default_detect_checker=False,
+            default_detect_prio=False, default_retain_hwhandler=False)
+    facts = MultipathConfFacts(configs=[good_config, bad_config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert reports and len(reports) == 3
+    _assert_default_checker_report(reports[0].report, 'all_bad.conf')
+    _assert_default_detect_report(reports[1].report, 'all_bad.conf')
+    _assert_reassign_maps(reports[2].report, 'all_bad.conf')
+
+
+def test_bad_then_nothing(current_actor_context):
+    bad_config = MultipathConfig(
+            pathname='all_bad.conf', default_path_checker='directio',
+            reassign_maps=True, default_detect_checker=False,
+            default_detect_prio=False, default_retain_hwhandler=False)
+    none_config = MultipathConfig(pathname='none.conf')
+    facts = MultipathConfFacts(configs=[bad_config, none_config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert reports and len(reports) == 3
+    _assert_default_checker_report(reports[0].report, 'all_bad.conf')
+    _assert_default_detect_report(reports[1].report, 'all_bad.conf')
+    _assert_reassign_maps(reports[2].report, 'all_bad.conf')
+
+
+def test_nothing_then_bad(current_actor_context):
+    bad_config = MultipathConfig(
+            pathname='all_bad.conf', default_path_checker='directio',
+            reassign_maps=True, default_detect_checker=False,
+            default_detect_prio=False, default_retain_hwhandler=False)
+    none_config = MultipathConfig(pathname='none.conf')
+    facts = MultipathConfFacts(configs=[none_config, bad_config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert reports and len(reports) == 3
+    _assert_default_checker_report(reports[0].report, 'all_bad.conf')
+    _assert_default_detect_report(reports[1].report, 'all_bad.conf')
+    _assert_reassign_maps(reports[2].report, 'all_bad.conf')
+
+
+def test_only_bad_checker(current_actor_context):
+    bad_checker_config = MultipathConfig(
+            pathname='bad_checker.conf', default_path_checker='rdac',
+            default_retain_hwhandler=True)
+    facts = MultipathConfFacts(configs=[bad_checker_config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert reports and len(reports) == 1
+    _assert_default_checker_report(reports[0].report, 'bad_checker.conf')
+
+
+def test_only_bad_detect(current_actor_context):
+    bad_detect_config = MultipathConfig(
+            pathname='bad_detect.conf', default_detect_prio=True,
+            default_detect_checker=False)
+    facts = MultipathConfFacts(configs=[bad_detect_config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert reports and len(reports) == 1
+    _assert_default_detect_report(reports[0].report, 'bad_detect.conf')
+
+
+def test_only_bad_reassign(current_actor_context):
+    bad_reassign_config = MultipathConfig(
+            pathname='bad_reassign.conf', reassign_maps=True)
+    facts = MultipathConfFacts(configs=[bad_reassign_config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert reports and len(reports) == 1
+    _assert_reassign_maps(reports[0].report, 'bad_reassign.conf')
+
+
+def test_different_files(current_actor_context):
+    bad_detect_checker_config = MultipathConfig(
+            pathname='bad_detect_checker.conf', default_detect_checker=False)
+    bad_detect_prio_config = MultipathConfig(
+            pathname='bad_detect_prio.conf', default_detect_prio=False)
+    bad_retain_hwhandler_config = MultipathConfig(
+            pathname='bad_retain_hwhandler.conf',
+            default_retain_hwhandler=False)
+    facts = MultipathConfFacts(
+            configs=[bad_detect_checker_config, bad_detect_prio_config,
+                     bad_retain_hwhandler_config])
+
+    current_actor_context.feed(facts)
+    current_actor_context.run()
+    reports = list(current_actor_context.consume(Report))
+    assert reports and len(reports) == 1
+    _assert_default_detect_report(
+            reports[0].report,
+            'bad_detect_checker.conf, bad_detect_prio.conf and '
+            'bad_retain_hwhandler.conf')

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import InstalledRedHatSignedRPM, MultipathConfFacts
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class MultipathConfRead(Actor):
+    '''
+    Reads multipath configuration files (multipath.conf, and any files in
+    the multipath config directory) and extracts the necessary information
+    '''
+
+    name = 'multipath_conf_read'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (MultipathConfFacts,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        if library.is_processable():
+            res = library.get_multipath_conf_facts()
+            if res:
+                self.produce(res)

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/libraries/library.py
@@ -1,0 +1,203 @@
+import errno
+import os
+
+from leapp.libraries.common import multipathutil
+from leapp.libraries.common.rpms import has_package
+from leapp.models import InstalledRedHatSignedRPM, MultipathConfFacts, MultipathConfig, MultipathConfigOption
+from leapp.libraries.stdlib import api
+
+
+def _change_existing_option(curr_options, opt_name, opt_value):
+    for option in curr_options:
+        if option.name == opt_name:
+            option.value = opt_value  # latest value is used
+            return True
+    return False
+
+
+def _add_options(curr_options, new_options):
+    ignore = ['hardware_handler', 'pg_timeout', 'product', 'unpriv_sgio',
+              'product_blacklist', 'revision', 'vendor']
+    for opt_name, opt_value in new_options:
+        if opt_name in ignore:
+            continue
+        if opt_name == 'detect_path_checker':
+            opt_name = 'detect_checker'
+        if not _change_existing_option(curr_options, opt_name, opt_value):
+            curr_options.append(MultipathConfigOption(name=opt_name,
+                                                      value=opt_value))
+
+
+def _remove_qinp(value):
+    items = value.split()
+    if items == [] or not items[0].isdigit():
+        return value
+    nr_features = int(items[0])
+    if nr_features != len(items) - 1:
+        return value
+    try:
+        items.remove('queue_if_no_path')
+    except ValueError:
+        return value
+    items[0] = str(nr_features - 1)
+    return ' '.join(items)
+
+
+def _fix_qinp_options(options):
+    have_npr = False
+    need_npr = False
+    for option in options:
+        if option.name == 'features' and 'queue_if_no_path' in option.value:
+            option.value = _remove_qinp(option.value)
+            need_npr = True
+        if option.name == 'no_path_retry':
+            have_npr = True
+    if need_npr and not have_npr:
+        options.append(MultipathConfigOption(name='no_path_retry',
+                                             value='queue'))
+
+
+def _options_match(overrides, all_devs):
+    if overrides == 'detect_path_checker' and all_devs == 'detect_checker':
+        return True
+    if overrides in ('path_checker', 'checker') and \
+            all_devs in ('path_checker', 'checker'):
+        return True
+    if overrides == all_devs:
+        return True
+    return False
+
+
+def _filter_options(all_dev_options, overrides_options):
+    for name, value in overrides_options:
+        if name == 'features' and 'queue_if_no_path' in value:
+            overrides_options.append(('no_path_retry', 'queue'))
+            break
+    for name, _value in overrides_options:
+        for option in all_dev_options:
+            if _options_match(name, option.name):
+                all_dev_options.remove(option)
+                break
+
+
+def _parse_config(path):
+    contents = multipathutil.read_config(path)
+    if contents is None:
+        return None
+    conf = MultipathConfig(pathname=path)
+    conf.all_devs_options = []
+    section = None
+    in_subsection = False
+    device_options = []
+    overrides_options = []
+    in_all_devs = False
+    for line in contents.split('\n'):
+        try:
+            data = multipathutil.LineData(line, section, in_subsection)
+        except ValueError:
+            continue
+        if data.type == data.TYPE_BLANK:
+            continue
+        if data.type == data.TYPE_SECTION_END:
+            if in_subsection:
+                in_subsection = False
+                if in_all_devs:
+                    _add_options(conf.all_devs_options, device_options)
+                in_all_devs = False
+                device_options = []
+            elif section:
+                section = None
+            continue
+        if data.type == data.TYPE_SECTION_START:
+            if not section:
+                section = data.section
+            elif not in_subsection:
+                in_subsection = True
+            continue
+        if data.type != data.TYPE_OPTION:
+            continue
+        if section == 'defaults':
+            if data.option == 'path_checker' or data.option == 'checker':
+                conf.default_path_checker = data.value
+            elif data.option == 'config_dir':
+                conf.config_dir = data.value
+            elif data.option == 'retain_attached_hw_handler':
+                conf.default_retain_hwhandler = data.is_enabled()
+            elif data.option == 'detect_prio':
+                conf.default_detect_prio = data.is_enabled()
+            elif data.option == 'detect_path_checker':
+                conf.default_detect_checker = data.is_enabled()
+            elif data.option == 'reassign_maps':
+                conf.reassign_maps = data.is_enabled()
+            elif data.option == 'hw_str_match':
+                conf.hw_str_match_exists = True
+            elif data.option == 'ignore_new_boot_devs':
+                conf.ignore_new_boot_devs_exists = True
+            elif data.option == 'new_bindings_in_boot':
+                conf.new_bindings_in_boot_exists = True
+        if section == 'devices' and in_subsection:
+            if data.option == 'all_devs' and data.is_enabled():
+                conf.all_devs_section_exists = True
+                in_all_devs = True
+            else:
+                device_options.append((data.option, data.value))
+        if section == 'overrides':
+            if data.option == 'hardware_handler':
+                conf.overrides_hwhandler_exists = True
+            elif data.option == 'pg_timeout':
+                conf.overrides_pg_timeout_exists = True
+            else:
+                overrides_options.append((data.option, data.value))
+        if data.option == 'unpriv_sgio':
+            conf.unpriv_sgio_exists = True
+        if data.option == 'detect_path_checker':
+            conf.detect_path_checker_exists = True
+        if data.option == 'features' and 'queue_if_no_path' in data.value:
+            conf.queue_if_no_path_exists = True
+
+    if in_subsection and in_all_devs:
+        _add_options(conf.all_devs_options, device_options)
+    _fix_qinp_options(conf.all_devs_options)
+    _filter_options(conf.all_devs_options, overrides_options)
+    return conf
+
+
+def _parse_config_dir(config_dir):
+    res = []
+    try:
+        for config_file in sorted(os.listdir(config_dir)):
+            path = os.path.join(config_dir, config_file)
+            if not path.endswith('.conf'):
+                continue
+            conf = _parse_config(path)
+            if conf:
+                res.append(conf)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            api.current_logger().debug('Multipath conf directory ' +
+                                       '"{}" doesn\'t exist'.format(config_dir))
+        else:
+            api.current_logger().warning('Failed to read multipath config ' +
+                                         'directory ' +
+                                         '"{}": {}'.format(config_dir, e))
+    return res
+
+
+def is_processable():
+    res = has_package(InstalledRedHatSignedRPM, 'device-mapper-multipath')
+    if not res:
+        api.current_logger().debug('device-mapper-multipath is not installed.')
+    return res
+
+
+def get_multipath_conf_facts(config_file='/etc/multipath.conf'):
+    res_configs = []
+    conf = _parse_config(config_file)
+    if not conf:
+        return None
+    res_configs.append(conf)
+    if conf.config_dir:
+        res_configs.extend(_parse_config_dir(conf.config_dir))
+    else:
+        res_configs.extend(_parse_config_dir('/etc/multipath/conf.d'))
+    return MultipathConfFacts(configs=res_configs)

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/all_the_things.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/all_the_things.conf
@@ -1,0 +1,1052 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "yes"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+	path_checker "directio"
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+	retain_attached_hw_handler no
+	detect_prio no
+	detect_path_checker no
+	hw_str_match no
+	force_sync no
+	deferred_remove no
+	ignore_new_boot_devs no
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	new_bindings_in_boot no
+	remove_retries 0
+	disable_changed_wwids no
+	unpriv_sgio no
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device {
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+	devnode "sda"
+	wwid "123456789"
+	device {
+		vendor "IBM"
+		product "S/390x"
+	}
+}
+		
+devices {
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "1 queue_if_no_path"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_path_checker yes
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "3 queue_if_no_path pg_init_retries 50"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+	device {
+		fast_io_fail_tmo 5
+		all_devs yes
+		no_path_retry fail
+		detect_path_checker yes
+	}
+	device {
+		features "1 queue_if_no_path"
+		path_checker "tur"
+		all_devs yes
+	}
+}
+multipaths {
+	multipath {
+		wwid "123456789"
+		alias "foo"
+	}
+}
+
+overrides {
+	checker "rdac"
+	detect_path_checker no
+	hardware_handler "1 alua"
+	pg_timeout no
+	fast_io_fail_tmo 10
+	unpriv_sgio no
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/already_updated.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/already_updated.conf
@@ -1,0 +1,1069 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+# 	reassign_maps "yes" # Commented out by Leapp
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+# 	path_checker "directio" # Commented out by Leapp
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+# 	retain_attached_hw_handler no # Commented out by Leapp
+# 	detect_prio no # Commented out by Leapp
+# 	detect_path_checker no # Commented out by Leapp
+# 	hw_str_match no # Commented out by Leapp
+	force_sync no
+	deferred_remove no
+# 	ignore_new_boot_devs no # Commented out by Leapp
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+# 	new_bindings_in_boot no # Commented out by Leapp
+	remove_retries 0
+	disable_changed_wwids no
+# 	unpriv_sgio no # Commented out by Leapp
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device {
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+	devnode "sda"
+	wwid "123456789"
+	device {
+		vendor "IBM"
+		product "S/390x"
+	}
+}
+		
+devices {
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_checker yes # Line modified by Leapp
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "2 pg_init_retries 50" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+# 	device { # Section commented out by Leapp
+# 		fast_io_fail_tmo 5
+# 		all_devs yes
+# 		no_path_retry fail
+# 		detect_checker yes # Line modified by Leapp
+# 	}
+# 	device { # Section commented out by Leapp
+# 		features "1 queue_if_no_path"
+# 		path_checker "tur"
+# 		all_devs yes
+# 	}
+}
+multipaths {
+	multipath {
+		wwid "123456789"
+		alias "foo"
+	}
+}
+
+overrides {
+	no_path_retry fail # Line added by Leapp
+	features 0 # Line added by Leapp
+	checker "rdac"
+	detect_checker no # Line modified by Leapp
+# 	hardware_handler "1 alua" # Commented out by Leapp
+# 	pg_timeout no # Commented out by Leapp
+	fast_io_fail_tmo 10
+# 	unpriv_sgio no # Commented out by Leapp
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/conf.d/all_devs.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/conf.d/all_devs.conf
@@ -1,0 +1,136 @@
+# This is a basic configuration file with some examples, for device mapper
+# multipath.
+#
+# For a complete list of the default configuration values, run either
+# multipath -t
+# or
+# multipathd show config
+#
+# For a list of configuration options with descriptions, see the multipath.conf
+# man page
+
+## By default, devices with vendor = "IBM" and product = "S/390.*" are
+## blacklisted. To enable mulitpathing on these devies, uncomment the
+## following lines.
+#blacklist_exceptions {
+#	device {
+#		vendor	"IBM"
+#		product	"S/390.*"
+#	}
+#}
+
+## Use user friendly names, instead of using WWIDs as names.
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+}
+
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy multibus
+		
+	}
+	device {
+		all_devs yes
+		path_checker tur
+		pg_timeout no
+		detect_path_checker yes
+	}
+
+	device {
+		features "3 queue_if_no_path pg_init_retries 50"
+		path_selector "service-time 0"
+		all_devs yes
+		unpriv_sgio no
+	}
+
+	device {
+		hardware_handler "1 alua"
+		vendor "test_vendor"
+		product "test_product"
+		revision 1
+		product_blacklist "test.*"
+		all_devs yes
+		fast_io_fail_tmo 5
+		path_checker rdac
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+		features "1 queue_if_no_path"
+	}
+		
+}
+
+
+
+##
+## Here is an example of how to configure some standard options.
+##
+#
+#defaults {
+#	polling_interval 	10
+#	path_selector		"round-robin 0"
+#	path_grouping_policy	multibus
+#	uid_attribute		ID_SERIAL
+#	prio			alua
+#	path_checker		readsector0
+#	rr_min_io		100
+#	max_fds			8192
+#	rr_weight		priorities
+#	failback		immediate
+#	no_path_retry		fail
+#	user_friendly_names	yes
+#}
+##
+## The wwid line in the following blacklist section is shown as an example
+## of how to blacklist devices by wwid.  The 2 devnode lines are the
+## compiled in default blacklist. If you want to blacklist entire types
+## of devices, such as all scsi devices, you should use a devnode line.
+## However, if you want to blacklist specific devices, you should use
+## a wwid line.  Since there is no guarantee that a specific device will
+## not change names on reboot (from /dev/sda to /dev/sdb for example)
+## devnode lines are not recommended for blacklisting specific devices.
+##
+blacklist {
+	devnode "sdb"
+#       wwid 26353900f02796769
+#	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+#	devnode "^hd[a-z]"
+}
+#multipaths {
+#	multipath {
+#		wwid			3600508b4000156d700012000000b0000
+#		alias			yellow
+#		path_grouping_policy	multibus
+#		path_selector		"round-robin 0"
+#		failback		manual
+#		rr_weight		priorities
+#		no_path_retry		5
+#	}
+#	multipath {
+#		wwid			1DEC_____321816758474
+#		alias			red
+#	}
+#}
+#devices {
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"HSV110 (C)COMPAQ"
+#		path_grouping_policy	multibus
+#		path_checker		readsector0
+#		path_selector		"round-robin 0"
+#		hardware_handler	"0"
+#		failback		15
+#		rr_weight		priorities
+#		no_path_retry		queue
+#	}
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"MSA1000         "
+#		path_grouping_policy	multibus
+#	}
+#}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/default_rhel7.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/default_rhel7.conf
@@ -1,0 +1,1021 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "yes"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+	path_checker "directio"
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+	retain_attached_hw_handler no
+	detect_prio no
+	detect_path_checker no
+	hw_str_match no
+	force_sync no
+	deferred_remove no
+	ignore_new_boot_devs no
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	new_bindings_in_boot no
+	remove_retries 0
+	disable_changed_wwids no
+	unpriv_sgio no
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device {
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+}
+devices {
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "1 queue_if_no_path"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_path_checker yes
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "3 queue_if_no_path pg_init_retries 50"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+}
+multipaths {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/default_rhel8.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/default_rhel8.conf
@@ -1,0 +1,1049 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "no"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+	path_checker "tur"
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds "max"
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file "/etc/multipath/wwids"
+	prkeys_file "/etc/multipath/prkeys"
+	log_checker_err always
+	all_tg_pt "no"
+	retain_attached_hw_handler "yes"
+	detect_prio "yes"
+	detect_checker "yes"
+	force_sync "yes"
+	strict_timing "no"
+	deferred_remove "no"
+	config_dir "/etc/multipath/conf.d"
+	delay_watch_checks "no"
+	delay_wait_checks "no"
+	san_path_err_threshold "no"
+	san_path_err_forget_rate "no"
+	san_path_err_recovery_time "no"
+	marginal_path_err_sample_time "no"
+	marginal_path_err_rate_threshold "no"
+	marginal_path_err_recheck_gap_time "no"
+	marginal_path_double_failed_time "no"
+	find_multipaths "on"
+	uxsock_timeout 4000
+	retrigger_tries 0
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	skip_kpartx "no"
+	disable_changed_wwids ignored
+	remove_retries 0
+	ghost_delay "no"
+	find_multipaths_timeout -10
+	enable_foreign "^$"
+	marginal_pathgroups "no"
+}
+blacklist {
+	devnode "^(ram|zram|raw|loop|fd|md|dm-|sr|scd|st|dcssblk)[0-9]"
+	devnode "^(td|hd|vd)[a-z]"
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "^DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(Intel|INTEL)"
+		product "VTrak V-LUN"
+	}
+	device {
+		vendor "Promise"
+		product "VTrak V-LUN"
+	}
+	device {
+		vendor "Promise"
+		product "Vess V-LUN"
+	}
+}
+blacklist_exceptions {
+	property "(SCSI_IDENT_|ID_WWN)"
+}
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		retain_attached_hw_handler "no"
+	}
+	device {
+		vendor "APPLE"
+		product "Xserve RAID"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+		vpd_vendor hp3par
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1[01]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "(MSA2[02]12fc|MSA2012i)"
+		path_grouping_policy "multibus"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "(MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "MSA [12]0[45]0 SA[NS]"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "(P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "LEFTHAND"
+		product "(P4000|iSCSIDisk|FCDISK)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "TP9100"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[3457]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SGI"
+		product "IS"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SGI"
+		product "^DD[46]A-"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "DDN"
+		product "^EF3010"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "DDN"
+		product "^(EF3015|S2A|SFA)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		no_path_retry 30
+	}
+	device {
+		vendor "TEGILE"
+		product "(ZEBI-(FC|ISCSI)|INTELLIFLASH)"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		no_path_retry 6
+	}
+	device {
+		vendor "^DGC"
+		product "^(RAID|DISK|VRAID)"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback "immediate"
+		no_path_retry 60
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		no_path_retry 5
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "(EUROLOGC|EuroLogc)"
+		product "FC2502"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "FUJITSU"
+		product "E[234]000"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "FUJITSU"
+		product "E[68]000"
+		path_grouping_policy "multibus"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "^OPEN-"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "HITACHI"
+		product "^DF"
+		path_grouping_policy "group_by_prio"
+		prio "hds"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "HITACHI"
+		product "^DF600F"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1813"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^(3542|3552)"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^2105"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(XIV|IBM)"
+		product "(NEXTRA|2810XIV)"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(TMS|IBM)"
+		product "(RamSan|FlashSystem)"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "^(DCS9900|2851)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303[ ]+NVDISK"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 60
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN"
+		path_grouping_policy "group_by_prio"
+		features "2 pg_init_retries 50"
+		prio "ontap"
+		failback "immediate"
+		no_path_retry "queue"
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names "no"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SolidFir"
+		product "SSD SAN"
+		path_grouping_policy "multibus"
+		no_path_retry 24
+	}
+	device {
+		vendor "NVME"
+		product "^NetApp ONTAP Controller"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "^Pillar"
+		product "^Axiom"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "^Oracle"
+		product "^Oracle FS"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "STK"
+		product "BladeCtlr"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "StorEdge 3"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "CSM[12]00_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "ArrayStorage"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "(Sun Storage|ZFS Storage|COMSTAR)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(NexGen|Pivot3)"
+		product "(TierStore|vSTAC)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(Intel|INTEL)"
+		product "Multi-Flex"
+		product_blacklist "VTrak V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(LIO-ORG|SUSE)"
+		product "RBD"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+	}
+	device {
+		vendor "KOVE"
+		product "XPD"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		rr_min_io 1
+		rr_min_io_rq 1
+		flush_on_last_del "yes"
+		fast_io_fail_tmo 15
+		dev_loss_tmo 15
+	}
+	device {
+		vendor "KMNRIO"
+		product "K2"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "NEXSAN"
+		product "NXS-B0"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEXSAN"
+		product "SATAB"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 15
+	}
+	device {
+		vendor "Nexsan"
+		product "(NestOS|NST5000)"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "SAN ARRAY$"
+		path_grouping_policy "group_by_serial"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "SAN ARRAY ALUA"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "CONCERTO ARRAY"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "ISE"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "IGLU DISK"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "Magnitude"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "Promise"
+		product "VTrak"
+		product_blacklist "VTrak V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "Promise"
+		product "Vess"
+		product_blacklist "Vess V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "^IFT"
+		product ".*"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "SANnet"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "R/Evo"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "^DH"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "AStor"
+		product "NeoSapphire"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "INSPUR"
+		product "MCS"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+}
+overrides {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/just_all_devs.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/just_all_devs.conf
@@ -1,0 +1,5 @@
+devices {
+	device {
+		all_devs yes
+	}
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/just_checker.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/just_checker.conf
@@ -1,0 +1,1049 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "no"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+	checker "rdac"
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds "max"
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file "/etc/multipath/wwids"
+	prkeys_file "/etc/multipath/prkeys"
+	log_checker_err always
+	all_tg_pt "no"
+	retain_attached_hw_handler "yes"
+	detect_prio "yes"
+	detect_checker "yes"
+	force_sync "yes"
+	strict_timing "no"
+	deferred_remove "no"
+	config_dir "/etc/multipath/conf.d"
+	delay_watch_checks "no"
+	delay_wait_checks "no"
+	san_path_err_threshold "no"
+	san_path_err_forget_rate "no"
+	san_path_err_recovery_time "no"
+	marginal_path_err_sample_time "no"
+	marginal_path_err_rate_threshold "no"
+	marginal_path_err_recheck_gap_time "no"
+	marginal_path_double_failed_time "no"
+	find_multipaths "on"
+	uxsock_timeout 4000
+	retrigger_tries 0
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	skip_kpartx "no"
+	disable_changed_wwids ignored
+	remove_retries 0
+	ghost_delay "no"
+	find_multipaths_timeout -10
+	enable_foreign "^$"
+	marginal_pathgroups "no"
+}
+blacklist {
+	devnode "^(ram|zram|raw|loop|fd|md|dm-|sr|scd|st|dcssblk)[0-9]"
+	devnode "^(td|hd|vd)[a-z]"
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "^DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(Intel|INTEL)"
+		product "VTrak V-LUN"
+	}
+	device {
+		vendor "Promise"
+		product "VTrak V-LUN"
+	}
+	device {
+		vendor "Promise"
+		product "Vess V-LUN"
+	}
+}
+blacklist_exceptions {
+	property "(SCSI_IDENT_|ID_WWN)"
+}
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		retain_attached_hw_handler "no"
+	}
+	device {
+		vendor "APPLE"
+		product "Xserve RAID"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+		vpd_vendor hp3par
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1[01]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "(MSA2[02]12fc|MSA2012i)"
+		path_grouping_policy "multibus"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "(MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "MSA [12]0[45]0 SA[NS]"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "(P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "LEFTHAND"
+		product "(P4000|iSCSIDisk|FCDISK)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "TP9100"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[3457]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SGI"
+		product "IS"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SGI"
+		product "^DD[46]A-"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "DDN"
+		product "^EF3010"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "DDN"
+		product "^(EF3015|S2A|SFA)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		no_path_retry 30
+	}
+	device {
+		vendor "TEGILE"
+		product "(ZEBI-(FC|ISCSI)|INTELLIFLASH)"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		no_path_retry 6
+	}
+	device {
+		vendor "^DGC"
+		product "^(RAID|DISK|VRAID)"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback "immediate"
+		no_path_retry 60
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		no_path_retry 5
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "(EUROLOGC|EuroLogc)"
+		product "FC2502"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "FUJITSU"
+		product "E[234]000"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "FUJITSU"
+		product "E[68]000"
+		path_grouping_policy "multibus"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "^OPEN-"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "HITACHI"
+		product "^DF"
+		path_grouping_policy "group_by_prio"
+		prio "hds"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "HITACHI"
+		product "^DF600F"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1813"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^(3542|3552)"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^2105"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(XIV|IBM)"
+		product "(NEXTRA|2810XIV)"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(TMS|IBM)"
+		product "(RamSan|FlashSystem)"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "^(DCS9900|2851)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303[ ]+NVDISK"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 60
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN"
+		path_grouping_policy "group_by_prio"
+		features "2 pg_init_retries 50"
+		prio "ontap"
+		failback "immediate"
+		no_path_retry "queue"
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names "no"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SolidFir"
+		product "SSD SAN"
+		path_grouping_policy "multibus"
+		no_path_retry 24
+	}
+	device {
+		vendor "NVME"
+		product "^NetApp ONTAP Controller"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "^Pillar"
+		product "^Axiom"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "^Oracle"
+		product "^Oracle FS"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "STK"
+		product "BladeCtlr"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "StorEdge 3"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "CSM[12]00_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "ArrayStorage"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "(Sun Storage|ZFS Storage|COMSTAR)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(NexGen|Pivot3)"
+		product "(TierStore|vSTAC)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(Intel|INTEL)"
+		product "Multi-Flex"
+		product_blacklist "VTrak V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(LIO-ORG|SUSE)"
+		product "RBD"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+	}
+	device {
+		vendor "KOVE"
+		product "XPD"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		rr_min_io 1
+		rr_min_io_rq 1
+		flush_on_last_del "yes"
+		fast_io_fail_tmo 15
+		dev_loss_tmo 15
+	}
+	device {
+		vendor "KMNRIO"
+		product "K2"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "NEXSAN"
+		product "NXS-B0"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEXSAN"
+		product "SATAB"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 15
+	}
+	device {
+		vendor "Nexsan"
+		product "(NestOS|NST5000)"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "SAN ARRAY$"
+		path_grouping_policy "group_by_serial"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "SAN ARRAY ALUA"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "CONCERTO ARRAY"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "ISE"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "IGLU DISK"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "Magnitude"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "Promise"
+		product "VTrak"
+		product_blacklist "VTrak V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "Promise"
+		product "Vess"
+		product_blacklist "Vess V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "^IFT"
+		product ".*"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "SANnet"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "R/Evo"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "^DH"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "AStor"
+		product "NeoSapphire"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "INSPUR"
+		product "MCS"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+}
+overrides {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/just_detect.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/just_detect.conf
@@ -1,0 +1,3 @@
+defaults {
+	detect_prio 0
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/just_exists.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/just_exists.conf
@@ -1,0 +1,32 @@
+# device-mapper-multipath configuration file
+
+# For a complete list of the default configuration values, run either:
+# # multipath -t
+# or
+# # multipathd show config
+
+# For a list of configuration options with descriptions, see the
+# multipath.conf man page.
+
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+}
+
+devices {
+	device {
+		vendor "Foo"
+		product "Bar"
+		features "1 queue_if_no_path"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+	}
+}
+
+blacklist_exceptions {
+        property "(SCSI_IDENT_|ID_WWN)"
+}
+
+blacklist {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/just_reassign.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/just_reassign.conf
@@ -1,0 +1,93 @@
+# This is a basic configuration file with some examples, for device mapper
+# multipath.
+#
+# For a complete list of the default configuration values, run either
+# multipath -t
+# or
+# multipathd show config
+#
+# For a list of configuration options with descriptions, see the multipath.conf
+# man page
+
+## By default, devices with vendor = "IBM" and product = "S/390.*" are
+## blacklisted. To enable mulitpathing on these devies, uncomment the
+## following lines.
+#blacklist_exceptions {
+#	device {
+#		vendor	"IBM"
+#		product	"S/390.*"
+#	}
+#}
+
+## Use user friendly names, instead of using WWIDs as names.
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+	reassign_maps "yes"
+}
+##
+## Here is an example of how to configure some standard options.
+##
+#
+#defaults {
+#	polling_interval 	10
+#	path_selector		"round-robin 0"
+#	path_grouping_policy	multibus
+#	uid_attribute		ID_SERIAL
+#	prio			alua
+#	path_checker		readsector0
+#	rr_min_io		100
+#	max_fds			8192
+#	rr_weight		priorities
+#	failback		immediate
+#	no_path_retry		fail
+#	user_friendly_names	yes
+#}
+##
+## The wwid line in the following blacklist section is shown as an example
+## of how to blacklist devices by wwid.  The 2 devnode lines are the
+## compiled in default blacklist. If you want to blacklist entire types
+## of devices, such as all scsi devices, you should use a devnode line.
+## However, if you want to blacklist specific devices, you should use
+## a wwid line.  Since there is no guarantee that a specific device will
+## not change names on reboot (from /dev/sda to /dev/sdb for example)
+## devnode lines are not recommended for blacklisting specific devices.
+##
+#blacklist {
+#       wwid 26353900f02796769
+#	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+#	devnode "^hd[a-z]"
+#}
+#multipaths {
+#	multipath {
+#		wwid			3600508b4000156d700012000000b0000
+#		alias			yellow
+#		path_grouping_policy	multibus
+#		path_selector		"round-robin 0"
+#		failback		manual
+#		rr_weight		priorities
+#		no_path_retry		5
+#	}
+#	multipath {
+#		wwid			1DEC_____321816758474
+#		alias			red
+#	}
+#}
+#devices {
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"HSV110 (C)COMPAQ"
+#		path_grouping_policy	multibus
+#		path_checker		readsector0
+#		path_selector		"round-robin 0"
+#		hardware_handler	"0"
+#		failback		15
+#		rr_weight		priorities
+#		no_path_retry		queue
+#	}
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"MSA1000         "
+#		path_grouping_policy	multibus
+#	}
+#}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/ugly1.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/ugly1.conf
@@ -1,0 +1,1055 @@
+defaults THIS SHOULDN'T BE HERE
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "yes"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+	path_checker "directio"
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+	retain_attached_hw_handler no
+	detect_prio no
+	detect_path_checker no
+	hw_str_match no
+	force_sync no
+	deferred_remove no
+	ignore_new_boot_devs no
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	new_bindings_in_boot no
+	remove_retries 0
+	disable_changed_wwids no
+	unpriv_sgio no
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+	devnode "sda"
+	wwid "123456789"
+	device {
+		vendor "IBM"
+		product "S/390x"
+	}
+}
+		
+devices { BAD DATA
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua" EXTRA DATA
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "1 queue_if_no_path"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_path_checker yes
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "3 queue_if_no_path pg_init_retries 50"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+	device {
+		fast_io_fail_tmo 5
+		dev_loss_tmo 60
+		all_devs yes
+		no_path_retry fail
+		detect_path_checker yes
+	}
+	device {
+		path_selector "service-time 0" JUNK IN LINE
+		features "1 queue_if_no_path"
+		path_checker "tur"
+		all_devs yes
+	}
+}
+multipaths {
+	multipath {
+		wwid "123456789"
+		alias "foo"
+	}
+}
+
+overrides 
+	checker "rdac"
+	detect_path_checker no
+	hardware_handler "1 alua"
+	pg_timeout no
+	fast_io_fail_tmo 10
+	unpriv_sgio no
+	features "3 queue_if_no_path pg_init_retries 50"
+# Missing closing brace

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/ugly2.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/files/ugly2.conf
@@ -1,0 +1,123 @@
+# This is a basic configuration file with some examples, for device mapper
+# multipath.
+#
+# For a complete list of the default configuration values, run either
+# multipath -t
+# or
+# multipathd show config
+#
+# For a list of configuration options with descriptions, see the multipath.conf
+# man page
+
+## By default, devices with vendor = "IBM" and product = "S/390.*" are
+## blacklisted. To enable mulitpathing on these devies, uncomment the
+## following lines.
+#blacklist_exceptions {
+#	device {
+#		vendor	"IBM"
+#		product	"S/390.*"
+#	}
+#}
+
+## Use user friendly names, instead of using WWIDs as names.
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+}
+
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy multibus
+		
+	}
+	device {
+		all_devs yes
+		path_checker tur
+		pg_timeout no
+		detect_path_checker yes
+	}
+
+	device {
+		features "3 queue_if_no_path pg_init_retries 50"
+		path_selector "service-time 0"
+		all_devs yes
+		unpriv_sgio no
+	}
+
+	device {
+		hardware_handler "1 alua"
+		vendor "test_vendor"
+		product "test_product"
+		revision 1
+		product_blacklist "test.*"
+		all_devs yes
+		fast_io_fail_tmo 5
+		path_checker rdac
+# no closing braces
+
+##
+## Here is an example of how to configure some standard options.
+##
+#
+#defaults {
+#	polling_interval 	10
+#	path_selector		"round-robin 0"
+#	path_grouping_policy	multibus
+#	uid_attribute		ID_SERIAL
+#	prio			alua
+#	path_checker		readsector0
+#	rr_min_io		100
+#	max_fds			8192
+#	rr_weight		priorities
+#	failback		immediate
+#	no_path_retry		fail
+#	user_friendly_names	yes
+#}
+##
+## The wwid line in the following blacklist section is shown as an example
+## of how to blacklist devices by wwid.  The 2 devnode lines are the
+## compiled in default blacklist. If you want to blacklist entire types
+## of devices, such as all scsi devices, you should use a devnode line.
+## However, if you want to blacklist specific devices, you should use
+## a wwid line.  Since there is no guarantee that a specific device will
+## not change names on reboot (from /dev/sda to /dev/sdb for example)
+## devnode lines are not recommended for blacklisting specific devices.
+##
+#       wwid 26353900f02796769
+#	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+#	devnode "^hd[a-z]"
+#multipaths {
+#	multipath {
+#		wwid			3600508b4000156d700012000000b0000
+#		alias			yellow
+#		path_grouping_policy	multibus
+#		path_selector		"round-robin 0"
+#		failback		manual
+#		rr_weight		priorities
+#		no_path_retry		5
+#	}
+#	multipath {
+#		wwid			1DEC_____321816758474
+#		alias			red
+#	}
+#}
+#devices {
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"HSV110 (C)COMPAQ"
+#		path_grouping_policy	multibus
+#		path_checker		readsector0
+#		path_selector		"round-robin 0"
+#		hardware_handler	"0"
+#		failback		15
+#		rr_weight		priorities
+#		no_path_retry		queue
+#	}
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"MSA1000         "
+#		path_grouping_policy	multibus
+#	}
+#}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/tests/test_library.py
@@ -1,0 +1,195 @@
+from leapp.libraries.actor import library
+from leapp.models import MultipathConfFacts, MultipathConfig, MultipathConfigOption
+from leapp.libraries.stdlib import api
+
+
+def build_config(val):
+    all_devs_options_val = []
+    for name_val, value_val in val[16]:
+        option = MultipathConfigOption(name=name_val, value=value_val)
+        all_devs_options_val.append(option)
+    return MultipathConfig(
+            pathname=val[0],
+            default_path_checker=val[1],
+            config_dir=val[2],
+            default_retain_hwhandler=val[3],
+            default_detect_prio=val[4],
+            default_detect_checker=val[5],
+            reassign_maps=val[6],
+            hw_str_match_exists=val[7],
+            ignore_new_boot_devs_exists=val[8],
+            new_bindings_in_boot_exists=val[9],
+            unpriv_sgio_exists=val[10],
+            detect_path_checker_exists=val[11],
+            overrides_hwhandler_exists=val[12],
+            overrides_pg_timeout_exists=val[13],
+            queue_if_no_path_exists=val[14],
+            all_devs_section_exists=val[15],
+            all_devs_options=all_devs_options_val)
+
+
+default_rhel7_conf = build_config(
+        ['tests/files/default_rhel7.conf', 'directio', 'tests/files/conf.d',
+         False, False, False, True, True, True, True, True, True, False, False,
+         True, False, []])
+
+all_devs_conf = build_config(
+        ['tests/files/conf.d/all_devs.conf', None, None, None, None, None,
+         None, False, False, False, True, True, False, False, True, True,
+         [('path_checker', 'rdac'), ('detect_checker', 'yes'),
+          ('features', '2 pg_init_retries 50'),
+          ('path_selector', 'service-time 0'), ('fast_io_fail_tmo', '5'),
+          ('no_path_retry', 'queue')]])
+
+empty_conf = build_config(
+        ['tests/files/conf.d/empty.conf', None, None, None, None, None, None,
+         False, False, False, False, False, False, False, False, False, []])
+
+default_rhel8_conf = build_config(
+        ['tests/files/default_rhel8.conf', 'tur', '/etc/multipath/conf.d',
+         True, True, None, False, False, False, False, False, False, False,
+         False, False, False, []])
+
+all_the_things_conf = build_config(
+        ['tests/files/all_the_things.conf', 'directio', 'tests/files/conf.d',
+         False, False, False, True, True, True, True, True, True, True, True,
+         True, True, [('no_path_retry', 'fail'), ('features', '0')]])
+
+already_updated_conf = build_config(
+        ['tests/files/already_updated.conf', None, 'tests/files/conf.d',
+         None, None, None, None, False, False, False, False, False, False,
+         False, False, False, []])
+
+ugly1_conf = build_config(
+        ['tests/files/ugly1.conf', 'directio', 'tests/files/conf.d',
+         False, False, False, True, True, True, True, True, True, True, True,
+         True, True, [('dev_loss_tmo', '60'),
+                      ('path_selector', 'service-time 0')]])
+
+# same results as all_devs_conf
+ugly2_conf = build_config(
+        ['tests/files/ugly2.conf', None, None, None, None, None, None,
+         False, False, False, True, True, False, False, True, True,
+         [('path_checker', 'rdac'), ('detect_checker', 'yes'),
+          ('features', '2 pg_init_retries 50'),
+          ('path_selector', 'service-time 0'), ('fast_io_fail_tmo', '5'),
+          ('no_path_retry', 'queue')]])
+
+just_checker_conf = build_config(
+        ['tests/files/just_checker.conf', 'rdac', '/etc/multipath/conf.d',
+         True, True, None, False, False, False, False, False, False, False,
+         False, False, False, []])
+
+just_detect_conf = build_config(
+        ['tests/files/just_detect.conf', None, None, None, False,
+         None, None, False, False, False, False, False, False, False, False,
+         False, []])
+
+just_reassign_conf = build_config(
+        ['tests/files/just_reassign.conf', None, None, None, None,
+         None, True, False, False, False, False, False, False, False, False,
+         False, []])
+
+just_exists_conf = build_config(
+        ['tests/files/just_exists.conf', None, None, None, None,
+         None, None, False, False, False, False, False, False, False, True,
+         False, []])
+
+just_all_devs_conf = build_config(
+        ['tests/files/just_all_devs.conf', None, None, None, None,
+         None, None, False, False, False, False, False, False, False, False,
+         True, []])
+
+
+def assert_config(config, expected):
+    assert config.pathname == expected.pathname
+    assert config.default_path_checker == expected.default_path_checker
+    assert config.config_dir == expected.config_dir
+    assert config.default_retain_hwhandler == expected.default_retain_hwhandler
+    assert config.default_detect_prio == expected.default_detect_prio
+    assert config.default_detect_checker == expected.default_detect_checker
+    assert config.reassign_maps == expected.reassign_maps
+    assert config.hw_str_match_exists == expected.hw_str_match_exists
+    assert config.ignore_new_boot_devs_exists == expected.ignore_new_boot_devs_exists
+    assert config.new_bindings_in_boot_exists == expected.new_bindings_in_boot_exists
+    assert config.unpriv_sgio_exists == expected.unpriv_sgio_exists
+    assert config.detect_path_checker_exists == expected.detect_path_checker_exists
+    assert config.overrides_hwhandler_exists == expected.overrides_hwhandler_exists
+    assert config.overrides_pg_timeout_exists == expected.overrides_pg_timeout_exists
+    assert config.queue_if_no_path_exists == expected.queue_if_no_path_exists
+    assert config.all_devs_section_exists == expected.all_devs_section_exists
+    assert len(config.all_devs_options) == len(expected.all_devs_options)
+    for i in range(len(config.all_devs_options)):
+        conf_opt = config.all_devs_options[i]
+        expt_opt = expected.all_devs_options[i]
+        assert conf_opt.name == expt_opt.name
+        assert conf_opt.value == expt_opt.value
+
+
+def test_config_dir():
+    expected_configs = (default_rhel7_conf, all_devs_conf, empty_conf)
+    facts = library.get_multipath_conf_facts(config_file='tests/files/default_rhel7.conf')
+    assert facts
+    assert len(facts.configs) == 3
+    for i in range(len(facts.configs)):
+        assert_config(facts.configs[i], expected_configs[i])
+
+
+def test_already_rhel8():
+    config = library._parse_config('tests/files/default_rhel8.conf')
+    assert config
+    assert_config(config, default_rhel8_conf)
+
+
+def test_all_the_things():
+    config = library._parse_config('tests/files/all_the_things.conf')
+    assert config
+    assert_config(config, all_the_things_conf)
+
+
+def test_already_updated():
+    config = library._parse_config('tests/files/already_updated.conf')
+    assert config
+    assert_config(config, already_updated_conf)
+
+
+def tests_ugly1():
+    config = library._parse_config('tests/files/ugly1.conf')
+    assert config
+    assert_config(config, ugly1_conf)
+
+
+def tests_ugly2():
+    config = library._parse_config('tests/files/ugly2.conf')
+    assert config
+    assert_config(config, ugly2_conf)
+
+
+def tests_just_checker():
+    config = library._parse_config('tests/files/just_checker.conf')
+    assert config
+    assert_config(config, just_checker_conf)
+
+
+def tests_just_detect():
+    config = library._parse_config('tests/files/just_detect.conf')
+    assert config
+    assert_config(config, just_detect_conf)
+
+
+def tests_just_reassign():
+    config = library._parse_config('tests/files/just_reassign.conf')
+    assert config
+    assert_config(config, just_reassign_conf)
+
+
+def tests_just_exists():
+    config = library._parse_config('tests/files/just_exists.conf')
+    assert config
+    assert_config(config, just_exists_conf)
+
+
+def tests_just_all_devs():
+    config = library._parse_config('tests/files/just_all_devs.conf')
+    assert config
+    assert_config(config, just_all_devs_conf)

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/actor.py
@@ -1,0 +1,29 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import MultipathConfFacts
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class MultipathConfUpdate(Actor):
+    '''
+    Modifies multipath configuration files on the target RHEL-8 system so that
+    they will run properly. This is done in three ways
+    1. commenting out lines for options that no longer exist, or whose value
+       is no longer current in RHEL-8
+    2. Migrating any options in an devices section with all_devs to an
+       overrides setions
+    3. Rename options that have changed names
+    '''
+
+    name = 'multipath_conf_update'
+    consumes = (MultipathConfFacts,)
+    produces = ()
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        facts = next(self.consume(MultipathConfFacts), None)
+        if facts is None:
+            self.log.debug('Skipping execution. No MultipathConfFacts has '
+                           'been produced')
+            return
+        library.update_configs(facts)

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/libraries/library.py
@@ -1,0 +1,251 @@
+import re
+
+from leapp.libraries.common import multipathutil
+
+_bool_options = {'retain_attached_hw_handler': True, 'detect_prio': True,
+                 'detect_path_checker': True, 'reassign_maps': False}
+
+_exist_options = ('hw_str_match', 'ignore_new_boot_devs',
+                  'new_bindings_in_boot', 'unpriv_sgio')
+
+_ovr_options = ('hardware_handler', 'pg_timeout')
+
+
+class _QueueIfNoPathInfo(object):
+    def __init__(self, line, value):
+        self.line = line
+        self.value = value
+        self.has_no_path_retry = False
+
+
+def _nothing_to_do(config):
+    if config.default_path_checker and config.default_path_checker != 'tur':
+        return False
+
+    config_checks = (
+        (config.default_retain_hwhandler, False),
+        (config.default_detect_prio, False),
+        (config.default_detect_checker, False),
+        (config.reassign_maps, True),
+        (config.hw_str_match_exists, True),
+        (config.ignore_new_boot_devs_exists, True),
+        (config.new_bindings_in_boot_exists, True),
+        (config.unpriv_sgio_exists, True),
+        (config.detect_path_checker_exists, True),
+        (config.overrides_hwhandler_exists, True),
+        (config.overrides_pg_timeout_exists, True),
+        (config.queue_if_no_path_exists, True),
+        (config.all_devs_section_exists, True)
+    )
+    for option, value in config_checks:
+        if option is value:
+            return False
+
+    return config.all_devs_options == []
+
+
+def _comment_out_line(line):
+    return '# ' + line + ' # Commented out by Leapp'
+
+
+def _comment_out_ranges(lines, ranges):
+    for start, end in ranges:
+        line = lines[start]
+        lines[start] = '# ' + line + ' # Section commented out by Leapp'
+        for i in range(start + 1, end):
+            line = lines[i]
+            if line == '':
+                lines[i] = '#'
+            elif line[0] != '#':
+                lines[i] = '# ' + line
+
+
+def _setup_value(value):
+    if re.search(r'\s', value):
+        return '"' + value + '"'
+    return value
+
+
+def _add_overrides(lines, options):
+    lines.append('overrides { # Section added by Leapp')
+    for option in options:
+        lines.append('\t{} {}'.format(option.name, _setup_value(option.value)))
+    lines.append('}')
+    lines.append('')
+
+
+def _update_overrides(lines, ovr_line, options):
+    new_lines = []
+    start = None
+    for i, line in enumerate(lines):
+        if line is ovr_line:
+            start = i + 1
+            break
+    if not start:
+        return
+    for option in options:
+        new_lines.append('\t{} {} # Line added by Leapp'.
+                         format(option.name, _setup_value(option.value)))
+    lines[start:start] = new_lines      # insert new_lines
+
+
+def _convert_checker_line(line):
+    return line.replace('detect_path_checker', 'detect_checker') + \
+            ' # Line modified by Leapp'
+
+
+def _modify_features_line(line, value):
+    items = value.split()
+    if items == [] or not items[0].isdigit():
+        return _comment_out_line(line)
+    nr_features = int(items[0])
+    if nr_features != len(items) - 1:
+        return _comment_out_line(line)
+    r = re.match('^(.*)features', line)
+    if not r:
+        return _comment_out_line(line)
+    line_start = r.group(1)
+    try:
+        items.remove('queue_if_no_path')
+    except ValueError:
+        return _comment_out_line(line)
+    items[0] = str(nr_features - 1)
+    return line_start + 'features "' + ' '.join(items) + \
+        '" # Line modified by Leapp'
+
+
+def _add_npr(lines, line, i):
+    r = re.match('^(.*)features', line)
+    if not r:
+        return
+    line_start = r.group(1)
+    lines.insert(i,
+                 line_start + 'no_path_retry queue # Line added by Leapp')
+
+
+def _remove_qinp(lines, qinp_infos):
+    infos_iter = iter(qinp_infos)
+    info = next(infos_iter, None)
+    if not info:
+        return
+    i = 0
+    while i < len(lines):
+        if lines[i] is info.line:
+            lines[i] = _modify_features_line(info.line, info.value)
+            if not info.has_no_path_retry:
+                _add_npr(lines, info.line, i + 1)
+            info = next(infos_iter, None)
+            if not info:
+                return
+        i += 1
+
+
+def _valid_npr(value):
+    if value.isdigit() and int(value) >= 0:
+        return True
+    if value in ('fail', 'queue'):
+        return True
+    return False
+
+
+def _update_config(config):
+    if _nothing_to_do(config):
+        return None
+    contents = multipathutil.read_config(config.pathname)
+    if contents is None:
+        return None
+    lines = contents.split('\n')
+    section = None
+    in_subsection = False
+    in_all_devs = False
+    subsection_start = None
+    all_devs_ranges = []
+    overrides_line = None
+    qinp_info = None
+    has_no_path_retry = False
+    qinp_infos = []
+    for i, line in enumerate(lines):
+        try:
+            data = multipathutil.LineData(line, section, in_subsection)
+        except ValueError:
+            continue
+        if data.type == data.TYPE_SECTION_END:
+            if qinp_info and not in_all_devs:
+                qinp_info.has_no_path_retry = has_no_path_retry
+                qinp_infos.append(qinp_info)
+            qinp_info = None
+            has_no_path_retry = False
+            if in_subsection:
+                in_subsection = False
+                if in_all_devs:
+                    all_devs_ranges.append((subsection_start, i + 1))
+                in_all_devs = False
+                subsection_start = None
+            elif section is not None:
+                section = None
+        elif data.type == data.TYPE_SECTION_START:
+            if section is None:
+                section = data.section
+                if section == 'overrides':
+                    overrides_line = line
+            elif not in_subsection:
+                in_subsection = True
+                subsection_start = i
+        if data.type != data.TYPE_OPTION:
+            continue
+        if section == 'defaults':
+            if (data.option == 'path_checker' or data.option == 'checker') and \
+                    data.value != 'tur':
+                lines[i] = _comment_out_line(line)
+                continue
+            if data.option in _bool_options and \
+                    _bool_options[data.option] != data.is_enabled():
+                lines[i] = _comment_out_line(line)
+                continue
+        elif section == 'overrides' and data.option in _ovr_options:
+            lines[i] = _comment_out_line(line)
+            continue
+        elif section == 'devices' and in_subsection and \
+                data.option == 'all_devs' and data.is_enabled():
+            in_all_devs = True
+            continue
+        if data.option in _exist_options:
+            lines[i] = _comment_out_line(line)
+        elif data.option == 'detect_path_checker':
+            lines[i] = _convert_checker_line(line)
+        elif data.option == 'no_path_retry' and _valid_npr(data.value):
+            has_no_path_retry = True
+        elif data.option == 'features' and 'queue_if_no_path' in data.value:
+            qinp_info = _QueueIfNoPathInfo(line, data.value)
+
+    if in_subsection:
+        lines.append('\t} # line added by Leapp')
+        if in_all_devs:
+            all_devs_ranges.append((subsection_start, len(lines)))
+        elif qinp_info:
+            qinp_info.has_no_path_retry = has_no_path_retry
+            qinp_infos.append(qinp_info)
+            qinp_info = None
+    if section is not None:
+        lines.append('} # line added by Leapp')
+        lines.append('')
+        if qinp_info:
+            qinp_info.has_no_path_retry = has_no_path_retry
+            qinp_infos.append(qinp_info)
+    _comment_out_ranges(lines, all_devs_ranges)
+    if qinp_infos != []:
+        _remove_qinp(lines, qinp_infos)
+    if config.all_devs_options != []:
+        if overrides_line:
+            _update_overrides(lines, overrides_line, config.all_devs_options)
+        else:
+            _add_overrides(lines, config.all_devs_options)
+    contents = '\n'.join(lines)
+    return contents
+
+
+def update_configs(facts):
+    for config in facts.configs:
+        contents = _update_config(config)
+        if contents:
+            multipathutil.write_config(config.pathname, contents)

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/all_devs.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/all_devs.conf
@@ -1,0 +1,146 @@
+# This is a basic configuration file with some examples, for device mapper
+# multipath.
+#
+# For a complete list of the default configuration values, run either
+# multipath -t
+# or
+# multipathd show config
+#
+# For a list of configuration options with descriptions, see the multipath.conf
+# man page
+
+## By default, devices with vendor = "IBM" and product = "S/390.*" are
+## blacklisted. To enable mulitpathing on these devies, uncomment the
+## following lines.
+#blacklist_exceptions {
+#	device {
+#		vendor	"IBM"
+#		product	"S/390.*"
+#	}
+#}
+
+## Use user friendly names, instead of using WWIDs as names.
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+}
+
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy multibus
+		
+	}
+# 	device { # Section commented out by Leapp
+# 		all_devs yes
+# 		path_checker tur
+# 		pg_timeout no
+# 		detect_checker yes # Line modified by Leapp
+# 	}
+
+# 	device { # Section commented out by Leapp
+# 		features "3 queue_if_no_path pg_init_retries 50"
+# 		path_selector "service-time 0"
+# 		all_devs yes
+# 		unpriv_sgio no # Commented out by Leapp
+# 	}
+
+# 	device { # Section commented out by Leapp
+# 		hardware_handler "1 alua"
+# 		vendor "test_vendor"
+# 		product "test_product"
+# 		revision 1
+# 		product_blacklist "test.*"
+# 		all_devs yes
+# 		fast_io_fail_tmo 5
+# 		path_checker rdac
+# 	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+	}
+		
+}
+
+
+
+##
+## Here is an example of how to configure some standard options.
+##
+#
+#defaults {
+#	polling_interval 	10
+#	path_selector		"round-robin 0"
+#	path_grouping_policy	multibus
+#	uid_attribute		ID_SERIAL
+#	prio			alua
+#	path_checker		readsector0
+#	rr_min_io		100
+#	max_fds			8192
+#	rr_weight		priorities
+#	failback		immediate
+#	no_path_retry		fail
+#	user_friendly_names	yes
+#}
+##
+## The wwid line in the following blacklist section is shown as an example
+## of how to blacklist devices by wwid.  The 2 devnode lines are the
+## compiled in default blacklist. If you want to blacklist entire types
+## of devices, such as all scsi devices, you should use a devnode line.
+## However, if you want to blacklist specific devices, you should use
+## a wwid line.  Since there is no guarantee that a specific device will
+## not change names on reboot (from /dev/sda to /dev/sdb for example)
+## devnode lines are not recommended for blacklisting specific devices.
+##
+blacklist {
+	devnode "sdb"
+#       wwid 26353900f02796769
+#	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+#	devnode "^hd[a-z]"
+}
+#multipaths {
+#	multipath {
+#		wwid			3600508b4000156d700012000000b0000
+#		alias			yellow
+#		path_grouping_policy	multibus
+#		path_selector		"round-robin 0"
+#		failback		manual
+#		rr_weight		priorities
+#		no_path_retry		5
+#	}
+#	multipath {
+#		wwid			1DEC_____321816758474
+#		alias			red
+#	}
+#}
+#devices {
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"HSV110 (C)COMPAQ"
+#		path_grouping_policy	multibus
+#		path_checker		readsector0
+#		path_selector		"round-robin 0"
+#		hardware_handler	"0"
+#		failback		15
+#		rr_weight		priorities
+#		no_path_retry		queue
+#	}
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"MSA1000         "
+#		path_grouping_policy	multibus
+#	}
+#}
+
+overrides { # Section added by Leapp
+	path_checker rdac
+	detect_checker yes
+	features "2 pg_init_retries 50"
+	path_selector "service-time 0"
+	fast_io_fail_tmo 5
+	no_path_retry queue
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/all_the_things.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/all_the_things.conf
@@ -1,0 +1,1069 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+# 	reassign_maps "yes" # Commented out by Leapp
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+# 	path_checker "directio" # Commented out by Leapp
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+# 	retain_attached_hw_handler no # Commented out by Leapp
+# 	detect_prio no # Commented out by Leapp
+# 	detect_path_checker no # Commented out by Leapp
+# 	hw_str_match no # Commented out by Leapp
+	force_sync no
+	deferred_remove no
+# 	ignore_new_boot_devs no # Commented out by Leapp
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+# 	new_bindings_in_boot no # Commented out by Leapp
+	remove_retries 0
+	disable_changed_wwids no
+# 	unpriv_sgio no # Commented out by Leapp
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device {
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+	devnode "sda"
+	wwid "123456789"
+	device {
+		vendor "IBM"
+		product "S/390x"
+	}
+}
+		
+devices {
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_checker yes # Line modified by Leapp
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "2 pg_init_retries 50" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+# 	device { # Section commented out by Leapp
+# 		fast_io_fail_tmo 5
+# 		all_devs yes
+# 		no_path_retry fail
+# 		detect_checker yes # Line modified by Leapp
+# 	}
+# 	device { # Section commented out by Leapp
+# 		features "1 queue_if_no_path"
+# 		path_checker "tur"
+# 		all_devs yes
+# 	}
+}
+multipaths {
+	multipath {
+		wwid "123456789"
+		alias "foo"
+	}
+}
+
+overrides {
+	no_path_retry fail # Line added by Leapp
+	features 0 # Line added by Leapp
+	checker "rdac"
+	detect_checker no # Line modified by Leapp
+# 	hardware_handler "1 alua" # Commented out by Leapp
+# 	pg_timeout no # Commented out by Leapp
+	fast_io_fail_tmo 10
+# 	unpriv_sgio no # Commented out by Leapp
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/default_rhel7.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/default_rhel7.conf
@@ -1,0 +1,1036 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+# 	reassign_maps "yes" # Commented out by Leapp
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+# 	path_checker "directio" # Commented out by Leapp
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+# 	retain_attached_hw_handler no # Commented out by Leapp
+# 	detect_prio no # Commented out by Leapp
+# 	detect_path_checker no # Commented out by Leapp
+# 	hw_str_match no # Commented out by Leapp
+	force_sync no
+	deferred_remove no
+# 	ignore_new_boot_devs no # Commented out by Leapp
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+# 	new_bindings_in_boot no # Commented out by Leapp
+	remove_retries 0
+	disable_changed_wwids no
+# 	unpriv_sgio no # Commented out by Leapp
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device {
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+}
+devices {
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_checker yes # Line modified by Leapp
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "2 pg_init_retries 50" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+}
+multipaths {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/just_all_devs.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/just_all_devs.conf
@@ -1,0 +1,5 @@
+devices {
+# 	device { # Section commented out by Leapp
+# 		all_devs yes
+# 	}
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/just_checker.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/just_checker.conf
@@ -1,0 +1,1049 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "no"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+# 	checker "rdac" # Commented out by Leapp
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds "max"
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file "/etc/multipath/wwids"
+	prkeys_file "/etc/multipath/prkeys"
+	log_checker_err always
+	all_tg_pt "no"
+	retain_attached_hw_handler "yes"
+	detect_prio "yes"
+	detect_checker "yes"
+	force_sync "yes"
+	strict_timing "no"
+	deferred_remove "no"
+	config_dir "/etc/multipath/conf.d"
+	delay_watch_checks "no"
+	delay_wait_checks "no"
+	san_path_err_threshold "no"
+	san_path_err_forget_rate "no"
+	san_path_err_recovery_time "no"
+	marginal_path_err_sample_time "no"
+	marginal_path_err_rate_threshold "no"
+	marginal_path_err_recheck_gap_time "no"
+	marginal_path_double_failed_time "no"
+	find_multipaths "on"
+	uxsock_timeout 4000
+	retrigger_tries 0
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	skip_kpartx "no"
+	disable_changed_wwids ignored
+	remove_retries 0
+	ghost_delay "no"
+	find_multipaths_timeout -10
+	enable_foreign "^$"
+	marginal_pathgroups "no"
+}
+blacklist {
+	devnode "^(ram|zram|raw|loop|fd|md|dm-|sr|scd|st|dcssblk)[0-9]"
+	devnode "^(td|hd|vd)[a-z]"
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "^DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(Intel|INTEL)"
+		product "VTrak V-LUN"
+	}
+	device {
+		vendor "Promise"
+		product "VTrak V-LUN"
+	}
+	device {
+		vendor "Promise"
+		product "Vess V-LUN"
+	}
+}
+blacklist_exceptions {
+	property "(SCSI_IDENT_|ID_WWN)"
+}
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		retain_attached_hw_handler "no"
+	}
+	device {
+		vendor "APPLE"
+		product "Xserve RAID"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+		vpd_vendor hp3par
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1[01]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "(MSA2[02]12fc|MSA2012i)"
+		path_grouping_policy "multibus"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "(MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "MSA [12]0[45]0 SA[NS]"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "(P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "LEFTHAND"
+		product "(P4000|iSCSIDisk|FCDISK)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "TP9100"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[3457]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SGI"
+		product "IS"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SGI"
+		product "^DD[46]A-"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "DDN"
+		product "^EF3010"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "DDN"
+		product "^(EF3015|S2A|SFA)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		no_path_retry 30
+	}
+	device {
+		vendor "TEGILE"
+		product "(ZEBI-(FC|ISCSI)|INTELLIFLASH)"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		no_path_retry 6
+	}
+	device {
+		vendor "^DGC"
+		product "^(RAID|DISK|VRAID)"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback "immediate"
+		no_path_retry 60
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		no_path_retry 5
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "(EUROLOGC|EuroLogc)"
+		product "FC2502"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "FUJITSU"
+		product "E[234]000"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "FUJITSU"
+		product "E[68]000"
+		path_grouping_policy "multibus"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "^OPEN-"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "HITACHI"
+		product "^DF"
+		path_grouping_policy "group_by_prio"
+		prio "hds"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "HITACHI"
+		product "^DF600F"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1813"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^(3542|3552)"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^2105"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(XIV|IBM)"
+		product "(NEXTRA|2810XIV)"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(TMS|IBM)"
+		product "(RamSan|FlashSystem)"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "^(DCS9900|2851)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303[ ]+NVDISK"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 60
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN"
+		path_grouping_policy "group_by_prio"
+		features "2 pg_init_retries 50"
+		prio "ontap"
+		failback "immediate"
+		no_path_retry "queue"
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names "no"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SolidFir"
+		product "SSD SAN"
+		path_grouping_policy "multibus"
+		no_path_retry 24
+	}
+	device {
+		vendor "NVME"
+		product "^NetApp ONTAP Controller"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "^Pillar"
+		product "^Axiom"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "^Oracle"
+		product "^Oracle FS"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "STK"
+		product "BladeCtlr"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "StorEdge 3"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "CSM[12]00_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "ArrayStorage"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "(Sun Storage|ZFS Storage|COMSTAR)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(NexGen|Pivot3)"
+		product "(TierStore|vSTAC)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(Intel|INTEL)"
+		product "Multi-Flex"
+		product_blacklist "VTrak V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(LIO-ORG|SUSE)"
+		product "RBD"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+	}
+	device {
+		vendor "KOVE"
+		product "XPD"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		rr_min_io 1
+		rr_min_io_rq 1
+		flush_on_last_del "yes"
+		fast_io_fail_tmo 15
+		dev_loss_tmo 15
+	}
+	device {
+		vendor "KMNRIO"
+		product "K2"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "NEXSAN"
+		product "NXS-B0"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEXSAN"
+		product "SATAB"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 15
+	}
+	device {
+		vendor "Nexsan"
+		product "(NestOS|NST5000)"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "SAN ARRAY$"
+		path_grouping_policy "group_by_serial"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "SAN ARRAY ALUA"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "CONCERTO ARRAY"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "ISE"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "IGLU DISK"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "Magnitude"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "Promise"
+		product "VTrak"
+		product_blacklist "VTrak V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "Promise"
+		product "Vess"
+		product_blacklist "Vess V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "^IFT"
+		product ".*"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "SANnet"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "R/Evo"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "^DH"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "AStor"
+		product "NeoSapphire"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "INSPUR"
+		product "MCS"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+}
+overrides {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/just_detect.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/just_detect.conf
@@ -1,0 +1,3 @@
+defaults {
+# 	detect_prio 0 # Commented out by Leapp
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/just_exists.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/just_exists.conf
@@ -1,0 +1,33 @@
+# device-mapper-multipath configuration file
+
+# For a complete list of the default configuration values, run either:
+# # multipath -t
+# or
+# # multipathd show config
+
+# For a list of configuration options with descriptions, see the
+# multipath.conf man page.
+
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+}
+
+devices {
+	device {
+		vendor "Foo"
+		product "Bar"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+	}
+}
+
+blacklist_exceptions {
+        property "(SCSI_IDENT_|ID_WWN)"
+}
+
+blacklist {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/just_reassign.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/just_reassign.conf
@@ -1,0 +1,93 @@
+# This is a basic configuration file with some examples, for device mapper
+# multipath.
+#
+# For a complete list of the default configuration values, run either
+# multipath -t
+# or
+# multipathd show config
+#
+# For a list of configuration options with descriptions, see the multipath.conf
+# man page
+
+## By default, devices with vendor = "IBM" and product = "S/390.*" are
+## blacklisted. To enable mulitpathing on these devies, uncomment the
+## following lines.
+#blacklist_exceptions {
+#	device {
+#		vendor	"IBM"
+#		product	"S/390.*"
+#	}
+#}
+
+## Use user friendly names, instead of using WWIDs as names.
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+# 	reassign_maps "yes" # Commented out by Leapp
+}
+##
+## Here is an example of how to configure some standard options.
+##
+#
+#defaults {
+#	polling_interval 	10
+#	path_selector		"round-robin 0"
+#	path_grouping_policy	multibus
+#	uid_attribute		ID_SERIAL
+#	prio			alua
+#	path_checker		readsector0
+#	rr_min_io		100
+#	max_fds			8192
+#	rr_weight		priorities
+#	failback		immediate
+#	no_path_retry		fail
+#	user_friendly_names	yes
+#}
+##
+## The wwid line in the following blacklist section is shown as an example
+## of how to blacklist devices by wwid.  The 2 devnode lines are the
+## compiled in default blacklist. If you want to blacklist entire types
+## of devices, such as all scsi devices, you should use a devnode line.
+## However, if you want to blacklist specific devices, you should use
+## a wwid line.  Since there is no guarantee that a specific device will
+## not change names on reboot (from /dev/sda to /dev/sdb for example)
+## devnode lines are not recommended for blacklisting specific devices.
+##
+#blacklist {
+#       wwid 26353900f02796769
+#	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+#	devnode "^hd[a-z]"
+#}
+#multipaths {
+#	multipath {
+#		wwid			3600508b4000156d700012000000b0000
+#		alias			yellow
+#		path_grouping_policy	multibus
+#		path_selector		"round-robin 0"
+#		failback		manual
+#		rr_weight		priorities
+#		no_path_retry		5
+#	}
+#	multipath {
+#		wwid			1DEC_____321816758474
+#		alias			red
+#	}
+#}
+#devices {
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"HSV110 (C)COMPAQ"
+#		path_grouping_policy	multibus
+#		path_checker		readsector0
+#		path_selector		"round-robin 0"
+#		hardware_handler	"0"
+#		failback		15
+#		rr_weight		priorities
+#		no_path_retry		queue
+#	}
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"MSA1000         "
+#		path_grouping_policy	multibus
+#	}
+#}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/ugly1.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/ugly1.conf
@@ -1,0 +1,1075 @@
+defaults THIS SHOULDN'T BE HERE
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+# 	reassign_maps "yes" # Commented out by Leapp
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+# 	path_checker "directio" # Commented out by Leapp
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+# 	retain_attached_hw_handler no # Commented out by Leapp
+# 	detect_prio no # Commented out by Leapp
+# 	detect_path_checker no # Commented out by Leapp
+# 	hw_str_match no # Commented out by Leapp
+	force_sync no
+	deferred_remove no
+# 	ignore_new_boot_devs no # Commented out by Leapp
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+# 	new_bindings_in_boot no # Commented out by Leapp
+	remove_retries 0
+	disable_changed_wwids no
+# 	unpriv_sgio no # Commented out by Leapp
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+	devnode "sda"
+	wwid "123456789"
+	device {
+		vendor "IBM"
+		product "S/390x"
+	}
+}
+		
+devices { BAD DATA
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua" EXTRA DATA
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_checker yes # Line modified by Leapp
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "2 pg_init_retries 50" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+# 	device { # Section commented out by Leapp
+# 		fast_io_fail_tmo 5
+# 		dev_loss_tmo 60
+# 		all_devs yes
+# 		no_path_retry fail
+# 		detect_checker yes # Line modified by Leapp
+# 	}
+# 	device { # Section commented out by Leapp
+# 		path_selector "service-time 0" JUNK IN LINE
+# 		features "1 queue_if_no_path"
+# 		path_checker "tur"
+# 		all_devs yes
+# 	}
+}
+multipaths {
+	multipath {
+		wwid "123456789"
+		alias "foo"
+	}
+}
+
+overrides 
+	dev_loss_tmo 60 # Line added by Leapp
+	path_selector "service-time 0" # Line added by Leapp
+	checker "rdac"
+	detect_checker no # Line modified by Leapp
+# 	hardware_handler "1 alua" # Commented out by Leapp
+# 	pg_timeout no # Commented out by Leapp
+	fast_io_fail_tmo 10
+# 	unpriv_sgio no # Commented out by Leapp
+	features "2 pg_init_retries 50" # Line modified by Leapp
+	no_path_retry queue # Line added by Leapp
+# Missing closing brace
+
+} # line added by Leapp

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/ugly2.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/after/ugly2.conf
@@ -1,0 +1,135 @@
+# This is a basic configuration file with some examples, for device mapper
+# multipath.
+#
+# For a complete list of the default configuration values, run either
+# multipath -t
+# or
+# multipathd show config
+#
+# For a list of configuration options with descriptions, see the multipath.conf
+# man page
+
+## By default, devices with vendor = "IBM" and product = "S/390.*" are
+## blacklisted. To enable mulitpathing on these devies, uncomment the
+## following lines.
+#blacklist_exceptions {
+#	device {
+#		vendor	"IBM"
+#		product	"S/390.*"
+#	}
+#}
+
+## Use user friendly names, instead of using WWIDs as names.
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+}
+
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy multibus
+		
+	}
+# 	device { # Section commented out by Leapp
+# 		all_devs yes
+# 		path_checker tur
+# 		pg_timeout no
+# 		detect_checker yes # Line modified by Leapp
+# 	}
+
+# 	device { # Section commented out by Leapp
+# 		features "3 queue_if_no_path pg_init_retries 50"
+# 		path_selector "service-time 0"
+# 		all_devs yes
+# 		unpriv_sgio no # Commented out by Leapp
+# 	}
+
+# 	device { # Section commented out by Leapp
+# 		hardware_handler "1 alua"
+# 		vendor "test_vendor"
+# 		product "test_product"
+# 		revision 1
+# 		product_blacklist "test.*"
+# 		all_devs yes
+# 		fast_io_fail_tmo 5
+# 		path_checker rdac
+# no closing braces
+#
+##
+## Here is an example of how to configure some standard options.
+##
+#
+#defaults {
+#	polling_interval 	10
+#	path_selector		"round-robin 0"
+#	path_grouping_policy	multibus
+#	uid_attribute		ID_SERIAL
+#	prio			alua
+#	path_checker		readsector0
+#	rr_min_io		100
+#	max_fds			8192
+#	rr_weight		priorities
+#	failback		immediate
+#	no_path_retry		fail
+#	user_friendly_names	yes
+#}
+##
+## The wwid line in the following blacklist section is shown as an example
+## of how to blacklist devices by wwid.  The 2 devnode lines are the
+## compiled in default blacklist. If you want to blacklist entire types
+## of devices, such as all scsi devices, you should use a devnode line.
+## However, if you want to blacklist specific devices, you should use
+## a wwid line.  Since there is no guarantee that a specific device will
+## not change names on reboot (from /dev/sda to /dev/sdb for example)
+## devnode lines are not recommended for blacklisting specific devices.
+##
+#       wwid 26353900f02796769
+#	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+#	devnode "^hd[a-z]"
+#multipaths {
+#	multipath {
+#		wwid			3600508b4000156d700012000000b0000
+#		alias			yellow
+#		path_grouping_policy	multibus
+#		path_selector		"round-robin 0"
+#		failback		manual
+#		rr_weight		priorities
+#		no_path_retry		5
+#	}
+#	multipath {
+#		wwid			1DEC_____321816758474
+#		alias			red
+#	}
+#}
+#devices {
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"HSV110 (C)COMPAQ"
+#		path_grouping_policy	multibus
+#		path_checker		readsector0
+#		path_selector		"round-robin 0"
+#		hardware_handler	"0"
+#		failback		15
+#		rr_weight		priorities
+#		no_path_retry		queue
+#	}
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"MSA1000         "
+#		path_grouping_policy	multibus
+#	}
+#}
+#
+# 	} # line added by Leapp
+} # line added by Leapp
+
+overrides { # Section added by Leapp
+	path_checker rdac
+	detect_checker yes
+	features "2 pg_init_retries 50"
+	path_selector "service-time 0"
+	fast_io_fail_tmo 5
+	no_path_retry queue
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/all_devs.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/all_devs.conf
@@ -1,0 +1,136 @@
+# This is a basic configuration file with some examples, for device mapper
+# multipath.
+#
+# For a complete list of the default configuration values, run either
+# multipath -t
+# or
+# multipathd show config
+#
+# For a list of configuration options with descriptions, see the multipath.conf
+# man page
+
+## By default, devices with vendor = "IBM" and product = "S/390.*" are
+## blacklisted. To enable mulitpathing on these devies, uncomment the
+## following lines.
+#blacklist_exceptions {
+#	device {
+#		vendor	"IBM"
+#		product	"S/390.*"
+#	}
+#}
+
+## Use user friendly names, instead of using WWIDs as names.
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+}
+
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy multibus
+		
+	}
+	device {
+		all_devs yes
+		path_checker tur
+		pg_timeout no
+		detect_path_checker yes
+	}
+
+	device {
+		features "3 queue_if_no_path pg_init_retries 50"
+		path_selector "service-time 0"
+		all_devs yes
+		unpriv_sgio no
+	}
+
+	device {
+		hardware_handler "1 alua"
+		vendor "test_vendor"
+		product "test_product"
+		revision 1
+		product_blacklist "test.*"
+		all_devs yes
+		fast_io_fail_tmo 5
+		path_checker rdac
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+		features "1 queue_if_no_path"
+	}
+		
+}
+
+
+
+##
+## Here is an example of how to configure some standard options.
+##
+#
+#defaults {
+#	polling_interval 	10
+#	path_selector		"round-robin 0"
+#	path_grouping_policy	multibus
+#	uid_attribute		ID_SERIAL
+#	prio			alua
+#	path_checker		readsector0
+#	rr_min_io		100
+#	max_fds			8192
+#	rr_weight		priorities
+#	failback		immediate
+#	no_path_retry		fail
+#	user_friendly_names	yes
+#}
+##
+## The wwid line in the following blacklist section is shown as an example
+## of how to blacklist devices by wwid.  The 2 devnode lines are the
+## compiled in default blacklist. If you want to blacklist entire types
+## of devices, such as all scsi devices, you should use a devnode line.
+## However, if you want to blacklist specific devices, you should use
+## a wwid line.  Since there is no guarantee that a specific device will
+## not change names on reboot (from /dev/sda to /dev/sdb for example)
+## devnode lines are not recommended for blacklisting specific devices.
+##
+blacklist {
+	devnode "sdb"
+#       wwid 26353900f02796769
+#	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+#	devnode "^hd[a-z]"
+}
+#multipaths {
+#	multipath {
+#		wwid			3600508b4000156d700012000000b0000
+#		alias			yellow
+#		path_grouping_policy	multibus
+#		path_selector		"round-robin 0"
+#		failback		manual
+#		rr_weight		priorities
+#		no_path_retry		5
+#	}
+#	multipath {
+#		wwid			1DEC_____321816758474
+#		alias			red
+#	}
+#}
+#devices {
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"HSV110 (C)COMPAQ"
+#		path_grouping_policy	multibus
+#		path_checker		readsector0
+#		path_selector		"round-robin 0"
+#		hardware_handler	"0"
+#		failback		15
+#		rr_weight		priorities
+#		no_path_retry		queue
+#	}
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"MSA1000         "
+#		path_grouping_policy	multibus
+#	}
+#}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/all_the_things.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/all_the_things.conf
@@ -1,0 +1,1052 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "yes"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+	path_checker "directio"
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+	retain_attached_hw_handler no
+	detect_prio no
+	detect_path_checker no
+	hw_str_match no
+	force_sync no
+	deferred_remove no
+	ignore_new_boot_devs no
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	new_bindings_in_boot no
+	remove_retries 0
+	disable_changed_wwids no
+	unpriv_sgio no
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device {
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+	devnode "sda"
+	wwid "123456789"
+	device {
+		vendor "IBM"
+		product "S/390x"
+	}
+}
+		
+devices {
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "1 queue_if_no_path"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_path_checker yes
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "3 queue_if_no_path pg_init_retries 50"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+	device {
+		fast_io_fail_tmo 5
+		all_devs yes
+		no_path_retry fail
+		detect_path_checker yes
+	}
+	device {
+		features "1 queue_if_no_path"
+		path_checker "tur"
+		all_devs yes
+	}
+}
+multipaths {
+	multipath {
+		wwid "123456789"
+		alias "foo"
+	}
+}
+
+overrides {
+	checker "rdac"
+	detect_path_checker no
+	hardware_handler "1 alua"
+	pg_timeout no
+	fast_io_fail_tmo 10
+	unpriv_sgio no
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/already_updated.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/already_updated.conf
@@ -1,0 +1,1069 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+# 	reassign_maps "yes" # Commented out by Leapp
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+# 	path_checker "directio" # Commented out by Leapp
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+# 	retain_attached_hw_handler no # Commented out by Leapp
+# 	detect_prio no # Commented out by Leapp
+# 	detect_path_checker no # Commented out by Leapp
+# 	hw_str_match no # Commented out by Leapp
+	force_sync no
+	deferred_remove no
+# 	ignore_new_boot_devs no # Commented out by Leapp
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+# 	new_bindings_in_boot no # Commented out by Leapp
+	remove_retries 0
+	disable_changed_wwids no
+# 	unpriv_sgio no # Commented out by Leapp
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device {
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+	devnode "sda"
+	wwid "123456789"
+	device {
+		vendor "IBM"
+		product "S/390x"
+	}
+}
+		
+devices {
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_checker yes # Line modified by Leapp
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0" # Line modified by Leapp
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "2 pg_init_retries 50" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0" # Line modified by Leapp
+		no_path_retry queue # Line added by Leapp
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+# 	device { # Section commented out by Leapp
+# 		fast_io_fail_tmo 5
+# 		all_devs yes
+# 		no_path_retry fail
+# 		detect_checker yes # Line modified by Leapp
+# 	}
+# 	device { # Section commented out by Leapp
+# 		features "1 queue_if_no_path"
+# 		path_checker "tur"
+# 		all_devs yes
+# 	}
+}
+multipaths {
+	multipath {
+		wwid "123456789"
+		alias "foo"
+	}
+}
+
+overrides {
+	no_path_retry fail # Line added by Leapp
+	features 0 # Line added by Leapp
+	checker "rdac"
+	detect_checker no # Line modified by Leapp
+# 	hardware_handler "1 alua" # Commented out by Leapp
+# 	pg_timeout no # Commented out by Leapp
+	fast_io_fail_tmo 10
+# 	unpriv_sgio no # Commented out by Leapp
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/default_rhel7.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/default_rhel7.conf
@@ -1,0 +1,1021 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "yes"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+	path_checker "directio"
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+	retain_attached_hw_handler no
+	detect_prio no
+	detect_path_checker no
+	hw_str_match no
+	force_sync no
+	deferred_remove no
+	ignore_new_boot_devs no
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	new_bindings_in_boot no
+	remove_retries 0
+	disable_changed_wwids no
+	unpriv_sgio no
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device {
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+}
+devices {
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "1 queue_if_no_path"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_path_checker yes
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "3 queue_if_no_path pg_init_retries 50"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+}
+multipaths {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/default_rhel8.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/default_rhel8.conf
@@ -1,0 +1,1049 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "no"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+	path_checker "tur"
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds "max"
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file "/etc/multipath/wwids"
+	prkeys_file "/etc/multipath/prkeys"
+	log_checker_err always
+	all_tg_pt "no"
+	retain_attached_hw_handler "yes"
+	detect_prio "yes"
+	detect_checker "yes"
+	force_sync "yes"
+	strict_timing "no"
+	deferred_remove "no"
+	config_dir "/etc/multipath/conf.d"
+	delay_watch_checks "no"
+	delay_wait_checks "no"
+	san_path_err_threshold "no"
+	san_path_err_forget_rate "no"
+	san_path_err_recovery_time "no"
+	marginal_path_err_sample_time "no"
+	marginal_path_err_rate_threshold "no"
+	marginal_path_err_recheck_gap_time "no"
+	marginal_path_double_failed_time "no"
+	find_multipaths "on"
+	uxsock_timeout 4000
+	retrigger_tries 0
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	skip_kpartx "no"
+	disable_changed_wwids ignored
+	remove_retries 0
+	ghost_delay "no"
+	find_multipaths_timeout -10
+	enable_foreign "^$"
+	marginal_pathgroups "no"
+}
+blacklist {
+	devnode "^(ram|zram|raw|loop|fd|md|dm-|sr|scd|st|dcssblk)[0-9]"
+	devnode "^(td|hd|vd)[a-z]"
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "^DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(Intel|INTEL)"
+		product "VTrak V-LUN"
+	}
+	device {
+		vendor "Promise"
+		product "VTrak V-LUN"
+	}
+	device {
+		vendor "Promise"
+		product "Vess V-LUN"
+	}
+}
+blacklist_exceptions {
+	property "(SCSI_IDENT_|ID_WWN)"
+}
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		retain_attached_hw_handler "no"
+	}
+	device {
+		vendor "APPLE"
+		product "Xserve RAID"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+		vpd_vendor hp3par
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1[01]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "(MSA2[02]12fc|MSA2012i)"
+		path_grouping_policy "multibus"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "(MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "MSA [12]0[45]0 SA[NS]"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "(P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "LEFTHAND"
+		product "(P4000|iSCSIDisk|FCDISK)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "TP9100"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[3457]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SGI"
+		product "IS"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SGI"
+		product "^DD[46]A-"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "DDN"
+		product "^EF3010"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "DDN"
+		product "^(EF3015|S2A|SFA)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		no_path_retry 30
+	}
+	device {
+		vendor "TEGILE"
+		product "(ZEBI-(FC|ISCSI)|INTELLIFLASH)"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		no_path_retry 6
+	}
+	device {
+		vendor "^DGC"
+		product "^(RAID|DISK|VRAID)"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback "immediate"
+		no_path_retry 60
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		no_path_retry 5
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "(EUROLOGC|EuroLogc)"
+		product "FC2502"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "FUJITSU"
+		product "E[234]000"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "FUJITSU"
+		product "E[68]000"
+		path_grouping_policy "multibus"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "^OPEN-"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "HITACHI"
+		product "^DF"
+		path_grouping_policy "group_by_prio"
+		prio "hds"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "HITACHI"
+		product "^DF600F"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1813"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^(3542|3552)"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^2105"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(XIV|IBM)"
+		product "(NEXTRA|2810XIV)"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(TMS|IBM)"
+		product "(RamSan|FlashSystem)"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "^(DCS9900|2851)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303[ ]+NVDISK"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 60
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN"
+		path_grouping_policy "group_by_prio"
+		features "2 pg_init_retries 50"
+		prio "ontap"
+		failback "immediate"
+		no_path_retry "queue"
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names "no"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SolidFir"
+		product "SSD SAN"
+		path_grouping_policy "multibus"
+		no_path_retry 24
+	}
+	device {
+		vendor "NVME"
+		product "^NetApp ONTAP Controller"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "^Pillar"
+		product "^Axiom"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "^Oracle"
+		product "^Oracle FS"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "STK"
+		product "BladeCtlr"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "StorEdge 3"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "CSM[12]00_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "ArrayStorage"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "(Sun Storage|ZFS Storage|COMSTAR)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(NexGen|Pivot3)"
+		product "(TierStore|vSTAC)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(Intel|INTEL)"
+		product "Multi-Flex"
+		product_blacklist "VTrak V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(LIO-ORG|SUSE)"
+		product "RBD"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+	}
+	device {
+		vendor "KOVE"
+		product "XPD"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		rr_min_io 1
+		rr_min_io_rq 1
+		flush_on_last_del "yes"
+		fast_io_fail_tmo 15
+		dev_loss_tmo 15
+	}
+	device {
+		vendor "KMNRIO"
+		product "K2"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "NEXSAN"
+		product "NXS-B0"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEXSAN"
+		product "SATAB"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 15
+	}
+	device {
+		vendor "Nexsan"
+		product "(NestOS|NST5000)"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "SAN ARRAY$"
+		path_grouping_policy "group_by_serial"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "SAN ARRAY ALUA"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "CONCERTO ARRAY"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "ISE"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "IGLU DISK"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "Magnitude"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "Promise"
+		product "VTrak"
+		product_blacklist "VTrak V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "Promise"
+		product "Vess"
+		product_blacklist "Vess V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "^IFT"
+		product ".*"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "SANnet"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "R/Evo"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "^DH"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "AStor"
+		product "NeoSapphire"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "INSPUR"
+		product "MCS"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+}
+overrides {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/just_all_devs.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/just_all_devs.conf
@@ -1,0 +1,5 @@
+devices {
+	device {
+		all_devs yes
+	}
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/just_checker.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/just_checker.conf
@@ -1,0 +1,1049 @@
+defaults {
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "no"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+	checker "rdac"
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds "max"
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file "/etc/multipath/wwids"
+	prkeys_file "/etc/multipath/prkeys"
+	log_checker_err always
+	all_tg_pt "no"
+	retain_attached_hw_handler "yes"
+	detect_prio "yes"
+	detect_checker "yes"
+	force_sync "yes"
+	strict_timing "no"
+	deferred_remove "no"
+	config_dir "/etc/multipath/conf.d"
+	delay_watch_checks "no"
+	delay_wait_checks "no"
+	san_path_err_threshold "no"
+	san_path_err_forget_rate "no"
+	san_path_err_recovery_time "no"
+	marginal_path_err_sample_time "no"
+	marginal_path_err_rate_threshold "no"
+	marginal_path_err_recheck_gap_time "no"
+	marginal_path_double_failed_time "no"
+	find_multipaths "on"
+	uxsock_timeout 4000
+	retrigger_tries 0
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	skip_kpartx "no"
+	disable_changed_wwids ignored
+	remove_retries 0
+	ghost_delay "no"
+	find_multipaths_timeout -10
+	enable_foreign "^$"
+	marginal_pathgroups "no"
+}
+blacklist {
+	devnode "^(ram|zram|raw|loop|fd|md|dm-|sr|scd|st|dcssblk)[0-9]"
+	devnode "^(td|hd|vd)[a-z]"
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "^DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(Intel|INTEL)"
+		product "VTrak V-LUN"
+	}
+	device {
+		vendor "Promise"
+		product "VTrak V-LUN"
+	}
+	device {
+		vendor "Promise"
+		product "Vess V-LUN"
+	}
+}
+blacklist_exceptions {
+	property "(SCSI_IDENT_|ID_WWN)"
+}
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		retain_attached_hw_handler "no"
+	}
+	device {
+		vendor "APPLE"
+		product "Xserve RAID"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+		vpd_vendor hp3par
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1[01]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "(MSA2[02]12fc|MSA2012i)"
+		path_grouping_policy "multibus"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "(MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "MSA [12]0[45]0 SA[NS]"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "(P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "LEFTHAND"
+		product "(P4000|iSCSIDisk|FCDISK)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 18
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "TP9100"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[3457]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SGI"
+		product "IS"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SGI"
+		product "^DD[46]A-"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "DDN"
+		product "^EF3010"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "DDN"
+		product "^(EF3015|S2A|SFA)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		no_path_retry 30
+	}
+	device {
+		vendor "TEGILE"
+		product "(ZEBI-(FC|ISCSI)|INTELLIFLASH)"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		no_path_retry 6
+	}
+	device {
+		vendor "^DGC"
+		product "^(RAID|DISK|VRAID)"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback "immediate"
+		no_path_retry 60
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		no_path_retry 5
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "(EUROLOGC|EuroLogc)"
+		product "FC2502"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "FUJITSU"
+		product "E[234]000"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 10
+	}
+	device {
+		vendor "FUJITSU"
+		product "E[68]000"
+		path_grouping_policy "multibus"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "^OPEN-"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "HITACHI"
+		product "^DF"
+		path_grouping_policy "group_by_prio"
+		prio "hds"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "HITACHI"
+		product "^DF600F"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1813"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^(3542|3552)"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "IBM"
+		product "^2105"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(XIV|IBM)"
+		product "(NEXTRA|2810XIV)"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(TMS|IBM)"
+		product "(RamSan|FlashSystem)"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "IBM"
+		product "^(DCS9900|2851)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303[ ]+NVDISK"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 60
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN"
+		path_grouping_policy "group_by_prio"
+		features "2 pg_init_retries 50"
+		prio "ontap"
+		failback "immediate"
+		no_path_retry "queue"
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names "no"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SolidFir"
+		product "SSD SAN"
+		path_grouping_policy "multibus"
+		no_path_retry 24
+	}
+	device {
+		vendor "NVME"
+		product "^NetApp ONTAP Controller"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "^Pillar"
+		product "^Axiom"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "^Oracle"
+		product "^Oracle FS"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+	device {
+		vendor "STK"
+		product "BladeCtlr"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "StorEdge 3"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "CSM[12]00_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "ArrayStorage"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "SUN"
+		product "(Sun Storage|ZFS Storage|COMSTAR)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(NexGen|Pivot3)"
+		product "(TierStore|vSTAC)"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(Intel|INTEL)"
+		product "Multi-Flex"
+		product_blacklist "VTrak V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "(LIO-ORG|SUSE)"
+		product "RBD"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 12
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+	}
+	device {
+		vendor "KOVE"
+		product "XPD"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		rr_min_io 1
+		rr_min_io_rq 1
+		flush_on_last_del "yes"
+		fast_io_fail_tmo 15
+		dev_loss_tmo 15
+	}
+	device {
+		vendor "KMNRIO"
+		product "K2"
+		path_grouping_policy "multibus"
+	}
+	device {
+		vendor "NEXSAN"
+		product "NXS-B0"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEXSAN"
+		product "SATAB"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 15
+	}
+	device {
+		vendor "Nexsan"
+		product "(NestOS|NST5000)"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "SAN ARRAY$"
+		path_grouping_policy "group_by_serial"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "SAN ARRAY ALUA"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "VIOLIN"
+		product "CONCERTO ARRAY"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "ISE"
+		path_grouping_policy "multibus"
+		no_path_retry 12
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "IGLU DISK"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "(XIOTECH|XIOtech)"
+		product "Magnitude"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "Promise"
+		product "VTrak"
+		product_blacklist "VTrak V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "Promise"
+		product "Vess"
+		product_blacklist "Vess V-LUN"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "^IFT"
+		product ".*"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "SANnet"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "R/Evo"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "DotHill"
+		product "^DH"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+		no_path_retry 30
+	}
+	device {
+		vendor "AStor"
+		product "NeoSapphire"
+		path_grouping_policy "multibus"
+		no_path_retry 30
+	}
+	device {
+		vendor "INSPUR"
+		product "MCS"
+		path_grouping_policy "group_by_prio"
+		prio "alua"
+		failback "immediate"
+	}
+}
+overrides {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/just_detect.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/just_detect.conf
@@ -1,0 +1,3 @@
+defaults {
+	detect_prio 0
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/just_exists.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/just_exists.conf
@@ -1,0 +1,32 @@
+# device-mapper-multipath configuration file
+
+# For a complete list of the default configuration values, run either:
+# # multipath -t
+# or
+# # multipathd show config
+
+# For a list of configuration options with descriptions, see the
+# multipath.conf man page.
+
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+}
+
+devices {
+	device {
+		vendor "Foo"
+		product "Bar"
+		features "1 queue_if_no_path"
+		path_grouping_policy "group_by_prio"
+		hardware_handler "1 alua"
+		prio "alua"
+	}
+}
+
+blacklist_exceptions {
+        property "(SCSI_IDENT_|ID_WWN)"
+}
+
+blacklist {
+}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/just_reassign.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/just_reassign.conf
@@ -1,0 +1,93 @@
+# This is a basic configuration file with some examples, for device mapper
+# multipath.
+#
+# For a complete list of the default configuration values, run either
+# multipath -t
+# or
+# multipathd show config
+#
+# For a list of configuration options with descriptions, see the multipath.conf
+# man page
+
+## By default, devices with vendor = "IBM" and product = "S/390.*" are
+## blacklisted. To enable mulitpathing on these devies, uncomment the
+## following lines.
+#blacklist_exceptions {
+#	device {
+#		vendor	"IBM"
+#		product	"S/390.*"
+#	}
+#}
+
+## Use user friendly names, instead of using WWIDs as names.
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+	reassign_maps "yes"
+}
+##
+## Here is an example of how to configure some standard options.
+##
+#
+#defaults {
+#	polling_interval 	10
+#	path_selector		"round-robin 0"
+#	path_grouping_policy	multibus
+#	uid_attribute		ID_SERIAL
+#	prio			alua
+#	path_checker		readsector0
+#	rr_min_io		100
+#	max_fds			8192
+#	rr_weight		priorities
+#	failback		immediate
+#	no_path_retry		fail
+#	user_friendly_names	yes
+#}
+##
+## The wwid line in the following blacklist section is shown as an example
+## of how to blacklist devices by wwid.  The 2 devnode lines are the
+## compiled in default blacklist. If you want to blacklist entire types
+## of devices, such as all scsi devices, you should use a devnode line.
+## However, if you want to blacklist specific devices, you should use
+## a wwid line.  Since there is no guarantee that a specific device will
+## not change names on reboot (from /dev/sda to /dev/sdb for example)
+## devnode lines are not recommended for blacklisting specific devices.
+##
+#blacklist {
+#       wwid 26353900f02796769
+#	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+#	devnode "^hd[a-z]"
+#}
+#multipaths {
+#	multipath {
+#		wwid			3600508b4000156d700012000000b0000
+#		alias			yellow
+#		path_grouping_policy	multibus
+#		path_selector		"round-robin 0"
+#		failback		manual
+#		rr_weight		priorities
+#		no_path_retry		5
+#	}
+#	multipath {
+#		wwid			1DEC_____321816758474
+#		alias			red
+#	}
+#}
+#devices {
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"HSV110 (C)COMPAQ"
+#		path_grouping_policy	multibus
+#		path_checker		readsector0
+#		path_selector		"round-robin 0"
+#		hardware_handler	"0"
+#		failback		15
+#		rr_weight		priorities
+#		no_path_retry		queue
+#	}
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"MSA1000         "
+#		path_grouping_policy	multibus
+#	}
+#}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/ugly1.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/ugly1.conf
@@ -1,0 +1,1055 @@
+defaults THIS SHOULDN'T BE HERE
+	verbosity 2
+	polling_interval 5
+	max_polling_interval 20
+	reassign_maps "yes"
+	multipath_dir "/lib64/multipath"
+	path_selector "service-time 0"
+	path_grouping_policy "failover"
+	uid_attribute "ID_SERIAL"
+	prio "const"
+	prio_args ""
+	features "0"
+	path_checker "directio"
+	alias_prefix "mpath"
+	failback "manual"
+	rr_min_io 1000
+	rr_min_io_rq 1
+	max_fds 1048576
+	rr_weight "uniform"
+	queue_without_daemon "no"
+	flush_on_last_del "no"
+	user_friendly_names "yes"
+	fast_io_fail_tmo 5
+	bindings_file "/etc/multipath/bindings"
+	wwids_file /etc/multipath/wwids
+	prkeys_file /etc/multipath/prkeys
+	log_checker_err always
+	find_multipaths yes
+	retain_attached_hw_handler no
+	detect_prio no
+	detect_path_checker no
+	hw_str_match no
+	force_sync no
+	deferred_remove no
+	ignore_new_boot_devs no
+	skip_kpartx no
+	config_dir "tests/files/conf.d"
+	delay_watch_checks no
+	delay_wait_checks no
+	retrigger_tries 3
+	retrigger_delay 10
+	missing_uev_wait_timeout 30
+	new_bindings_in_boot no
+	remove_retries 0
+	disable_changed_wwids no
+	unpriv_sgio no
+	ghost_delay no
+	all_tg_pt no
+	marginal_path_err_sample_time no
+	marginal_path_err_rate_threshold no
+	marginal_path_err_recheck_gap_time no
+	marginal_path_double_failed_time no
+}
+blacklist {
+	devnode "sdb"
+	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+	devnode "^(td|hd|vd)[a-z]"
+	devnode "^dcssblk[0-9]*"
+	device
+		vendor "DGC"
+		product "LUNZ"
+	}
+	device {
+		vendor "EMC"
+		product "LUNZ"
+	}
+	device {
+		vendor "IBM"
+		product "Universal Xport"
+	}
+	device {
+		vendor "IBM"
+		product "S/390.*"
+	}
+	device {
+		vendor "DELL"
+		product "Universal Xport"
+	}
+	device {
+		vendor "LENOVO"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SGI"
+		product "Universal Xport"
+	}
+	device {
+		vendor "STK"
+		product "Universal Xport"
+	}
+	device {
+		vendor "SUN"
+		product "Universal Xport"
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "Universal Xport"
+	}
+}
+blacklist_exceptions {
+	devnode "sda"
+	wwid "123456789"
+	device {
+		vendor "IBM"
+		product "S/390x"
+	}
+}
+		
+devices { BAD DATA
+	device {
+		vendor "COMPELNT"
+		product "Compellent Vol"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "APPLE*"
+		product "Xserve RAID "
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "3PARdata"
+		product "VV"
+		path_grouping_policy "group_by_prio"
+		path_selector "service-time 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua" EXTRA DATA
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		fast_io_fail_tmo 10
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "DEC"
+		product "HSG80"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HP"
+		product "A6189A"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "(MSA|HSV)1.0.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "hp_sw"
+		features "1 queue_if_no_path"
+		hardware_handler "1 hp_sw"
+		prio "hp_sw"
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "MSA VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "(COMPAQ|HP)"
+		product "HSV1[01]1|HSV2[01]0|HSV3[046]0|HSV4[05]0"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2[02]12fc|MSA2012i"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA2012sa|MSA23(12|24)(fc|i|sa)|MSA2000s VOLUME"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "MSA (1|2)040 SA(N|S)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "HSVX700"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 12
+		rr_min_io 100
+	}
+	device {
+		vendor "HP"
+		product "LOGICAL VOLUME.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 12
+	}
+	device {
+		vendor "HP"
+		product "P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 18
+		rr_min_io 100
+	}
+	device {
+		vendor "DDN"
+		product "SAN DataDirector"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EMC"
+		product "SYMMETRIX"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 6
+	}
+	device {
+		vendor "DGC"
+		product ".*"
+		product_blacklist "LUNZ"
+		path_grouping_policy "group_by_prio"
+		path_checker "emc_clariion"
+		features "1 queue_if_no_path"
+		hardware_handler "1 emc"
+		prio "emc"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+		retain_attached_hw_handler yes
+		detect_prio yes
+		detect_path_checker yes
+	}
+	device {
+		vendor "EMC"
+		product "Invista"
+		product_blacklist "LUNZ"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		no_path_retry 5
+	}
+	device {
+		vendor "FSC"
+		product "CentricStor"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "FUJITSU"
+		product "ETERNUS_DX(H|L|M|400|8000)"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 10
+	}
+	device {
+		vendor "(HITACHI|HP)"
+		product "OPEN-.*"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "HITACHI"
+		product "DF.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "hds"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "ProFibre 4000R"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1722-600"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1724"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1726"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "1 queue_if_no_path"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 300
+	}
+	device {
+		vendor "IBM"
+		product "^1742"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1745|^1746"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "IBM"
+		product "^1814"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1815"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^1818"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3526"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "IBM"
+		product "^3542"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105800"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2105F20"
+		path_grouping_policy "group_by_serial"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^1750500"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2107900"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD ECKD"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "S/390 DASD FBA"
+		product_blacklist "S/390.*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_UID"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "^IPR.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "IBM"
+		product "1820N00"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 100
+	}
+	device {
+		vendor "IBM"
+		product "2810XIV"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback 15
+		rr_weight "uniform"
+		rr_min_io 15
+	}
+	device {
+		vendor "AIX"
+		product "VDASD"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "IBM"
+		product "3303      NVDISK"
+		path_grouping_policy "failover"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "AIX"
+		product "NVDISK"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 60
+	}
+	device {
+		vendor "DELL"
+		product "^MD3"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+	}
+	device {
+		vendor "LENOVO"
+		product "DE_Series"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		no_path_retry 30
+	}
+	device {
+		vendor "NETAPP"
+		product "LUN.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "3 queue_if_no_path pg_init_retries 50"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+		flush_on_last_del "yes"
+		dev_loss_tmo "infinity"
+		user_friendly_names no
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "NEXENTA"
+		product "COMSTAR"
+		path_grouping_policy "group_by_serial"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		rr_min_io 128
+	}
+	device {
+		vendor "IBM"
+		product "Nseries.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "ontap"
+		failback immediate
+		rr_weight "uniform"
+		rr_min_io 128
+	}
+	device {
+		vendor "Pillar"
+		product "Axiom.*"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[13]00"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SGI"
+		product "TP9[45]00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SGI"
+		product "IS.*"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 15
+	}
+	device {
+		vendor "NEC"
+		product "DISK ARRAY"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "STK"
+		product "OPENstorage D280"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "(StorEdge 3510|T4)"
+		path_grouping_policy "multibus"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "SUN"
+		product "STK6580_6780"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+	}
+	device {
+		vendor "EUROLOGC"
+		product "FC2502"
+		path_grouping_policy "group_by_prio"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+	}
+	device {
+		vendor "PIVOT3"
+		product "RAIGE VOLUME"
+		path_grouping_policy "multibus"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "0"
+		prio "const"
+		rr_weight "uniform"
+		rr_min_io 100
+	}
+	device {
+		vendor "SUN"
+		product "CSM200_R"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "LCSM100_[IEFS]"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "SUN"
+		product "SUN_6180"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+		rr_min_io 1000
+		rr_min_io_rq 1
+	}
+	device {
+		vendor "(NETAPP|LSI|ENGENIO)"
+		product "INF-01-00"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "2 pg_init_retries 50"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry 30
+		retain_attached_hw_handler yes
+		detect_prio yes
+	}
+	device {
+		vendor "STK"
+		product "FLEXLINE 380"
+		product_blacklist "Universal Xport"
+		path_grouping_policy "group_by_prio"
+		path_checker "rdac"
+		features "0"
+		hardware_handler "1 rdac"
+		prio "rdac"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "Intel"
+		product "Multi-Flex"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "SANmelody"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "DataCore"
+		product "Virtual Disk"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		rr_weight "uniform"
+		no_path_retry "queue"
+	}
+	device {
+		vendor "NFINIDAT"
+		product "InfiniBox.*"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback 30
+		rr_weight "priorities"
+		no_path_retry "fail"
+		flush_on_last_del "yes"
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "Nimble"
+		product "Server"
+		path_grouping_policy "group_by_prio"
+		path_selector "round-robin 0"
+		path_checker "tur"
+		features "1 queue_if_no_path"
+		hardware_handler "1 alua"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo "infinity"
+	}
+	device {
+		vendor "XtremIO"
+		product "XtremApp"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "directio"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 15
+	}
+	device {
+		vendor "PURE"
+		product "FlashArray"
+		path_grouping_policy "multibus"
+		path_selector "queue-length 0"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "const"
+		failback immediate
+		fast_io_fail_tmo 10
+		dev_loss_tmo 60
+		user_friendly_names no
+	}
+	device {
+		vendor "HUAWEI"
+		product "XSG1"
+		path_grouping_policy "group_by_prio"
+		path_checker "tur"
+		features "0"
+		hardware_handler "0"
+		prio "alua"
+		failback immediate
+		dev_loss_tmo 30
+	}
+	device {
+		vendor "NVME"
+		product "^EMC PowerMax_"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		prio "const"
+	}
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy "multibus"
+		uid_attribute "ID_WWN"
+		path_checker "none"
+		detect_prio yes
+	}
+	device {
+		vendor "IBM"
+		product "^2145"
+		path_selector "service-time 0"
+	}
+	device {
+		fast_io_fail_tmo 5
+		dev_loss_tmo 60
+		all_devs yes
+		no_path_retry fail
+		detect_path_checker yes
+	}
+	device {
+		path_selector "service-time 0" JUNK IN LINE
+		features "1 queue_if_no_path"
+		path_checker "tur"
+		all_devs yes
+	}
+}
+multipaths {
+	multipath {
+		wwid "123456789"
+		alias "foo"
+	}
+}
+
+overrides 
+	checker "rdac"
+	detect_path_checker no
+	hardware_handler "1 alua"
+	pg_timeout no
+	fast_io_fail_tmo 10
+	unpriv_sgio no
+	features "3 queue_if_no_path pg_init_retries 50"
+# Missing closing brace

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/ugly2.conf
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/files/before/ugly2.conf
@@ -1,0 +1,123 @@
+# This is a basic configuration file with some examples, for device mapper
+# multipath.
+#
+# For a complete list of the default configuration values, run either
+# multipath -t
+# or
+# multipathd show config
+#
+# For a list of configuration options with descriptions, see the multipath.conf
+# man page
+
+## By default, devices with vendor = "IBM" and product = "S/390.*" are
+## blacklisted. To enable mulitpathing on these devies, uncomment the
+## following lines.
+#blacklist_exceptions {
+#	device {
+#		vendor	"IBM"
+#		product	"S/390.*"
+#	}
+#}
+
+## Use user friendly names, instead of using WWIDs as names.
+defaults {
+	user_friendly_names yes
+	find_multipaths yes
+}
+
+devices {
+	device {
+		vendor "NVME"
+		product ".*"
+		path_grouping_policy multibus
+		
+	}
+	device {
+		all_devs yes
+		path_checker tur
+		pg_timeout no
+		detect_path_checker yes
+	}
+
+	device {
+		features "3 queue_if_no_path pg_init_retries 50"
+		path_selector "service-time 0"
+		all_devs yes
+		unpriv_sgio no
+	}
+
+	device {
+		hardware_handler "1 alua"
+		vendor "test_vendor"
+		product "test_product"
+		revision 1
+		product_blacklist "test.*"
+		all_devs yes
+		fast_io_fail_tmo 5
+		path_checker rdac
+# no closing braces
+
+##
+## Here is an example of how to configure some standard options.
+##
+#
+#defaults {
+#	polling_interval 	10
+#	path_selector		"round-robin 0"
+#	path_grouping_policy	multibus
+#	uid_attribute		ID_SERIAL
+#	prio			alua
+#	path_checker		readsector0
+#	rr_min_io		100
+#	max_fds			8192
+#	rr_weight		priorities
+#	failback		immediate
+#	no_path_retry		fail
+#	user_friendly_names	yes
+#}
+##
+## The wwid line in the following blacklist section is shown as an example
+## of how to blacklist devices by wwid.  The 2 devnode lines are the
+## compiled in default blacklist. If you want to blacklist entire types
+## of devices, such as all scsi devices, you should use a devnode line.
+## However, if you want to blacklist specific devices, you should use
+## a wwid line.  Since there is no guarantee that a specific device will
+## not change names on reboot (from /dev/sda to /dev/sdb for example)
+## devnode lines are not recommended for blacklisting specific devices.
+##
+#       wwid 26353900f02796769
+#	devnode "^(ram|raw|loop|fd|md|dm-|sr|scd|st)[0-9]*"
+#	devnode "^hd[a-z]"
+#multipaths {
+#	multipath {
+#		wwid			3600508b4000156d700012000000b0000
+#		alias			yellow
+#		path_grouping_policy	multibus
+#		path_selector		"round-robin 0"
+#		failback		manual
+#		rr_weight		priorities
+#		no_path_retry		5
+#	}
+#	multipath {
+#		wwid			1DEC_____321816758474
+#		alias			red
+#	}
+#}
+#devices {
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"HSV110 (C)COMPAQ"
+#		path_grouping_policy	multibus
+#		path_checker		readsector0
+#		path_selector		"round-robin 0"
+#		hardware_handler	"0"
+#		failback		15
+#		rr_weight		priorities
+#		no_path_retry		queue
+#	}
+#	device {
+#		vendor			"COMPAQ  "
+#		product			"MSA1000         "
+#		path_grouping_policy	multibus
+#	}
+#}

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/test_library.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/tests/test_library.py
@@ -1,0 +1,128 @@
+from leapp.libraries.actor import library
+from leapp.models import MultipathConfig, MultipathConfigOption
+from leapp.libraries.common import multipathutil
+
+
+def build_config(val):
+    all_devs_options_val = []
+    for name_val, value_val in val[16]:
+        option = MultipathConfigOption(name=name_val, value=value_val)
+        all_devs_options_val.append(option)
+    return MultipathConfig(
+            pathname=val[0],
+            default_path_checker=val[1],
+            config_dir=val[2],
+            default_retain_hwhandler=val[3],
+            default_detect_prio=val[4],
+            default_detect_checker=val[5],
+            reassign_maps=val[6],
+            hw_str_match_exists=val[7],
+            ignore_new_boot_devs_exists=val[8],
+            new_bindings_in_boot_exists=val[9],
+            unpriv_sgio_exists=val[10],
+            detect_path_checker_exists=val[11],
+            overrides_hwhandler_exists=val[12],
+            overrides_pg_timeout_exists=val[13],
+            queue_if_no_path_exists=val[14],
+            all_devs_section_exists=val[15],
+            all_devs_options=all_devs_options_val)
+
+
+default_rhel7_conf = build_config(
+        ['tests/files/before/default_rhel7.conf', 'directio',
+         'tests/files/conf.d', False, False, False, True, True, True, True,
+         True, True, False, False, True, False, []])
+
+all_devs_conf = build_config(
+        ['tests/files/before/all_devs.conf', None, None, None, None, None,
+         None, False, False, False, True, True, False, False, True, True,
+         [('path_checker', 'rdac'), ('detect_checker', 'yes'),
+          ('features', '2 pg_init_retries 50'),
+          ('path_selector', 'service-time 0'), ('fast_io_fail_tmo', '5'),
+          ('no_path_retry', 'queue')]])
+
+empty_conf = build_config(
+        ['tests/files/before/empty.conf', None, None, None, None, None, None,
+         False, False, False, False, False, False, False, False, False, []])
+
+default_rhel8_conf = build_config(
+        ['tests/files/before/default_rhel8.conf', 'tur',
+         '/etc/multipath/conf.d', True, True, None, False, False, False,
+         False, False, False, False, False, False, False, []])
+
+all_the_things_conf = build_config(
+        ['tests/files/before/all_the_things.conf', 'directio',
+         'tests/files/conf.d', False, False, False, True, True, True, True,
+         True, True, True, True, True, True,
+         [('no_path_retry', 'fail'), ('features', '0')]])
+
+already_updated_conf = build_config(
+        ['tests/files/before/already_updated.conf', None, 'tests/files/conf.d',
+         None, None, None, None, False, False, False, False, False, False,
+         False, False, False, []])
+
+ugly1_conf = build_config(
+        ['tests/files/before/ugly1.conf', 'directio', 'tests/files/conf.d',
+         False, False, False, True, True, True, True, True, True, True, True,
+         True, True, [('dev_loss_tmo', '60'),
+                      ('path_selector', 'service-time 0')]])
+
+# same results as all_devs_conf
+ugly2_conf = build_config(
+        ['tests/files/before/ugly2.conf', None, None, None, None, None, None,
+         False, False, False, True, True, False, False, True, True,
+         [('path_checker', 'rdac'), ('detect_checker', 'yes'),
+          ('features', '2 pg_init_retries 50'),
+          ('path_selector', 'service-time 0'), ('fast_io_fail_tmo', '5'),
+          ('no_path_retry', 'queue')]])
+
+just_checker_conf = build_config(
+        ['tests/files/before/just_checker.conf', 'rdac',
+         '/etc/multipath/conf.d', True, True, None, False, False, False, False,
+         False, False, False, False, False, False, []])
+
+just_detect_conf = build_config(
+        ['tests/files/before/just_detect.conf', None, None, None, False,
+         None, None, False, False, False, False, False, False, False, False,
+         False, []])
+
+just_reassign_conf = build_config(
+        ['tests/files/before/just_reassign.conf', None, None, None, None,
+         None, True, False, False, False, False, False, False, False, False,
+         False, []])
+
+just_exists_conf = build_config(
+        ['tests/files/before/just_exists.conf', None, None, None, None,
+         None, None, False, False, False, False, False, False, False, True,
+         False, []])
+
+just_all_devs_conf = build_config(
+        ['tests/files/before/just_all_devs.conf', None, None, None, None,
+         None, None, False, False, False, False, False, False, False, False,
+         True, []])
+
+
+def test_configs():
+    tests = [(default_rhel7_conf, 'tests/files/after/default_rhel7.conf'),
+             (all_devs_conf, 'tests/files/after/all_devs.conf'),
+             (empty_conf, None),
+             (default_rhel8_conf, None),
+             (all_the_things_conf, 'tests/files/after/all_the_things.conf'),
+             (already_updated_conf, None),
+             (ugly1_conf, 'tests/files/after/ugly1.conf'),
+             (ugly2_conf, 'tests/files/after/ugly2.conf'),
+             (just_checker_conf, 'tests/files/after/just_checker.conf'),
+             (just_detect_conf, 'tests/files/after/just_detect.conf'),
+             (just_reassign_conf, 'tests/files/after/just_reassign.conf'),
+             (just_exists_conf, 'tests/files/after/just_exists.conf'),
+             (just_all_devs_conf, 'tests/files/after/just_all_devs.conf')]
+    for config, expected_config in tests:
+        config_lines = library._update_config(config)
+        if config_lines is None:
+            assert expected_config is None
+            continue
+        expected_lines = multipathutil.read_config(expected_config)
+        assert expected_lines is not None
+        assert len(config_lines) == len(expected_lines)
+        for config_line, expected_line in zip(config_lines, expected_lines):
+            assert config_line == expected_line

--- a/repos/system_upgrade/el7toel8/libraries/multipathutil.py
+++ b/repos/system_upgrade/el7toel8/libraries/multipathutil.py
@@ -1,0 +1,102 @@
+import errno
+import re
+
+from leapp.libraries.stdlib import api
+
+_sections = ('defaults', 'blacklist', 'blacklist_exceptions', 'devices',
+             'overrides', 'multipaths')
+
+_subsections = {'blacklist': 'device', 'blacklist_exceptions': 'device',
+                'devices': 'device', 'multipaths': 'multipath'}
+
+
+def read_config(path):
+    try:
+        with open(path, 'r') as f:
+            return f.read()
+    except IOError as e:
+        if e.errno == errno.ENOENT:
+            api.current_logger().debug(
+                'multipath configuration file {} does not exist.'.format(path)
+            )
+        else:
+            api.current_logger().warn(
+                'Failed to read multipath configuration file {}: {}'.
+                format(path, e)
+            )
+        return None
+
+
+def write_config(path, contents):
+    try:
+        with open(path, 'w') as f:
+            f.write(contents)
+    except IOError as e:
+        api.current_logger().warn(
+            'Failed to write multipath configuration file {}: {}'.
+            format(path, e)
+        )
+
+
+class LineData(object):
+    TYPE_BLANK = 0
+    TYPE_SECTION_START = 1
+    TYPE_SECTION_END = 2
+    TYPE_OPTION = 3
+
+    def __init__(self, line, section, in_subsection):
+        comment_pattern = re.compile('^([^"#!]*)[#!]')
+        string_pattern = re.compile('^([^"]*)"([^"]*)')
+        utf8_pattern = re.compile('[^\x00-\x7F]+')
+        line_pattern = re.compile(r'^([^\s{}]+)\s*(\S*)')
+        value = None
+
+        r = comment_pattern.match(line)
+        if r:
+            line = r.group(1)
+        r = string_pattern.match(line)
+        if r:
+            line = r.group(1)
+            value = r.group(2)
+        line = utf8_pattern.sub(' ', line)
+        line = line.strip()
+
+        if line == '':
+            self.type = self.TYPE_BLANK
+            return
+        if line[0] == '}':
+            self.type = self.TYPE_SECTION_END
+            return
+
+        r = line_pattern.match(line)
+        if r is None:
+            raise ValueError
+        keyword = r.group(1)
+        if r.group(2) != '':
+            value = r.group(2)  # even if value was set before
+
+        if section is None:
+            if keyword in _sections:
+                self.type = self.TYPE_SECTION_START
+                self.section = keyword
+                return
+            raise ValueError
+
+        if not in_subsection and section in _subsections and \
+                keyword == _subsections[section]:
+            self.type = self.TYPE_SECTION_START
+            self.section = keyword
+            return
+
+        if value is None:
+            raise ValueError
+        self.type = self.TYPE_OPTION
+        self.option = keyword
+        self.value = value
+
+    def is_enabled(self):
+        if self.value == 'yes' or self.value == '1':
+            return True
+        if self.value == 'no' or self.value == '0':
+            return False
+        return None

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_multipathutil.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_multipathutil.py
@@ -1,0 +1,115 @@
+import leapp.libraries.common.multipathutil as lib
+
+
+def test_no_config():
+    content = lib.read_config('/this/does/not/exist')
+    assert content is None
+
+
+def test_blank_line():
+    data = lib.LineData('', None, False)
+    assert data.type == data.TYPE_BLANK
+    data = lib.LineData('    ', 'devices', True)
+    assert data.type == data.TYPE_BLANK
+    data = lib.LineData('# comment at start of line', 'defaults', False)
+    assert data.type == data.TYPE_BLANK
+    data = lib.LineData('  ! alternate comment method!!!', 'blacklist', True)
+    assert data.type == data.TYPE_BLANK
+    data = lib.LineData('# } still a comment', None, False)
+    assert data.type == data.TYPE_BLANK
+    data = lib.LineData('   # "also a comment!"', "multipaths", True)
+    assert data.type == data.TYPE_BLANK
+    data = lib.LineData(' "ignore lines starting with a string"', None, False)
+    assert data.type == data.TYPE_BLANK
+
+
+def test_section_end():
+    data = lib.LineData('}', None, False)
+    assert data.type == data.TYPE_SECTION_END
+    data = lib.LineData('     }  # trailing comment', 'devices', True)
+    assert data.type == data.TYPE_SECTION_END
+    data = lib.LineData('     }  JUNK AFTERWARDS', 'defaults', False)
+    assert data.type == data.TYPE_SECTION_END
+    data = lib.LineData('\t \t}  !!tabs', 'multipaths', True)
+    assert data.type == data.TYPE_SECTION_END
+
+
+def test_section_start():
+    sections = ('defaults', 'blacklist', 'blacklist_exceptions', 'devices',
+                'overrides', 'multipaths')
+    subsections = {'blacklist': 'device', 'blacklist_exceptions': 'device',
+                   'devices': 'device', 'multipaths': 'multipath'}
+    for section in sections:
+        data = lib.LineData(section + ' {', None, False)
+        assert data.type == data.TYPE_SECTION_START
+        assert data.section == section
+
+    try:
+        data = lib.LineData('not_a_section {', None, False)
+        assert False
+    except ValueError:
+        pass
+
+    data = lib.LineData('defaults # works even without brace', None, False)
+    assert data.type == data.TYPE_SECTION_START
+    assert data.section == 'defaults'
+
+    data = lib.LineData('\t \tmultipaths { # tabs', None, False)
+    assert data.type == data.TYPE_SECTION_START
+    assert data.section == 'multipaths'
+
+    data = lib.LineData('devices{ # do not need a space', None, False)
+    assert data.type == data.TYPE_SECTION_START
+    assert data.section == 'devices'
+
+    for section in subsections:
+        data = lib.LineData(subsections[section] + ' {', section, False)
+        assert data.type == data.TYPE_SECTION_START
+        assert data.section == subsections[section]
+
+    data = lib.LineData('devices { # wrong section', 'multipath', False)
+    assert data.type != data.TYPE_SECTION_START
+
+    data = lib.LineData('devices { # already in subsection', 'device', True)
+    assert data.type != data.TYPE_SECTION_START
+
+
+def test_option():
+    data = lib.LineData('key value', 'defaults', False)
+    assert data.type == data.TYPE_OPTION
+    assert data.option == 'key'
+    assert data.value == 'value'
+
+    data = lib.LineData('key value # comment', 'devices', True)
+    assert data.option == 'key'
+    assert data.value == 'value'
+
+    data = lib.LineData('    key value "extra string"', 'multipaths', True)
+    assert data.option == 'key'
+    assert data.value == 'value'
+
+    data = lib.LineData(' \t\tkey "string value" junk', 'blacklist', False)
+    assert data.option == 'key'
+    assert data.value == 'string value'
+
+    try:
+        data = lib.LineData('key  # comment', 'devices', True)
+        assert False
+    except ValueError:
+        pass
+
+
+def test_enabled():
+    values = (('yes', True), ('1', True), ('no', False), ('0', False))
+    for value, is_enabled in values:
+        data = lib.LineData('key ' + value, 'defaults', False)
+        assert data.type == data.TYPE_OPTION
+        assert data.option == 'key'
+        assert data.value == value
+        assert data.is_enabled() == is_enabled
+
+    data = lib.LineData('key neither_yes_nor_no', 'defaults', False)
+    assert data.type == data.TYPE_OPTION
+    assert data.option == 'key'
+    assert data.value == 'neither_yes_nor_no'
+    assert data.is_enabled() is None

--- a/repos/system_upgrade/el7toel8/models/multipathconffacts.py
+++ b/repos/system_upgrade/el7toel8/models/multipathconffacts.py
@@ -1,0 +1,59 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class MultipathConfigOption(Model):
+    '''Model representing information about a multipath configuration option'''
+    topic = SystemInfoTopic
+
+    name = fields.String(default='')
+    value = fields.String(default='')
+
+
+class MultipathConfig(Model):
+    '''Model representing information about a multipath configuration file'''
+    topic = SystemInfoTopic
+
+    pathname = fields.String()
+    '''Config file path name'''
+
+    default_path_checker = fields.Nullable(fields.String())
+    config_dir = fields.Nullable(fields.String())
+    '''Values of path_checker and config_dir in the defaults section.
+       None if not set'''
+
+    default_retain_hwhandler = fields.Nullable(fields.Boolean())
+    default_detect_prio = fields.Nullable(fields.Boolean())
+    default_detect_checker = fields.Nullable(fields.Boolean())
+    reassign_maps = fields.Nullable(fields.Boolean())
+    '''True if retain_attached_hw_handler, detect_prio, detect_path_checker,
+       or reassign_maps is set to "yes" in the defaults section. False
+       if set to "no". None if not set.'''
+
+    hw_str_match_exists = fields.Boolean(default=False)
+    ignore_new_boot_devs_exists = fields.Boolean(default=False)
+    new_bindings_in_boot_exists = fields.Boolean(default=False)
+    unpriv_sgio_exists = fields.Boolean(default=False)
+    detect_path_checker_exists = fields.Boolean(default=False)
+    overrides_hwhandler_exists = fields.Boolean(default=False)
+    overrides_pg_timeout_exists = fields.Boolean(default=False)
+    queue_if_no_path_exists = fields.Boolean(default=False)
+    all_devs_section_exists = fields.Boolean(default=False)
+    '''True if hw_str_match, ignore_new_boot_devs, new_bindings_in_boot,
+       detect_path_checker, or unpriv_sgio is set in any section,
+       if queue_if_no_path is included in the features line in any
+       section or if hardware_handler or pg_timeout is set in the
+       overrides section. False otherwise'''
+
+    all_devs_options = fields.List(fields.Model(MultipathConfigOption),
+                                   default=[])
+    '''options in an all_devs device configuration section to be converted to
+       an overrides section'''
+
+
+class MultipathConfFacts(Model):
+    '''Model representing information from multipath configuration files'''
+    topic = SystemInfoTopic
+
+    configs = fields.List(fields.Model(MultipathConfig), default=[])
+    '''List of multipath configuration files'''


### PR DESCRIPTION
This actor changes the the multipath configuration files so that they
will work in RHEL8, with as close a configuration to the RHEL7 version
as possible.

The actor silently comments out all removed configuration options,
specifically "hw_str_match", "ignore_new_boot_devs",
"new_bindings_in_boot" and "unpriv_sgio", since these all are no longer
necessary in RHEL8. It changes the option "detect_path_checker" to
"detect_checker", since the name has changed, and it removes
"hardware_handler" and "pg_timeout" from the overrides section, since
these no longer exist and never did anything in RHEL7.

If a features option contains "queue_if_no_path" it is removed, since it
has been deprecated in the config, and adds a "no_path_retry queue" option
instead, if the "no_path_retry" option did not already exist. This has
not change on the effective configuration.

If a device section with "all_devs" exist, the configuration values are
added to an overrides sections, since this replaces "all_devs" device
configs in RHEL8. If an overrides section already exists in the RHEL7
config, its values have priority over the all_devs values.

The actor also changes the values of "retain_attached_hw_handler",
"detect_checker", "detect_prio", and "reassign_maps" to the RHEL8
defaults, because this is necessary for proper functioning, but warns
the user of this.

Finally, if the path checker is set in the defaults section to something
other than "tur", it is not obvious how to upgrade the configuration,
and so the actor inhibits it.