### PR TITLE
verifycheckresults: Mark inhibiting errors as such

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -30,7 +30,7 @@ Requires:       leapp-repository-dependencies = 5
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' this instead of the real framework rpm version.
-Requires:       leapp-framework >= 1.0, leapp-framework < 2
+Requires:       leapp-framework >= 1.1, leapp-framework < 2
 Requires:       python2-leapp
 
 # That's temporary to ensure the obsoleted subpackage is not installed

--- a/repos/system_upgrade/el7toel8/actors/verifycheckresults/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/verifycheckresults/libraries/library.py
@@ -1,8 +1,8 @@
+from leapp.exceptions import RequestStopAfterPhase
 from leapp.libraries.stdlib import api
 from leapp.reporting import Report
 
 
 def check():
-    results = list(api.consume(Report))
-    for error in [msg for msg in results if 'inhibitor' in msg.report.get('flags', [])]:
-        api.report_error(error.report['title'])
+    if [msg for msg in api.consume(Report) if 'inhibitor' in msg.report.get('flags', [])]:
+        raise RequestStopAfterPhase()

--- a/repos/system_upgrade/el7toel8/actors/verifycheckresults/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/verifycheckresults/tests/unit_test.py
@@ -1,9 +1,10 @@
 from collections import namedtuple
-import json
 
+import pytest
+
+from leapp.exceptions import RequestStopAfterPhase
 from leapp.libraries.actor import library
 from leapp.libraries.stdlib import api
-from leapp import reporting
 
 
 class Report(object):
@@ -19,35 +20,19 @@ class Report(object):
         return self.message
 
 
-class ReportError(object):
-    def __init__(self):
-        self.message = None
-        self.called = 0
-
-    def set(self, message):
-        self.called += 1
-        self.message = message
-
-
 def test_actor(monkeypatch):
     def report_mocked(*models):
         yield namedtuple('msg', ['report'])(Report('title_with_inhibitor'))
 
-    report_error = ReportError()
     monkeypatch.setattr(api, "consume", report_mocked)
-    monkeypatch.setattr(api, "report_error", report_error.set)
-    library.check()
-    assert report_error.message == 'title_with_inhibitor'
-    assert report_error.called == 1
+
+    with pytest.raises(RequestStopAfterPhase):
+        library.check()
 
 
 def test_actor_no_inhibitor(monkeypatch):
     def report_mocked(*models):
         yield namedtuple('msg', ['report'])(Report('title_without_inhibitor'))
 
-    report_error = ReportError()
     monkeypatch.setattr(api, "consume", report_mocked)
-    monkeypatch.setattr(api, "report_error", report_error.set)
     library.check()
-    assert not report_error.message
-    assert report_error.called == 0


### PR DESCRIPTION
Previously there was no way to distinguish a normal error from an
inhibitor related error. Having the information will help in improving
the user experience by giving the user a hint where to look for more
information in regards to the error (preupgrade report).

This patch will add a flag to the error details that indicates that this
error was due to an inhibitor being raised.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>