### PR TITLE
Inhibit upgrade if FIPS is enabled

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkfips/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfips/actor.py
@@ -1,0 +1,35 @@
+from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.models import Report, KernelCmdline
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+from leapp import reporting
+
+
+class CheckFips(Actor):
+    """
+    Inhibit upgrade if FIPS is detected as enabled.
+    """
+
+    name = 'check_fips'
+    consumes = (KernelCmdline,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        cmdline = next(self.consume(KernelCmdline), None)
+        if not cmdline:
+            raise StopActorExecutionError('Cannot check FIPS state due to missing command line parameters',
+                                          details={'Problem': 'Did not receive a message with kernel command '
+                                                              'line parameters (KernelCmdline)'})
+        for parameter in cmdline.parameters:
+            if parameter.key == 'fips' and parameter.value == '1':
+                title = 'Cannot upgrade a system with FIPS mode enabled'
+                summary = 'Leapp has detected that FIPS is enabled on this system. ' \
+                          'In-place upgrade of systems in FIPS mode is currently unsupported.'
+                reporting.create_report([
+                    reporting.Title(title),
+                    reporting.Summary(summary),
+                    reporting.Severity(reporting.Severity.HIGH),
+                    reporting.Tags([reporting.Tags.SECURITY]),
+                    reporting.Flags([reporting.Flags.INHIBITOR])
+                ])

--- a/repos/system_upgrade/el7toel8/actors/checkfips/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfips/tests/unit_test.py
@@ -1,0 +1,38 @@
+import pytest
+
+from leapp.models import KernelCmdline, KernelCmdlineArg, Report
+from leapp.snactor.fixture import current_actor_context
+
+
+ballast1 = [KernelCmdlineArg(key=k, value=v) for k, v in [
+    ('BOOT_IMAGE', '/vmlinuz-3.10.0-1127.el7.x86_64'),
+    ('root', '/dev/mapper/rhel_ibm--p8--kvm--03--guest--02-root'),
+    ('ro', ''),
+    ('console', 'tty0'),
+    ('console', 'ttyS0,115200'),
+    ('rd_NO_PLYMOUTH', '')]]
+ballast2 = [KernelCmdlineArg(key=k, value=v) for k, v in [
+    ('crashkernel', 'auto'),
+    ('rd.lvm.lv', 'rhel_ibm-p8-kvm-03-guest-02/root'),
+    ('rd.lvm.lv', 'rhel_ibm-p8-kvm-03-guest-02/swap'),
+    ('rhgb', ''),
+    ('quiet', ''),
+    ('LANG', 'en_US.UTF-8')]]
+
+
+@pytest.mark.parametrize('parameters,expected_report', [
+    ([], False),
+    ([KernelCmdlineArg(key='fips', value='')], False),
+    ([KernelCmdlineArg(key='fips', value='0')], False),
+    ([KernelCmdlineArg(key='fips', value='1')], True),
+    ([KernelCmdlineArg(key='fips', value='11')], False),
+    ([KernelCmdlineArg(key='fips', value='yes')], False)
+])
+def test_check_fips(current_actor_context, parameters, expected_report):
+    cmdline = KernelCmdline(parameters=ballast1+parameters+ballast2)
+    current_actor_context.feed(cmdline)
+    current_actor_context.run()
+    if expected_report:
+        assert current_actor_context.consume(Report)
+    else:
+        assert not current_actor_context.consume(Report)

--- a/repos/system_upgrade/el7toel8/actors/scankernelcmdline/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scankernelcmdline/actor.py
@@ -1,0 +1,26 @@
+from leapp.actors import Actor
+from leapp.libraries.stdlib import run
+from leapp.models import KernelCmdline, KernelCmdlineArg
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanKernelCmdline(Actor):
+    """
+    No documentation has been provided for the scan_kernel_cmdline actor.
+    """
+
+    name = 'scan_kernel_cmdline'
+    consumes = ()
+    produces = (KernelCmdline,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        cmdline = run(['cat', '/proc/cmdline'])['stdout'].strip()
+        parameters = []
+        for parameter in cmdline.split(' '):
+            if '=' in parameter:
+                kv = parameter.split('=')
+                parameters.append(KernelCmdlineArg(key=kv[0], value=kv[1]))
+            else:
+                parameters.append(KernelCmdlineArg(key=parameter))
+        self.produce(KernelCmdline(parameters=parameters))

--- a/repos/system_upgrade/el7toel8/models/kernelcmdlineargs.py
+++ b/repos/system_upgrade/el7toel8/models/kernelcmdlineargs.py
@@ -4,9 +4,20 @@ from leapp.topics import SystemInfoTopic
 
 class KernelCmdlineArg(Model):
     """
-    Single kernel command line argument to include to RHEL-8 kernel cmdline
+    Single kernel command line parameter with/without a value
+
+    When produced alone, represents a parameter to include in RHEL-8 kernel cmdline.
     """
     topic = SystemInfoTopic
 
     key = fields.String()
-    value = fields.String()
+    value = fields.Nullable(fields.String())
+
+
+class KernelCmdline(Model):
+    """
+    Kernel command line parameters the system was booted with
+    """
+    topic = SystemInfoTopic
+
+    parameters = fields.List(fields.Model(KernelCmdlineArg))


### PR DESCRIPTION
Due to a multitude of issues we've encountered, we can't ensure a stable and FIPS-compliant upgrade if FIPS is enabled. Because of that, if FIPS is detected as enabled in kernel command line (`fips=1`), we inhibit the upgrade.

Included is a model and an actor for scanning the kernel command line, since we didn't have one.