### PR TITLE
Revert "Make authconfig->authselect actors non-experimental"

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/authselectapply/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectapply/actor.py
@@ -3,7 +3,7 @@ from leapp.libraries.stdlib import run, CalledProcessError
 from leapp.models import Authselect, AuthselectDecision
 from leapp import reporting
 from leapp.reporting import Report, create_report
-from leapp.tags import IPUWorkflowTag, ApplicationsPhaseTag
+from leapp.tags import IPUWorkflowTag, ApplicationsPhaseTag, ExperimentalTag
 
 
 resources = [
@@ -24,7 +24,7 @@ class AuthselectApply(Actor):
     name = 'authselect_apply'
     consumes = (Authselect, AuthselectDecision,)
     produces = (Report,)
-    tags = (IPUWorkflowTag, ApplicationsPhaseTag)
+    tags = (IPUWorkflowTag, ApplicationsPhaseTag, ExperimentalTag)
 
     def process(self):
         model = next(self.consume(Authselect))

--- a/repos/system_upgrade/el7toel8/actors/authselectcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectcheck/actor.py
@@ -4,7 +4,7 @@ from leapp.dialogs.components import BooleanComponent
 from leapp.models import Authselect, AuthselectDecision
 from leapp.reporting import Report, create_report
 from leapp import reporting
-from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag
 
 
 resources = [
@@ -26,7 +26,7 @@ class AuthselectCheck(Actor):
     name = 'authselect_check'
     consumes = (Authselect,)
     produces = (AuthselectDecision, Report,)
-    tags = (IPUWorkflowTag, ChecksPhaseTag)
+    tags = (IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag)
     dialogs = (
         Dialog(
             scope='authselect_check',

--- a/repos/system_upgrade/el7toel8/actors/authselectscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectscanner/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import AuthselectScannerLibrary, Authconfig, DConf, read_file
 from leapp.libraries.common.pam import PAM
 from leapp.models import Authselect
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag, ExperimentalTag
 
 
 class AuthselectScanner(Actor):
@@ -43,7 +43,7 @@ class AuthselectScanner(Actor):
     name = 'authselect_scanner'
     consumes = ()
     produces = (Authselect,)
-    tags = (IPUWorkflowTag, FactsPhaseTag)
+    tags = (IPUWorkflowTag, FactsPhaseTag, ExperimentalTag)
 
     known_modules = [
         'pam_access',

--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulesapply/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulesapply/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import comment_modules, read_file
 from leapp.libraries.common.pam import PAM
 from leapp.models import RemovedPAMModules
-from leapp.tags import IPUWorkflowTag, PreparationPhaseTag
+from leapp.tags import IPUWorkflowTag, PreparationPhaseTag, ExperimentalTag
 
 
 class RemoveOldPAMModulesApply(Actor):
@@ -14,7 +14,7 @@ class RemoveOldPAMModulesApply(Actor):
     name = 'removed_pam_modules_apply'
     consumes = (RemovedPAMModules,)
     produces = ()
-    tags = (IPUWorkflowTag, PreparationPhaseTag)
+    tags = (IPUWorkflowTag, PreparationPhaseTag, ExperimentalTag)
 
     def process(self):
         for model in self.consume(RemovedPAMModules):

--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulescheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulescheck/actor.py
@@ -4,7 +4,7 @@ from leapp.dialogs.components import BooleanComponent
 from leapp.models import RemovedPAMModules
 from leapp.reporting import Report, create_report
 from leapp import reporting
-from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag
 
 
 class RemoveOldPAMModulesCheck(Actor):
@@ -18,7 +18,7 @@ class RemoveOldPAMModulesCheck(Actor):
     name = 'removed_pam_modules_check'
     consumes = (RemovedPAMModules,)
     produces = (Report,)
-    tags = (IPUWorkflowTag, ChecksPhaseTag)
+    tags = (IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag)
     dialogs = (
         Dialog(
             scope='remove_pam_pkcs11_module_check',

--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulesscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulesscanner/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import RemoveOldPAMModulesScannerLibrary
 from leapp.libraries.common.pam import PAM
 from leapp.models import RemovedPAMModules
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag, ExperimentalTag
 
 
 class RemoveOldPAMModulesScanner(Actor):
@@ -16,7 +16,7 @@ class RemoveOldPAMModulesScanner(Actor):
     name = 'removed_pam_modules_scanner'
     consumes = ()
     produces = (RemovedPAMModules,)
-    tags = (IPUWorkflowTag, FactsPhaseTag)
+    tags = (IPUWorkflowTag, FactsPhaseTag, ExperimentalTag)
 
     def process(self):
         pam = PAM.from_system_configuration()


### PR DESCRIPTION
- This reverts commit 51a93e75acf50b7fafac3a27dc1b95e944bd2edd.
- We have decided to not use the answerfile functionality for the next
  release of Leapp as it is not mature enough - there are still some bugs.
  We'll actually keep functionality in the framework, but it just won't be
  used actors now.