### PR TITLE
Fix/get target repoids

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -143,7 +143,8 @@ def gather_target_repositories(context):
     :rtype: List(string)
     """
     # Get the RHSM repos available in the RHEL 8 container
-    available_repos = rhsm.get_available_repo_ids(context, releasever=api.current_actor().configuration.version.target)
+    # FIXME: this cannot happen with custom --no-rhsm setup
+    available_repos = rhsm.get_available_repo_ids(context)
 
     # FIXME: check that required repo IDs (baseos, appstream)
     # + or check that all required RHEL repo IDs are available.

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
@@ -171,7 +171,7 @@ def test_consume_data(monkeypatch, raised, pkg_msgs, rhsm_info, xfs, storage):
 def test_gather_target_repositories(monkeypatch):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     # The available RHSM repos
-    monkeypatch.setattr(rhsm, 'get_available_repo_ids', lambda x, releasever: ['repoidX', 'repoidY', 'repoidZ'])
+    monkeypatch.setattr(rhsm, 'get_available_repo_ids', lambda x: ['repoidX', 'repoidY', 'repoidZ'])
     monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: False)
     # The required RHEL repos based on the repo mapping and PES data + custom repos required by third party actors
     monkeypatch.setattr(api, 'consume', lambda x: iter([models.TargetRepositories(
@@ -186,7 +186,7 @@ def test_gather_target_repositories(monkeypatch):
 
 def test_gather_target_repositories_none_available(monkeypatch):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
-    monkeypatch.setattr(rhsm, 'get_available_repo_ids', lambda x, releasever: [])
+    monkeypatch.setattr(rhsm, 'get_available_repo_ids', lambda x: [])
     monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: False)
     with pytest.raises(StopActorExecutionError) as err:
         userspacegen.gather_target_repositories(None)
@@ -200,7 +200,7 @@ def test_gather_target_repositories_required_not_available(monkeypatch):
 
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
     # The available RHSM repos
-    monkeypatch.setattr(rhsm, 'get_available_repo_ids', lambda x, releasever: ['repoidA', 'repoidB', 'repoidC'])
+    monkeypatch.setattr(rhsm, 'get_available_repo_ids', lambda x: ['repoidA', 'repoidB', 'repoidC'])
     monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: False)
     # The required RHEL repos based on the repo mapping and PES data + custom repos required by third party actors
     monkeypatch.setattr(api, 'consume', lambda x: iter([models.TargetRepositories(

--- a/repos/system_upgrade/el7toel8/libraries/repofileutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/repofileutils.py
@@ -1,0 +1,85 @@
+import json
+
+from leapp.libraries.common import mounting, utils
+from leapp.models import RepositoryFile, RepositoryData, fields
+
+
+def _parse_repository(repoid, repo_data):
+    def asbool(x):
+        return x == '1'
+    prepared = {'repoid': repoid, 'additional_fields': {}}
+    for key in repo_data.keys():
+        if key in RepositoryData.fields:
+            if isinstance(RepositoryData.fields[key], fields.Boolean):
+                repo_data[key] = asbool(repo_data[key])
+            prepared[key] = repo_data[key]
+        else:
+            prepared['additional_fields'][key] = repo_data[key]
+    prepared['additional_fields'] = json.dumps(prepared['additional_fields'])
+    return RepositoryData(**prepared)
+
+
+def parse_repofile(repofile):
+    """
+    Parse the given repo file.
+
+    :param repofile: Path to the repo file
+    :type repofile: str
+    :rtype: RepositoryFile
+    """
+    data = []
+    with open(repofile, mode='r') as fp:
+        cp = utils.parse_config(fp, strict=False)
+        for repoid in cp.sections():
+            data.append(_parse_repository(repoid, dict(cp.items(repoid))))
+    return RepositoryFile(file=repofile, data=data)
+
+
+def get_parsed_repofiles(context=mounting.NotIsolatedActions(base_dir='/')):
+    """
+    Scan all repositories on the system.
+
+    Repositories are scanned under /etc/yum.repos.d/ of the given context.
+    By default the context is the host system.
+
+    ATTENTION: Do not forget to ensure the redhat.repo file is regenerated
+    by RHSM when used.
+
+    :param context: An instance of a mounting.IsolatedActions class
+    :type context: mounting.IsolatedActions class
+    :rtype: List(RepositoryFile)
+    """
+    repofiles = []
+    cmd = ['find', '/etc/yum.repos.d/', '-type', 'f', '-name', '*.repo']
+    repofiles_paths = context.call(cmd, split=True)['stdout']
+    for repofile_path in repofiles_paths:
+        repofile = parse_repofile(context.full_path(repofile_path))
+        # we want full path in cotext, not the real full path
+        repofile.file = repofile_path
+        repofiles.append(repofile)
+    return repofiles
+
+
+def _invert_dict(data):
+    """{a: [b]} -> {b: [a]}"""
+    inv_dict = {}
+    for key in data.keys():
+        for value in data[key]:
+            inv_dict[value] = inv_dict.get(value, []) + [key]
+    return inv_dict
+
+
+def get_duplicate_repositories(repofiles):
+    """
+    Return dict of duplicate repositories {repoid: [repofile_path]}
+
+    A repository is defined multiple times if it exists in multiple repofiles.
+    Redefinition inside one repository file is ignored (same in DNF).
+
+    :param repofiles:
+    :type repofiles: List(RepositoryFile)
+    :rtype: dict {repoid: repofilepath}
+    """
+    rf_repos = {repofile.file: [repo.repoid for repo in repofile.data] for repofile in repofiles}
+    repos = _invert_dict(rf_repos)
+    return {repo: set(rfiles) for repo, rfiles in repos.items() if len(set(rfiles)) > 1}

--- a/repos/system_upgrade/el7toel8/libraries/tests/sample_repos.txt
+++ b/repos/system_upgrade/el7toel8/libraries/tests/sample_repos.txt
@@ -1,0 +1,28 @@
+[AppStream]
+name=CentOS-$releasever - AppStream
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=AppStream&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/$releasever/AppStream/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+cost=77
+
+[leapp-copr]
+name=Copr repo for devel Leapp builds
+baseurl=http://coprbe.devel.redhat.com/results/oam-group/leapp/rhel-7-x86_64/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=0
+gpgkey=http://coprbe.devel.redhat.com/results/oam-group/leapp/pubkey.gpg
+repo_gpgcheck=0
+enabled=0
+enabled_metadata=1
+
+[spe-ci_al.cha:rs]
+name=Special characters test
+
+[duplicate]
+name=Duplicate 1
+
+[duplicate]
+name=Duplicate 2

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_repofileutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_repofileutils.py
@@ -1,0 +1,47 @@
+import json
+
+from leapp.libraries.common import repofileutils
+
+
+def test_invert_dict():
+    input_dict = {1: ['a', 'b'], 2: ['b'], 3: []}
+    inv_dict = repofileutils._invert_dict(input_dict)
+    assert inv_dict == {'a': [1], 'b': [1, 2]}
+
+
+def test_parse_repofile():
+    repofile = repofileutils.parse_repofile('tests/sample_repos.txt')
+
+    repo_appstream = [repo for repo in repofile.data if repo.repoid == 'AppStream'][0]
+    assert repo_appstream.name == 'CentOS-$releasever - AppStream'
+    assert repo_appstream.baseurl is None  # comments shouldn't get parsed
+    assert repo_appstream.metalink is None
+    assert repo_appstream.mirrorlist == ('http://mirrorlist.centos.org/?release=$releasever'
+                                         '&arch=$basearch&repo=AppStream&infra=$infra')
+    assert repo_appstream.enabled is True
+    additional_appstream = json.loads(repo_appstream.additional_fields)
+    assert additional_appstream['gpgcheck'] == '1'
+    assert additional_appstream['gpgkey'] == 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'
+    assert additional_appstream['cost'] == '77'
+    assert additional_appstream.get('baseurl') is None
+
+    repo_leapp = [repo for repo in repofile.data if repo.repoid == 'leapp-copr'][0]
+    assert repo_leapp.name == 'Copr repo for devel Leapp builds'
+    assert repo_leapp.baseurl == 'http://coprbe.devel.redhat.com/results/oam-group/leapp/rhel-7-x86_64/'
+    assert repo_leapp.metalink is None
+    assert repo_leapp.mirrorlist is None
+    assert repo_leapp.enabled is False
+    additional_leapp = json.loads(repo_leapp.additional_fields)
+    assert additional_leapp['type'] == 'rpm-md'
+    assert additional_leapp['skip_if_unavailable'] == 'True'
+    assert additional_leapp['gpgcheck'] == '0'
+    assert additional_leapp['gpgkey'] == 'http://coprbe.devel.redhat.com/results/oam-group/leapp/pubkey.gpg'
+    assert additional_leapp['repo_gpgcheck'] == '0'
+    assert additional_leapp['enabled_metadata'] == '1'
+    assert len(additional_leapp) == 6
+
+    assert len([repo for repo in repofile.data if repo.repoid == 'spe-ci_al.cha:rs']) == 1
+
+    repos_duplicate = [repo for repo in repofile.data if repo.repoid == 'duplicate']
+    assert len(repos_duplicate) == 1  # only one instance got through
+    assert repos_duplicate[0].name == 'Duplicate 2'  # and it's the latter one

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_rhsm.py
@@ -4,9 +4,10 @@ import pytest
 
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common import rhsm
+from leapp.libraries.common import repofileutils, rhsm
 from leapp.libraries.common.testutils import create_report_mocked
 from leapp.libraries.stdlib import CalledProcessError, api
+from leapp.models import RepositoryFile, RepositoryData
 
 Repository = namedtuple('Repository', ['repoid', 'file'])
 LIST_SEPARATOR = '\n    - '
@@ -48,32 +49,48 @@ class LoggerMocked(object):
         return self
 
 
-@pytest.mark.parametrize('releasever', ['8.2', None])
-@pytest.mark.parametrize('available_repos', [
+def _gen_repo(repoid):
+    return RepositoryData(repoid=repoid, name='name {}'.format(repoid))
+
+
+def _gen_repofile(rfile, data=None):
+    if data is None:
+        data = [_gen_repo("{}-{}".format(rfile.split("/")[-1], i)) for i in range(3)]
+    return RepositoryFile(file=rfile, data=data)
+
+
+@pytest.mark.parametrize('other_repofiles', [
     [],
-    [Repository(repoid='repoidX', file=rhsm._DEFAULT_RHSM_REPOFILE),
-     Repository(repoid='repoidY', file='random_test_file')]
+    [_gen_repofile("foo")],
+    [_gen_repofile("foo"), _gen_repofile("bar")],
 ])
-def test_get_available_repo_ids(monkeypatch, releasever, available_repos):
+@pytest.mark.parametrize('rhsm_repofile', [
+    None,
+    _gen_repofile(rhsm._DEFAULT_RHSM_REPOFILE, []),
+    _gen_repofile(rhsm._DEFAULT_RHSM_REPOFILE, [_gen_repo("rh-0")]),
+    _gen_repofile(rhsm._DEFAULT_RHSM_REPOFILE),
+])
+def test_get_available_repo_ids(monkeypatch, other_repofiles, rhsm_repofile):
     context_mocked = IsolatedActionsMocked()
-    monkeypatch.setattr(rhsm, '_inhibit_on_duplicate_repos', lambda x: None)
-    monkeypatch.setattr(rhsm, '_get_repos', lambda x: iter(available_repos))
+    repos = other_repofiles[:]
+    if rhsm_repofile:
+        repos.append(rhsm_repofile)
+    rhsm_repos = [repo.repoid for repo in rhsm_repofile.data] if rhsm_repofile else []
+
     monkeypatch.setattr(api, 'current_logger', LoggerMocked())
+    monkeypatch.setattr(rhsm, '_inhibit_on_duplicate_repos', lambda x: None)
+    monkeypatch.setattr(repofileutils, 'get_parsed_repofiles', lambda x: repos)
 
-    available_repos = rhsm.get_available_repo_ids(context_mocked, releasever)
+    result = rhsm.get_available_repo_ids(context_mocked)
 
-    if releasever:
-        assert context_mocked.commands_called == [['yum', 'repoinfo', '--releasever', '8.2']]
-    else:
-        assert context_mocked.commands_called == [['yum', 'repoinfo']]
-    if available_repos:
-        available_repoid = 'repoidX'
-        assert available_repos == [available_repoid]
+    rhsm_repos.sort()
+    assert context_mocked.commands_called == [['yum', 'clean', 'all']]
+    assert result == rhsm_repos
+    if result:
         assert api.current_logger.infomsg == (
             'The following repoids are available through RHSM:{0}{1}'
-            .format(LIST_SEPARATOR, available_repoid))
+            .format(LIST_SEPARATOR, LIST_SEPARATOR.join(rhsm_repos)))
     else:
-        assert available_repos == []
         assert api.current_logger.infomsg == 'There are no repos available through RHSM.'
 
 
@@ -83,95 +100,35 @@ def test_get_available_repo_ids_error():
     with pytest.raises(StopActorExecutionError) as err:
         rhsm.get_available_repo_ids(context_mocked)
 
-    assert 'Unable to get list of available yum repositories.' in str(err)
-    assert "Command ['yum', 'repoinfo'] failed" in err.value.details['details']
-
-
-YUM_REPOINFO_TYPICAL = ("""
-Repo-id      : custom-repo-id
-Repo-name    : Custom repository
-Repo-revision: 1583940534
-Repo-updated : Wed Mar 11 15:28:55 2020
-Repo-pkgs    : 548
-Repo-size    : 1.2 G
-Repo-baseurl : http://custom-repo-url/
-Repo-expire  : 21,600 second(s) (last: Wed Mar 11 16:05:04 2020)
-  Filter     : read-only:present
-Repo-excluded: 205
-Repo-filename: /etc/yum.repos.d/custom-repo.repo
-
-Repo-id      : rhel-7-server-rpms/7Server/x86_64
-Repo-name    : Red Hat Enterprise Linux 7 Server (RPMs)
-Repo-revision: 1583726307
-Repo-updated : Mon Mar  9 03:58:27 2020
-Repo-pkgs    : 5,231
-Repo-size    : 3.6 G
-Repo-baseurl : https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os
-Repo-expire  : 86,400 second(s) (last: Mon Mar  9 21:06:18 2020)
-  Filter     : read-only:present
-Repo-filename: /etc/yum.repos.d/redhat.repo
-
-repolist: 5,779
-""")
-
-
-YUM_REPOINFO_DUPS = ("""
-Repository rhel-7-server-eus-rpms is listed more than once in the configuration
-Repository rhel-7-server-extras-rpms is listed more than once in the configuration
-Repository rhel-7-server-eus-optional-rpms is listed more than once in the configuration
-""")
+    assert 'Unable to use yum' in str(err)
 
 
 def test_inhibit_on_duplicate_repos(monkeypatch):
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     monkeypatch.setattr(api, 'current_logger', LoggerMocked())
+    repofiles = [
+        _gen_repofile("foo", [_gen_repo('repoX'), _gen_repo('repoY')]),
+        _gen_repofile("bar", [_gen_repo('repoX')]),
+    ]
 
-    rhsm._inhibit_on_duplicate_repos(YUM_REPOINFO_DUPS + YUM_REPOINFO_TYPICAL)
+    rhsm._inhibit_on_duplicate_repos(repofiles)
 
-    dups = ['rhel-7-server-eus-rpms', 'rhel-7-server-extras-rpms', 'rhel-7-server-eus-optional-rpms']
+    dups = ['repoX']
     assert ('The following repoids are defined multiple times:{0}{1}'
             .format(LIST_SEPARATOR, LIST_SEPARATOR.join(dups))) in api.current_logger.warnmsg
     assert reporting.create_report.called == 1
     assert 'inhibitor' in reporting.create_report.report_fields['flags']
     assert reporting.create_report.report_fields['title'] == 'A YUM/DNF repository defined multiple times'
-    assert ('the following repositories are defined multiple times:{0}{1}'
-            .format(LIST_SEPARATOR, LIST_SEPARATOR.join(dups))) in reporting.create_report.report_fields['summary']
+    summary = ('The following repositories are defined multiple times:{0}{1}'
+               .format(LIST_SEPARATOR, LIST_SEPARATOR.join(dups)))
+    assert summary in reporting.create_report.report_fields['summary']
 
 
 def test_inhibit_on_duplicate_repos_no_dups(monkeypatch):
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     monkeypatch.setattr(api, 'current_logger', LoggerMocked())
 
-    rhsm._inhibit_on_duplicate_repos(YUM_REPOINFO_TYPICAL)
+    rhsm._inhibit_on_duplicate_repos([_gen_repofile("foo")])
 
     assert api.current_logger.warnmsg is None
     assert reporting.create_report.called == 0
-
-
-def test_get_repos():
-    repos = list(rhsm._get_repos(YUM_REPOINFO_TYPICAL))
-
-    assert repos == [Repository(repoid='custom-repo-id', file='/etc/yum.repos.d/custom-repo.repo'),
-                     Repository(repoid='rhel-7-server-rpms', file='/etc/yum.repos.d/redhat.repo')]
-
-
-# There's an additional space between 'Repo-filename' and ':'
-YUM_REPOINFO_ADDITIONAL_SPACE = ("""Repo-id      : rhel-7-server-rpms/7Server/x86_64
-Repo-name    : Red Hat Enterprise Linux 7 Server (RPMs)
-Repo-revision: 1583726307
-Repo-updated : Mon Mar  9 03:58:27 2020
-Repo-pkgs    : 5,231
-Repo-size    : 3.6 G
-Repo-baseurl : https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os
-Repo-expire  : 86,400 second(s) (last: Mon Mar  9 21:06:18 2020)
-  Filter     : read-only:present
-Repo-filename : /etc/yum.repos.d/redhat.repo""")
-
-
-def test_parse_repo_params():
-    with pytest.raises(StopActorExecutionError) as err:
-        rhsm._parse_repo_params(YUM_REPOINFO_ADDITIONAL_SPACE)
-
-    assert 'Failed to parse the `yum repoinfo` output' in str(err)
-    assert ("Failed to parse the 'Repo-filename' repo parameter within the following part of the `yum repoinfo`"
-            " output:\n{0}".format(YUM_REPOINFO_ADDITIONAL_SPACE)) in err.value.details['details']

--- a/repos/system_upgrade/el7toel8/libraries/utils.py
+++ b/repos/system_upgrade/el7toel8/libraries/utils.py
@@ -8,7 +8,7 @@ from leapp.libraries.common import mounting
 from leapp.libraries.stdlib import STDOUT, CalledProcessError, api, config, run
 
 
-def parse_config(cfg=None):
+def parse_config(cfg=None, strict=True):
     """
     Applies a workaround to parse a config file using py3 AND py2
 
@@ -17,8 +17,12 @@ def parse_config(cfg=None):
     ConfigParser on Py2 and Py3
 
     :type cfg: str
+    :type strict: bool
     """
-    parser = six.moves.configparser.ConfigParser()
+    if six.PY3:
+        parser = six.moves.configparser.ConfigParser(strict=strict)  # pylint: disable=unexpected-keyword-arg
+    else:
+        parser = six.moves.configparser.ConfigParser()
 
     # we do not handle exception here, handle with it when these function is called
     if cfg and six.PY3:


### PR DESCRIPTION
    add repository_scanning library and rewrite scan of repos
    
    We realized that we cannot use YUM reliably to get information about
    repositories in all cases (similar to DNF) with connection to RHSM...
    
    Issues with YUM:
      `yum repolist` downloads metadata about repositories (which we do
      not need) and with set --releasever to 8.x, many URLs of repos
      are invalid. E.g.:
          http://example.com/rhel7/$releasever/os
      will be in evaluated as:
          http://example.com/rhel7/8.x/os
      which causes crash.
    
    Issues with DNF:
      By default, the rhsm plugin for dnf is not installed on the system
      and not sure whether coexistence of yum & dnf is safe when used
      plugins for RHSM in the same time as RHSM itself is very tricky
      and we spent already too much time to fix every feature around.
    
    For these reasons we scan repositories directly. The final code is
    based on @shaded-enmity implementation used in the systemfacts actor.
    Unfortunately, we still have to think about RHSM, in this case, we
    need to use YUM to regenerate the redhat.repo file inside container
    to get RHEL 8 content. Currently the `yum clean all` is used, but
    ideally it should be replaced by something that will not do anythin
    but redeploy redhat.repo file using RHSM.

Related ticket: OAMG-2923