### PR TITLE
Custom repos

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -30,7 +30,7 @@ Requires:       leapp-repository-dependencies = 5
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' this instead of the real framework rpm version.
-Requires:       leapp-framework >= 1.1, leapp-framework < 2
+Requires:       leapp-framework >= 1.2, leapp-framework < 2
 Requires:       python2-leapp
 
 # That's temporary to ensure the obsoleted subpackage is not installed

--- a/repos/system_upgrade/el7toel8/actors/checkrhsmsku/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrhsmsku/actor.py
@@ -9,7 +9,8 @@ class CheckRedHatSubscriptionManagerSKU(Actor):
     Ensure the system is subscribed to the subscription manager
 
     This actor verifies that the system is correctly subscribed to via the Red Hat Subscription Manager and
-    has attached SKUs. The actor will inhibit the upgrade if there are none.
+    has attached SKUs. The actor will inhibit the upgrade if there are none and RHSM is not supposed
+    to be skipped.
     """
 
     name = 'check_rhsmsku'

--- a/repos/system_upgrade/el7toel8/actors/checkrhsmsku/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrhsmsku/actor.py
@@ -1,8 +1,6 @@
 from leapp.actors import Actor
-from leapp.libraries.common import rhsm
+from leapp.libraries.actor import library
 from leapp.models import Report, RHSMInfo
-from leapp.reporting import create_report
-from leapp import reporting
 from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
 
 
@@ -20,19 +18,4 @@ class CheckRedHatSubscriptionManagerSKU(Actor):
     tags = (IPUWorkflowTag, ChecksPhaseTag)
 
     def process(self):
-        if not rhsm.skip_rhsm():
-            for info in self.consume(RHSMInfo):
-                if not info.attached_skus:
-                    create_report([
-                        reporting.Title('The system is not registered or subscribed.'),
-                        reporting.Summary(
-                            'The system has to be registered and subscribed to be able to proceed the upgrade.'
-                        ),
-                        reporting.Severity(reporting.Severity.HIGH),
-                        reporting.Tags([reporting.Tags.SANITY]),
-                        reporting.Flags([reporting.Flags.INHIBITOR]),
-                        reporting.Remediation(
-                            hint='Register your system with the subscription-manager tool and attach it to proper SKUs'
-                                 ' to be able to proceed the upgrade.'),
-                        reporting.RelatedResource('package', 'subscription-manager')
-                    ])
+        library.process()

--- a/repos/system_upgrade/el7toel8/actors/checkrhsmsku/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrhsmsku/libraries/library.py
@@ -1,0 +1,24 @@
+from leapp import reporting
+from leapp.libraries.common import rhsm
+from leapp.libraries.stdlib import api
+from leapp.models import RHSMInfo
+from leapp.reporting import create_report
+
+
+def process():
+    if not rhsm.skip_rhsm():
+        for info in api.consume(RHSMInfo):
+            if not info.attached_skus:
+                create_report([
+                    reporting.Title('The system is not registered or subscribed.'),
+                    reporting.Summary(
+                        'The system has to be registered and subscribed to be able to proceed the upgrade.'
+                    ),
+                    reporting.Severity(reporting.Severity.HIGH),
+                    reporting.Tags([reporting.Tags.SANITY]),
+                    reporting.Flags([reporting.Flags.INHIBITOR]),
+                    reporting.Remediation(
+                        hint='Register your system with the subscription-manager tool and attach it to proper SKUs'
+                             ' to be able to proceed the upgrade.'),
+                    reporting.RelatedResource('package', 'subscription-manager')
+                ])

--- a/repos/system_upgrade/el7toel8/actors/checkrhsmsku/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrhsmsku/libraries/library.py
@@ -12,13 +12,16 @@ def process():
                 create_report([
                     reporting.Title('The system is not registered or subscribed.'),
                     reporting.Summary(
-                        'The system has to be registered and subscribed to be able to proceed the upgrade.'
+                        'The system has to be registered and subscribed to be able to proceed'
+                        ' with the upgrade, unless the --no-rhsm option is specified when'
+                        ' executing leapp.'
                     ),
                     reporting.Severity(reporting.Severity.HIGH),
                     reporting.Tags([reporting.Tags.SANITY]),
                     reporting.Flags([reporting.Flags.INHIBITOR]),
                     reporting.Remediation(
-                        hint='Register your system with the subscription-manager tool and attach it to proper SKUs'
-                             ' to be able to proceed the upgrade.'),
+                        hint='Register your system with the subscription-manager tool and attach'
+                             ' proper SKUs to be able to proceed the upgrade or use the --no-rhsm'
+                             ' leapp option if you want to provide target repositories by yourself.'),
                     reporting.RelatedResource('package', 'subscription-manager')
                 ])

--- a/repos/system_upgrade/el7toel8/actors/checkrhsmsku/tests/test_rhsmsku.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrhsmsku/tests/test_rhsmsku.py
@@ -4,7 +4,7 @@ from leapp.models import Report, RHSMInfo
 
 def test_sku_report_skipped(monkeypatch, current_actor_context):
     with monkeypatch.context() as context:
-        context.setenv('LEAPP_DEVEL_SKIP_RHSM', '1')
+        context.setenv('LEAPP_NO_RHSM', '1')
         current_actor_context.feed(RHSMInfo(attached_skus=[]))
         current_actor_context.run()
         assert not list(current_actor_context.consume(Report))
@@ -12,7 +12,7 @@ def test_sku_report_skipped(monkeypatch, current_actor_context):
 
 def test_sku_report_has_skus(monkeypatch, current_actor_context):
     with monkeypatch.context() as context:
-        context.setenv('LEAPP_DEVEL_SKIP_RHSM', '0')
+        context.setenv('LEAPP_NO_RHSM', '0')
         current_actor_context.feed(RHSMInfo(attached_skus=['testing-sku']))
         current_actor_context.run()
         assert not list(current_actor_context.consume(Report))
@@ -20,7 +20,7 @@ def test_sku_report_has_skus(monkeypatch, current_actor_context):
 
 def test_sku_report_has_no_skus(monkeypatch, current_actor_context):
     with monkeypatch.context() as context:
-        context.setenv('LEAPP_DEVEL_SKIP_RHSM', '0')
+        context.setenv('LEAPP_NO_RHSM', '0')
         current_actor_context.feed(RHSMInfo(attached_skus=[]))
         current_actor_context.run()
         reports = list(current_actor_context.consume(Report))

--- a/repos/system_upgrade/el7toel8/actors/checkrhsmsku/tests/test_rhsmsku.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrhsmsku/tests/test_rhsmsku.py
@@ -1,30 +1,34 @@
+
+from leapp import reporting
+from leapp.libraries.actor import library
 from leapp.libraries.common import rhsm
-from leapp.models import Report, RHSMInfo
+from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import RHSMInfo
 
 
-def test_sku_report_skipped(monkeypatch, current_actor_context):
-    with monkeypatch.context() as context:
-        context.setenv('LEAPP_NO_RHSM', '1')
-        current_actor_context.feed(RHSMInfo(attached_skus=[]))
-        current_actor_context.run()
-        assert not list(current_actor_context.consume(Report))
+def test_sku_report_skipped(monkeypatch):
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: True)
+    monkeypatch.setattr(api, 'consume', lambda x: (RHSMInfo(attached_skus=[]),))
+    monkeypatch.setattr(library, 'create_report', create_report_mocked())
+    library.process()
+    assert not library.create_report.called
 
 
-def test_sku_report_has_skus(monkeypatch, current_actor_context):
-    with monkeypatch.context() as context:
-        context.setenv('LEAPP_NO_RHSM', '0')
-        current_actor_context.feed(RHSMInfo(attached_skus=['testing-sku']))
-        current_actor_context.run()
-        assert not list(current_actor_context.consume(Report))
+def test_sku_report_has_skus(monkeypatch):
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: False)
+    monkeypatch.setattr(api, 'consume', lambda x: (RHSMInfo(attached_skus=['testing-sku']),))
+    monkeypatch.setattr(library, 'create_report', create_report_mocked())
+    library.process()
+    assert not library.create_report.called
 
 
-def test_sku_report_has_no_skus(monkeypatch, current_actor_context):
-    with monkeypatch.context() as context:
-        context.setenv('LEAPP_NO_RHSM', '0')
-        current_actor_context.feed(RHSMInfo(attached_skus=[]))
-        current_actor_context.run()
-        reports = list(current_actor_context.consume(Report))
-        assert reports and len(reports) == 1
-        report_fields = reports[0].report
-        assert report_fields['severity'] == 'high'
-        assert report_fields['title'] == 'The system is not registered or subscribed.'
+def test_sku_report_has_no_skus(monkeypatch):
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: False)
+    monkeypatch.setattr(api, 'consume', lambda x: (RHSMInfo(attached_skus=[]),))
+    monkeypatch.setattr(library, 'create_report', create_report_mocked())
+    library.process()
+    assert library.create_report.called == 1
+    assert library.create_report.report_fields['title'] == 'The system is not registered or subscribed.'
+    assert library.create_report.report_fields['severity'] == 'high'
+    assert 'inhibitor' in library.create_report.report_fields['flags']

--- a/repos/system_upgrade/el7toel8/actors/checktargetrepos/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checktargetrepos/actor.py
@@ -8,18 +8,23 @@ class Checktargetrepos(Actor):
     """
     Check whether target yum repositories are specified.
 
-    RHSM | CTR | CTRF || result
-    -----+-----+------++-------
-     Yes | --- | ---- || -
-    -----+-----+------++-------
-     No  | No  | No   || inhibit
-    -----+-----+------++-------
-     No  | No  | Yes  || inhibit
-    -----+-----+------++-------
-     No  | Yes | No   || warn/report info
-    -----+-----+------++-------
-     No  | Yes | Yes  || -
+    RHSM | ER | CTR | CTRF || result
+    -----+----+-----+------++-------
+     Yes | -- | --- | ---- || -
+    -----+----+-----+------++-------
+     No  | -- | No  | No   || inhibit
+    -----+----+-----+------++-------
+     No  | -- | No  | Yes  || inhibit
+    -----+----+-----+------++-------
+     No  | No | Yes | No   || warn/report info
+    -----+----+-----+------++-------
+     No  | No | Yes | Yes  || -
+    -----+----+-----+------++-------
+     No  | Yes| Yes | No   || -
+    -----+----+-----+------++-------
+     No  | Yes| Yes | Yes  || -
 
+       ER   - config.get_env('LEAPP_ENABLE_REPOS') is non-empty
        CTR  - CustomTargetRepositories found
        CTRF - the expected CustomTargetRepositoryFile found
        RHSM - RHSM is used (it is not skipped)

--- a/repos/system_upgrade/el7toel8/actors/checktargetrepos/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checktargetrepos/actor.py
@@ -1,0 +1,39 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import CustomTargetRepositoryFile, Report, TargetRepositories
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+
+
+class Checktargetrepos(Actor):
+    """
+    Check whether target yum repositories are specified.
+
+    RHSM | CTR | CTRF || result
+    -----+-----+------++-------
+     Yes | --- | ---- || -
+    -----+-----+------++-------
+     No  | No  | No   || inhibit
+    -----+-----+------++-------
+     No  | No  | Yes  || inhibit
+    -----+-----+------++-------
+     No  | Yes | No   || warn/report info
+    -----+-----+------++-------
+     No  | Yes | Yes  || -
+
+       CTR  - CustomTargetRepositories found
+       CTRF - the expected CustomTargetRepositoryFile found
+       RHSM - RHSM is used (it is not skipped)
+
+    This is not 100 % reliable check. This cover just the most obvious cases
+    that are expected to fail. Reporting of such issues in this way, here,
+    will be probably much more clear, without additional errors that could
+    be raised.
+    """
+
+    name = 'checktargetrepos'
+    consumes = (CustomTargetRepositoryFile, TargetRepositories)
+    produces = (Report)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        library.process()

--- a/repos/system_upgrade/el7toel8/actors/checktargetrepos/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checktargetrepos/libraries/library.py
@@ -1,0 +1,91 @@
+from leapp.models import CustomTargetRepositoryFile, TargetRepositories
+from leapp.libraries.stdlib import api
+from leapp import reporting
+from leapp.libraries.common import rhsm
+
+
+_IPU_DOC_URL = ('https://access.redhat.com/documentation/en-us/'
+                'red_hat_enterprise_linux/8/html-single/upgrading_to_rhel_8/index')
+# TODO: we need to provide this path in a shared library
+CUSTOM_REPO_PATH = '/etc/leapp/files/leapp_upgrade_repositories.repo'
+
+
+def _any_custom_repo_defined():
+    for tr in api.consume(TargetRepositories):
+        if tr.custom_repos:
+            return True
+    return False
+
+
+def _the_custom_repofile_defined():
+    for ctrf in api.consume(CustomTargetRepositoryFile):
+        if ctrf and ctrf.file == CUSTOM_REPO_PATH:
+            return True
+    return False
+
+
+def process():
+    if not rhsm.skip_rhsm():
+        # getting RH repositories through RHSM; resolved by seatbelts
+        # implemented in other actors
+        return
+
+    # rhsm skipped; take your seatbelts please
+    is_ctr = _any_custom_repo_defined()
+    is_ctrf = _the_custom_repofile_defined()
+    if not is_ctr:
+        # no rhsm, no custom repositories.. this will really not work :)
+        # TODO: add link to the RH article about use of custom repositories!!
+        # NOTE: we can put here now the link to the main document, as this
+        # will be described there or at least the link to the right document
+        # will be delivered here.
+        if is_ctrf:
+            summary_ctrf = 'The custom repository file has been detected. Maybe it is empty?'
+        else:
+            summary_ctrf = 'The custom repository file has not been detected.'
+        reporting.create_report([
+            reporting.Title('Using RHSM has been skipped but no custom repositories have been delivered.'),
+            reporting.Summary(
+                'Leapp is run in the mode when the Red Hat Subscription Manager'
+                ' is not used (the --no-rhsm option or the LEAPP_NO_RHSM=1'
+                ' environment variable has been set) so leapp is not able to'
+                ' obtain YUM/DNF repositories with the content for the target'
+                ' system in the standard way and has to be delivered by user'
+                ' manually.'
+                ),
+            reporting.Remediation(hint=(
+                'Create the repository file according to instructions in the'
+                ' referred document on the following path with all'
+                ' repositories that should be used during the upgrade: "{}".'
+                '\n\n{}'
+                .format(CUSTOM_REPO_PATH, summary_ctrf)
+            )),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.SANITY]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.ExternalLink(url=_IPU_DOC_URL, title='UPGRADING TO RHEL 8'),
+            reporting.RelatedResource('file', CUSTOM_REPO_PATH),
+        ])
+    elif not is_ctrf:
+        # Some custom repositories have been discovered, but the custom repo
+        # file not. Inform about the official recommended way.
+        reporting.create_report([
+            reporting.Title('CustomTargetRepositories discovered, but the CustomTargetRepositoryFile is missing.'),
+            reporting.Summary(
+                'Red Hat provides now official way how to use custom'
+                ' repositories during the in-place upgrade through'
+                ' the referred custom repository file. The CustomTargetRepositories'
+                ' have been detected (from custom actors?) but the repository'
+                ' file not.'
+            ),
+            reporting.Remediation(hint=(
+                'Follow the new simple way to enable custom repositories'
+                ' during the upgrade (see the referred document) or create'
+                ' the empty custom repository file to acknowledge this report'
+                ' message.'
+
+            )),
+            reporting.Severity(reporting.Severity.INFO),
+            reporting.ExternalLink(url=_IPU_DOC_URL, title='UPGRADING TO RHEL 8'),
+            reporting.RelatedResource('file', CUSTOM_REPO_PATH),
+        ])

--- a/repos/system_upgrade/el7toel8/actors/checktargetrepos/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/checktargetrepos/libraries/library.py
@@ -55,8 +55,8 @@ def process():
                 ' is not used (the --no-rhsm option or the LEAPP_NO_RHSM=1'
                 ' environment variable has been set) so leapp is not able to'
                 ' obtain YUM/DNF repositories with the content for the target'
-                ' system in the standard way and has to be delivered by user'
-                ' manually.'
+                ' system in the standard way. The content has to be delivered'
+                ' by the user manually.'
                 ),
             reporting.Remediation(hint=(
                 'Create the repository file according to instructions in the'
@@ -73,12 +73,12 @@ def process():
         ])
     elif not (is_ctrf or is_re):
         # Some custom repositories have been discovered, but the custom repo
-        # file not - neither the --enablerepo option is usedd. Inform about
+        # file not - neither the --enablerepo option is used. Inform about
         # the official recommended way.
         reporting.create_report([
-            reporting.Title('CustomTargetRepositories discovered, but no new provided mechanisms used.'),
+            reporting.Title('Detected "CustomTargetRepositories" without using new provided mechanisms used.'),
             reporting.Summary(
-                'Red Hat provides now official way how to use custom'
+                'Red Hat now provides an official way for using custom'
                 ' repositories during the in-place upgrade through'
                 ' the referred custom repository file or through the'
                 ' --enablerepo option for leapp. The CustomTargetRepositories'
@@ -89,7 +89,6 @@ def process():
                 ' during the upgrade (see the referred document) or create'
                 ' the empty custom repository file to acknowledge this report'
                 ' message.'
-
             )),
             reporting.Severity(reporting.Severity.INFO),
             reporting.ExternalLink(url=_IPU_DOC_URL, title='UPGRADING TO RHEL 8'),

--- a/repos/system_upgrade/el7toel8/actors/checktargetrepos/tests/test_checktargetrepos.py
+++ b/repos/system_upgrade/el7toel8/actors/checktargetrepos/tests/test_checktargetrepos.py
@@ -1,5 +1,91 @@
+from collections import namedtuple
+
+import pytest
+
+from leapp.models import (CustomTargetRepository, CustomTargetRepositoryFile, EnvVar, Report,
+                          RepositoryData, RHELTargetRepository, TargetRepositories)
+from leapp.libraries.actor import library
+from leapp import reporting
+from leapp.libraries.stdlib import api
+from leapp.libraries.common import rhsm
+from leapp.libraries.common.testutils import create_report_mocked
 
 
-# TODO: unit tests are required  (@drehak?)
-def test_sth():
-    pass
+class MockedConsume(object):
+    def __init__(self, *args):
+        self._msgs = []
+        for arg in args:
+            if not arg:
+                continue
+            if isinstance(arg, list):
+                self._msgs.extend(arg)
+            else:
+                self._msgs.append(arg)
+
+    def __call__(self, model):
+        return iter([msg for msg in self._msgs if isinstance(msg, model)])
+
+
+class CurrentActorMocked(object):
+    def __init__(self, envars=None):
+        if envars:
+            envarsList = [EnvVar(name=key, value=value) for key, value in envars.items()]
+        else:
+            envarsList = []
+        self.configuration = namedtuple('configuration', ['leapp_env_vars'])(envarsList)
+
+    def __call__(self):
+        return self
+
+
+_RHEL_REPOS = [
+    RHELTargetRepository(repoid='repo1'),
+    RHELTargetRepository(repoid='repo2'),
+    RHELTargetRepository(repoid='repo3'),
+    RHELTargetRepository(repoid='repo4'),
+]
+
+_CUSTOM_REPOS = [
+    CustomTargetRepository(repoid='repo1', name='repo1name', baseurl='repo1url', enabled=True),
+    CustomTargetRepository(repoid='repo2', name='repo2name', baseurl='repo2url', enabled=False),
+    CustomTargetRepository(repoid='repo3', name='repo3name', baseurl=None, enabled=True),
+    CustomTargetRepository(repoid='repo4', name='repo4name', baseurl=None, enabled=True),
+]
+
+_TARGET_REPOS_CUSTOM = TargetRepositories(rhel_repos=_RHEL_REPOS, custom_repos=_CUSTOM_REPOS)
+_TARGET_REPOS_NO_CUSTOM = TargetRepositories(rhel_repos=_RHEL_REPOS)
+_CUSTOM_TARGET_REPOFILE = CustomTargetRepositoryFile(file='/etc/leapp/files/leapp_upgrade_repositories.repo')
+
+
+def test_checktargetrepos_rhsm(monkeypatch):
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: False)
+    monkeypatch.setattr(api, 'consume', MockedConsume())
+    library.process()
+    assert reporting.create_report.called == 0
+
+
+@pytest.mark.parametrize('enable_repos', [True, False])
+@pytest.mark.parametrize('custom_target_repos', [True, False])
+@pytest.mark.parametrize('custom_target_repofile', [True, False])
+def test_checktargetrepos_no_rhsm(monkeypatch, enable_repos, custom_target_repos, custom_target_repofile):
+    mocked_consume = MockedConsume(_TARGET_REPOS_CUSTOM if custom_target_repos else _TARGET_REPOS_NO_CUSTOM)
+    if custom_target_repofile:
+        mocked_consume._msgs.append(_CUSTOM_TARGET_REPOFILE)
+    envvars = {'LEAPP_ENABLE_REPOS': 'hill,spencer'} if enable_repos else {}
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envvars))
+
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: True)
+    monkeypatch.setattr(api, 'consume', mocked_consume)
+
+    library.process()
+
+    if not custom_target_repos:
+        assert reporting.create_report.called == 1
+        assert 'inhibitor' in reporting.create_report.report_fields.get('flags', [])
+    elif not enable_repos and custom_target_repos and not custom_target_repofile:
+        assert reporting.create_report.called == 1
+        assert 'inhibitor' not in reporting.create_report.report_fields.get('flags', [])
+    else:
+        assert reporting.create_report.called == 0

--- a/repos/system_upgrade/el7toel8/actors/checktargetrepos/tests/test_checktargetrepos.py
+++ b/repos/system_upgrade/el7toel8/actors/checktargetrepos/tests/test_checktargetrepos.py
@@ -1,0 +1,5 @@
+
+
+# TODO: unit tests are required  (@drehak?)
+def test_sth():
+    pass

--- a/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/libraries/library.py
@@ -6,7 +6,7 @@ from leapp.models import UsedTargetRepositories
 def set_rhsm_release():
     """Set the RHSM release to the target RHEL 8 minor version."""
     if rhsm.skip_rhsm():
-        api.current_logger().debug('Skipping setting the RHSM release due to the use of LEAPP_DEVEL_SKIP_RHSM.')
+        api.current_logger().debug('Skipping setting the RHSM release due to --no-rhsm or environment variables.')
         return
 
     if config.get_product_type('target') != 'ga':
@@ -29,8 +29,8 @@ def enable_rhsm_repos():
     the known repositories.
     """
     if rhsm.skip_rhsm():
-        api.current_logger().debug('Skipping enabling repositories through subscription-manager due to the use of'
-                                   ' LEAPP_DEVEL_SKIP_RHSM.')
+        api.current_logger().debug('Skipping enabling repositories through subscription-manager due to --no-rhsm'
+                                   ' or environment variables.')
         return
     try:
         run(get_submgr_cmd(get_repos_to_enable()))

--- a/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/tests/test_enablerhsmreposonrhel8.py
+++ b/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/tests/test_enablerhsmreposonrhel8.py
@@ -93,7 +93,7 @@ def test_setrelease_submgr_throwing_error(monkeypatch):
 @pytest.mark.parametrize('product', ['beta', 'htb'])
 def test_setrelease_skip_rhsm(monkeypatch, product):
     commands_called, _ = not_isolated_actions()
-    monkeypatch.setenv('LEAPP_DEVEL_SKIP_RHSM', '1')
+    monkeypatch.setenv('LEAPP_NO_RHSM', '1')
     monkeypatch.setattr(config, 'get_product_type', lambda dummy: product)
     # To make this work we need to re-apply the decorator, so it respects the environment variable
     monkeypatch.setattr(rhsm, 'set_release', rhsm.with_rhsm(rhsm.set_release))
@@ -134,7 +134,7 @@ def test_running_submgr_fail(monkeypatch):
 
 
 def test_enable_repos_skip_rhsm(monkeypatch):
-    monkeypatch.setenv('LEAPP_DEVEL_SKIP_RHSM', '1')
+    monkeypatch.setenv('LEAPP_NO_RHSM', '1')
     monkeypatch.setattr(library, 'run', run_mocked())
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
     library.enable_rhsm_repos()

--- a/repos/system_upgrade/el7toel8/actors/removeleftoverpackages/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeleftoverpackages/actor.py
@@ -1,5 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries import stdlib
+from leapp.libraries.common import rhsm
 from leapp.libraries.common.rpms import get_installed_rpms
 from leapp.models import LeftoverPackages, RemovedPackages, RPM
 from leapp.reporting import Report
@@ -29,6 +30,9 @@ class RemoveLeftoverPackages(Actor):
 
         to_remove = ['-'.join([pkg.name, pkg.version, pkg.release]) for pkg in leftover_packages.items]
         cmd = ['dnf', 'remove', '-y', '--noautoremove'] + to_remove
+        if rhsm.skip_rhsm():
+            # ensure we don't use suscription-manager when it should be skipped
+            cmd += ['--disableplugin', 'subscription-manager']
         try:
             stdlib.run(cmd)
         except stdlib.CalledProcessError:

--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/actor.py
@@ -6,7 +6,12 @@ from leapp.tags import IPUWorkflowTag, TargetTransactionChecksPhaseTag
 
 class ReportSetTargetRelease(Actor):
     """
-    Reports that a release will be set in the subscription-manager after the upgrade.
+    Reports information related to the release set in the subscription-manager after the upgrade.
+
+    When using Red Hat subscription-manager (RHSM), the release is set by default
+    to the target version release. In case of skip of the RHSM (--no-rhsm), the
+    release stay as it is on the RHEL 7 and user has to handle it manually after
+    the upgrade.
     """
 
     name = 'report_set_target_release'

--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/tests/test_targetreleasereport.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/tests/test_targetreleasereport.py
@@ -4,6 +4,7 @@ import pytest
 
 from leapp import reporting
 from leapp.libraries.actor import library
+from leapp.libraries.common import rhsm
 from leapp.libraries.common.testutils import create_report_mocked
 from leapp.libraries.stdlib import api
 
@@ -21,8 +22,19 @@ class CurrentActorMocked(object):
 @pytest.mark.parametrize('version', ['8.{}'.format(i) for i in range(4)])
 def test_report_target_version(monkeypatch, version):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(dst_ver=version))
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: False)
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     SUMMARY_FMT = 'will be set to {}.'
     library.process()
     assert reporting.create_report.called == 1
     assert SUMMARY_FMT.format(version) in reporting.create_report.report_fields['summary']
+    assert 'is going to be set' in reporting.create_report.report_fields['title']
+
+
+def test_report_unhandled_release(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(dst_ver='8.1'))
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: True)
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    library.process()
+    assert reporting.create_report.called == 1
+    assert 'is going to be kept' in reporting.create_report.report_fields['title']

--- a/repos/system_upgrade/el7toel8/actors/scanclienablerepo/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scanclienablerepo/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import library
+from leapp.models import CustomTargetRepository
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanCLIenablrepo(Actor):
+    """
+    Produce CustomTargetRepository based on the LEAPP_ENABLE_REPOS in config.
+    """
+
+    name = 'scanclienablerepo'
+    consumes = ()
+    produces = (CustomTargetRepository)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        library.process()

--- a/repos/system_upgrade/el7toel8/actors/scanclienablerepo/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/scanclienablerepo/libraries/library.py
@@ -1,0 +1,11 @@
+from leapp.libraries.stdlib import api
+from leapp.libraries.common import config
+from leapp.models import CustomTargetRepository
+
+
+def process():
+    if not config.get_env('LEAPP_ENABLE_REPOS'):
+        return
+    api.current_logger().info('The --enablerepo option has been used,')
+    for repoid in config.get_env('LEAPP_ENABLE_REPOS').split(','):
+        api.produce(CustomTargetRepository(repoid=repoid))

--- a/repos/system_upgrade/el7toel8/actors/scanclienablerepo/tests/test_unit.py
+++ b/repos/system_upgrade/el7toel8/actors/scanclienablerepo/tests/test_unit.py
@@ -1,0 +1,75 @@
+from collections import namedtuple
+import os
+
+import pytest
+
+from leapp.libraries.actor import library
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import CustomTargetRepository
+from leapp import models
+
+
+class CurrentActorMocked(object):
+    def __init__(self, kernel='3.10.0-957.43.1.el7.x86_64', release_id='rhel',
+                 src_ver='7.6', dst_ver='8.1', arch=architecture.ARCH_X86_64,
+                 envars=None):
+
+        if envars:
+            envarsList = [models.EnvVar(name=key, value=value) for key, value in envars.items()]
+        else:
+            envarsList = []
+
+        version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
+        os_release = namedtuple('OS_release', ['release_id', 'version_id'])(release_id, src_ver)
+        args = (version, kernel, os_release, arch, envarsList)
+        conf_fields = ['version', 'kernel', 'os_release', 'architecture', 'leapp_env_vars']
+        self.configuration = namedtuple('configuration', conf_fields)(*args)
+        self._common_folder = '../../files'
+
+    def __call__(self):
+        return self
+
+    def get_common_folder_path(self, folder):
+        return os.path.join(self._common_folder, folder)
+
+
+class LoggerMocked(object):
+    def __init__(self):
+        self.infomsg = None
+        self.debugmsg = None
+
+    def info(self, msg):
+        self.infomsg = msg
+
+    def debug(self, msg):
+        self.debugmsg = msg
+
+    def __call__(self):
+        return self
+
+
+def test_no_enabledrepos(monkeypatch):
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(api, 'current_logger', LoggerMocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    library.process()
+    assert not api.current_logger.infomsg
+    assert not api.produce.called
+
+
+@pytest.mark.parametrize('envars,result', [
+    ({'LEAPP_ENABLE_REPOS': 'repo1'}, [CustomTargetRepository(repoid='repo1')]),
+    ({'LEAPP_ENABLE_REPOS': 'repo1,repo2'}, [CustomTargetRepository(repoid='repo1'),
+                                             CustomTargetRepository(repoid='repo2')]),
+])
+def test_enabledrepos(monkeypatch, envars, result):
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(api, 'current_logger', LoggerMocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars=envars))
+    library.process()
+    assert api.current_logger.infomsg
+    assert api.produce.called == len(result)
+    for i in result:
+        assert i in api.produce.model_instances

--- a/repos/system_upgrade/el7toel8/actors/scancustomrepofile/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scancustomrepofile/actor.py
@@ -1,0 +1,24 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scancustomrepofile
+from leapp.models import CustomTargetRepository
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanCustomRepofile(Actor):
+    """
+    Scan the custom /etc/leapp/files/leapp_upgrade_repositories.repo repo file.
+
+    This is the official path where to put the YUM/DNF repository file with
+    custom repositories for the target system. These repositories will be used
+    automatically for the in-place upgrade despite the enable/disable settings.
+
+    If the file doesn't exist, nothing happens.
+    """
+
+    name = 'scan_custom_repofile'
+    consumes = ()
+    produces = (CustomTargetRepository,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        scancustomrepofile.process()

--- a/repos/system_upgrade/el7toel8/actors/scancustomrepofile/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scancustomrepofile/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import scancustomrepofile
-from leapp.models import CustomTargetRepository
+from leapp.models import CustomTargetRepository, CustomTargetRepositoryFile
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
@@ -12,12 +12,15 @@ class ScanCustomRepofile(Actor):
     custom repositories for the target system. These repositories will be used
     automatically for the in-place upgrade despite the enable/disable settings.
 
+    Additionally the CustomTargetRepositoryFile message is produced if the file
+    exists to let the other actors know they should handle the file as well.
+
     If the file doesn't exist, nothing happens.
     """
 
     name = 'scan_custom_repofile'
     consumes = ()
-    produces = (CustomTargetRepository,)
+    produces = (CustomTargetRepository, CustomTargetRepositoryFile)
     tags = (FactsPhaseTag, IPUWorkflowTag)
 
     def process(self):

--- a/repos/system_upgrade/el7toel8/actors/scancustomrepofile/libraries/scancustomrepofile.py
+++ b/repos/system_upgrade/el7toel8/actors/scancustomrepofile/libraries/scancustomrepofile.py
@@ -2,7 +2,7 @@ import os
 
 from leapp.libraries.common import repofileutils
 from leapp.libraries.stdlib import api
-from leapp.models import CustomTargetRepository
+from leapp.models import CustomTargetRepository, CustomTargetRepositoryFile
 
 
 CUSTOM_REPO_PATH = "/etc/leapp/files/leapp_upgrade_repositories.repo"
@@ -23,6 +23,9 @@ def process():
         return
     api.current_logger().info("The {} file exists.".format(CUSTOM_REPO_PATH))
     repofile = repofileutils.parse_repofile(CUSTOM_REPO_PATH)
+    if not repofile.data:
+        return
+    api.produce(CustomTargetRepositoryFile(file=CUSTOM_REPO_PATH))
     for repo in repofile.data:
         api.produce(CustomTargetRepository(
             repoid=repo.repoid,

--- a/repos/system_upgrade/el7toel8/actors/scancustomrepofile/libraries/scancustomrepofile.py
+++ b/repos/system_upgrade/el7toel8/actors/scancustomrepofile/libraries/scancustomrepofile.py
@@ -1,0 +1,32 @@
+import os
+
+from leapp.libraries.common import repofileutils
+from leapp.libraries.stdlib import api
+from leapp.models import CustomTargetRepository
+
+
+CUSTOM_REPO_PATH = "/etc/leapp/files/leapp_upgrade_repositories.repo"
+
+
+def process():
+    """
+    Produce CustomTargetRepository msgs for the custom repo file if the file
+    exists.
+
+    The CustomTargetRepository msg is produced for every repository inside
+    the <CUSTOM_REPO_PATH> file.
+    """
+    if not os.path.isfile(CUSTOM_REPO_PATH):
+        api.current_logger().debug(
+                "The {} file doesn't exist. Nothing to do."
+                .format(CUSTOM_REPO_PATH))
+        return
+    api.current_logger().info("The {} file exists.".format(CUSTOM_REPO_PATH))
+    repofile = repofileutils.parse_repofile(CUSTOM_REPO_PATH)
+    for repo in repofile.data:
+        api.produce(CustomTargetRepository(
+            repoid=repo.repoid,
+            name=repo.name,
+            baseurl=repo.baseurl,
+            enabled=repo.enabled,
+        ))

--- a/repos/system_upgrade/el7toel8/actors/scancustomrepofile/tests/test_scancustomrepofile.py
+++ b/repos/system_upgrade/el7toel8/actors/scancustomrepofile/tests/test_scancustomrepofile.py
@@ -1,0 +1,75 @@
+import os
+
+from leapp.libraries.actor import scancustomrepofile
+from leapp.libraries.common import repofileutils
+from leapp.libraries.common.testutils import produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import CustomTargetRepository, RepositoryData, RepositoryFile
+
+
+_REPODATA = [
+    RepositoryData(repoid="repo1", name="repo1name", baseurl="repo1url", enabled=True),
+    RepositoryData(repoid="repo2", name="repo2name", baseurl="repo2url", enabled=False),
+    RepositoryData(repoid="repo3", name="repo3name", enabled=True),
+    RepositoryData(repoid="repo4", name="repo4name", mirrorlist="mirror4list", enabled=True),
+]
+
+_CUSTOM_REPOS = [
+    CustomTargetRepository(repoid="repo1", name="repo1name", baseurl="repo1url", enabled=True),
+    CustomTargetRepository(repoid="repo2", name="repo2name", baseurl="repo2url", enabled=False),
+    CustomTargetRepository(repoid="repo3", name="repo3name", baseurl=None, enabled=True),
+    CustomTargetRepository(repoid="repo4", name="repo4name", baseurl=None, enabled=True),
+]
+
+
+class LoggerMocked(object):
+    def __init__(self):
+        self.infomsg = None
+        self.debugmsg = None
+
+    def info(self, msg):
+        self.infomsg = msg
+
+    def debug(self, msg):
+        self.debugmsg = msg
+
+    def __call__(self):
+        return self
+
+
+def test_no_repofile(monkeypatch):
+    monkeypatch.setattr(os.path, 'isfile', lambda dummy: False)
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(api, 'current_logger', LoggerMocked())
+    scancustomrepofile.process()
+    msg = "The {} file doesn't exist. Nothing to do.".format(scancustomrepofile.CUSTOM_REPO_PATH)
+    assert api.current_logger.debugmsg == msg
+    assert not api.produce.called
+
+
+def test_valid_repofile_exists(monkeypatch):
+    def _mocked_parse_repofile(fpath):
+        return RepositoryFile(file=fpath, data=_REPODATA)
+    monkeypatch.setattr(os.path, 'isfile', lambda dummy: True)
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(repofileutils, 'parse_repofile', _mocked_parse_repofile)
+    monkeypatch.setattr(api, 'current_logger', LoggerMocked())
+    scancustomrepofile.process()
+    msg = "The {} file exists.".format(scancustomrepofile.CUSTOM_REPO_PATH)
+    assert api.current_logger.infomsg == msg
+    assert api.produce.called == len(_CUSTOM_REPOS)
+    for crepo in _CUSTOM_REPOS:
+        assert crepo in api.produce.model_instances
+
+
+def test_empty_repofile_exists(monkeypatch):
+    def _mocked_parse_repofile(fpath):
+        return RepositoryFile(file=fpath, data=[])
+    monkeypatch.setattr(os.path, 'isfile', lambda dummy: True)
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(repofileutils, 'parse_repofile', _mocked_parse_repofile)
+    monkeypatch.setattr(api, 'current_logger', LoggerMocked())
+    scancustomrepofile.process()
+    msg = "The {} file exists.".format(scancustomrepofile.CUSTOM_REPO_PATH)
+    assert api.current_logger.infomsg == msg
+    assert not api.produce.called

--- a/repos/system_upgrade/el7toel8/actors/scancustomrepofile/tests/test_scancustomrepofile.py
+++ b/repos/system_upgrade/el7toel8/actors/scancustomrepofile/tests/test_scancustomrepofile.py
@@ -4,7 +4,7 @@ from leapp.libraries.actor import scancustomrepofile
 from leapp.libraries.common import repofileutils
 from leapp.libraries.common.testutils import produce_mocked
 from leapp.libraries.stdlib import api
-from leapp.models import CustomTargetRepository, RepositoryData, RepositoryFile
+from leapp.models import CustomTargetRepository, CustomTargetRepositoryFile, RepositoryData, RepositoryFile
 
 
 _REPODATA = [
@@ -20,6 +20,8 @@ _CUSTOM_REPOS = [
     CustomTargetRepository(repoid="repo3", name="repo3name", baseurl=None, enabled=True),
     CustomTargetRepository(repoid="repo4", name="repo4name", baseurl=None, enabled=True),
 ]
+
+_CUSTOM_REPO_FILE_MSG = CustomTargetRepositoryFile(file=scancustomrepofile.CUSTOM_REPO_PATH)
 
 
 class LoggerMocked(object):
@@ -57,7 +59,8 @@ def test_valid_repofile_exists(monkeypatch):
     scancustomrepofile.process()
     msg = "The {} file exists.".format(scancustomrepofile.CUSTOM_REPO_PATH)
     assert api.current_logger.infomsg == msg
-    assert api.produce.called == len(_CUSTOM_REPOS)
+    assert api.produce.called == len(_CUSTOM_REPOS) + 1
+    assert _CUSTOM_REPO_FILE_MSG in api.produce.model_instances
     for crepo in _CUSTOM_REPOS:
         assert crepo in api.produce.model_instances
 

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
@@ -4,7 +4,7 @@ from leapp.libraries.common.config import get_env, version
 from leapp.models import (CustomTargetRepositoryFile, RepositoriesMap, RequiredTargetUserspacePackages,
                           RHSMInfo, StorageInfo, TargetRepositories,
                           TargetUserSpaceInfo, UsedTargetRepositories,
-                          XFSPresence)
+                          XFSPresence, Report)
 from leapp.tags import IPUWorkflowTag, TargetTransactionFactsPhaseTag
 
 
@@ -22,7 +22,7 @@ class TargetUserspaceCreator(Actor):
     name = 'target_userspace_creator'
     consumes = (CustomTargetRepositoryFile, RepositoriesMap, RequiredTargetUserspacePackages,
                 StorageInfo, RHSMInfo, TargetRepositories, XFSPresence)
-    produces = (TargetUserSpaceInfo, UsedTargetRepositories)
+    produces = (TargetUserSpaceInfo, UsedTargetRepositories, Report)
     tags = (IPUWorkflowTag, TargetTransactionFactsPhaseTag)
 
     def process(self):

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
@@ -1,7 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import userspacegen
 from leapp.libraries.common.config import get_env, version
-from leapp.models import (RepositoriesMap, RequiredTargetUserspacePackages,
+from leapp.models import (CustomTargetRepositoryFile, RepositoriesMap, RequiredTargetUserspacePackages,
                           RHSMInfo, StorageInfo, TargetRepositories,
                           TargetUserSpaceInfo, UsedTargetRepositories,
                           XFSPresence)
@@ -20,7 +20,7 @@ class TargetUserspaceCreator(Actor):
     """
 
     name = 'target_userspace_creator'
-    consumes = (RepositoriesMap, RequiredTargetUserspacePackages,
+    consumes = (CustomTargetRepositoryFile, RepositoriesMap, RequiredTargetUserspacePackages,
                 StorageInfo, RHSMInfo, TargetRepositories, XFSPresence)
     produces = (TargetUserSpaceInfo, UsedTargetRepositories)
     tags = (IPUWorkflowTag, TargetTransactionFactsPhaseTag)

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -205,10 +205,13 @@ def gather_target_repositories(context):
                 details={
                     # FIXME: update the text - mention the possibility of custom repos
                     'hint': ('It is required to have RHEL repositories on the system'
-                             ' provided by the subscription-manager. Possibly you'
+                             ' provided by the subscription-manager unless the --no-rhsm'
+                             ' options is specified. Possibly you'
                              ' are missing a valid SKU for the target system or network'
                              ' connection failed. Check whether your system is attached'
-                             ' to a valid SKU providing RHEL 8 repositories.')
+                             ' to a valid SKU providing RHEL 8 repositories.'
+                             ' In case the Satellite is used, read the upgrade documentation'
+                             ' to setup the satellite and the system properly.')
                 }
             )
     else:
@@ -238,7 +241,10 @@ def gather_target_repositories(context):
             message='There are no enabled target repositories for the upgrade process to proceed.',
             details={'hint': (
                 'Ensure your system is correctly registered with the subscription manager and that'
-                ' your current subscription is entitled to install the requested target version {version}'
+                ' your current subscription is entitled to install the requested target version {version}.'
+                ' In case the --no-rhsm option (or the LEAPP_NO_RHSM=1 environment variable is set)'
+                ' ensure the custom repository file is provided regarding the documentation with'
+                ' properly defined repositories.'
                 ).format(version=api.current_actor().configuration.version.target)
             }
         )
@@ -274,7 +280,7 @@ def _gather_target_repositories(context, indata, prod_cert_path):
     :type context: mounting.IsolatedActions class
     :param indata: majority of input data for the actor
     :type indata: class _InputData
-    :param prod_cert_path: path where is stored the target product cert
+    :param prod_cert_path: path where the target product cert is stored
     :type prod_cert_path: string
     """
     rhsm.set_container_mode(context)

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -332,7 +332,9 @@ def gather_target_repositories(context):
                 ' your current subscription is entitled to install the requested target version {version}.'
                 ' In case the --no-rhsm option (or the LEAPP_NO_RHSM=1 environment variable is set)'
                 ' ensure the custom repository file is provided regarding the documentation with'
-                ' properly defined repositories.'
+                ' properly defined repositories or in case repositories are already defined'
+                ' in any repofiles under /etc/yum.repos.d/ directory, use the --enablerepo option'
+                ' for leapp'
                 ).format(version=api.current_actor().configuration.version.target)
             }
         )
@@ -341,11 +343,14 @@ def gather_target_repositories(context):
             message='Some required custom target repositories are not available.',
             details={'hint': (
                 ' The most probably you are using custom or third party actor'
-                ' that produces CustomTargetRepository message. However,'
-                ' inside the upgrade container, we are not able to find such'
+                ' that produces CustomTargetRepository message or you did a typo'
+                ' in one of repoids specified on command line for the leapp --enablerepo'
+                ' option.'
+                ' Inside the upgrade container, we are not able to find such'
                 ' repository inside any repository file. Consider use of the'
                 ' custom repository file regarding the official upgrade'
-                ' documentation.'
+                ' documentation or check whether you did not do a typo in any'
+                ' repoids you specified for the --enablerepo option of leapp.'
                 )
             }
         )

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -83,6 +83,8 @@ def prepare_target_userspace(context, userspace_dir, enabled_repos, packages):
                ] + repos_opt + packages
         if config.is_verbose():
             cmd.append('-v')
+        if rhsm.skip_rhsm():
+            cmd += ['--disableplugin', 'subscription-manager']
         try:
             context.call(cmd, callback_raw=utils.logging_handler)
         except CalledProcessError as exc:

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
@@ -150,7 +150,7 @@ def test_consume_data(monkeypatch, raised, pkg_msgs, rhsm_info, xfs, storage):
     mocked_consume = MockedConsume(pkg_msgs, rhsm_info, xfs, storage)
     monkeypatch.setattr(api, 'consume', mocked_consume)
     monkeypatch.setattr(api, 'current_logger', mocked_logger())
-    monkeypatch.setenv('LEAPP_DEVEL_SKIP_RHSM', '0')
+    monkeypatch.setenv('LEAPP_NO_RHSM', '0')
     if not xfs:
         xfs = models.XFSPresence()
     if not raised:

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
@@ -150,7 +150,7 @@ def test_consume_data(monkeypatch, raised, pkg_msgs, rhsm_info, xfs, storage):
     mocked_consume = MockedConsume(pkg_msgs, rhsm_info, xfs, storage)
     monkeypatch.setattr(api, 'consume', mocked_consume)
     monkeypatch.setattr(api, 'current_logger', mocked_logger())
-    monkeypatch.setenv('LEAPP_NO_RHSM', '0')
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars={'LEAPP_NO_RHSM': '0'}))
     if not xfs:
         xfs = models.XFSPresence()
     if not raised:

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
@@ -106,6 +106,12 @@ _PACKAGES_MSGS = [
 _RHSMINFO_MSG = models.RHSMInfo(attached_skus=['testing-sku'])
 _XFS_MSG = models.XFSPresence()
 _STORAGEINFO_MSG = models.StorageInfo()
+_CTRF_MSGS = [
+    models.CustomTargetRepositoryFile(file='rfileA'),
+    models.CustomTargetRepositoryFile(file='rfileB'),
+]
+_SAEE = StopActorExecutionError
+_SAE = StopActorExecution
 
 
 class MockedConsume(object):
@@ -123,43 +129,92 @@ class MockedConsume(object):
         return iter([msg for msg in self._msgs if isinstance(msg, model)])
 
 
-# FIXME: the results should be probably different with supported disconnected
-# systems (see rhsm)
-# undefined: (????, _PACKAGES_MSGS, None, _XFS_MSG, None),
-@pytest.mark.parametrize('raised,pkg_msgs,rhsm_info,xfs,storage', [
-    (None, _PACKAGES_MSGS, _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG),
-    (None, _PACKAGES_MSGS[0], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG),
-    (None, [], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG),
-    (None, _PACKAGES_MSGS, _RHSMINFO_MSG, None, _STORAGEINFO_MSG),
-    ((StopActorExecution, 'RHSM information'), _PACKAGES_MSGS, None, _XFS_MSG, _STORAGEINFO_MSG),
-    ((StopActorExecution, 'RHSM information'), _PACKAGES_MSGS, None, None, _STORAGEINFO_MSG),
-    ((StopActorExecution, 'RHSM information'), [], None, _XFS_MSG, _STORAGEINFO_MSG),
-    ((StopActorExecution, 'RHSM information'), [], None, None, _STORAGEINFO_MSG),
-    ((StopActorExecutionError, 'No storage'), _PACKAGES_MSGS, _RHSMINFO_MSG, _XFS_MSG, None),
-    ((StopActorExecutionError, 'No storage'), _PACKAGES_MSGS, _RHSMINFO_MSG, None, None),
-    ((StopActorExecutionError, 'No storage'), [], _RHSMINFO_MSG, _XFS_MSG, None),
-    ((StopActorExecutionError, 'No storage'), [], _RHSMINFO_MSG, None, None),
+testInData = namedtuple('TestInData', ['pkg_msgs', 'rhsm_info', 'xfs', 'storage', 'custom_repofiles'])
+
+
+@pytest.mark.parametrize('raised,no_rhsm,testdata', [
+    # valid cases with RHSM
+    (None, '0', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, None)),
+    (None, '0', testInData(_PACKAGES_MSGS[0], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, None)),
+    (None, '0', testInData([], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, None)),
+    (None, '0', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, None, _STORAGEINFO_MSG, None)),
+    (None, '0', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, _CTRF_MSGS)),
+    (None, '0', testInData(_PACKAGES_MSGS[0], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, _CTRF_MSGS)),
+    (None, '0', testInData([], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, _CTRF_MSGS)),
+    (None, '0', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, None, _STORAGEINFO_MSG, _CTRF_MSGS)),
+
+    # valid cases without RHSM (== skip_rhsm)
+    (None, '1', testInData(_PACKAGES_MSGS, None, _XFS_MSG, _STORAGEINFO_MSG, None)),
+    (None, '1', testInData(_PACKAGES_MSGS, None, None, _STORAGEINFO_MSG, None)),
+    (None, '1', testInData([], None, _XFS_MSG, _STORAGEINFO_MSG, None)),
+    (None, '1', testInData([], None, None, _STORAGEINFO_MSG, None)),
+    (None, '1', testInData(_PACKAGES_MSGS, None, _XFS_MSG, _STORAGEINFO_MSG, _CTRF_MSGS)),
+    (None, '1', testInData(_PACKAGES_MSGS, None, None, _STORAGEINFO_MSG, _CTRF_MSGS)),
+    (None, '1', testInData([], None, _XFS_MSG, _STORAGEINFO_MSG, _CTRF_MSGS)),
+    (None, '1', testInData([], None, None, _STORAGEINFO_MSG, _CTRF_MSGS)),
+
+    # no-rhsm but RHSMInfo defined (should be _RHSMINFO_MSG)
+    ((_SAEE, 'RHSM is not'), '1', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, None)),
+    ((_SAEE, 'RHSM is not'), '1', testInData(_PACKAGES_MSGS[0], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, None)),
+    ((_SAEE, 'RHSM is not'), '1', testInData([], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, None)),
+    ((_SAEE, 'RHSM is not'), '1', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, None, _STORAGEINFO_MSG, None)),
+    ((_SAEE, 'RHSM is not'), '1', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, _CTRF_MSGS)),
+    ((_SAEE, 'RHSM is not'), '1', testInData(_PACKAGES_MSGS[0], _RHSMINFO_MSG, _XFS_MSG,
+                                             _STORAGEINFO_MSG, _CTRF_MSGS)),
+    ((_SAEE, 'RHSM is not'), '1', testInData([], _RHSMINFO_MSG, _XFS_MSG, _STORAGEINFO_MSG, _CTRF_MSGS)),
+    ((_SAEE, 'RHSM is not'), '1', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, None, _STORAGEINFO_MSG, _CTRF_MSGS)),
+
+    # missing RHSMInfo but it should exist
+    # NOTE: should be this Error?!
+    ((_SAE, 'RHSM information'), '0', testInData(_PACKAGES_MSGS, None, _XFS_MSG, _STORAGEINFO_MSG, None)),
+    ((_SAE, 'RHSM information'), '0', testInData(_PACKAGES_MSGS, None, None, _STORAGEINFO_MSG, None)),
+    ((_SAE, 'RHSM information'), '0', testInData([], None, _XFS_MSG, _STORAGEINFO_MSG, None)),
+    ((_SAE, 'RHSM information'), '0', testInData([], None, None, _STORAGEINFO_MSG, None)),
+
+    # in the end, error when StorageInfo is missing
+    ((_SAEE, 'No storage'), '0', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, _XFS_MSG, None, None)),
+    ((_SAEE, 'No storage'), '0', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, None, None, None)),
+    ((_SAEE, 'No storage'), '0', testInData([], _RHSMINFO_MSG, _XFS_MSG, None, None)),
+    ((_SAEE, 'No storage'), '0', testInData([], _RHSMINFO_MSG, None, None, None)),
+    ((_SAEE, 'No storage'), '0', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, _XFS_MSG, None, _CTRF_MSGS)),
+    ((_SAEE, 'No storage'), '0', testInData(_PACKAGES_MSGS, _RHSMINFO_MSG, None, None, _CTRF_MSGS)),
+    ((_SAEE, 'No storage'), '0', testInData([], _RHSMINFO_MSG, _XFS_MSG, None, _CTRF_MSGS)),
+    ((_SAEE, 'No storage'), '0', testInData([], _RHSMINFO_MSG, None, None, _CTRF_MSGS)),
 ])
-def test_consume_data(monkeypatch, raised, pkg_msgs, rhsm_info, xfs, storage):
+def test_consume_data(monkeypatch, raised, no_rhsm, testdata):
+    # do not write never into testdata inside the test !!
+    xfs = testdata.xfs
+    custom_repofiles = testdata.custom_repofiles
     _exp_pkgs = {'dnf'}
-    if isinstance(pkg_msgs, list):
-        for msg in pkg_msgs:
+    if isinstance(testdata.pkg_msgs, list):
+        for msg in testdata.pkg_msgs:
             _exp_pkgs.update(msg.packages)
     else:
-        _exp_pkgs.update(pkg_msgs.packages)
-    mocked_consume = MockedConsume(pkg_msgs, rhsm_info, xfs, storage)
+        _exp_pkgs.update(testdata.pkg_msgs.packages)
+    mocked_consume = MockedConsume(testdata.pkg_msgs,
+                                   testdata.rhsm_info,
+                                   xfs,
+                                   testdata.storage,
+                                   custom_repofiles)
     monkeypatch.setattr(api, 'consume', mocked_consume)
     monkeypatch.setattr(api, 'current_logger', mocked_logger())
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars={'LEAPP_NO_RHSM': '0'}))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars={'LEAPP_NO_RHSM': no_rhsm}))
     if not xfs:
         xfs = models.XFSPresence()
+    if not custom_repofiles:
+        custom_repofiles = []
     if not raised:
-        assert userspacegen._consume_data() == (_exp_pkgs, rhsm_info, xfs, storage)
+        result = userspacegen._InputData()
+        assert result.packages == _exp_pkgs
+        assert result.rhsm_info == testdata.rhsm_info
+        assert result.xfs_info == xfs
+        assert result.storage_info == testdata.storage
+        assert result.custom_repofiles == custom_repofiles
         assert not api.current_logger.warnmsg
         assert not api.current_logger.errmsg
     else:
         with pytest.raises(raised[0]) as err:
-            userspacegen._consume_data()
+            userspacegen._InputData()
         if isinstance(err.value, StopActorExecutionError):
             assert raised[1] in err.value.message
         else:
@@ -218,17 +273,23 @@ def mocked_consume_data():
     rhsm_info = _RHSMINFO_MSG
     xfs_info = models.XFSPresence()
     storage_info = models.StorageInfo()
-    return packages, rhsm_info, xfs_info, storage_info
+    custom_repofiles = []
+    fields = ['packages', 'rhsm_info', 'xfs_info', 'storage_info', 'custom_repofiles']
+
+    return namedtuple('TestInData', fields)(
+                packages, rhsm_info, xfs_info, storage_info, custom_repofiles
+    )
 
 
 # TODO: come up with additional tests for the main function
 def test_perform_ok(monkeypatch):
     repoids = ['repoidX', 'repoidY']
-    monkeypatch.setattr(userspacegen, '_consume_data', mocked_consume_data)
+    monkeypatch.setattr(userspacegen, '_InputData', mocked_consume_data)
     monkeypatch.setattr(userspacegen, '_get_product_certificate_path', lambda: _DEFAULT_CERT_PATH)
     monkeypatch.setattr(overlaygen, 'create_source_overlay', MockedMountingBase)
     monkeypatch.setattr(userspacegen, '_gather_target_repositories', lambda *x: repoids)
     monkeypatch.setattr(userspacegen, '_create_target_userspace', lambda *x: None)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars={'LEAPP_NO_RHSM': '0'}))
     monkeypatch.setattr(api, 'produce', testutils.produce_mocked())
     userspacegen.perform()
     msg_target_repos = models.UsedTargetRepositories(

--- a/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
+++ b/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
@@ -5,7 +5,7 @@ import os
 import shutil
 
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common import guards, mounting, overlaygen, utils
+from leapp.libraries.common import guards, mounting, overlaygen, rhsm, utils
 from leapp.libraries.stdlib import CalledProcessError, api, config
 
 DNF_PLUGIN_NAME = 'rhel_upgrade.py'
@@ -97,6 +97,7 @@ def _transaction(context, stage, target_repoids, tasks, test=False, cmd_prefix=N
     create_config(context=context, target_repoids=target_repoids, debug=config.is_debug(), test=test, tasks=tasks)
     backup_config(context=context)
 
+    # FIXME: rhsm
     with guards.guarded_execution(guards.connection_guard(), guards.space_guard()):
         cmd = [
             '/usr/bin/dnf',
@@ -106,6 +107,8 @@ def _transaction(context, stage, target_repoids, tasks, test=False, cmd_prefix=N
         ]
         if config.is_verbose():
             cmd.append('-v')
+        if rhsm.skip_rhsm():
+            cmd += ['--disableplugin', 'subscription-manager']
         if cmd_prefix:
             cmd = cmd_prefix + cmd
         try:
@@ -159,6 +162,8 @@ def install_initramdisk_requirements(packages, target_userspace_info, used_repos
         ] + repos_opt + list(packages)
         if config.is_verbose():
             cmd.append('-v')
+        if rhsm.skip_rhsm():
+            cmd += ['--disableplugin', 'subscription-manager']
         context.call(cmd)
 
 

--- a/repos/system_upgrade/el7toel8/libraries/rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/rhsm.py
@@ -140,6 +140,12 @@ def get_available_repo_ids(context):
         )
 
     repofiles = repofileutils.get_parsed_repofiles(context)
+
+    # TODO: move this functionality out! Create check actor that will do
+    # the inhibit. The functionality is really not good here in the current
+    # shape of the leapp-repository. See the targetuserspacecreator and
+    # systemfacts actor if this is moved out.
+    # Issue: #486
     _inhibit_on_duplicate_repos(repofiles)
     rhsm_repos = []
     for rfile in repofiles:

--- a/repos/system_upgrade/el7toel8/libraries/rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/rhsm.py
@@ -70,12 +70,20 @@ def _handle_rhsm_exceptions(hint=None):
             }
         )
     except CalledProcessError as e:
+        _def_hint = (
+            'Please ensure you have a valid RHEL subscription and your network is up.'
+            ' If you are using proxy for Red Hat subscription-manager, please make sure'
+            ' it is specified inside the /etc/rhsm/rhsm.conf file.'
+            ' Or use the --no-rhsm option when running leapp, if you do not want to'
+            ' use subscription-manager for the in-place upgrade and you want to'
+            ' deliver all target repositories by yourself.'
+        )
         raise StopActorExecutionError(
             message='A subscription-manager command failed to execute',
             details={
                 'details': str(e),
                 'stderr': e.stderr,
-                'hint': hint or 'Please ensure you have a valid RHEL subscription and your network is up.'
+                'hint': hint or _def_hint
             }
         )
 

--- a/repos/system_upgrade/el7toel8/libraries/rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/rhsm.py
@@ -81,7 +81,7 @@ def _handle_rhsm_exceptions(hint=None):
 
 def skip_rhsm():
     """Check whether we should skip RHSM related code."""
-    return os.getenv('LEAPP_DEVEL_SKIP_RHSM', '0') == '1'
+    return os.getenv('LEAPP_NO_RHSM', '0') == '1'
 
 
 def with_rhsm(f):

--- a/repos/system_upgrade/el7toel8/libraries/rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/rhsm.py
@@ -269,7 +269,7 @@ def get_existing_product_certificates(context):
     return certs
 
 
-@with_rhsm
+# DO NOT SET the with_rhsm decorator for this function
 def set_container_mode(context):
     """
     Put RHSM into the container mode.

--- a/repos/system_upgrade/el7toel8/libraries/rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/rhsm.py
@@ -7,6 +7,7 @@ import time
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import repofileutils
+from leapp.libraries.common.config import get_env
 from leapp.libraries.stdlib import CalledProcessError, api
 from leapp.models import RHSMInfo
 
@@ -81,17 +82,17 @@ def _handle_rhsm_exceptions(hint=None):
 
 def skip_rhsm():
     """Check whether we should skip RHSM related code."""
-    return os.getenv('LEAPP_NO_RHSM', '0') == '1'
+    return get_env('LEAPP_NO_RHSM', '0') == '1'
 
 
 def with_rhsm(f):
     """Decorator to allow skipping RHSM functions by executing a no-op."""
-    if skip_rhsm():
-        @functools.wraps(f)
-        def _no_op(*args, **kwargs):
-            return
-        return _no_op
-    return f
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        if not skip_rhsm():
+            return f(*args, **kwargs)
+        return None
+    return wrapper
 
 
 @with_rhsm

--- a/repos/system_upgrade/el7toel8/models/targetrepositories.py
+++ b/repos/system_upgrade/el7toel8/models/targetrepositories.py
@@ -30,3 +30,8 @@ class TargetRepositories(Model):
 class UsedTargetRepositories(Model):
     topic = TransactionTopic
     repos = fields.List(fields.Model(UsedTargetRepository))
+
+
+class CustomTargetRepositoryFile(Model):
+    topic = TransactionTopic
+    file = fields.String()


### PR DESCRIPTION
The PR introduces new way to add custom repositories into the IPU process, with possibility to skip rhsm without need of any devel switch.

The PR covers these possible scenarios:
1. IPU with subscribed system, but without other custom repositories
2. IPU with subscribed system, and with additional custom repositories
(but the primary one around RHEL are provided still by RHSM)
3. IPU with subscribed system, but RHSM should not be used during IPU and only custom repositories should be used
4. IPU with unsubscribed system, everything provided through custom repositories

To add custom repositories into the IPU process:
1. use the `--enablerepo` option
1.  create the repo file in `/etc/leapp/files/leapp_upgrade_repositories.repo`

Both solutions can be combined (but it is not so much expected).

In case of the `--enablerepo` option, that one can be specified multiple times and for each obtained repoid is produced the `CustomTargetRepository` message. The repo has to be already specified under the `/etc/yum.repos.d` otherwise raised errors are later expected.

The repofile will be automatically parsed during the scan phase and copied later into the containers. It is possible to use the repofile in combination with RHSM (e.g. get RH repositories via RHSM and add additional ones via the repofile) and without RHSM as well. In the second case, you need the leapp build from the PR 622. Actually, it is possible to test it without the new build as well, but part of the functionality (e.g. --no-rhsm option) and compatibility with the original devel solution is kept only with builds from that PR.

With this PR, the RHSM is set into the container mode inside the containers every time - despite the set of `--no-rhsm`. It's seatbelt to ensure we really will not affect the host by mistake. As well, all calls of yum & dnf includes `--disableplugin subscription-manager` when RHSM should be skipped. So we will be pretty sure, that yum/dnf will not fail when used for any reason connected to RHSM. Even the repofile should be kept as it is in such mode. Which is what we want.

As well, several other actors and models have been added, to be able to improve checks regarding the official possibility of skip of RHSM. New model:
- `CustomTargetRepositoryFile` - representing information about the custom repository files. It's expected that most of the time, only the default custom repo file could be defined as that's handled automatically. But in case that users will want to use the mechanism for other repository files, it's possible as well. Just the scanning has to be handled on their own. All such files will be copied into the containers automatically

Regarding the checks, I tried to effectively minimalized possibility of raised errors, so I created inhibitor(s) that could reduce number of reported "issues". Better solution will be part of future work. See the issue #486 (not only this problem, but big part of it).

All RHSM related texts have been updated to reflect new possibilities.

Part of the PR is fix of the `@with_rhsm` decorator. So the tests are not affected now by the environment variables, as really everything..at least the LEAPP_NO_RHSM... is read from the configuration of the actor. (thanks @vinzenz for big help - Vinnie is practically author of that one). 

Note: There are still missing many unit-tests. Regarding the situation, I expect to cover everything in following PRs. Now I will spend rather more time with additional testing.

Requries PR #480 
Requires Leapp PR oamg/leapp/pull/622