### PR TITLE
Add "java-11-openjdk-headless" to "to_remove"

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -1,1 +1,3 @@
 ### List of packages (each on new line) to be removed from the upgrade transaction
+# https://bugzilla.redhat.com/show_bug.cgi?id=1820172
+java-11-openjdk-headless


### PR DESCRIPTION
"java-11-openjdk-headless" scriptlet failure results
in dnf upgrade transaction exiting with non-zero
exit code.