### PR TITLE
Implement generic CurrentActorMocked and logger_mocked

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/tests/unit_test.py
@@ -5,6 +5,7 @@ import pytest
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import library
 from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.stdlib import api
 from leapp.models import BootContent
 
@@ -23,14 +24,6 @@ class write_to_file_mocked(object):
 
     def __call__(self, filename, content):
         self.content = content
-
-
-class CurrentActorMocked(object):
-    def __init__(self, arch):
-        self.configuration = namedtuple('configuration', ['architecture'])(arch)
-
-    def __call__(self):
-        return self
 
 
 def test_add_boot_entry_non_s390x(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/checkcpu/tests/test_check_cpu.py
+++ b/repos/system_upgrade/el7toel8/actors/checkcpu/tests/test_check_cpu.py
@@ -7,16 +7,9 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import cpu
 from leapp.libraries.common import testutils
 from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.stdlib import api
 from leapp.models import CPUInfo
-
-
-class CurrentActorMocked(object):
-    def __init__(self, arch):
-        self.configuration = namedtuple('configuration', ['architecture'])(arch)
-
-    def __call__(self):
-        return self
 
 
 def test_non_ibmz_arch(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/checkmemory/tests/test_checkmemory.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmemory/tests/test_checkmemory.py
@@ -5,37 +5,29 @@ import pytest
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import library
-from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
 from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 from leapp.models import MemoryInfo
 
 
-class CurrentActorMocked(object):
-    def __init__(self, arch):
-        self.configuration = namedtuple('configuration', ['architecture'])(arch)
-
-    def __call__(self):
-        return self
-
-
 def test_check_memory_low(monkeypatch):
     minimum_req_error = []
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     minimum_req_error = library._check_memory(MemoryInfo(mem_total=1024))
     assert minimum_req_error
 
 
 def test_check_memory_high(monkeypatch):
     minimum_req_error = []
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     minimum_req_error = library._check_memory(MemoryInfo(mem_total=16273492))
     assert not minimum_req_error
 
 
 def test_report(monkeypatch):
     title_msg = 'Minimum memory requirements for RHEL 8 are not met'
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     monkeypatch.setattr(api, 'consume', lambda x: iter([MemoryInfo(mem_total=129)]))
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
     library.process()

--- a/repos/system_upgrade/el7toel8/actors/checksystemarch/tests/test_checksystemarch.py
+++ b/repos/system_upgrade/el7toel8/actors/checksystemarch/tests/test_checksystemarch.py
@@ -3,16 +3,13 @@ from collections import namedtuple
 from leapp import reporting
 from leapp.libraries.actor import library
 from leapp.libraries.common.config import architecture
-from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
 from leapp.libraries.stdlib import api
 
 
 def test_valid_architectures(monkeypatch):
-    class CurrentActorMocked(object):
-        configuration = namedtuple('configuration', ['architecture'])(architecture.ARCH_ACCEPTED[0])
-
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_ACCEPTED[0]))
 
     library.check_architecture()
 
@@ -20,11 +17,8 @@ def test_valid_architectures(monkeypatch):
 
 
 def test_invalid_architecture(monkeypatch):
-    class CurrentActorMocked(object):
-        configuration = namedtuple('configuration', ['architecture'])('invalid_architecture')
-
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch='invalid_architecture'))
 
     library.check_architecture()
     assert reporting.create_report.called == 1

--- a/repos/system_upgrade/el7toel8/actors/checktargetrepos/tests/test_checktargetrepos.py
+++ b/repos/system_upgrade/el7toel8/actors/checktargetrepos/tests/test_checktargetrepos.py
@@ -8,7 +8,7 @@ from leapp.libraries.actor import library
 from leapp import reporting
 from leapp.libraries.stdlib import api
 from leapp.libraries.common import rhsm
-from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
 
 
 class MockedConsume(object):
@@ -24,18 +24,6 @@ class MockedConsume(object):
 
     def __call__(self, model):
         return iter([msg for msg in self._msgs if isinstance(msg, model)])
-
-
-class CurrentActorMocked(object):
-    def __init__(self, envars=None):
-        if envars:
-            envarsList = [EnvVar(name=key, value=value) for key, value in envars.items()]
-        else:
-            envarsList = []
-        self.configuration = namedtuple('configuration', ['leapp_env_vars'])(envarsList)
-
-    def __call__(self):
-        return self
 
 
 _RHEL_REPOS = [
@@ -72,8 +60,8 @@ def test_checktargetrepos_no_rhsm(monkeypatch, enable_repos, custom_target_repos
     mocked_consume = MockedConsume(_TARGET_REPOS_CUSTOM if custom_target_repos else _TARGET_REPOS_NO_CUSTOM)
     if custom_target_repofile:
         mocked_consume._msgs.append(_CUSTOM_TARGET_REPOFILE)
-    envvars = {'LEAPP_ENABLE_REPOS': 'hill,spencer'} if enable_repos else {}
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envvars))
+    envars = {'LEAPP_ENABLE_REPOS': 'hill,spencer'} if enable_repos else {}
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars=envars))
 
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: True)

--- a/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/tests/test_modscan.py
+++ b/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/tests/test_modscan.py
@@ -4,12 +4,9 @@ from collections import namedtuple
 
 from leapp.libraries.actor import modscan
 from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.stdlib import api
 from leapp.models import UpgradeDracutModule, RequiredUpgradeInitramPackages
-
-
-class CurrentActorMocked(object):
-    configuration = namedtuple('configuration', ['architecture'])('x86_64')
 
 
 def _files_get_folder_path(name):
@@ -52,7 +49,7 @@ def test_required_packages(monkeypatch):
 
     # for non-intel archs, the set of required rpms should be same as the default
     # one
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     monkeypatch.setattr(architecture, 'matches_architecture', lambda x: False)
     assert set(modscan._REQUIRED_PACKAGES) == set(modscan._create_initram_packages().packages)
 
@@ -61,7 +58,7 @@ def test_required_packages(monkeypatch):
 
 
 def test_process_produces_modules(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     messages = []
     monkeypatch.setattr(api, 'produce', lambda *x: messages.extend(x))
     monkeypatch.setattr(api, 'get_actor_folder_path', _files_get_folder_path)

--- a/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/tests/test_enablerhsmreposonrhel8.py
+++ b/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/tests/test_enablerhsmreposonrhel8.py
@@ -8,6 +8,7 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import library
 from leapp.libraries.common import config, mounting, rhsm
 from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.stdlib import CalledProcessError, api
 from leapp.models import UsedTargetRepositories, UsedTargetRepository, EnvVar
 
@@ -65,33 +66,6 @@ class logger_mocked(object):
 
     def __call__(self):
         return self
-
-
-# TODO: this is kinda overpowered mock, but we plan to provide something like
-# that in the testutils library in future, so using as it is.
-class CurrentActorMocked(object):
-    def __init__(self, kernel='3.10.0-957.43.1.el7.x86_64', release_id='rhel',
-                 src_ver='7.6', dst_ver='8.1', arch=architecture.ARCH_X86_64,
-                 envars=None):
-
-        if envars:
-            envarsList = [EnvVar(name=key, value=value) for key, value in envars.items()]
-        else:
-            envarsList = []
-
-        version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
-        os_release = namedtuple('OS_release', ['release_id', 'version_id'])(release_id, src_ver)
-        args = (version, kernel, os_release, arch, envarsList)
-        conf_fields = ['version', 'kernel', 'os_release', 'architecture', 'leapp_env_vars']
-        self.configuration = namedtuple('configuration', conf_fields)(*args)
-        self._common_folder = '../../files'
-        self.log = logger_mocked()
-
-    def __call__(self):
-        return self
-
-    def get_common_folder_path(self, folder):
-        return os.path.join(self._common_folder, folder)
 
 
 def test_setrelease(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/tests/test_enablerhsmreposonrhel8.py
+++ b/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/tests/test_enablerhsmreposonrhel8.py
@@ -8,7 +8,7 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import library
 from leapp.libraries.common import config, mounting, rhsm
 from leapp.libraries.common.config import architecture
-from leapp.libraries.common.testutils import CurrentActorMocked
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
 from leapp.libraries.stdlib import CalledProcessError, api
 from leapp.models import UsedTargetRepositories, UsedTargetRepository, EnvVar
 
@@ -49,25 +49,6 @@ class run_mocked(object):
             raise_call_error(args)
 
 
-class logger_mocked(object):
-    def __init__(self):
-        self.warnmsg = None
-        self.dbgmsg = None
-        self.infomsg = None
-
-    def info(self, *args):
-        self.infomsg = args
-
-    def warning(self, *args):
-        self.warnmsg = args
-
-    def debug(self, *args):
-        self.dbgmsg = args
-
-    def __call__(self):
-        return self
-
-
 def test_setrelease(monkeypatch):
     commands_called, klass = not_isolated_actions()
     monkeypatch.setattr(mounting, 'NotIsolatedActions', klass)
@@ -97,6 +78,7 @@ def test_setrelease_submgr_throwing_error(monkeypatch):
 def test_setrelease_skip_rhsm(monkeypatch, product):
     commands_called, _ = not_isolated_actions()
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars={'LEAPP_NO_RHSM': '1'}))
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(config, 'get_product_type', lambda dummy: product)
     # To make this work we need to re-apply the decorator, so it respects the environment variable
     monkeypatch.setattr(rhsm, 'set_release', rhsm.with_rhsm(rhsm.set_release))

--- a/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/tests/test_forcedefaultboot.py
+++ b/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/tests/test_forcedefaultboot.py
@@ -6,7 +6,7 @@ import pytest
 from leapp.libraries import stdlib
 from leapp.libraries.actor import forcedefaultboot
 from leapp.libraries.common.config import architecture
-from leapp.libraries.common.testutils import CurrentActorMocked
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import InstalledTargetKernelVersion
 
@@ -158,25 +158,6 @@ def mocked_exists(case, orig_path_exists):
     return impl
 
 
-class mocked_logger(object):
-    def __init__(self):
-        self.errmsg = None
-        self.warnmsg = None
-        self.dbgmsg = None
-
-    def error(self, *args):
-        self.errmsg = args
-
-    def warning(self, *args):
-        self.warnmsg = args
-
-    def debug(self, *args):
-        self.dbgmsg = args
-
-    def __call__(self):
-        return self
-
-
 @pytest.mark.parametrize('case_result', CASES)
 def test_force_default_boot_target_scenario(case_result, monkeypatch):
     case, result = case_result
@@ -186,7 +167,7 @@ def test_force_default_boot_target_scenario(case_result, monkeypatch):
     monkeypatch.setattr(stdlib, 'run', mocked_run)
     monkeypatch.setattr(os.path, 'exists', mocked_exists(case, os.path.exists))
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=arch))
-    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
     forcedefaultboot.process()
     assert result.grubby_setdefault == mocked_run.called_setdefault
     assert result.zipl_called == mocked_run.called_zipl

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/tests/unit_test.py
@@ -3,19 +3,11 @@ from collections import namedtuple
 from leapp import reporting
 from leapp.libraries.actor import library
 from leapp.libraries.common.config import architecture
-from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
 from leapp.libraries.stdlib import api
 from leapp.models import InstalledRedHatSignedRPM, RPM
 
 RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
-
-
-class CurrentActorMocked(object):
-    def __init__(self, arch=architecture.ARCH_X86_64, kernel='3.10.0-957.43.1.el7.x86_64'):
-        self.configuration = namedtuple('configuration', ['architecture', 'kernel'])(arch, kernel)
-
-    def __call__(self):
-        return self
 
 
 class mocked_logger(object):

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/tests/unit_test.py
@@ -3,22 +3,11 @@ from collections import namedtuple
 from leapp import reporting
 from leapp.libraries.actor import library
 from leapp.libraries.common.config import architecture
-from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, logger_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import InstalledRedHatSignedRPM, RPM
 
 RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
-
-
-class mocked_logger(object):
-    def __init__(self):
-        self.errmsg = None
-
-    def error(self, *args):
-        self.errmsg = args
-
-    def __call__(self):
-        return self
 
 
 def mocked_consume(pkgs):  # pkgs = [(name, version-number)]
@@ -42,7 +31,7 @@ s390x_pkgs_multi = [('kernel', 957), ('something', 957), ('kernel', 956)]
 
 def test_single_kernel_s390x(monkeypatch):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
-    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'consume', mocked_consume(s390x_pkgs_single))
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     library.process()
@@ -56,7 +45,7 @@ def test_single_kernel_s390x(monkeypatch):
 
 def test_multi_kernel_s390x(monkeypatch):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
-    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'consume', mocked_consume(s390x_pkgs_multi))
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     library.process()
@@ -74,14 +63,14 @@ versioned_kernel_pkgs = [('kernel', 456), ('kernel', 789), ('kernel', 1234)]
 
 def test_newest_kernel(monkeypatch):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='3.10.0-1234.21.1.el7.x86_64'))
-    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     library.process()
     assert not reporting.create_report.called
 
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='3.10.0-456.43.1.el7.x86_64'))
-    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     library.process()
@@ -89,7 +78,7 @@ def test_newest_kernel(monkeypatch):
     assert reporting.create_report.report_fields['title'] == 'Newest installed kernel not in use'
 
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='3.10.0-789.35.2.el7.x86_64'))
-    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     library.process()

--- a/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
+++ b/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from leapp.libraries import stdlib
 from leapp.libraries.actor import kernelcmdlineconfig
 from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.stdlib import api
 from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg
 
@@ -16,14 +17,6 @@ class MockedRun(object):
     def __call__(self, cmd, *args, **kwargs):
         self.commands.append(cmd)
         return {}
-
-
-class CurrentActorMocked(object):
-    def __init__(self, arch):
-        self.configuration = namedtuple('configuration', ['architecture'])(arch)
-
-    def __call__(self):
-        return self
 
 
 def mocked_consume(*models):

--- a/repos/system_upgrade/el7toel8/actors/removebootfiles/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/removebootfiles/tests/unit_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from leapp.exceptions import StopActorExecution
 from leapp.libraries.stdlib import api
+from leapp.libraries.common.testutils import logger_mocked
 from leapp.libraries.actor import library
 from leapp.models import BootContent
 
@@ -14,21 +15,6 @@ class remove_file_mocked(object):
     def __call__(self, filename):
         self.called += 1
         self.files_to_remove.append(filename)
-
-
-class logger_mocked(object):
-    def __init__(self):
-        self.warnmsg = None
-        self.errmsg = None
-
-    def warning(self, msg):
-        self.warnmsg = msg
-
-    def error(self, msg):
-        self.errmsg = msg
-
-    def __call__(self):
-        return self
 
 
 def test_remove_boot_files(monkeypatch):
@@ -53,7 +39,7 @@ def test_remove_boot_files(monkeypatch):
         library.remove_boot_files()
 
     assert library.remove_file.called == 0
-    assert "Did not receive a message" in api.current_logger.warnmsg
+    assert any("Did not receive a message" in msg for msg in api.current_logger.warnmsg)
 
 
 def test_remove_file_that_does_not_exist(monkeypatch):
@@ -64,4 +50,4 @@ def test_remove_file_that_does_not_exist(monkeypatch):
 
     library.remove_file('/filepath')
 
-    assert "Could not remove /filepath" in api.current_logger.errmsg
+    assert any("Could not remove /filepath" in msg for msg in api.current_logger.errmsg)

--- a/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/tests/unit_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import library
+from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 from leapp.models import BootContent, FirmwareFacts
@@ -30,14 +31,6 @@ class mocked_logger(object):
 
     def debug(self, *args):
         self.dbgmsg = args
-
-    def __call__(self):
-        return self
-
-
-class CurrentActorMocked(object):
-    def __init__(self, arch):
-        self.configuration = namedtuple('configuration', ['architecture'])(arch)
 
     def __call__(self):
         return self

--- a/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/removeupgradebootentry/tests/unit_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import library
-from leapp.libraries.common.testutils import CurrentActorMocked
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
 from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 from leapp.models import BootContent, FirmwareFacts
@@ -15,25 +15,6 @@ class run_mocked(object):
 
     def __call__(self, args, split=True):
         self.args.append(args)
-
-
-class mocked_logger(object):
-    def __init__(self):
-        self.errmsg = None
-        self.warnmsg = None
-        self.dbgmsg = None
-
-    def error(self, *args):
-        self.errmsg = args
-
-    def warning(self, *args):
-        self.warnmsg = args
-
-    def debug(self, *args):
-        self.dbgmsg = args
-
-    def __call__(self):
-        return self
 
 
 @pytest.mark.parametrize('firmware', ['bios', 'efi'])
@@ -49,7 +30,7 @@ def test_remove_boot_entry(firmware, arch, monkeypatch):
     monkeypatch.setattr(api, 'consume', consume_systemfacts_mocked)
     monkeypatch.setattr(library, 'run', run_mocked())
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch))
-    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
 
     library.remove_boot_entry()
 

--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/tests/test_targetreleasereport.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/tests/test_targetreleasereport.py
@@ -5,18 +5,8 @@ import pytest
 from leapp import reporting
 from leapp.libraries.actor import library
 from leapp.libraries.common import rhsm
-from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
 from leapp.libraries.stdlib import api
-
-
-class CurrentActorMocked(object):
-    def __init__(self, src_ver='7.6', dst_ver='8.1'):
-
-        version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
-        self.configuration = namedtuple('configuration', ['version'])(version)
-
-    def __call__(self):
-        return self
 
 
 @pytest.mark.parametrize('version', ['8.{}'.format(i) for i in range(4)])

--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/tests/test_repositoriesblacklist.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/tests/test_repositoriesblacklist.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 import pytest
 
 from leapp.libraries.actor import library
-from leapp.libraries.common.testutils import produce_mocked
+from leapp.libraries.common.testutils import produce_mocked, CurrentActorMocked
 from leapp.libraries.stdlib import api
 from leapp.models import (
     EnvVar,
@@ -15,18 +15,6 @@ from leapp.models import (
     RepositoryMap,
 )
 from leapp.snactor.fixture import current_actor_context
-
-
-class CurrentActorMocked(object):
-    def __init__(self, envars=None):
-        if envars:
-            envarsList = [EnvVar(name=key, value=value) for key, value in envars.items()]
-        else:
-            envarsList = []
-        self.configuration = namedtuple('configuration', ['leapp_env_vars'])(envarsList)
-
-    def __call__(self):
-        return self
 
 
 @pytest.mark.parametrize('valid_opt_repoid,product_type', [
@@ -64,7 +52,8 @@ def test_with_optionals(monkeypatch, valid_opt_repoid, product_type):
         yield RepositoriesMap(repositories=mapping)
 
     monkeypatch.setattr(api, "consume", repositories_mock)
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked({'LEAPP_DEVEL_SOURCE_PRODUCT_TYPE': product_type}))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        envars={'LEAPP_DEVEL_SOURCE_PRODUCT_TYPE': product_type}))
     optionals = set(library._get_list_of_optional_repos().keys())
     assert {valid_opt_repoid} == optionals
     assert not non_opt_repoids & optionals

--- a/repos/system_upgrade/el7toel8/actors/repositoriesmapping/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesmapping/tests/unit_test.py
@@ -5,23 +5,11 @@ import pytest
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import library
 from leapp.libraries.common.config import architecture
-from leapp.libraries.common.testutils import produce_mocked
+from leapp.libraries.common.testutils import produce_mocked, CurrentActorMocked
 from leapp.libraries.stdlib import api
 from leapp.models import EnvVar, RepositoriesMap, RepositoryMap
 
 PRODUCT_TYPE = ['ga', 'beta', 'htb']
-
-
-class CurrentActorMocked(object):
-    def __init__(self, arch, envars=None):
-        if envars:
-            envarsList = [EnvVar(name=key, value=value) for key, value in envars.items()]
-        else:
-            envarsList = []
-        self.configuration = namedtuple('configuration', ['architecture', 'leapp_env_vars'])(arch, envarsList)
-
-    def __call__(self):
-        return self
 
 
 class ReadRepoFileMock(object):

--- a/repos/system_upgrade/el7toel8/actors/scanclienablerepo/tests/test_unit.py
+++ b/repos/system_upgrade/el7toel8/actors/scanclienablerepo/tests/test_unit.py
@@ -5,34 +5,10 @@ import pytest
 
 from leapp.libraries.actor import library
 from leapp.libraries.common.config import architecture
-from leapp.libraries.common.testutils import produce_mocked
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import CustomTargetRepository
 from leapp import models
-
-
-class CurrentActorMocked(object):
-    def __init__(self, kernel='3.10.0-957.43.1.el7.x86_64', release_id='rhel',
-                 src_ver='7.6', dst_ver='8.1', arch=architecture.ARCH_X86_64,
-                 envars=None):
-
-        if envars:
-            envarsList = [models.EnvVar(name=key, value=value) for key, value in envars.items()]
-        else:
-            envarsList = []
-
-        version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
-        os_release = namedtuple('OS_release', ['release_id', 'version_id'])(release_id, src_ver)
-        args = (version, kernel, os_release, arch, envarsList)
-        conf_fields = ['version', 'kernel', 'os_release', 'architecture', 'leapp_env_vars']
-        self.configuration = namedtuple('configuration', conf_fields)(*args)
-        self._common_folder = '../../files'
-
-    def __call__(self):
-        return self
-
-    def get_common_folder_path(self, folder):
-        return os.path.join(self._common_folder, folder)
 
 
 class LoggerMocked(object):

--- a/repos/system_upgrade/el7toel8/actors/storagescanner/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/storagescanner/tests/unit_test.py
@@ -1,6 +1,6 @@
 from leapp.libraries.actor import library
 from leapp import reporting
-from leapp.libraries.common.testutils import create_report_mocked
+from leapp.libraries.common.testutils import create_report_mocked, logger_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import PartitionEntry, FstabEntry, MountEntry, LsblkEntry, PvsEntry, VgsEntry, \
     LvdisplayEntry, SystemdMountEntry
@@ -65,16 +65,6 @@ def test_get_fstab_info(monkeypatch):
 
 
 def test_invalid_fstab_info(monkeypatch):
-    class logger_mocked(object):
-        def __init__(self):
-            self.errmsg = None
-
-        def error(self, msg):
-            self.errmsg = msg
-
-        def __call__(self):
-            return self
-
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
 
@@ -83,7 +73,7 @@ def test_invalid_fstab_info(monkeypatch):
     assert reporting.create_report.report_fields['severity'] == 'high'
     assert 'Problems with parsing data in /etc/fstab' in reporting.create_report.report_fields['title']
     assert 'inhibitor' in reporting.create_report.report_fields['flags']
-    assert "The fstab configuration file seems to be invalid" in api.current_logger.errmsg
+    assert any("The fstab configuration file seems to be invalid" in msg for msg in api.current_logger.errmsg)
 
 
 def test_get_mount_info(monkeypatch):

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
@@ -6,7 +6,7 @@ import pytest
 from leapp.exceptions import StopActorExecutionError, StopActorExecution
 from leapp.libraries.actor import userspacegen
 from leapp.libraries.common import overlaygen, rhsm
-from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked, logger_mocked
 from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 from leapp import models
@@ -52,25 +52,6 @@ def test_get_product_certificate_path(monkeypatch, result, dst_ver, arch, prod_t
     curr_actor_mocked = CurrentActorMocked(dst_ver=dst_ver, arch=arch, envars=envars)
     monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
     assert userspacegen._get_product_certificate_path() == result
-
-
-class mocked_logger(object):
-    def __init__(self):
-        self.errmsg = []
-        self.warnmsg = []
-        self.debugmsg = []
-
-    def error(self, msg):
-        self.errmsg.append(msg)
-
-    def warn(self, msg):
-        self.warnmsg.append(msg)
-
-    def debug(self, msg):
-        self.debugmsg.append(msg)
-
-    def __call__(self):
-        return self
 
 
 _PACKAGES_MSGS = [
@@ -173,7 +154,7 @@ def test_consume_data(monkeypatch, raised, no_rhsm, testdata):
                                    testdata.storage,
                                    custom_repofiles)
     monkeypatch.setattr(api, 'consume', mocked_consume)
-    monkeypatch.setattr(api, 'current_logger', mocked_logger())
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars={'LEAPP_NO_RHSM': no_rhsm}))
     if not xfs:
         xfs = models.XFSPresence()

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_architecture.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_architecture.py
@@ -1,22 +1,17 @@
-from collections import namedtuple
-
 import pytest
 
 from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.stdlib import api
 
 
-class CurrentActorMocked(object):
-    configuration = namedtuple('configuration', ['architecture'])(architecture.ARCH_ACCEPTED[0])
-
-
 def test_matches_architecture_pass(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_ACCEPTED[0]))
     assert architecture.matches_architecture(*architecture.ARCH_ACCEPTED)
 
 
 def test_matches_architecture_fail(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_ACCEPTED[0]))
     assert not architecture.matches_architecture()
     assert not architecture.matches_architecture(*architecture.ARCH_ACCEPTED[1:])
 

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_getenvvars.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_getenvvars.py
@@ -1,29 +1,15 @@
-from collections import namedtuple
-
 import pytest
 
 from leapp.libraries.common.config import get_env, get_all_envs, get_product_type
+from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.stdlib import api
-from leapp.models import EnvVar
-
-
-class CurrentActorMocked(object):
-    def __init__(self, envars=None):
-        if envars:
-            envarsList = [EnvVar(name=key, value=value) for key, value in envars.items()]
-        else:
-            envarsList = []
-        self.configuration = namedtuple('configuration', ['leapp_env_vars'])(envarsList)
-
-    def __call__(self):
-        return self
 
 
 def test_env_var_match(monkeypatch):
     envars = {'LEAPP_DEVEL_SKIP_WIP': '0',
               'LEAPP_DEVEL_SKIP_DIP': '1',
               'LEAPP_DEVEL_SKIP_RIP': '2'}
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars=envars))
     assert get_env('LEAPP_DEVEL_SKIP_WIP') == '0'
     assert not get_env('LEAPP_DEVEL_SKIP_PIP')
 
@@ -32,9 +18,9 @@ def test_get_all_vars(monkeypatch):
     envars = {'LEAPP_DEVEL_SKIP_WIP': '0',
               'LEAPP_DEVEL_SKIP_DIP': '1',
               'LEAPP_DEVEL_SKIP_RIP': '2'}
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars=envars))
     assert api.current_actor().configuration.leapp_env_vars == get_all_envs()
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
     assert api.current_actor().configuration.leapp_env_vars == get_all_envs()
 
 
@@ -45,11 +31,11 @@ def test_get_product_type_valid(monkeypatch):
                   'LEAPP_DEVEL_TARGET_PRODUCT_TYPE': dst}
         exp_src = 'ga' if not src else src.lower()
         exp_dst = 'ga' if not dst else dst.lower()
-        monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars))
+        monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars=envars))
         assert exp_src == get_product_type('source')
         assert exp_dst == get_product_type('target')
     # return 'ga' if envars are not specified
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked)
     assert get_product_type('source') == 'ga'
     assert get_product_type('target') == 'ga'
 
@@ -57,7 +43,7 @@ def test_get_product_type_valid(monkeypatch):
 def test_get_product_type_invalid_product(monkeypatch):
     for sys_type, envar in [('source', 'LEAPP_DEVEL_SOURCE_PRODUCT_TYPE'),
                             ('target', 'LEAPP_DEVEL_TARGET_PRODUCT_TYPE')]:
-        monkeypatch.setattr(api, 'current_actor', CurrentActorMocked({envar: 'wrong'}))
+        monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars={envar: 'wrong'}))
         with pytest.raises(ValueError) as err:
             get_product_type(sys_type)
         assert 'Invalid value in the {} envar'.format(envar) in str(err)

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
@@ -1,22 +1,8 @@
-from collections import namedtuple
-
 import pytest
 
 from leapp.libraries.common.config import version
+from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.stdlib import api
-
-
-class CurrentActorMocked(object):
-    def __init__(self, kernel='3.10.0-957.43.1.el7.x86_64', release_id='rhel',
-                 src_ver='7.6', dst_ver='8.1'):
-
-        version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
-        os_release = namedtuple('OS_release', ['release_id', 'version_id'])(release_id, src_ver)
-        args = (version, kernel, os_release)
-        self.configuration = namedtuple('configuration', ['version', 'kernel', 'os_release'])(*args)
-
-    def __call__(self):
-        return self
 
 
 def test_version_to_tuple():
@@ -74,7 +60,7 @@ def test_matches_version_pass():
     (False, ['7.5']),
 ])
 def test_matches_source_version(monkeypatch, result, version_list):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver='7.6'))
     assert version.matches_source_version(*version_list) == result
 
 
@@ -85,7 +71,7 @@ def test_matches_source_version(monkeypatch, result, version_list):
     (False, ['8.2', '8.0']),
 ])
 def test_matches_target_version(monkeypatch, result, version_list):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver='7.6'))
     assert version.matches_target_version(*version_list) == result
 
 
@@ -96,7 +82,8 @@ def test_matches_target_version(monkeypatch, result, version_list):
     (False, '5.14.0-100.8.2.el7a.x86_64', 'rhel'),
 ])
 def test_is_rhel_alt(monkeypatch, result, kernel, release_id):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=kernel, release_id=release_id))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver='7.6', kernel=kernel,
+                                                                 release_id=release_id))
     assert version.is_rhel_alt() == result
 
 

--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -29,7 +29,33 @@ class create_report_mocked(object):
             self.report_fields.update(report.to_dict())
 
 
-class CurrentActorMocked(object):  # pylint: disable=too-many-public-methods
+class logger_mocked(object):
+    def __init__(self):
+        self.dbgmsg = []
+        self.infomsg = []
+        self.warnmsg = []
+        self.errmsg = []
+
+    def debug(self, *args):
+        self.dbgmsg.extend(args)
+
+    def info(self, *args):
+        self.infomsg.extend(args)
+
+    def warn(self, *args):
+        self.warnmsg.extend(args)
+
+    def warning(self, *args):
+        self.warnmsg.extend(args)
+
+    def error(self, *args):
+        self.errmsg.extend(args)
+
+    def __call__(self):
+        return self
+
+
+class CurrentActorMocked(object):  # pylint:disable=R0904
     def __init__(self, arch=architecture.ARCH_X86_64, envars=None, kernel='3.10.0-957.43.1.el7.x86_64',
                  release_id='rhel', src_ver='7.8', dst_ver='8.1'):
         envarsList = [EnvVar(name=k, value=v) for k, v in envars.items()] if envars else []

--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -1,4 +1,9 @@
+from collections import namedtuple
+import logging
 import os
+
+from leapp.libraries.common.config import architecture
+from leapp.models import EnvVar
 
 
 class produce_mocked(object):
@@ -22,6 +27,102 @@ class create_report_mocked(object):
         for report in report_fields:
             # last element of path is our field name
             self.report_fields.update(report.to_dict())
+
+
+class CurrentActorMocked(object):  # pylint: disable=too-many-public-methods
+    def __init__(self, arch=architecture.ARCH_X86_64, envars=None, kernel='3.10.0-957.43.1.el7.x86_64',
+                 release_id='rhel', src_ver='7.8', dst_ver='8.1'):
+        envarsList = [EnvVar(name=k, value=v) for k, v in envars.items()] if envars else []
+        version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
+        release = namedtuple('OS_release', ['release_id', 'version_id'])(release_id, src_ver)
+
+        self._common_folder = '../../files'
+        self.configuration = namedtuple(
+            'configuration', ['architecture', 'kernel', 'leapp_env_vars', 'os_release', 'version']
+        )(arch, kernel, envarsList, release, version)
+
+    def __call__(self):
+        return self
+
+    def get_common_folder_path(self, folder):
+        return os.path.join(self._common_folder, folder)
+
+    def consume(self, model):
+        return filter(  # pylint:disable=W0110,W1639
+            lambda msg: isinstance(msg, model), self._msgs
+        )
+
+    @property
+    def log(self):
+        return logging.getLogger(__name__)
+
+    # other functions and properties from the API - can be implemented as needed
+
+    def serialize(self):
+        raise NotImplementedError
+
+    def get_answers(self, dialog):
+        raise NotImplementedError
+
+    def show_message(self, message):
+        raise NotImplementedError
+
+    @property
+    def actor_files_paths(self):
+        raise NotImplementedError
+
+    @property
+    def files_paths(self):
+        raise NotImplementedError
+
+    @property
+    def common_files_paths(self):
+        raise NotImplementedError
+
+    @property
+    def actor_tools_paths(self):
+        raise NotImplementedError
+
+    @property
+    def common_tools_paths(self):
+        raise NotImplementedError
+
+    @property
+    def tools_paths(self):
+        raise NotImplementedError
+
+    def get_folder_path(self, name):
+        raise NotImplementedError
+
+    def get_actor_folder_path(self, name):
+        raise NotImplementedError
+
+    def get_file_path(self, name):
+        raise NotImplementedError
+
+    def get_common_file_path(self, name):
+        raise NotImplementedError
+
+    def get_actor_file_path(self, name):
+        raise NotImplementedError
+
+    def get_tool_path(self, name):
+        raise NotImplementedError
+
+    def get_common_tool_path(self, name):
+        raise NotImplementedError
+
+    def get_actor_tool_path(self, name):
+        raise NotImplementedError
+
+    def run(self, *args):
+        raise NotImplementedError
+
+    def produce(self, *models):
+        raise NotImplementedError
+
+    def report_error(self, message, severity, details):
+        raise NotImplementedError
 
 
 def make_IOError(error):


### PR DESCRIPTION
Despite being mocked fairly often in our tests, `current_actor` and `current_logger` didn't have a united mock implementation so far.
This commit implements a generic, fully configurable mocked actor and logger for use in all repository unit tests. All old implementations are removed.