### PR TITLE
Release 0.10.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -13,7 +13,7 @@ py2_byte_compile "%1" "%2"}
 
 
 Name:           leapp-repository
-Version:        0.9.0
+Version:        0.10.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Packaging
- Add python-requests as dependency (#407)
- Remove dependency on Jinja2 related packages (#407)
- Add dependency on python2-leapp and leapp-framework
- Drop leapp sos plugin (it's part of the sos rpm in RHEL 7.7+)

## Fixes
- Fix handling of XFS without ftype for every such mounted FS
- Fix failures caused by local rpms added into the upgrade transaction
- Fix issues with failing rpm transaction calculation because of duplicate instructions for dnf
- Fix boot order on EFI systems
- Fix issues with device mapper and udev in a container
- Fix getting mount information with mountpoints with spaces in the path
- Print warnings instead of a hard failure when expected rpms cannot be found (e.g. python3-nss inside an rpm module) (#405)
- Parse correctly kernel cmdline inside the initrd (#383) (fixes various issues on s390x)
- Fix checking of kernel drivers (#400)
- Throw a nice error when invalid locale is set (#430)
- Fix issue with random booting into old RHEL 7 kernel after the upgrade
- Do not mount pseudo and unsupposrted FS to overlayfs (e.g. proc)
- Evaluate PES events transitively to create correct data for the upgrade transaction
- Fix various issues related to RHSM (e.g. https://bugzilla.redhat.com/show_bug.cgi?id=1702691)
- Inhibit the upgrade if multiple kernel-devel rpms are installed
- Inhibit the upgrade when links on root dir '/' are not absolute to save the world
- Fix issues on systems with statically mapped IPs in /etc/hosts
- Fix yum repository scan in case of repositories with invalid URL
- Remove java11-openjdk-headless during the upgrade (https://bugzilla.redhat.com/show_bug.cgi?id=1820172)

## Enhancements
- Various texts are improved based on the feedback
- Inhibit the upgrade on EFI systems when efibootmgr is not installed
- Dump `grub2-editenv list` output to help with issues related to the default kernel for the boot
- Add initial multipath support (it doesn't handle all cases yet)
- Modify vim configuration to keep the original behaviour
- Migrate cups-filters
- The name and baseurl field in the CustomTargetRepository message are optional now
- Check that the system satisfies minimum memory requirements for the upgrade (#413)
- Migrate SpamAssassin
- Inhibit the upgrade when the raised dialogs are missing answers (#589)
- Make report messages more explicit about Dialogs (#600)
- Report changes in wireshark
- Improved report related to KDE/GNOME
- Changed upgrade paths: RHEL-ALT 7.6 -> 8.2; RHEL 7.8 -> 8.2
- Migrate sane-backend
- Check if the latest installed kernel is booted before the upgrade
- Inhibit the upgrade on FIPS systems
- Inhibit the upgrade for ipa-server (#481)
- Use the new framework mechanism to inhibit the upgrade without reporting errors
- Introduce new ways of using custom repositories during the transaction
- Support the upgrade without the use of subscription-manager

## Additional changes interesting for devels
- Add new functions in the config library to get envars related to leapp
- LEAPP_SKIP_CHECK_OS_RELEASE has been renamed to LEAPP_DEVEL_SKIP_CHECK_OS_RELEASE
- The code is mostly Py2/Py3 compatible now and all PRs are tested on Py2 and Py3 compatibility (linters, unit-tests)
- Add support for testing with Beta and HTB systems
- The IPUConfig message contains information about booted kernel
- The config.version library contains is_rhel_alt() for detection of RHEL-ALT
- Provide info about kernel cmdline via KernelCmdline message