### PR TITLE
grubdevname: Read block device directly instead of through dd

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/grubdevname/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/grubdevname/libraries/library.py
@@ -10,13 +10,15 @@ def has_grub(blk_dev):
     Check whether GRUB is present on block device
     """
     try:
-        result = run(['dd', 'status=none', 'if={}'.format(blk_dev), 'bs=512', 'count=1'], encoding=None)
-    except CalledProcessError:
+        blk = os.open(blk_dev, os.O_RDONLY)
+        mbr = os.read(blk, 512)
+    except OSError:
         api.current_logger().warning(
             'Could not read first sector of {} in order to identify the bootloader'.format(blk_dev)
         )
         raise StopActorExecution()
-    return b'GRUB' in result['stdout']
+    os.close(blk)
+    return 'GRUB' in mbr
 
 
 def blk_dev_from_partition(partition):

--- a/repos/system_upgrade/el7toel8/actors/grubdevname/tests/invalid
+++ b/repos/system_upgrade/el7toel8/actors/grubdevname/tests/invalid
@@ -1,0 +1,1 @@
+Nothing here

--- a/repos/system_upgrade/el7toel8/actors/grubdevname/tests/valid
+++ b/repos/system_upgrade/el7toel8/actors/grubdevname/tests/valid
@@ -1,0 +1,1 @@
+GRUB GeomHard DiskRead Error


### PR DESCRIPTION
The previously used dd command prints out binary data. If debug is enabled, the binary data gets displayed, which looks bad and potentially can break terminal output.
This more direct method has less overhead and no output at all.