### PR TITLE
Chore/tests/sctpconfigread

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/sctpconfigread/libraries/sctpdlm.py
+++ b/repos/system_upgrade/el7toel8/actors/sctpconfigread/libraries/sctpdlm.py
@@ -7,12 +7,15 @@ from leapp.libraries.stdlib import api
 from leapp.libraries.common import utils
 
 
-def check_dlm_cfgfile():
-    """Parse DLM config file"""
-    fname = "/etc/dlm/dlm.conf"
+def check_dlm_cfgfile(_open=open):
+    """Parse DLM config file.
+    :param _open: object behind opening a file. Might be replaced
+        by mocked one for the purpose of testing
+    """
+    fname = '/etc/dlm/dlm.conf'
 
     try:
-        with open(fname, 'r') as fp:
+        with _open(fname, 'r') as fp:
             cfgs = '[dlm]\n' + fp.read()
     except (OSError, IOError):
         return False
@@ -26,12 +29,16 @@ def check_dlm_cfgfile():
     return proto in ['sctp', 'detect', '1', '2']
 
 
-def check_dlm_sysconfig():
-    """Parse /etc/sysconfig/dlm"""
+def check_dlm_sysconfig(_open=open):
+    """Parse /etc/sysconfig/dlm
+    :param _open: object behind opening a file. Might be replaced
+        by mocked one for the purpose of testing
+    """
+
     regex = re.compile('^[^#]*DLM_CONTROLD_OPTS.*=.*(?:--protocol|-r)[ =]*([^"\' ]+).*', re.IGNORECASE)
 
     try:
-        with open('/etc/sysconfig/dlm', 'r') as fp:
+        with _open('/etc/sysconfig/dlm', 'r') as fp:
             lines = fp.readlines()
     except (OSError, IOError):
         return False

--- a/repos/system_upgrade/el7toel8/actors/sctpconfigread/libraries/sctplib.py
+++ b/repos/system_upgrade/el7toel8/actors/sctpconfigread/libraries/sctplib.py
@@ -13,6 +13,7 @@ def anyfile(files):
     """
     Determines if any of the given paths exist and are a file.
 
+    :type files: tuple of str
     :return: True if any of the given paths exists and it is a file.
     :rtype: bool
     """

--- a/repos/system_upgrade/el7toel8/actors/sctpconfigread/tests/test_unit_sctpconfigread_sctpdlm.py
+++ b/repos/system_upgrade/el7toel8/actors/sctpconfigread/tests/test_unit_sctpconfigread_sctpdlm.py
@@ -1,0 +1,90 @@
+import logging
+
+import pytest
+import six
+
+from leapp.libraries.actor import sctpdlm
+
+if six.PY2:
+    from mock import mock_open
+else:
+    from unittest.mock import mock_open
+
+
+# TODO Confirm with the team the way to mock builtin open
+#   and apply this throughout the repo
+
+
+@pytest.mark.parametrize(
+    ('config', 'open_raises', 'exp_return',),
+    [
+        ('', IOError, False),
+        ('', OSError, False),
+        ('log_debug=1\npost_join_delay=10', None, False),
+        ('log_debug=1\npost_join_delay=10\nprotocol=sctp', None, True),
+        ('log_debug=1\npost_join_delay=10\nprotocol=detect', None, True),
+        ('log_debug=1\npost_join_delay=10\nprotocol=1', None, True),
+        ('log_debug=1\npost_join_delay=10\nprotocol=2', None, True),
+        ('log_debug=1\npost_join_delay=10\nprotocol=tcp', None, False),
+        ('log_debug=1\npost_join_delay=10', None, False),
+    ],
+)
+def test_check_dlm_cfgfile(config, open_raises, exp_return):
+    if open_raises:
+        mock_open.side_effect = open_raises
+    assert (
+        sctpdlm.check_dlm_cfgfile(_open=mock_open(read_data=config))
+        == exp_return
+    )
+
+
+@pytest.mark.parametrize(
+    ('config', 'open_raises', 'exp_return'),
+    [
+        ('', IOError, False),
+        ('', OSError, False),
+        ('DLM_CONTROLD_OPTS="- f 0 -q 0 --protocol=sctp"', None, True),
+        ('DLM_CONTROLD_OPTS="- f 0 -q 0 -r detect"', None, True),
+        ('DLM_CONTROLD_OPTS="- f 0 -q 0 --protocol tcp"', None, False),
+    ],
+)
+def test_check_dlm_sysconfig(config, open_raises, exp_return):
+    if open_raises:
+        mock_open.side_effect = open_raises
+    assert (
+        sctpdlm.check_dlm_sysconfig(_open=mock_open(read_data=config))
+        == exp_return
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        'check_dlm_cfg_file_returns',
+        'check_dlm_sysconfig_returns',
+        'exp_return',
+        'text_in_log',
+    ),
+    [
+        (True, False, True, 'DLM is configured to use SCTP on dlm.conf.'),
+        (False, True, True, 'DLM is configured to use SCTP on sysconfig.'),
+        (False, False, False, ''),
+    ],
+)
+def test_is_dlm_using_sctp(
+    check_dlm_cfg_file_returns,
+    check_dlm_sysconfig_returns,
+    exp_return,
+    text_in_log,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(
+        sctpdlm, 'check_dlm_cfgfile', lambda: check_dlm_cfg_file_returns
+    )
+    monkeypatch.setattr(
+        sctpdlm, 'check_dlm_sysconfig', lambda: check_dlm_sysconfig_returns
+    )
+    with caplog.at_level(logging.DEBUG):
+        assert sctpdlm.is_dlm_using_sctp() == exp_return
+    if text_in_log:
+        assert text_in_log in caplog.text

--- a/repos/system_upgrade/el7toel8/actors/sctpconfigread/tests/test_unit_sctpconfigread_sctplib.py
+++ b/repos/system_upgrade/el7toel8/actors/sctpconfigread/tests/test_unit_sctpconfigread_sctplib.py
@@ -1,0 +1,239 @@
+import logging
+from functools import partial
+
+import pytest
+
+from leapp.libraries.actor import sctplib, sctpdlm
+from leapp.libraries.common.testutils import CurrentActorMocked
+from leapp.models import ActiveKernelModulesFacts, ActiveKernelModule
+
+FILENAME_SCTP = 'sctp'
+FILENAME_NO_SCTP = 'no_sctp'
+SRC_VER = '7.6'
+
+logger = logging.getLogger(__name__)
+
+
+def test_anyfile(tmpdir):
+    file1 = tmpdir.join('file1')
+    file2 = tmpdir.join('file2')
+    file1.write('I am not empty')
+    file2.write('And me either')
+
+    assert sctplib.anyfile((str(file1),))
+    assert sctplib.anyfile((str(file1), str(tmpdir)))
+    assert not sctplib.anyfile((str(tmpdir),))
+    assert not sctplib.anyfile(('Iam not exist',))
+
+
+def test_is_module_loaded(monkeypatch):
+    monkeypatch.setattr(
+        sctplib.api,
+        'current_actor',
+        CurrentActorMocked(
+            src_ver=SRC_VER,
+            msgs=[
+                ActiveKernelModulesFacts(
+                    kernel_modules=[
+                        ActiveKernelModule(
+                            filename=FILENAME_SCTP, parameters=()
+                        ),
+                    ]
+                ),
+            ],
+        ),
+    )
+    assert sctplib.is_module_loaded(FILENAME_SCTP)
+    assert not sctplib.is_module_loaded('not exists filename')
+
+
+@pytest.mark.parametrize(
+    (
+        'actor',
+        'exp_return',
+        'anyfile_returns',
+        'check_dlm_cfgfile_returns',
+        'check_dlm_sysconfig_returns',
+        'text_in_log',
+    ),
+    [
+        # test if module name is sctp
+        (
+            CurrentActorMocked(
+                src_ver=SRC_VER,
+                msgs=[
+                    ActiveKernelModulesFacts(
+                        kernel_modules=[
+                            ActiveKernelModule(
+                                filename=FILENAME_SCTP, parameters=()
+                            )
+                        ]
+                    )
+                ],
+            ),
+            True,
+            False,
+            False,
+            False,
+            '',
+        ),
+        # test if module name is different, but one of lksctp is present
+        (
+            CurrentActorMocked(
+                src_ver=SRC_VER,
+                msgs=[
+                    ActiveKernelModulesFacts(
+                        kernel_modules=[
+                            ActiveKernelModule(
+                                filename=FILENAME_NO_SCTP, parameters=()
+                            )
+                        ]
+                    )
+                ],
+            ),
+            True,
+            True,
+            False,
+            False,
+            'lksctp files',
+        ),
+        # test if check_dlm_cfgfile is True
+        (
+            CurrentActorMocked(
+                src_ver=SRC_VER,
+                msgs=[
+                    ActiveKernelModulesFacts(
+                        kernel_modules=[
+                            ActiveKernelModule(
+                                filename=FILENAME_NO_SCTP, parameters=()
+                            )
+                        ]
+                    )
+                ],
+            ),
+            True,
+            False,
+            True,
+            False,
+            'dlm.conf',
+        ),
+        # test if check_dlm_sysconfig is True
+        (
+            CurrentActorMocked(
+                src_ver=SRC_VER,
+                msgs=[
+                    ActiveKernelModulesFacts(
+                        kernel_modules=[
+                            ActiveKernelModule(
+                                filename=FILENAME_NO_SCTP, parameters=()
+                            )
+                        ]
+                    )
+                ],
+            ),
+            True,
+            False,
+            False,
+            True,
+            'sysconfig',
+        ),
+    ],
+)
+def test_is_sctp_used(
+    actor,
+    exp_return,
+    anyfile_returns,
+    check_dlm_cfgfile_returns,
+    check_dlm_sysconfig_returns,
+    text_in_log,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(sctplib.api, 'current_actor', actor)
+    monkeypatch.setattr(sctplib, 'anyfile', lambda arg: anyfile_returns)
+    monkeypatch.setattr(
+        sctpdlm, 'check_dlm_cfgfile', lambda: check_dlm_cfgfile_returns
+    )
+    monkeypatch.setattr(
+        sctpdlm, 'check_dlm_sysconfig', lambda: check_dlm_sysconfig_returns
+    )
+    with caplog.at_level(logging.DEBUG):
+        assert sctplib.is_sctp_used() == exp_return
+    if text_in_log:
+        assert text_in_log in caplog.text
+
+
+class RunMocked(object):
+    """Simple mock class for leapp.libraries.stdlib.run."""
+
+    def __init__(self, exc_type=None):
+        """if exc_type provided, then it will be raised on
+        instance call.
+
+        :type exc_type: None or BaseException
+        """
+        self.exc_type = exc_type
+
+    def __call__(self, *args, **kwargs):
+        if self.exc_type:
+            logger.info('Mocked `run` raising %r', self.exc_type)
+            raise self.exc_type()
+        logger.info('Mocked `run` passed without exp.')
+
+
+@pytest.mark.parametrize(
+    ('run_fails', 'exp_return', 'text_in_log'),
+    [
+        (True, False, 'Nothing regarding SCTP was found on journal.'),
+        (False, True, 'Found logs regarding SCTP on journal.'),
+    ],
+)
+def test_was_sctp_used(
+    monkeypatch, caplog, run_fails, exp_return, text_in_log
+):
+    monkeypatch.setattr(
+        sctplib,
+        'run',
+        RunMocked(
+            exc_type=partial(
+                sctplib.CalledProcessError, 'message', 'command', 'result'
+            )
+            if run_fails
+            else None
+        ),
+    )
+    with caplog.at_level(logging.DEBUG):
+        assert sctplib.was_sctp_used() == exp_return
+    if text_in_log:
+        assert text_in_log in caplog.text
+
+
+@pytest.mark.parametrize(
+    (
+        'is_sctp_used_returns',
+        'was_sctp_used_returns',
+        'exp_return',
+        'text_in_log',
+    ),
+    [
+        (True, False, True, 'SCTP is being used.'),
+        (False, True, True, 'SCTP was used.'),
+        (False, False, False, 'SCTP is not being used and neither wanted.'),
+    ],
+)
+def test_is_sctp_wanted(
+    is_sctp_used_returns,
+    was_sctp_used_returns,
+    exp_return,
+    text_in_log,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(sctplib, 'is_sctp_used', lambda: is_sctp_used_returns)
+    monkeypatch.setattr(
+        sctplib, 'was_sctp_used', lambda: was_sctp_used_returns
+    )
+    with caplog.at_level(logging.DEBUG):
+        assert sctplib.is_sctp_wanted() == exp_return
+    if text_in_log:
+        assert text_in_log in caplog.text


### PR DESCRIPTION
Closes OAMG-1285

Introduces unit tests for `sctpconfigread` actor.
There are two specific points to discuss here:
1. ~~Possible conflict with PR #489~~ /cc @drehak
2. A new way of mocking builtin open is introduced, which looks safer implementation.
3. I don't understand the need to use the mocked logger from here https://github.com/oamg/leapp-repository/pull/489/files#diff-18f04a4c5ff25e505ff29b8c482d2c5fR33 . There is a pytest fixture `caplog`(https://docs.pytest.org/en/latest/logging.html#caplog-fixture) which looks like could cover all our needs. /cc @drehak @pirat89 

Coverage report:

```bash
----------- coverage: platform linux, python 3.8.2-final-0 -----------
Name                                        Stmts   Miss  Cover
---------------------------------------------------------------
tests/test_unit_sctpconfigread_sctpdlm.py      22      0   100%
tests/test_unit_sctpconfigread_sctplib.py      56      0   100%
---------------------------------------------------------------
TOTAL                                          78      0   100%
```

/cc @bocekm 

Update:
- agreed with @pirat89 to Merge it after PR #489 /cc @drehak 