### PR TITLE
Check if machine_type is empty

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkcpu/tests/test_check_cpu.py
+++ b/repos/system_upgrade/el7toel8/actors/checkcpu/tests/test_check_cpu.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+import logging
 
 import pytest
 
@@ -46,3 +46,12 @@ def test_ibmz_cpu_unsupported(monkeypatch):
     assert reporting.create_report.called
     assert title_msg == reporting.create_report.report_fields['title']
     assert reporting.Flags.INHIBITOR in reporting.create_report.report_fields['flags']
+
+
+def test_ibmz_cpu_is_empty(monkeypatch, caplog):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
+    monkeypatch.setattr(reporting, "create_report", testutils.create_report_mocked())
+    monkeypatch.setattr(api, 'consume', lambda x: iter([CPUInfo(machine_type=None)]))
+    with caplog.at_level(logging.DEBUG):
+        cpu.process()
+    assert 'The machine (CPU) type is empty.' in caplog.text


### PR DESCRIPTION
Add a little test to check if log msg generated when machine type is empty

Ref PR #488 when there was a typo in the method name and tests passes

Now the actor coverage is 100%

```bash
----------- coverage: platform linux, python 3.8.2-final-0 -----------
Name                      Stmts   Miss  Cover
---------------------------------------------
tests/test_check_cpu.py      53      0   100%
```