### PR TITLE
Add msgs arg to CurrentActorMocked

### DIFF
--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -57,7 +57,7 @@ class logger_mocked(object):
 
 class CurrentActorMocked(object):  # pylint:disable=R0904
     def __init__(self, arch=architecture.ARCH_X86_64, envars=None, kernel='3.10.0-957.43.1.el7.x86_64',
-                 release_id='rhel', src_ver='7.8', dst_ver='8.1'):
+                 release_id='rhel', src_ver='7.8', dst_ver='8.1', msgs=None):
         envarsList = [EnvVar(name=k, value=v) for k, v in envars.items()] if envars else []
         version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
         release = namedtuple('OS_release', ['release_id', 'version_id'])(release_id, src_ver)
@@ -66,6 +66,7 @@ class CurrentActorMocked(object):  # pylint:disable=R0904
         self.configuration = namedtuple(
             'configuration', ['architecture', 'kernel', 'leapp_env_vars', 'os_release', 'version']
         )(arch, kernel, envarsList, release, version)
+        self._msgs = msgs
 
     def __call__(self):
         return self


### PR DESCRIPTION
A fix to the MR #489 which is already merged. The reason is that the new mock Actor object is not tested ref #497 
This allows defining messages which will be filtered against model inside consume method