### PR TITLE
InitrdInclude: Refactor code and add tests

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/initrdinclude/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/initrdinclude/actor.py
@@ -1,9 +1,7 @@
-
 from leapp.actors import Actor
-from leapp.models import InitrdIncludes
+from leapp.libraries.actor import initrdinclude
+from leapp.models import InitrdIncludes, InstalledTargetKernelVersion
 from leapp.tags import IPUWorkflowTag, FinalizationPhaseTag
-from leapp.libraries.stdlib import run, CalledProcessError
-from leapp.exceptions import StopActorExecutionError
 
 
 class InitrdInclude(Actor):
@@ -12,46 +10,9 @@ class InitrdInclude(Actor):
     """
 
     name = 'initrdinclude'
-    consumes = (InitrdIncludes, )
+    consumes = (InitrdIncludes, InstalledTargetKernelVersion)
     produces = ()
     tags = (FinalizationPhaseTag, IPUWorkflowTag)
 
-    def get_rhel8_kernel_version(self):
-        kernels = run(["rpm", "-q", "kernel"], split=True)["stdout"]
-        for kernel in kernels:
-            version = kernel.split("-", 1)[1]
-            if "el8" in version:
-                return version
-        raise StopActorExecutionError(
-            "Cannot get version of the installed RHEL-8 kernel",
-            details={"details": "\n".join(kernels)})
-
     def process(self):
-        files = []
-
-        for i in self.consume(InitrdIncludes):
-            files += i.files
-
-        if not files:
-            self.log.debug("No additional files required to add into the initrd.")
-            return
-
-        # TODO(pstodulk): consume message that provides info about currently
-        # # installed rpms; - it doesn't exist yet
-        try:
-            kernel_version = self.get_rhel8_kernel_version()
-            self.log.debug("The detected RHEL 8 kernel: {}".format(kernel_version))
-        except CalledProcessError as e:
-            # just hypothetic check, it should not die
-            # NOTE(pstodulk): raise an exception and stop leapp execution now?
-            raise StopActorExecutionError(
-                "Cannot get info about the installed kernel.",
-                details={"details": str(e)})
-        try:
-            cmd = ["dracut", "--install", " ".join(files), "-f", "--kver", kernel_version]
-            run(cmd)
-        except CalledProcessError as e:
-            # NOTE(pstodulk) same note as above
-            raise StopActorExecutionError(
-                "Cannot regenerate dracut image.",
-                details={"details": str(e)})
+        initrdinclude.process()

--- a/repos/system_upgrade/el7toel8/actors/initrdinclude/libraries/initrdinclude.py
+++ b/repos/system_upgrade/el7toel8/actors/initrdinclude/libraries/initrdinclude.py
@@ -1,0 +1,25 @@
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import InitrdIncludes, InstalledTargetKernelVersion
+
+
+def process():
+    files = [f for i in api.consume(InitrdIncludes) for f in i.files]
+    if not files:
+        api.current_logger().debug("No additional files required to add into the initrd.")
+        return
+
+    target_kernel = next(api.consume(InstalledTargetKernelVersion), None)
+    if not target_kernel:
+        raise StopActorExecutionError(
+            "Cannot get version of the installed RHEL-8 kernel",
+            details={'Problem': 'Did not receive a message with installed RHEL-8 kernel version'
+                                ' (InstalledTargetKernelVersion)'})
+
+    try:
+        # multiple files need to be quoted, see --install in dracut(8)
+        cmd = ["dracut", "--install", '"' + " ".join(files) + '"', "-f", "--kver", target_kernel.version]
+        run(cmd)
+    except CalledProcessError as e:
+        # just hypothetic check, it should not die
+        raise StopActorExecutionError("Cannot regenerate dracut image.", details={"details": str(e)})

--- a/repos/system_upgrade/el7toel8/actors/initrdinclude/tests/test_initrdinclude.py
+++ b/repos/system_upgrade/el7toel8/actors/initrdinclude/tests/test_initrdinclude.py
@@ -1,0 +1,81 @@
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import initrdinclude
+from leapp.libraries.stdlib import api, CalledProcessError
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
+from leapp.models import InitrdIncludes, InstalledTargetKernelVersion
+
+
+INCLUDES1 = ["/file1", "/file2", "/dir/ect/ory/file3"]
+INCLUDES2 = ["/file4", "/file5"]
+KERNEL_VERSION = "4.18.0"
+
+
+def raise_call_error(args=None):
+    raise CalledProcessError(
+        message='A Leapp Command Error occured.',
+        command=args,
+        result={'signal': None, 'exit_code': 1, 'pid': 0, 'stdout': 'fake', 'stderr': 'fake'})
+
+
+class RunMocked(object):
+    def __init__(self, raise_err=False):
+        self.called = 0
+        self.args = []
+        self.raise_err = raise_err
+
+    def __call__(self, args):
+        self.called += 1
+        self.args = args
+        if self.raise_err:
+            raise_call_error(args)
+
+
+def test_no_includes(monkeypatch):
+    run_mocked = RunMocked()
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[]))
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(initrdinclude, 'run', run_mocked)
+
+    initrdinclude.process()
+    assert "No additional files required to add into the initrd." in api.current_logger.dbgmsg
+    assert not run_mocked.called
+
+
+def test_no_kernel_version(monkeypatch):
+    run_mocked = RunMocked()
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        msgs=[InitrdIncludes(files=INCLUDES1), InitrdIncludes(files=INCLUDES2)]))
+    monkeypatch.setattr(initrdinclude, 'run', run_mocked)
+
+    with pytest.raises(StopActorExecutionError) as e:
+        initrdinclude.process()
+    assert 'Cannot get version of the installed RHEL-8 kernel' in str(e)
+    assert not run_mocked.called
+
+
+def test_dracut_fail(monkeypatch):
+    run_mocked = RunMocked(raise_err=True)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        msgs=[InitrdIncludes(files=INCLUDES1), InitrdIncludes(files=INCLUDES2),
+              InstalledTargetKernelVersion(version=KERNEL_VERSION)]))
+    monkeypatch.setattr(initrdinclude, 'run', run_mocked)
+
+    with pytest.raises(StopActorExecutionError) as e:
+        initrdinclude.process()
+    assert 'Cannot regenerate dracut image' in str(e)
+    assert run_mocked.called
+
+
+def test_flawless(monkeypatch):
+    run_mocked = RunMocked()
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        msgs=[InitrdIncludes(files=INCLUDES1), InitrdIncludes(files=INCLUDES2),
+              InstalledTargetKernelVersion(version=KERNEL_VERSION)]))
+    monkeypatch.setattr(initrdinclude, 'run', run_mocked)
+
+    initrdinclude.process()
+    assert run_mocked.called
+    for f in INCLUDES1 + INCLUDES2:
+        assert (f in arg for arg in run_mocked.args)

--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -75,9 +75,9 @@ class CurrentActorMocked(object):  # pylint:disable=R0904
         return os.path.join(self._common_folder, folder)
 
     def consume(self, model):
-        return filter(  # pylint:disable=W0110,W1639
+        return iter(filter(  # pylint:disable=W0110,W1639
             lambda msg: isinstance(msg, model), self._msgs
-        )
+        ))
 
     @property
     def log(self):


### PR DESCRIPTION
Previously a model representing installed RHEL 8 kernel didn't exist. Now it does, so the actor has been modified to use it instead of calling `rpm -q kernel`. Missing tests have also been added.

Coverage data:
```
----------- coverage: platform linux, python 3.8.2-final-0 -----------
Name                   Stmts   Miss  Cover
------------------------------------------
actor.py                  11      1    91%
libraries/library.py      16      0   100%
tests/unit_test.py        53      0   100%
------------------------------------------
TOTAL                     80      1    99%
```