### PR TITLE
scansaphana: SAP HANA scanning implementation

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checksaphana/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checksaphana/actor.py
@@ -1,0 +1,28 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.checksaphana import perform_check
+from leapp.models import SapHanaInfo
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckSapHana(Actor):
+    """
+    If SAP HANA has been detected, several checks are performed to ensure a successful upgrade.
+
+    If the upgrade flavour is 'default' no checks are being executed.
+
+    The following checks are executed:
+    - If this system is _NOT_ running on x86_64, the upgrade is inhibited.
+    - If SAP HANA 1 has been detected on the system the upgrade is inhibited since it is not supported on RHEL8.
+    - If SAP HANA 2 has been detected, the upgrade will be inhibited if an unsupported version for the target release
+      has been detected.
+    - If SAP HANA is running the upgrade is inhibited.
+    """
+
+    name = 'check_sap_hana'
+    consumes = (SapHanaInfo,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        perform_check()

--- a/repos/system_upgrade/el7toel8/actors/checksaphana/libraries/checksaphana.py
+++ b/repos/system_upgrade/el7toel8/actors/checksaphana/libraries/checksaphana.py
@@ -1,0 +1,213 @@
+from leapp.libraries.stdlib import api
+from leapp.libraries.common.config import architecture
+from leapp.models import SapHanaInfo
+from leapp import reporting
+
+
+# SAP HANA Compatibility
+# Requirement is SAP HANA 2.00 which contains SP4 Rev48 PatchLevel 02 compatibility
+# SP5 rev52 does contain the patches from 48.02 therefore it is eligible and the information
+# is contained within the manifest file.
+# Therefore we only have to write down SP4 48.02 s minimal required patch level
+
+SAP_HANA_MINIMAL_MAJOR_VERSION = 2
+SAP_HANA_RHEL8_REQUIRED_PATCH_LEVELS = ((4, 48, 2), (5, 52, 0))
+SAP_HANA_MINIMAL_VERSION_STRING = 'HANA 2.0 SPS04 rev 48.02 or later SPS04, or HANA 2.0 SPS05 rev 52 or later'
+
+
+def _manifest_get(manifest, key, default_value=None):
+    for entry in manifest:
+        if entry.key == key:
+            return entry.value
+    return default_value
+
+
+def running_check(info):
+    """ Creates a report if a running instance of SAP HANA has been detected """
+    if info.running:
+        reporting.create_report([
+            reporting.Title('Found running SAP HANA instances'),
+            reporting.Summary(
+                'In order to perform a system upgrade it is necessary that all instances of SAP HANA are stopped.'
+            ),
+            reporting.RemediationHint('Shutdown all SAP HANA instances before you continue with the upgrade.'),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.SANITY]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.Audience('sysadmin')
+        ])
+
+
+def _add_hana_details(target, instance):
+    """ Adds instance information into the target dictionary for creating later reports. """
+    target.setdefault(instance.name, {'numbers': set(), 'path': instance.path, 'admin': instance.admin})
+    target[instance.name]['numbers'].add(instance.instance_number)
+
+
+def _create_detected_instances_list(details):
+    """ Generates report data for detected instances in list form with details """
+    result = []
+    for name, meta in details.items():
+        result.append(('Name: {name}\n'
+                       '  Instances: {instances}\n'
+                       '  Admin: {admin}\n'
+                       '  Path: {path}').format(name=name,
+                                                instances=', '.join(meta['numbers']),
+                                                admin=meta['admin'],
+                                                path=meta['path']))
+    if result:
+        return '- {}'.format('\n- '.join(result))
+    return ''
+
+
+def version1_check(info):
+    """ Creates a report for SAP HANA instances running on version 1 """
+    found = {}
+    for instance in info.instances:
+        if _manifest_get(instance.manifest, 'release') == '1.00':
+            _add_hana_details(found, instance)
+
+    if found:
+        detected = _create_detected_instances_list(found)
+        reporting.create_report([
+            reporting.Title('Found SAP HANA 1 which is not supported with the target version of RHEL'),
+            reporting.Summary(
+                ('SAP HANA 1.00 is not supported with the version of RHEL you are upgrading to.\n\n'
+                 'The following instances have been detected to be version 1.00:\n'
+                 '{}'.format(detected))
+            ),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.RemediationHint((
+                'In order to upgrade RHEL, you will have to upgrade your SAP HANA 1.0 software to '
+                '{supported}.'.format(supported=SAP_HANA_MINIMAL_VERSION_STRING))),
+            reporting.ExternalLink(url='https://launchpad.support.sap.com/#/notes/2235581',
+                                   title='SAP HANA: Supported Operating Systems'),
+            reporting.Tags([reporting.Tags.SANITY]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.Audience('sysadmin')
+        ])
+
+
+def _major_version_check(instance):
+    """ Performs the check for the major version of SAP HANA """
+    release = _manifest_get(instance.manifest, 'release', '0.00')
+    parts = release.split('.')
+
+    try:
+        if int(parts[0]) != SAP_HANA_MINIMAL_MAJOR_VERSION:
+            api.current_logger().info('Unsupported major version {} for instance {}'.format(release, instance.name))
+            return False
+        return True
+    except (ValueError, IndexError):
+        api.current_logger().warn(
+            'Failed to parse manifest release field for instance {}'.format(instance.name), exc_info=True)
+        return False
+
+
+def _sp_rev_patchlevel_check(instance):
+    """ Checks whether this SP, REV & PatchLevel are eligible """
+    number = _manifest_get(instance.manifest, 'rev-number', '000')
+    if len(number) > 2 and number.isdigit():
+        required_sp_levels = [r[0] for r in SAP_HANA_RHEL8_REQUIRED_PATCH_LEVELS]
+        lowest_sp = min(required_sp_levels)
+        highest_sp = max(required_sp_levels)
+        sp = int(number[0:2].lstrip('0') or '0')
+        if sp < lowest_sp:
+            # Less than minimal required SP
+            return False
+        if sp > highest_sp:
+            # Less than minimal required SP
+            return True
+        for requirements in SAP_HANA_RHEL8_REQUIRED_PATCH_LEVELS:
+            req_sp, req_rev, req_pl = requirements
+            if sp == req_sp:
+                rev = int(number.lstrip('0') or '0')
+                if rev < req_rev:
+                    continue
+                if rev == req_rev:
+                    patch_level = int(_manifest_get(instance.manifest, 'rev-patchlevel', '00').lstrip('0') or '0')
+                    if patch_level < req_pl:
+                        continue
+                return True
+        return False
+    # if not 'len(number) > 2 and number.isdigit()'
+    api.current_logger().warn(
+        'Invalid rev-number field value `{}` in manifest for instance {}'.format(number, instance.name))
+    return False
+
+
+def _fullfills_hana_min_version(instance):
+    """ Performs a check whether the version of SAP HANA fullfills the minimal requirements for the target RHEL """
+    return _major_version_check(instance) and _sp_rev_patchlevel_check(instance)
+
+
+def version2_check(info):
+    """ Performs all checks for SAP HANA 2 and creates a report if anything unsupported has been detected """
+    found = {}
+    for instance in info.instances:
+        if _manifest_get(instance.manifest, 'release', None) == '1.00':
+            continue
+        if not _fullfills_hana_min_version(instance):
+            _add_hana_details(found, instance)
+
+    if found:
+        detected = _create_detected_instances_list(found)
+        reporting.create_report([
+            reporting.Title('SAP HANA needs to be updated before upgrade'),
+            reporting.Summary(
+                ('A newer version of SAP HANA is required in order continue with the upgrade.'
+                 ' {min_hana_version} is required for the target version of RHEL.\n\n'
+                 'The following SAP HANA instances have been detected to be running with a lower version'
+                 ' than required on the target system:\n'
+                 '{detected}').format(detected=detected, min_hana_version=SAP_HANA_MINIMAL_VERSION_STRING)
+            ),
+            reporting.RemediationHint('Update SAP HANA at least to {}'.format(SAP_HANA_MINIMAL_VERSION_STRING)),
+            reporting.ExternalLink(url='https://launchpad.support.sap.com/#/notes/2235581',
+                                   title='SAP HANA: Supported Operating Systems'),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.SANITY]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.Audience('sysadmin')
+        ])
+
+
+def platform_check():
+    """ Creates an inhibitor report in case the system is not running on x86_64 """
+    if not architecture.matches_architecture(architecture.ARCH_X86_64):
+        reporting.create_report([
+            reporting.Title('SAP HANA upgrades are only supported on X86_64 systems'),
+            reporting.Summary(
+                ('Upgrades for SAP HANA are only supported on X86_64 systems.'
+                 ' For more information please consult the documentation.')
+            ),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.SANITY]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.Audience('sysadmin'),
+            reporting.ExternalLink(
+                url='https://access.redhat.com/solutions/5533441',
+                title='How do I upgrade from Red Hat Enterprise Linux 7 to Red Hat Enterprise Linux 8 with SAP HANA')
+        ])
+        return False
+
+    return True
+
+
+def perform_check():
+    """ Performs all checks for SAP HANA and will skip if the upgrade flavour is not `saphana` """
+
+    if api.current_actor().configuration.flavour != 'saphana':
+        # Do not run on non saphana upgrades
+        return
+
+    if not platform_check():
+        # If this architecture is not supported, there's no sense in continuing.
+        return
+
+    info = next(api.consume(SapHanaInfo), None)
+    if not info:
+        return
+
+    running_check(info)
+    version1_check(info)
+    version2_check(info)

--- a/repos/system_upgrade/el7toel8/actors/checksaphana/tests/test_checksaphana.py
+++ b/repos/system_upgrade/el7toel8/actors/checksaphana/tests/test_checksaphana.py
@@ -1,0 +1,244 @@
+import pytest
+
+from leapp.libraries.actor import checksaphana
+from leapp.libraries.common import testutils
+from leapp.libraries.stdlib import run
+from leapp.models import SapHanaManifestEntry
+
+SAPHANA1_MANIFEST = '''comptype: HDB
+keyname: HDB
+keycaption: SAP HANA DATABASE
+supported-phases: prepare,offline,online
+requires-restart: system
+keyvendor: sap.com
+release: 1.00
+rev-number: 122
+rev-patchlevel: 33
+sp-number: 122
+sp-patchlevel: 33
+makeid: 7407089
+date: 2020-10-08 16:23:37
+platform: linuxx86_64
+hdb-state: RAMP
+fullversion: 1.00.122.33 Build 1602166441-1530
+'''
+
+
+SAPHANA2_MANIFEST = '''comptype: HDB
+keyname: HDB
+keycaption: SAP HANA DATABASE
+supported-phases: prepare,offline,configure,online
+requires-restart: system
+keyvendor: sap.com
+release: 2.00
+rev-number: 053
+rev-patchlevel: 00
+sp-number: 053
+sp-patchlevel: 00
+max_rel2.0_sps2_rev-number: 24
+max_rel2.0_sps2_patchlevel: 10
+max_rel2.0_sps3_rev-number: 37
+max_rel2.0_sps3_patchlevel: 07
+max_rel2.0_sps4_rev-number: 48
+max_rel2.0_sps4_patchlevel: 02
+date: 2020-11-11 12:12:22
+platform: linuxx86_64
+hdb-state: RAMP
+fullversion: 2.00.053.00 Build 1605092543-1530
+'''
+
+
+SAPHANA2_LOW_VERSION_MANIFEST = '''comptype: HDB
+keyname: HDB
+keycaption: SAP HANA DATABASE
+supported-phases: prepare,offline,configure,online
+requires-restart: system
+keyvendor: sap.com
+release: 2.00
+rev-number: 040
+rev-patchlevel: 00
+sp-number: 040
+sp-patchlevel: 00
+max_rel2.0_sps2_rev-number: 24
+max_rel2.0_sps2_patchlevel: 10
+max_rel2.0_sps3_rev-number: 37
+max_rel2.0_sps3_patchlevel: 07
+date: 2020-11-11 12:12:22
+platform: linuxx86_64
+hdb-state: RAMP
+fullversion: 2.00.040.00 Build 1605092543-1530
+'''
+
+
+def _report_has_pattern(report, pattern):
+    return pattern in report[0].to_dict().get('title', '')
+
+
+EXPECTED_TITLE_PATTERNS = {
+    'running': lambda report: _report_has_pattern(report, 'running SAP HANA'),
+    'v1': lambda report: _report_has_pattern(report, 'Found SAP HANA 1'),
+    'low': lambda report: _report_has_pattern(report, 'SAP HANA needs to be updated before upgrade'),
+}
+
+
+def list_clear(l):
+    del l[:]
+
+
+def _parse_manifest_data(manifest):
+    result = []
+    for line in manifest.split('\n'):
+        line = line.strip()
+        if not line:
+            continue
+        # If there is a ValueError during the split, just burn with fire in this test
+        key, value = line.split(': ', 1)
+        result.append(SapHanaManifestEntry(key=key, value=value.strip()))
+    return result
+
+
+class MockSapHanaInstanceInfo(object):
+    def __init__(self, name, number, path, admin, manifest_data, running=True):
+        self.manifest = _parse_manifest_data(manifest_data)
+        self.name = name
+        self.instance_number = number
+        self.path = path
+        self.running = running
+        self.admin = admin
+
+
+def _gen_instance_info(name, manifest_data, index, running=True):
+    return MockSapHanaInstanceInfo(
+        name=name,
+        number='{:02}'.format(index),
+        path='/hana/shared/{name}/HDB{number:02}'.format(name=name, number=index),
+        admin='{name}adm'.format(name=name.lower()),
+        manifest_data=manifest_data,
+        running=running
+    )
+
+
+class MockSapHanaInfo(object):
+    def __init__(self, v1names, v2names, v2lownames, running=None):
+        self.installed = bool(v1names or v2names or v2lownames)
+        self.running = running if running is not None else self.installed
+        self.instances = [_gen_instance_info(name,
+                                             SAPHANA1_MANIFEST,
+                                             index,
+                                             running=running)
+                          for index, name in enumerate(v1names)]
+        self.instances += [_gen_instance_info(name,
+                                              SAPHANA2_MANIFEST,
+                                              index + len(v1names),
+                                              running=running)
+                           for index, name in enumerate(v2names)]
+        self.instances += [_gen_instance_info(name,
+                                              SAPHANA2_LOW_VERSION_MANIFEST,
+                                              index + len(v1names) + len(v2names),
+                                              running=running)
+                           for index, name in enumerate(v2lownames)]
+
+
+def _report_collector(reports):
+    def _mock_report(args):
+        reports.append(args)
+    return _mock_report
+
+
+def _consume_mock_sap_hana_info(v1names=(), v2names=(), v2lownames=(), running=True):
+    def _consume(*models):
+        return iter([MockSapHanaInfo(v1names, v2names, v2lownames, running=running)])
+    return _consume
+
+
+class MockSAPHanaVersionInstance(object):
+    def __init__(self, major, rev, patchlevel):
+        self.name = "TestName"
+
+        def _kv(k, v):
+            return SapHanaManifestEntry(key=k, value=v)
+        self.manifest = [
+            _kv('release', '{major}.00'.format(major=major)),
+            _kv('rev-number', '{rev:03}'.format(rev=rev)),
+            _kv('rev-patchlevel', '{pl:02}'.format(pl=patchlevel)),
+            _kv('sp-number', '{rev:03}'.format(rev=rev)),
+            _kv('sp-patchlevel', '{pl:02}'.format(pl=patchlevel)),
+        ]
+
+
+@pytest.mark.parametrize(
+    'major,rev,patchlevel,result', (
+        (2, 52, 0, True),
+        (2, 52, 1, True),
+        (2, 52, 2, True),
+        (2, 53, 0, True),
+        (2, 60, 0, True),
+        (2, 48, 2, True),
+        (2, 48, 1, False),
+        (2, 48, 0, False),
+        (2, 38, 2, False),
+        (2, 49, 0, True),
+    )
+)
+def test_checksaphana__fullfills_hana_min_version(monkeypatch, major, rev, patchlevel, result):
+    monkeypatch.setattr(checksaphana, 'SAP_HANA_RHEL8_REQUIRED_PATCH_LEVELS', ((4, 48, 2), (5, 52, 0)))
+    assert checksaphana._fullfills_hana_min_version(
+        MockSAPHanaVersionInstance(
+            major=major,
+            rev=rev,
+            patchlevel=patchlevel,
+        )
+    ) == result
+
+
+def test_checksaphana_perform_check(monkeypatch):
+    v1names = ('ABC', 'DEF', 'GHI')
+    v2names = ('JKL', 'MNO', 'PQR', 'STU')
+    v2lownames = ('VWX', 'YZA')
+    reports = []
+    monkeypatch.setattr(checksaphana, 'SAP_HANA_RHEL8_REQUIRED_PATCH_LEVELS', ((4, 48, 2), (5, 52, 0)))
+    monkeypatch.setattr(checksaphana.reporting, 'create_report', _report_collector(reports))
+    monkeypatch.setattr(checksaphana.api, 'consume', _consume_mock_sap_hana_info(
+        v1names=v1names, v2names=v2names, v2lownames=v2lownames, running=True))
+
+    for arch in (testutils.architecture.ARCH_PPC64LE,
+                 testutils.architecture.ARCH_ARM64,
+                 testutils.architecture.ARCH_S390X):
+        for flavour in ('default', 'saphana'):
+            list_clear(reports)
+            monkeypatch.setattr(checksaphana.api,
+                                'current_actor',
+                                testutils.CurrentActorMocked(arch=arch, flavour=flavour))
+            checksaphana.perform_check()
+            if flavour == 'saphana':
+                assert reports and len(reports) == 1
+                assert 'X86_64' in reports[0][0].to_dict()['title']
+            else:
+                assert not reports
+
+    list_clear(reports)
+    monkeypatch.setattr(checksaphana.api,
+                        'current_actor',
+                        testutils.CurrentActorMocked(arch=testutils.architecture.ARCH_X86_64))
+    checksaphana.perform_check()
+    assert not reports
+
+    monkeypatch.setattr(checksaphana.api,
+                        'current_actor',
+                        testutils.CurrentActorMocked(arch=testutils.architecture.ARCH_X86_64, flavour='saphana'))
+    checksaphana.perform_check()
+    assert reports
+    # Expected 3 reports due to v1names + v2lownames + running
+    assert len(reports) == 3
+    # Verifies that all expected title patterns are within the reports and not just coincidentally 3
+    assert all([any([pattern(report) for report in reports]) for pattern in EXPECTED_TITLE_PATTERNS.values()])
+
+    list_clear(reports)
+    monkeypatch.setattr(checksaphana.api, 'consume', _consume_mock_sap_hana_info(
+        v1names=v1names, v2names=v2names, v2lownames=v2lownames, running=False))
+    checksaphana.perform_check()
+    assert reports
+    # Expected 2 reports due to v1names + v2lownames
+    assert len(reports) == 2
+    # Verifies that all expected title patterns are within the reports and not just coincidentally 2
+    assert all([any([EXPECTED_TITLE_PATTERNS[pattern](report) for report in reports]) for pattern in ['v1', 'low']])

--- a/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/ipuworkflowconfig/actor.py
@@ -18,12 +18,14 @@ class IPUWorkflowConfig(Actor):
     tags = (IPUWorkflowTag,)
 
     def process(self):
-        target_version = ipuworkflowconfig.get_target_version()
+        flavour = ipuworkflowconfig.get_upgrade_flavour()
+        target_version = ipuworkflowconfig.get_target_version(flavour)
         os_release = ipuworkflowconfig.get_os_release('/etc/os-release')
         self.produce(IPUConfig(
             leapp_env_vars=ipuworkflowconfig.get_env_vars(),
             os_release=os_release,
             architecture=platform.machine(),
             version=Version(source=os_release.version_id, target=target_version),
-            kernel=ipuworkflowconfig.get_booted_kernel()
+            kernel=ipuworkflowconfig.get_booted_kernel(),
+            flavour=flavour
         ))

--- a/repos/system_upgrade/el7toel8/actors/scansaphana/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scansaphana/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.scansaphana import perform_sap_hana_scan
+from leapp.models import SapHanaInfo
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanSapHana(Actor):
+    """
+    Gathers information related to SAP HANA instances on the system.
+
+    This actor collects information from SAP HANA installations and produces a message containing the details.
+    The actor will determine whether SAP HANA is installed, running and which version is present on the system.
+    """
+
+    name = 'scan_sap_hana'
+    consumes = ()
+    produces = (SapHanaInfo,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        perform_sap_hana_scan()

--- a/repos/system_upgrade/el7toel8/actors/scansaphana/libraries/scansaphana.py
+++ b/repos/system_upgrade/el7toel8/actors/scansaphana/libraries/scansaphana.py
@@ -1,0 +1,133 @@
+from os import listdir, path
+
+from leapp.libraries.stdlib import CalledProcessError, api, run
+from leapp.models import SapHanaInfo, SapHanaInstanceInfo, SapHanaManifestEntry
+
+HANA_BASE_PATH = '/hana/shared'
+HANA_MANIFEST_PATH = 'exe/linuxx86_64/hdb/manifest'
+HANA_SAPCONTROL_PATH = 'exe/linuxx86_64/hdb/sapcontrol'
+
+
+def perform_sap_hana_scan():
+    """
+    Produces a message with details collected around SAP HANA.
+    """
+
+    api.produce(search_sap_hana_instances())
+
+
+def parse_manifest(path):
+    """ Parses a SAP HANA manifest into a dictionary """
+    def _decoded(s):
+        """
+        Compatibility between Python2 and 3 - Python 2 has no str.decode but we can process str directly.
+        Python3 needs the byte data to be decoded so we can process the string data.
+        """
+        if hasattr(s, 'decode'):
+            return s.decode('utf-8')
+        return s
+
+    data = []
+    try:
+        with open(path, 'r') as f:
+            for line in _decoded(f.read()).split('\n'):
+                try:
+                    key, value = line.split(':', 1)
+                except ValueError:
+                    # Most likely an empty line, but we're being permissive here and ignore failures.
+                    # In the end it's all about having the right values available.
+                    if line:
+                        api.current_logger().warn(
+                            'Failed to parse line in manifest: {file}. Line was: `{line}`'.format(file=path,
+                                                                                                  line=line),
+                            exc_info=True)
+                    continue
+                data.append(SapHanaManifestEntry(key=key, value=value.strip()))
+    except OSError:
+        return None
+    return data
+
+
+def search_sap_hana_instances():
+    """
+    Searches for all instances of SAP HANA on the system and gets the information for it
+
+    This code will go through all entries in /hana/shared and checks for all instances within.
+    For each instance it will check the status and record the location.
+
+    :return: SapHanaInfo
+    """
+    # Keeps track of found instances
+    result = []
+    # Keeps track if any instance is running
+    any_running = False
+    # Keeps track if any SAP HANA installation was found. In theory it could be also derived from len(result) != 0
+    installed = False
+    if path.isdir(HANA_BASE_PATH):
+        for entry in listdir(HANA_BASE_PATH):
+
+            entry_path = path.join(HANA_BASE_PATH, entry)
+            sapcontrol_path = path.join(entry_path, HANA_SAPCONTROL_PATH)
+            entry_manifest_path = path.join(entry_path, HANA_MANIFEST_PATH)
+            if path.isfile(entry_manifest_path):
+                # We found the manifest file in the expected relative path.
+                # Now we are going to look for instance directories.
+                for instance in listdir(entry_path):
+                    instance_number = None
+                    if 'HDB' in instance:
+                        # We found an instance. Instance directories follow HDB[0-9][0-9] naming pattern,
+                        # where the numbers represent the instance number.
+                        instance_number = instance[-2:]
+                    if not instance_number:
+                        # This is not a folder we are interested in
+                        continue
+                    # Now obviously SAP HANA is installed
+                    installed = True
+                    # We can derive the admin name from `entry` directory name
+                    admin_name = '{}adm'.format(entry.lower())
+                    # Retrieving the status of this instance
+                    running = get_instance_status(instance_number, sapcontrol_path, admin_name)
+                    # Update the variable that tracks all instances if any is running.
+                    # This makes the inhibitor code easier later.
+                    any_running = any_running or running
+                    # Append the found instance to the list
+                    result.append(
+                        SapHanaInstanceInfo(
+                            name=entry,
+                            manifest=parse_manifest(entry_manifest_path),
+                            path=entry_path,
+                            instance_number=instance_number,
+                            running=running,
+                            admin=admin_name
+                        )
+                    )
+    # Return the results
+    return SapHanaInfo(instances=result, running=any_running, installed=installed)
+
+
+def get_instance_status(instance_number, sapcontrol_path, admin_name):
+    """ Gets the status for the instance given """
+    try:
+        # Executes sapcontrol in the context of the instance admin user to retrieve the process list for the given
+        # SAP HANA instance.
+        # GetProcessList has some oddities, like returning non zero exit codes with special meanings.
+        # Exit code 3 = All processes are running correctly
+        # Exit code 4 = All processes stopped
+        # Other exit codes aren't handled at this time and it's assumed that SAP HANA is possibly in some unusal
+        # state. Such as starting/stopping but also that it is in some kind of failure state.
+        output = run([
+            'sudo', '-u', admin_name, sapcontrol_path, '-nr', instance_number, '-function', 'GetProcessList'],
+            checked=False)
+        if output['exit_code'] == 3:
+            # GetProcessList succeeded, all processes running correctly
+            return True
+        if output['exit_code'] == 4:
+            # GetProcessList succeeded, all processes stopped
+            return False
+        # SAP HANA might be somewhere in between (Starting/Stopping)
+        # In that case there are always more than 7 lines.
+        return len(output['stdout'].split('\n')) > 7
+    except CalledProcessError:
+        api.current_logger().warn(
+            'Failed to retrieve SAP HANA instance status from sapcontrol - Considering it as not running.')
+        return False

--- a/repos/system_upgrade/el7toel8/actors/scansaphana/tests/test_scansaphana.py
+++ b/repos/system_upgrade/el7toel8/actors/scansaphana/tests/test_scansaphana.py
@@ -1,0 +1,187 @@
+import subprocess
+from io import BytesIO
+
+from leapp.compat import IS_PYTHON3, unicode_type
+from leapp.libraries.actor import scansaphana
+
+SAPHANA_TEST_INSTANCES = ('00', '10', '23', '34', '66')
+SAPHANA2_MANIFEST = ''.join(('''compversion-id: 73554900100200005327
+comptype: HDB
+keyname: HDB
+keycaption: SAP HANA DATABASE
+supported-phases: prepare,offline,configure,online
+requires-restart: system
+keyvendor: sap.com
+release: 2.00
+rev-number: 053
+rev-patchlevel: 00
+rev-changelist: 1605092543
+max_sps12_rev-number: 122
+max_sps12_patchlevel: 33
+max_rel2.0_sps0_rev-number: 02
+max_rel2.0_sps0_patchlevel: 02
+max_rel2.0_sps1_rev-number: 12
+max_rel2.0_sps1_patchlevel: 05
+max_rel2.0_sps2_rev-number: 24
+max_rel2.0_sps2_patchlevel: 10
+max_rel2.0_sps3_rev-number: 37
+max_rel2.0_sps3_patchlevel: 07
+max_rel2.0_sps4_rev-number: 48
+max_rel2.0_sps4_patchlevel: 02
+upgrade-restriction: sourceVersion="[1.00.000.00,1.00.69.07)"; message="You must first upgrade your system to the ''',
+                             '''latest HANA 1.0 SPS6 Revision (69.07), then to HANA 1.0 SPS12 if you want to ''',
+                             '''upgrade to HANA 2.0"
+upgrade-restriction: sourceVersion="[1.00.69.07,1.00.120.00)"; message="You must first make an intermediate update ''',
+                             '''to HANA SPS12 if you want to upgrade to HANA 2.0. Please see SAP Note 2372809."
+restrict-supported-components: name="REMOTE_DATA_SYNC"; vendor="sap.com"; version="[2.0.010.00,3.00.000.00)"
+sp-number: 053
+sp-patchlevel: 00
+makeid: 7694334
+date: 2020-11-11 12:12:22
+platform: linuxx86_64
+hdb-state: RAMP
+fullversion: 2.00.053.00 Build 1605092543-1530
+auxversion: 0000.00.0
+cloud_edition: 0000.00.00
+changeinfo: CONT 49fd3e766fbee9a5c22dd609397d2fa640b9df09 (fa/hana2sp05)
+compiletype: rel
+compilebranch: fa/hana2sp05
+git-hash: 49fd3e766fbee9a5c22dd609397d2fa640b9df09
+git-headcount: 500015
+git-mergetime: 2020-11-11 12:02:23
+git-mergeepoch: 1605092543
+sapexe-version: 753
+sapexe-branch: 753_REL
+sapexe-changelist: 2007209
+compiler-version-full: gcc (SAP release 20200227, based on SUSE gcc9-9.2.1+r275327-1.3.7) 9.2.1 20190903 ''',
+                             '''[gcc-9-branch revision 275330]
+compiler-version: GCC 9
+lcmserver-artifact-version: 2.5.46'''))
+
+
+class CallMock(object):
+    def __init__(self, ret):
+        self.args = None
+        self.ret = ret
+
+    def __call__(self, *args, **kwargs):
+        self.args = args
+        return self.ret
+
+
+class SubprocessCall(object):
+    def __init__(self, admusername):
+        self.admusername = admusername
+
+    def __call__(self, *args, **kwargs):
+        assert args[0][0:3] == ['sudo', '-u', self.admusername]
+        cmd = args[0][3:]
+        kwargs.pop('checked', None)
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        p.wait()
+        return {'exit_code': p.returncode, 'stdout': p.stdout.read()}
+
+
+def test_scansaphana_get_instance_status(monkeypatch):
+    call = CallMock(ret={})
+    monkeypatch.setattr(scansaphana, 'run', call)
+
+    call.ret = {'exit_code': 3, 'stdout': ''}
+    assert scansaphana.get_instance_status('00', 'fake/control/path', 'tstadm')
+    assert call.args[0] == ['sudo', '-u', 'tstadm', 'fake/control/path', '-nr', '00', '-function', 'GetProcessList']
+
+    call.ret = {'exit_code': 4, 'stdout': ''}
+    assert not scansaphana.get_instance_status('00', 'fake/control/path', 'tstadm')
+    assert call.args[0] == ['sudo', '-u', 'tstadm', 'fake/control/path', '-nr', '00', '-function', 'GetProcessList']
+
+    call.ret = {'exit_code': 0, 'stdout': '\n'}
+    assert not scansaphana.get_instance_status('00', 'fake/control/path', 'tstadm')
+    assert call.args[0] == ['sudo', '-u', 'tstadm', 'fake/control/path', '-nr', '00', '-function', 'GetProcessList']
+
+    call.ret = {'exit_code': 0, 'stdout': ' \n' * 6}
+    assert not scansaphana.get_instance_status('00', 'fake/control/path', 'tstadm')
+    assert call.args[0] == ['sudo', '-u', 'tstadm', 'fake/control/path', '-nr', '00', '-function', 'GetProcessList']
+
+    call.ret = {'exit_code': 0, 'stdout': '\n' * 7}
+    assert scansaphana.get_instance_status('00', 'fake/control/path', 'tstadm')
+    assert call.args[0] == ['sudo', '-u', 'tstadm', 'fake/control/path', '-nr', '00', '-function', 'GetProcessList']
+
+
+def test_scansaphana_parse_manifest(monkeypatch):
+    class _mock_open(object):
+        def __init__(self, path, mode):
+            self._fp = BytesIO(SAPHANA2_MANIFEST.encode('utf-8'))
+
+        def __enter__(self):
+            return self._fp
+
+        def __exit__(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(scansaphana, 'open', _mock_open, False)
+    data = scansaphana.parse_manifest('yadda')
+
+    def _get_manifest_entry(key):
+        for entry in data:
+            if entry.key == key:
+                return entry.value
+        return None
+    assert _get_manifest_entry('sapexe-version') == '753'
+    assert _get_manifest_entry('keycaption') == 'SAP HANA DATABASE'
+
+
+def test_scansaphana_search_saphana_databases(monkeypatch, tmpdir):
+    base_path = tmpdir
+    monkeypatch.setattr(scansaphana, 'HANA_BASE_PATH', str(base_path))
+    cur_path = base_path
+    manifest_path_parts = scansaphana.HANA_MANIFEST_PATH.split('/')
+    for part in manifest_path_parts[0:-1]:
+        cur_path = cur_path.join(part)
+        cur_path.mkdir()
+
+    linkpath = base_path.join(manifest_path_parts[0])
+
+    manifest = cur_path.join(manifest_path_parts[-1])
+    manifest.write_text(unicode_type(SAPHANA2_MANIFEST), encoding='utf-8')
+
+    sapcontrol = cur_path.join(scansaphana.HANA_SAPCONTROL_PATH.split('/')[-1])
+    sapcontrol.write_text(unicode_type('''#!/bin/bash
+echo ''
+echo '26.01.2021 17:55:17'
+echo 'GetProcessList'
+echo 'OK'
+echo 'name, description, dispstatus, textstatus, starttime, elapsedtime, pid'
+echo 'hdbdaemon, HDB Daemon, GREEN, Running, 2020 05 08 21:56:28, 6307:58:49, 16043'
+echo 'hdbcompileserver, HDB Compileserver, GREEN, Running, 2020 05 08 21:57:00, 6307:58:17, 16365'
+echo 'hdbdiserver, HDB Deployment Infrastructure Server, GREEN, Running, 2020 05 08 21:57:37, 6307:57:40, 16546'
+echo 'hdbindexserver, HDB Indexserver-HXE, GREEN, Running, 2020 05 08 21:57:01, 6307:58:16, 16391'
+echo 'hdbnameserver, HDB Nameserver, GREEN, Running, 2020 05 08 21:56:29, 6307:58:48, 16061'
+echo 'hdbwebdispatcher, HDB Web Dispatcher, GREEN, Running, 2020 05 08 21:57:38, 6307:57:39, 16549'
+exit 3
+    '''), encoding='utf-8')
+    sapcontrol.chmod(0o755)
+
+    result = scansaphana.search_sap_hana_instances()
+    assert not result.instances
+    assert not result.running
+    assert not result.installed
+
+    monkeypatch.setattr(scansaphana, 'run', SubprocessCall('lppadm'))
+    admin = base_path.join('LPP')
+    admin.mkdir()
+    admin.join(manifest_path_parts[0]).mksymlinkto(str(linkpath))
+
+    for instance in SAPHANA_TEST_INSTANCES:
+        instance_path = admin.join(('HDB' + instance))
+        instance_path.mkdir()
+
+    result = scansaphana.search_sap_hana_instances()
+    assert result.instances
+    assert len(result.instances) == len(SAPHANA_TEST_INSTANCES)
+    check_instance_numbers = set(SAPHANA_TEST_INSTANCES)
+    for instance in result.instances:
+        assert instance.instance_number in check_instance_numbers
+        check_instance_numbers.remove(instance.instance_number)
+    assert not check_instance_numbers
+    assert result.running
+    assert result.installed

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
@@ -87,14 +87,19 @@ def test_is_rhel_alt(monkeypatch, result, kernel, release_id):
     assert version.is_rhel_alt() == result
 
 
-@pytest.mark.parametrize('result,is_alt,src_ver', [
-    (True, True, '7.6'),
-    (True, False, '7.8'),
-    (False, True, '7.8'),
-    (False, False, '7.6'),
+@pytest.mark.parametrize('result,is_alt,src_ver,saphana', [
+    (True, True, '7.6', False),
+    (True, False, '7.8', False),
+    (False, True, '7.8', False),
+    (False, False, '7.6', False),
+    (True, True, '7.6', True),
+    (True, False, '7.7', True),
+    (False, True, '7.7', True),
+    (False, False, '7.6', True),
 ])
-def test_is_supported_version(monkeypatch, result, is_alt, src_ver):
+def test_is_supported_version(monkeypatch, result, is_alt, src_ver, saphana):
     monkeypatch.setattr(version, 'is_rhel_alt', lambda: is_alt)
-    monkeypatch.setattr(version, 'SUPPORTED_VERSIONS', {'rhel': ['7.8'], 'rhel-alt': ['7.6']})
+    monkeypatch.setattr(version, 'is_sap_hana_flavour', lambda: saphana)
+    monkeypatch.setattr(version, 'SUPPORTED_VERSIONS', {'rhel': ['7.8'], 'rhel-alt': ['7.6'], 'rhel-saphana': ['7.7']})
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver=src_ver))
     assert version.is_supported_version() == result

--- a/repos/system_upgrade/el7toel8/libraries/config/version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/version.py
@@ -12,7 +12,7 @@ OP_MAP = {
 }
 
 # Note: 'rhel-alt' is detected when on 'rhel' with kernel 4.x
-SUPPORTED_VERSIONS = {'rhel': ['7.9'], 'rhel-alt': ['7.6']}
+SUPPORTED_VERSIONS = {'rhel': ['7.9'], 'rhel-alt': ['7.6'], 'rhel-saphana': ['7.7']}
 
 
 def _version_to_tuple(version):
@@ -141,6 +141,26 @@ def current_version():
     return release.release_id, release.version_id
 
 
+def is_default_flavour():
+    """
+    Check if the current system uses the default upgrade path.
+
+    :return: `True` if this upgrade process is using the default upgrade path and `False` otherwise.
+    :rtype: bool
+    """
+    return api.current_actor().configuration.flavour == 'default'
+
+
+def is_sap_hana_flavour():
+    """
+    Check if the current system needs to use the SAP HANA upgrade path.
+
+    :return: `True` if this upgrade process is using the SAP HANA upgrade path and `False` otherwise.
+    :rtype: bool
+    """
+    return api.current_actor().configuration.flavour == 'saphana'
+
+
 def is_rhel_alt():
     """
     Check if the current system is RHEL-ALT or not.
@@ -163,6 +183,8 @@ def is_supported_version():
     release_id, version_id = current_version()
     if is_rhel_alt():
         release_id = 'rhel-alt'
+    elif is_sap_hana_flavour():
+        release_id = 'rhel-saphana'
 
     if not matches_release(SUPPORTED_VERSIONS, release_id):
         return False

--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -62,15 +62,15 @@ class logger_mocked(object):
 
 class CurrentActorMocked(object):  # pylint:disable=R0904
     def __init__(self, arch=architecture.ARCH_X86_64, envars=None, kernel='3.10.0-957.43.1.el7.x86_64',
-                 release_id='rhel', src_ver='7.8', dst_ver='8.1', msgs=None):
+                 release_id='rhel', src_ver='7.8', dst_ver='8.1', msgs=None, flavour='default'):
         envarsList = [EnvVar(name=k, value=v) for k, v in envars.items()] if envars else []
         version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
         release = namedtuple('OS_release', ['release_id', 'version_id'])(release_id, src_ver)
 
         self._common_folder = '../../files'
         self.configuration = namedtuple(
-            'configuration', ['architecture', 'kernel', 'leapp_env_vars', 'os_release', 'version']
-        )(arch, kernel, envarsList, release, version)
+            'configuration', ['architecture', 'kernel', 'leapp_env_vars', 'os_release', 'version', 'flavour']
+        )(arch, kernel, envarsList, release, version, flavour)
         self._msgs = msgs or []
 
     def __call__(self):

--- a/repos/system_upgrade/el7toel8/models/ipuconfig.py
+++ b/repos/system_upgrade/el7toel8/models/ipuconfig.py
@@ -54,3 +54,6 @@ class IPUConfig(Model):
 
     kernel = fields.String()
     """Originally booted kernel when on the source system."""
+
+    flavour = fields.StringEnum(('default', 'saphana'), default='default')
+    """Flavour of the upgrade - Used to influence changes in supported source/target release"""

--- a/repos/system_upgrade/el7toel8/models/saphanainfo.py
+++ b/repos/system_upgrade/el7toel8/models/saphanainfo.py
@@ -1,0 +1,44 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class SapHanaManifestEntry(Model):
+    """ SAP HANA manifest file key/value pair entry """
+    topic = SystemInfoTopic
+    key = fields.String()
+    """ Key of the key value pairs in a SAP HANA manifest file """
+    value = fields.String()
+    """ Value of the key value pairs in a SAP HANA manifest file """
+
+
+class SapHanaInstanceInfo(Model):
+    """ Details of SAP HANA instances """
+    topic = SystemInfoTopic
+
+    name = fields.String()
+    """ Name of the instance """
+    path = fields.String()
+    """ Directory of the SAP HANA instance """
+    instance_number = fields.String()
+    """ SAP HANA Instance number """
+    running = fields.Boolean()
+    """ Is the instance currently running? """
+    admin = fields.String()
+    """ Name of the instance administrator """
+    manifest = fields.List(fields.Model(SapHanaManifestEntry))
+    """ Content of the SAP HANA manifest file """
+
+
+class SapHanaInfo(Model):
+    """
+    This message contains information collected around SAP HANA
+
+    If SAP HANA has been detected on the machine, it is running and which versions have been detected.
+    """
+    topic = SystemInfoTopic
+    installed = fields.Boolean(default=False)
+    """ True if SAP HANA has been detected on the system """
+    running = fields.Boolean(default=False)
+    """ True if an instance of SAP HANA is running """
+    instances = fields.List(fields.Model(SapHanaInstanceInfo))
+    """ List of instance details of SAP HANA detected on the system """


### PR DESCRIPTION
scansaphana: SAP HANA scanning implementation

    This patch introduces detection of SAP HANA and adds a check for it.
    It is assumed that SAP Hana instances are installed to /hana/shared.

    From there leapp will detect all instances located there and parses the
    manifest file to retrieve information about the installed binaries.
    Additionally it will perform a check to determine whether or not SAP
    Hana has currently any active instances. If the check later determines
    that there are any running instances the upgrade will be inhibited, as
    upgrading with running SAP Hana instances is not supported.

    The tests for discovery will also recreate as much as is needed to fake
    the environment to make the code think that SAP Hana is either not
    installed/running or that there are several instances.
    It will also check that it will detect all instances that are faked.