### PR TITLE
Cleaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-repos/*/.leapp/leapp.db
+repos/**/.leapp/leapp.db
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -49,6 +49,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,8 @@ help:
 clean:
 	@echo "--- Clean repo ---"
 	@rm -rf packaging/{sources,SRPMS,tmp}/
-	@rm -rf build/ dist/ *.egg-info
+	@rm -rf build/ dist/ *.egg-info .pytest_cache/
+	@find . -name 'leapp.db' | grep "\.leapp/leapp.db" | xargs rm -f
 	@find . -name '__pycache__' -exec rm -fr {} +
 	@find . -name '*.pyc' -exec rm -f {} +
 	@find . -name '*.pyo' -exec rm -f {} +


### PR DESCRIPTION
Update the `.gitignore` file to ignore another artefacts created during running of tests: `.pytest_cache/` and `leapp.db`. As well, remove those files when execute `make clean`.