### PR TITLE
Allow to skip teardown of actor context when no actors loaded

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -64,7 +64,10 @@ def pytest_collectstart(collector):
 
 
 def pytest_runtestloop(session):
-    session.current_actor_context.__exit__(None, None, None)
-    logger.info(
-        "Actor %r context teardown complete", session.current_actor.name,
-    )
+    try:
+        session.current_actor_context.__exit__(None, None, None)
+        logger.info(
+            "Actor %r context teardown complete", session.current_actor.name,
+        )
+    except AttributeError:
+        pass


### PR DESCRIPTION
Fix #511

Small fix related to the need to suppress of AttributeError when doing a teardown of actor context. The reason is that when testing something which doesn't require the actor context (common libraries for example) we don't need to teardown actor context