### PR TITLE
disable grubdevname for s390x

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/grubdevname/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/grubdevname/actor.py
@@ -1,9 +1,14 @@
+import platform
+
 from leapp.actors import Actor
 from leapp.libraries.actor.grubdevname import get_grub_device
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.utils import skip_actor_execution_if
 from leapp.models import GrubDevice
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
+@skip_actor_execution_if(platform.machine() == architecture.ARCH_S390X)
 class Grubdevname(Actor):
     """
     Get name of block device where GRUB is located

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_utils.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_utils.py
@@ -1,0 +1,45 @@
+import logging
+
+import pytest
+
+from leapp.actors import Actor
+from leapp.libraries.common.utils import skip_actor_execution_if
+
+
+@pytest.mark.parametrize(
+    ('conditions', 'exp_return', 'exp_msg_in_log'),
+    [
+        ((True,), None, 'processing skipped'),
+        ((True, True), None, 'processing skipped'),
+        ((True, False), None, 'processing skipped'),
+        ((False,), 'processed', None),
+        ((False, False), 'processed', None),
+    ],
+)
+def test_skip_actor_if(conditions, exp_return, exp_msg_in_log, caplog):
+    class SomeActor(Actor):
+        name = 'some_actor'
+        consumes = ()
+        produces = ()
+        tags = ()
+
+        def process(self):
+            return 'processed'
+
+    DecoratedActor = skip_actor_execution_if(*conditions)(SomeActor)
+    decorated_actor = DecoratedActor()
+    with caplog.at_level(logging.DEBUG):
+        assert decorated_actor.process() == exp_return
+    if exp_msg_in_log:
+        assert exp_msg_in_log in caplog.text
+
+
+def test_skip_actor_if_not_actor_subclass(caplog):
+    with caplog.at_level(logging.DEBUG):
+
+        @skip_actor_execution_if(False)
+        class A(object):
+            pass
+        A()
+
+    assert 'decorator can be used only for Actor' in caplog.text


### PR DESCRIPTION
ref JIRA OAMG-3131

This MR introduces two things:
1. Decorator skip_actor_execution_if(*conditions) for any Actors classes, which allows to skip the actor execution
2. Skip execution of grubdevname actor for s390x cpu architecture with the help of introduced decorator

During the work there were one enhancement ticket created:
https://github.com/oamg/leapp-repository/issues/514