### PR TITLE
Skip grubdevname on s390x cpu arch

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/grubdevname/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/grubdevname/actor.py
@@ -1,5 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.grubdevname import get_grub_device
+from leapp.libraries.common.config import architecture
 from leapp.models import GrubDevice
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
@@ -15,4 +16,6 @@ class Grubdevname(Actor):
     tags = (FactsPhaseTag, IPUWorkflowTag)
 
     def process(self):
+        if architecture.matches_architecture(architecture.ARCH_S390X):
+            return
         get_grub_device()


### PR DESCRIPTION
ref JIRA OAMG-3131

Skip grubdevname on s390x cpu architecture