### PR TITLE
Add: qlcnic and qlge drivers to removed_drivers.txt

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/kernel/checkkerneldrivers/files/removed_drivers.txt
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkkerneldrivers/files/removed_drivers.txt
@@ -7,8 +7,6 @@
 aic79xx
 aoe
 arcmsr
-qlcnic
-qlge
 
 # ata drivers
 
@@ -25,6 +23,9 @@ sata_sx4
 sata_uli
 sata_via
 sata_vsc
+
+# end of ata drivers
+
 bfa
 cxgb3
 cxgb3i
@@ -47,6 +48,9 @@ mvumi
 
 osd
 libosd
+
+# end of OSD drivers
+
 osst
 
 # pata drivers
@@ -81,9 +85,14 @@ pata_sil680
 pata_sis
 pata_via
 pdc_adma
+
+# end of pata drivers
+
 pm80xx
 pmcraid
 qla3xxx
+qlcnic
+qlge
 stex
 sx8
 tulip
@@ -99,3 +108,5 @@ rt73usb
 rt61pci
 rtl8187
 wil6210
+
+# end of wireless drivers

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkkerneldrivers/files/removed_drivers.txt
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkkerneldrivers/files/removed_drivers.txt
@@ -7,6 +7,8 @@
 aic79xx
 aoe
 arcmsr
+qlcnic
+qlge
 
 # ata drivers
 


### PR DESCRIPTION
Adding qlcnic and qlge to removed drivers list, according to this documentation:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/hardware-enablement_considerations-in-adopting-rhel-8#removed-device-drivers_hardware-enablement

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>

Implementation task: OAMG-3323
Verification task: OAMG-3606