### PR TITLE
Add actor localreposinhibit

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
@@ -54,8 +54,8 @@ class LocalReposInhibit(Actor):
                     reporting.Remediation(
                         hint=(
                             "By using Apache HTTP Server you can expose "
-                            "your local repository via http. For details "
-                            "see external link."
+                            "your local repository via http. See the linked "
+                            "article for details. "
                         )
                     ),
                     reporting.ExternalLink(

--- a/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
@@ -41,12 +41,12 @@ class LocalReposInhibit(Actor):
         if self.file_baseurl_in_use():
             warn_msg = (
                 "Local repository found (baseurl starts with file:///). "
-                "Currently leapp is not supporting this option."
+                "Currently leapp does not support this option."
             )
             self.log.warning(warn_msg)
             reporting.create_report(
                 [
-                    reporting.Title("Local repository identified"),
+                    reporting.Title("Local repository detected"),
                     reporting.Summary(warn_msg),
                     reporting.Severity(reporting.Severity.HIGH),
                     reporting.Tags([reporting.Tags.REPOSITORY]),

--- a/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
@@ -19,10 +19,8 @@ class LocalReposInhibit(Actor):
     tags = (IPUWorkflowTag, TargetTransactionChecksPhaseTag)
 
     def process(self):
-        # fmt: off
         used_target_repos = next(self.consume(UsedTargetRepositories)).repos
         target_repos = next(self.consume(TMPTargetRepositoriesFacts)).repositories
-        # fmt: on
         target_repo_id_to_url_map = {
             repo.repoid: repo.baseurl
             for repofile in target_repos

--- a/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
@@ -3,8 +3,10 @@ from leapp.actors import Actor
 from leapp.models import TMPTargetRepositoriesFacts, UsedTargetRepositories
 from leapp.reporting import Report
 from leapp.tags import IPUWorkflowTag, TargetTransactionChecksPhaseTag
+from leapp.utils.deprecation import suppress_deprecation
 
 
+@suppress_deprecation(TMPTargetRepositoriesFacts)
 class LocalReposInhibit(Actor):
     """Inhibits the upgrade if local repositories were found."""
 

--- a/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
@@ -1,0 +1,64 @@
+from leapp import reporting
+from leapp.actors import Actor
+from leapp.models import TMPTargetRepositoriesFacts, UsedTargetRepositories
+from leapp.reporting import Report
+from leapp.tags import IPUWorkflowTag, TargetTransactionChecksPhaseTag
+
+
+class LocalReposInhibit(Actor):
+    """Inhibits the upgrade if local repositories were found."""
+
+    name = "local_repos_inhibit"
+    consumes = (
+        UsedTargetRepositories,
+        TMPTargetRepositoriesFacts,
+    )
+    produces = (Report,)
+    tags = (IPUWorkflowTag, TargetTransactionChecksPhaseTag)
+
+    def process(self):
+        # fmt: off
+        used_target_repos = next(self.consume(UsedTargetRepositories)).repos
+        target_repos = next(self.consume(TMPTargetRepositoriesFacts)).repositories
+        # fmt: on
+        target_repo_id_to_url_map = {
+            repo.repoid: repo.baseurl
+            for repofile in target_repos
+            for repo in repofile.data
+            if repo.baseurl
+        }
+        if any(
+            target_repo_id_to_url_map[repo.repoid].startswith("file:")
+            for repo in used_target_repos
+        ):
+            warn_msg = (
+                "Local repository found (baseurl starts with file:///). "
+                "Currently leapp is not supporting this option."
+            )
+            self.log.warning(warn_msg)
+            reporting.create_report(
+                [
+                    reporting.Title("Local repository identified"),
+                    reporting.Summary(warn_msg),
+                    reporting.Severity(reporting.Severity.HIGH),
+                    reporting.Tags([reporting.Tags.REPOSITORY]),
+                    reporting.Flags([reporting.Flags.INHIBITOR]),
+                    reporting.Remediation(
+                        hint=(
+                            "By using Apache HTTP Server you can expose "
+                            "your local repository via http. For details "
+                            "see external link."
+                        )
+                    ),
+                    reporting.ExternalLink(
+                        title=(
+                            "Customizing your Red Hat Enterprise Linux "
+                            "in-place upgrade"
+                        ),
+                        url=(
+                            "https://access.redhat.com/articles/4977891/"
+                            "#repos-known-issues"
+                        ),
+                    ),
+                ]
+            )

--- a/repos/system_upgrade/el7toel8/actors/localreposinhibit/tests/test_unit_localreposinhibit.py
+++ b/repos/system_upgrade/el7toel8/actors/localreposinhibit/tests/test_unit_localreposinhibit.py
@@ -19,34 +19,35 @@ def test_unit_localreposinhibit(current_actor_context, baseurl, exp_msgs_len):
 
     :type current_actor_context: ActorContext
     """
-    current_actor_context.feed(
-        TMPTargetRepositoriesFacts(
-            repositories=[
-                RepositoryFile(
-                    file="the/path/to/some/file",
-                    data=[
-                        RepositoryData(
-                            name="BASEOS",
-                            baseurl=(
-                                "http://example.com/path/to/repo/BaseOS/x86_64/os/"
+    with pytest.deprecated_call():
+        current_actor_context.feed(
+            TMPTargetRepositoriesFacts(
+                repositories=[
+                    RepositoryFile(
+                        file="the/path/to/some/file",
+                        data=[
+                            RepositoryData(
+                                name="BASEOS",
+                                baseurl=(
+                                    "http://example.com/path/to/repo/BaseOS/x86_64/os/"
+                                ),
+                                repoid="BASEOS",
                             ),
-                            repoid="BASEOS",
-                        ),
-                        RepositoryData(
-                            name="APPSTREAM",
-                            baseurl=(
-                                "http://example.com/path/to/repo/AppStream/x86_64/os/"
+                            RepositoryData(
+                                name="APPSTREAM",
+                                baseurl=(
+                                    "http://example.com/path/to/repo/AppStream/x86_64/os/"
+                                ),
+                                repoid="APPSTREAM",
                             ),
-                            repoid="APPSTREAM",
-                        ),
-                        RepositoryData(
-                            name="CRB", repoid="CRB", baseurl=baseurl
-                        ),
-                    ],
-                )
-            ]
+                            RepositoryData(
+                                name="CRB", repoid="CRB", baseurl=baseurl
+                            ),
+                        ],
+                    )
+                ]
+            )
         )
-    )
     current_actor_context.feed(
         UsedTargetRepositories(
             repos=[

--- a/repos/system_upgrade/el7toel8/actors/localreposinhibit/tests/test_unit_localreposinhibit.py
+++ b/repos/system_upgrade/el7toel8/actors/localreposinhibit/tests/test_unit_localreposinhibit.py
@@ -1,0 +1,59 @@
+import pytest
+
+from leapp.models import (
+    RepositoryData,
+    RepositoryFile,
+    TMPTargetRepositoriesFacts,
+    UsedTargetRepositories,
+    UsedTargetRepository,
+)
+from leapp.snactor.fixture import ActorContext
+
+
+@pytest.mark.parametrize(
+    ("baseurl", "exp_msgs_len"),
+    [("file:///root/crb", 1), ("http://localhost/crb", 0)],
+)
+def test_unit_localreposinhibit(current_actor_context, baseurl, exp_msgs_len):
+    """Ensure the Report is generated when local path is used as a baseurl.
+
+    :type current_actor_context: ActorContext
+    """
+    current_actor_context.feed(
+        TMPTargetRepositoriesFacts(
+            repositories=[
+                RepositoryFile(
+                    file="the/path/to/some/file",
+                    data=[
+                        RepositoryData(
+                            name="BASEOS",
+                            baseurl=(
+                                "http://example.com/path/to/repo/BaseOS/x86_64/os/"
+                            ),
+                            repoid="BASEOS",
+                        ),
+                        RepositoryData(
+                            name="APPSTREAM",
+                            baseurl=(
+                                "http://example.com/path/to/repo/AppStream/x86_64/os/"
+                            ),
+                            repoid="APPSTREAM",
+                        ),
+                        RepositoryData(
+                            name="CRB", repoid="CRB", baseurl=baseurl
+                        ),
+                    ],
+                )
+            ]
+        )
+    )
+    current_actor_context.feed(
+        UsedTargetRepositories(
+            repos=[
+                UsedTargetRepository(repoid="BASEOS"),
+                UsedTargetRepository(repoid="CRB"),
+            ]
+        )
+    )
+    current_actor_context.run()
+    assert len(current_actor_context.messages()) == exp_msgs_len

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
@@ -4,7 +4,7 @@ from leapp.libraries.common.config import get_env, version
 from leapp.models import (CustomTargetRepositoryFile, RepositoriesMap, RequiredTargetUserspacePackages,
                           RHSMInfo, StorageInfo, TargetRepositories,
                           TargetUserSpaceInfo, UsedTargetRepositories,
-                          XFSPresence, Report)
+                          XFSPresence, Report, TMPTargetRepositoriesFacts)
 from leapp.tags import IPUWorkflowTag, TargetTransactionFactsPhaseTag
 
 
@@ -22,7 +22,7 @@ class TargetUserspaceCreator(Actor):
     name = 'target_userspace_creator'
     consumes = (CustomTargetRepositoryFile, RepositoriesMap, RequiredTargetUserspacePackages,
                 StorageInfo, RHSMInfo, TargetRepositories, XFSPresence)
-    produces = (TargetUserSpaceInfo, UsedTargetRepositories, Report)
+    produces = (TargetUserSpaceInfo, UsedTargetRepositories, Report, TMPTargetRepositoriesFacts, )
     tags = (IPUWorkflowTag, TargetTransactionFactsPhaseTag)
 
     def process(self):

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/actor.py
@@ -6,8 +6,10 @@ from leapp.models import (CustomTargetRepositoryFile, RepositoriesMap, RequiredT
                           TargetUserSpaceInfo, UsedTargetRepositories,
                           XFSPresence, Report, TMPTargetRepositoriesFacts)
 from leapp.tags import IPUWorkflowTag, TargetTransactionFactsPhaseTag
+from leapp.utils.deprecation import suppress_deprecation
 
 
+@suppress_deprecation(TMPTargetRepositoriesFacts)
 class TargetUserspaceCreator(Actor):
     """
     Initializes a directory to be populated as a minimal environment to run binaries from the target system.

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -10,7 +10,7 @@ from leapp.libraries.stdlib import CalledProcessError, api, config, run
 from leapp.models import (CustomTargetRepositoryFile, RequiredTargetUserspacePackages, RHSMInfo,
                           StorageInfo, TargetRepositories, TargetUserSpaceInfo,
                           UsedTargetRepositories, UsedTargetRepository,
-                          XFSPresence)
+                          XFSPresence, TMPTargetRepositoriesFacts)
 
 # TODO: "refactor" (modify) the library significantly
 # The current shape is really bad and ineffective (duplicit parsing
@@ -421,6 +421,11 @@ def perform():
         with overlay.nspawn() as context:
             target_repoids = _gather_target_repositories(context, indata, prod_cert_path)
             _create_target_userspace(context, indata.packages, target_repoids)
+            # TODO: this is tmp solution as proper one needs significant refactoring
+            # refactorings..
+            target_repo_facts = repofileutils.get_parsed_repofiles(context)
+            api.produce(TMPTargetRepositoriesFacts(repositories=target_repo_facts))
+            # ## fixme ends here
             api.produce(UsedTargetRepositories(
                 repos=[UsedTargetRepository(repoid=repo) for repo in target_repoids]))
             api.produce(TargetUserSpaceInfo(

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -422,7 +422,6 @@ def perform():
             target_repoids = _gather_target_repositories(context, indata, prod_cert_path)
             _create_target_userspace(context, indata.packages, target_repoids)
             # TODO: this is tmp solution as proper one needs significant refactoring
-            # refactorings..
             target_repo_facts = repofileutils.get_parsed_repofiles(context)
             api.produce(TMPTargetRepositoriesFacts(repositories=target_repo_facts))
             # ## fixme ends here

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
@@ -33,6 +33,9 @@ class MockedMountingBase(object):
     def __call__(self, **dummy_kwarg):
         yield self
 
+    def call(self, *args, **kwargs):
+        return {'stdout': ''}
+
     def nspawn(self):
         return self
 
@@ -259,7 +262,8 @@ def test_perform_ok(monkeypatch):
     userspacegen.perform()
     msg_target_repos = models.UsedTargetRepositories(
         repos=[models.UsedTargetRepository(repoid=repo) for repo in repoids])
-    assert userspacegen.api.produce.called == 2
-    assert userspacegen.api.produce.model_instances[0] == msg_target_repos
+    assert userspacegen.api.produce.called == 3
+    assert isinstance(userspacegen.api.produce.model_instances[0], models.TMPTargetRepositoriesFacts)
+    assert userspacegen.api.produce.model_instances[1] == msg_target_repos
     # this one is full of contants, so it's safe to check just the instance
-    assert isinstance(userspacegen.api.produce.model_instances[1], models.TargetUserSpaceInfo)
+    assert isinstance(userspacegen.api.produce.model_instances[2], models.TargetUserSpaceInfo)

--- a/repos/system_upgrade/el7toel8/models/repositoriesfacts.py
+++ b/repos/system_upgrade/el7toel8/models/repositoriesfacts.py
@@ -29,7 +29,7 @@ class RepositoriesFacts(Model):
 
 
 @deprecated(
-    since="2020-02-01",
+    since="2020-09-01",
     message=(
         "The model is temporary and not assumed to be used in any "
         "other actors."

--- a/repos/system_upgrade/el7toel8/models/repositoriesfacts.py
+++ b/repos/system_upgrade/el7toel8/models/repositoriesfacts.py
@@ -1,5 +1,6 @@
 from leapp.models import Model, fields
 from leapp.topics import SystemFactsTopic
+from leapp.utils.deprecation import deprecated
 
 
 class RepositoryData(Model):
@@ -26,10 +27,18 @@ class RepositoriesFacts(Model):
 
     repositories = fields.List(fields.Model(RepositoryFile))
 
+
+@deprecated(
+    since="2020-02-01",
+    message=(
+        "The model is temporary and not assumed to be used in any "
+        "other actors."
+    ),
+)
 class TMPTargetRepositoriesFacts(RepositoriesFacts):
-    """
-    Do not consume this model anywhere outside of localreposinhibit
+    """Do not consume this model anywhere outside of localreposinhibit.
 
     The model is temporary and will be removed in close future
     """
+
     pass

--- a/repos/system_upgrade/el7toel8/models/repositoriesfacts.py
+++ b/repos/system_upgrade/el7toel8/models/repositoriesfacts.py
@@ -25,3 +25,11 @@ class RepositoriesFacts(Model):
     topic = SystemFactsTopic
 
     repositories = fields.List(fields.Model(RepositoryFile))
+
+class TMPTargetRepositoriesFacts(RepositoriesFacts):
+    """
+    Do not consume this model anywhere outside of localreposinhibit
+
+    The model is temporary and will be removed in close future
+    """
+    pass


### PR DESCRIPTION
ref OAMG-3610

We are unable currently to handle local repos, specified
by baseurl=file:///.+

This actor inhibits the upgrade if such repos exists

# TODO

- [ ] squash commits before merge

# report inside the shell

```
============================================================
                     UPGRADE INHIBITED                      
============================================================

Upgrade has been inhibited due to the following problems:
    1. Inhibitor: Local repository identified.
Consult the pre-upgrade report for details and possible remediation.
```

# content  snippet from leapp-report.txt
```
----------------------------------------
Risk Factor: high (inhibitor)
Title: Local repository identified.
Summary: Local repository &s with baseurl %s were found. Currently leapp is not supporting this option.
Remediation: [hint] By using Apache HTTP Server you can expose your local repo via http. For details see external link.
----------------------------------------
```

# test coverage
```

----------- coverage: platform linux, python 3.8.3-final-0 -----------
Name    Stmts   Miss  Cover   Missing
-------------------------------------
-------------------------------------
TOTAL      28      0   100%

2 files skipped due to complete coverage.

Required test coverage of 95.0% reached. Total coverage: 100.00%
```
