### PR TITLE
fix: Make PreparePythonWorkround more robust

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/preparepythonworkround/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/preparepythonworkround/actor.py
@@ -1,6 +1,5 @@
-import os
-
 from leapp.actors import Actor
+from leapp.libraries.actor.workaround import apply_python3_workaround
 from leapp.tags import IPUWorkflowTag, RPMUpgradePhaseTag
 
 
@@ -20,20 +19,4 @@ class PreparePythonWorkround(Actor):
     tags = (IPUWorkflowTag, RPMUpgradePhaseTag)
 
     def process(self):
-        leapp_home = "/root/tmp_leapp_py3"
-        py3_leapp = os.path.join(leapp_home, "leapp3")
-        os.mkdir(leapp_home)
-        os.symlink(
-            "/usr/lib/python2.7/site-packages/leapp",
-            os.path.join(leapp_home, "leapp"))
-        with open(py3_leapp, "w") as f:
-            f_content = [
-                "#!/usr/bin/python3",
-                "import sys",
-                "sys.path.append('{}')".format(leapp_home),
-                "",
-                "import leapp.cli",
-                "sys.exit(leapp.cli.main())",
-            ]
-            f.write("{}\n\n".format("\n".join(f_content)))
-        os.chmod(py3_leapp, 0o770)
+        apply_python3_workaround()

--- a/repos/system_upgrade/el7toel8/actors/preparepythonworkround/libraries/workaround.py
+++ b/repos/system_upgrade/el7toel8/actors/preparepythonworkround/libraries/workaround.py
@@ -1,0 +1,24 @@
+import os
+
+from leapp.libraries.common.utils import makedirs
+
+LEAPP_HOME = '/root/tmp_leapp_py3'
+
+
+def apply_python3_workaround():
+    py3_leapp = os.path.join(LEAPP_HOME, 'leapp3')
+    makedirs(LEAPP_HOME)
+    leapp_lib_symlink_path = os.path.join(LEAPP_HOME, 'leapp')
+    if not os.path.exists(leapp_lib_symlink_path):
+        os.symlink('/usr/lib/python2.7/site-packages/leapp', leapp_lib_symlink_path)
+    with open(py3_leapp, 'w') as f:
+        f_content = [
+            '#!/usr/bin/python3',
+            'import sys',
+            'sys.path.append(\'{}\')'.format(LEAPP_HOME),
+            '',
+            'import leapp.cli',
+            'sys.exit(leapp.cli.main())',
+        ]
+        f.write('{}\n\n'.format('\n'.join(f_content)))
+    os.chmod(py3_leapp, 0o770)

--- a/repos/system_upgrade/el7toel8/actors/preparepythonworkround/tests/test_preparepythonworkaround.py
+++ b/repos/system_upgrade/el7toel8/actors/preparepythonworkround/tests/test_preparepythonworkaround.py
@@ -1,0 +1,31 @@
+from os import symlink, path, access, X_OK
+
+import pytest
+
+from leapp.libraries.actor import workaround
+from leapp.libraries.common.utils import makedirs
+
+
+def fake_symlink(basedir):
+    def impl(source, target):
+        source_path = str(basedir.join(*source.lstrip('/').split('/')))
+        makedirs(source_path)
+        symlink(source_path, target)
+    return impl
+
+
+def test_apply_python3_workaround(monkeypatch, tmpdir):
+    leapp_home = tmpdir.mkdir('tmp_leapp_py3')
+    monkeypatch.setattr(workaround.os, 'symlink', fake_symlink(tmpdir.mkdir('lib')))
+    monkeypatch.setattr(workaround, 'LEAPP_HOME', str(leapp_home))
+
+    # Ensure double invocation doesn't cause a problem
+    workaround.apply_python3_workaround()
+    workaround.apply_python3_workaround()
+
+    # Ensure creation of all required elements
+    assert path.islink(str(leapp_home.join('leapp')))
+    assert path.isfile(str(leapp_home.join('leapp3')))
+    assert access(str(leapp_home.join('leapp3')), X_OK)
+
+    assert str(leapp_home) in leapp_home.join('leapp3').read_text('utf-8')


### PR DESCRIPTION
Previously multiple executions of leapp after a failing in the initram
phase caused this actor to fail. This patch fixes up the issue and
additionally adds some unit test.

BZ-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1858479
OAMG-Issue: OAMG-3640
Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>