### PR TITLE
Change upgrade path: RHEL 7.9 -> 8.2

### DIFF
--- a/repos/system_upgrade/el7toel8/libraries/config/version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/version.py
@@ -12,7 +12,7 @@ OP_MAP = {
 }
 
 # Note: 'rhel-alt' is detected when on 'rhel' with kernel 4.x
-SUPPORTED_VERSIONS = {'rhel': ['7.8'], 'rhel-alt': ['7.6']}
+SUPPORTED_VERSIONS = {'rhel': ['7.9'], 'rhel-alt': ['7.6']}
 
 
 def _version_to_tuple(version):


### PR DESCRIPTION
The upgrade path for primary architectures was RHEL 7.8 -> 8.2, now it is 7.9 -> 8.2.