### PR TITLE
Multi-command remediations are not supported

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkrootsymlinks/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrootsymlinks/actor.py
@@ -28,6 +28,10 @@ class CheckRootSymlinks(Actor):
         absolute_links = [item for item in rootdir.items if item.target and os.path.isabs(item.target)]
 
         if absolute_links:
+            commands = [' '.join(['ln', '-snf',
+                                  os.path.relpath(item.target, '/'),
+                                  os.path.join('/', item.name)]) for item in absolute_links]
+            remediation = [['sh', '-c', ' && '.join(commands)]]
             reporting.create_report([
                 reporting.Title('Upgrade requires links in root directory to be relative'),
                 reporting.Summary(
@@ -37,7 +41,5 @@ class CheckRootSymlinks(Actor):
                 ),
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Flags([reporting.Flags.INHIBITOR]),
-                reporting.Remediation(commands=[['ln', '-snf',
-                                                 os.path.relpath(item.target, '/'),
-                                                 os.path.join('/', item.name)] for item in absolute_links])
+                reporting.Remediation(commands=remediation)
             ])

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddevelkernels/libraries/checkinstalleddevelkernels.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddevelkernels/libraries/checkinstalleddevelkernels.py
@@ -27,8 +27,10 @@ def process():
         summary = ('DNF cannot produce a valid upgrade transaction when'
                    ' multiple kernel-devel packages are installed.')
         hint = ('Remove all but one kernel-devel packages before running Leapp again.')
-        commands = ([['yum', '-y', 'remove', '{n}-{v}.{r}'.format(
-            n=pkg.name, v=pkg.version, r=pkg.release)] for pkg in pkgs[:-1]])
+        all_but_latest_kernel_devel = pkgs[:-1]
+        packages = ['{n}-{v}-{r}'.format(n=pkg.name, v=pkg.version, r=pkg.release)
+                    for pkg in all_but_latest_kernel_devel]
+        commands = [['yum', '-y', 'remove'] + packages]
         reporting.create_report([
             reporting.Title(title),
             reporting.Summary(summary),

--- a/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/libraries/reportsettargetrelease.py
+++ b/repos/system_upgrade/el7toel8/actors/reportsettargetrelease/libraries/reportsettargetrelease.py
@@ -25,11 +25,10 @@ def _report_set_release():
 def _report_unhandled_release():
     # TODO: set the POST group after it's created.
     target_version = api.current_actor().configuration.version.target
-    commands = [
-        ['subscription-manager', 'release', '--unset'],
-        ['subscription-manager', 'release', '--set', target_version],
-    ]
-    hint = 'Set the new release (or unset it) after the upgrade using subscription-manager.'
+    hint_command = 'subscription-manager release --set {}'.format(target_version)
+    # FIXME: This should use Dialogs and Answers to offer post-upgrade remediation
+    # so that users can choose whether to --set or --unset the release number
+    hint = 'Set the new release (or unset it) after the upgrade using subscription-manager: ' + hint_command
     reporting.create_report([
         reporting.Title(
             'The subscription-manager release is going to be kept as it is during the upgrade'),
@@ -41,7 +40,7 @@ def _report_unhandled_release():
             ' after the upgrade.'
         ),
         reporting.Severity(reporting.Severity.LOW),
-        reporting.Remediation(commands=commands, hint=hint),
+        reporting.Remediation(hint=hint),
         reporting.Tags([reporting.Tags.UPGRADE_PROCESS]),
         reporting.RelatedResource('package', 'subscription-manager')
     ])

--- a/repos/system_upgrade/el7toel8/actors/verifydialogs/libraries/verifydialogs.py
+++ b/repos/system_upgrade/el7toel8/actors/verifydialogs/libraries/verifydialogs.py
@@ -12,8 +12,9 @@ def check_dialogs(inhibit_if_no_userchoice=True):
         dialog_resources = [reporting.RelatedResource('dialog', s) for s in sections]
         dialogs_remediation = ('Please register user choices with leapp answer cli command or by manually editing '
                                'the answerfile.')
+        # FIXME: Enable more choices once we can do multi-command remediations
         cmd_remediation = [['leapp', 'answer', '--section', "{}={}".format(s, choice)]
-                           for s, choices in dialog.answerfile_sections.items() for choice in choices]
+                           for s, choices in dialog.answerfile_sections.items() for choice in choices[:1]]
         report_data = [reporting.Title('Missing required answers in the answer file'),
                        reporting.Severity(reporting.Severity.HIGH),
                        reporting.Summary(summary.format('\n'.join(sections))),


### PR DESCRIPTION
Before we have a mechanism to provide users with either/or choice
for remediations we need to make sure that there is always one and only
one remediation command