### PR TITLE
Skip test which rely on dnf package if dnf is unavailable

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
@@ -9,6 +9,7 @@ from leapp.libraries.actor import userspacegen
 from leapp.libraries.common import overlaygen, rhsm
 from leapp.libraries.common.config import architecture
 from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked, produce_mocked
+from leapp.libraries.common.repofileutils import DNF_AVAILABLE
 
 CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 _CERTS_PATH = os.path.join(CUR_DIR, '../../../files', userspacegen.PROD_CERTS_FOLDER)
@@ -246,6 +247,7 @@ def mocked_consume_data():
 
 
 # TODO: come up with additional tests for the main function
+@pytest.mark.skipif(not DNF_AVAILABLE, reason='dnf package is not available.')
 def test_perform_ok(monkeypatch):
     repoids = ['repoidX', 'repoidY']
     monkeypatch.setattr(userspacegen, '_InputData', mocked_consume_data)

--- a/repos/system_upgrade/el7toel8/libraries/repofileutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/repofileutils.py
@@ -7,8 +7,10 @@ from leapp.models import RepositoryFile, RepositoryData, fields
 
 try:
     import dnf
+    DNF_AVAILABLE = True
 except ImportError:
     api.current_logger().warn('repofileutils.py: failed to import dnf')
+    DNF_AVAILABLE = False
 
 
 def _parse_repository(repoid, repo_data):


### PR DESCRIPTION
This is a small MR linked with recent #525 (already merged). After merging #525, the tests are failing on systems which don't have dnf package.

This MR resolves this problem