### PR TITLE
Chore/improve msgs about transaction changes

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/peseventsscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/peseventsscanner.py
@@ -407,6 +407,15 @@ def filter_out_out_pkgs(event_in_pkgs, event_out_pkgs):
     return {k: v for k, v in event_in_pkgs.items() if k not in event_out_pkgs}
 
 
+SKIPPED_PKGS_MSG = (
+    'packages will be skipped because they are available only in '
+    'RHEL 8 repositories that are intentionally excluded from the '
+    'list of repositories used during the upgrade. '
+    'See the report message titled "Excluded RHEL 8 repositories" '
+    'for details.\n The list of these packages (repositories: {}):'
+)
+
+
 def filter_out_pkgs_in_blacklisted_repos(to_install):
     """
     Do not install packages that are available in blacklisted repositories
@@ -415,7 +424,7 @@ def filter_out_pkgs_in_blacklisted_repos(to_install):
     setuptargetrepos actor. So even if they fall into the 'yum upgrade' bucket, they won't be available thus upgraded.
     """
     # FIXME The to_install contains just a limited subset of packages - those that are *not* currently installed and
-    # are to be installed. But we should also warn about the packages that *are* installed.
+    #   are to be installed. But we should also warn about the packages that *are* installed.
     blacklisted_pkgs = set()
     blacklisted_repos = get_repositories_blacklisted()
     for pkg, repo in to_install.items():
@@ -426,8 +435,10 @@ def filter_out_pkgs_in_blacklisted_repos(to_install):
         del to_install[pkg]
 
     if blacklisted_pkgs:
-        report_skipped_packages('packages will not be installed due to blacklisted repositories:',
-                                blacklisted_pkgs)
+        report_skipped_packages(
+            message=SKIPPED_PKGS_MSG.format(', '.join(blacklisted_repos)),
+            packages=blacklisted_pkgs,
+        )
 
 
 def resolve_conflicting_requests(tasks):
@@ -475,27 +486,33 @@ def map_repositories(packages):
 
     if repo_without_mapping:
         report_skipped_packages('packages will not be installed or upgraded due to repositories unknown to leapp:',
-                                repo_without_mapping)
+                                repo_without_mapping,
+                                "Please file a bug in http://bugzilla.redhat.com/ for leapp-repository component of"
+                                "the Red Hat Enterprise Linux 7 product.")
 
 
-def report_skipped_packages(message, packages):
+def report_skipped_packages(message, packages, remediation=None):
     """Generate report message about skipped packages"""
     packages = sorted(packages)
     title = 'Packages will not be installed'
     summary = '{} {}\n{}'.format(len(packages), message, '\n'.join(['- ' + p for p in packages]))
-    reporting.create_report([
+    report_content = [
         reporting.Title(title),
         reporting.Summary(summary),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Tags([reporting.Tags.REPOSITORY]),
-    ] + [reporting.RelatedResource('package', p) for p in packages])
+    ]
+    if remediation:
+        report_content += [reporting.Remediation(hint=remediation)]
+    report_content += [reporting.RelatedResource('package', p) for p in packages]
+    reporting.create_report(report_content)
     if is_verbose():
-        api.show_message(summary)
+        api.current_logger().info(summary)
 
 
 def add_output_pkgs_to_transaction_conf(transaction_configuration, events):
     """
-    Add more packages for removal to transaction configuration if they can be derived as outputs of PES events.
+    Filter out those PES events that conflict with the higher priority transaction configuration files.
 
     Output packages from an event are added to packages for removal only if all input packages are already there.
 
@@ -503,16 +520,21 @@ def add_output_pkgs_to_transaction_conf(transaction_configuration, events):
                                       on the user configuration files
     :param events: List of Event tuples, where each event contains event type and input/output pkgs
     """
-    message = 'Marking packages for removal:\n'
+    message = 'The following RHEL 8 packages will not be installed:\n'
 
     for event in events:
         if event.action in (Action.split, Action.merged, Action.replaced, Action.renamed):
             if all([pkg in transaction_configuration.to_remove for pkg in event.in_pkgs]):
                 transaction_configuration.to_remove.extend(event.out_pkgs)
-                message += '- [{action}] {ins} -> {outs}\n'.format(
-                    action=event.action.name,
-                    ins=', '.join(sorted(event.in_pkgs.keys())),
-                    outs=', '.join(sorted(event.out_pkgs.keys()))
+                message += (
+                    '- {outs}\n - Reason: {ins} being {action} {to_or_by} {outs} {is_or_are} mentioned in the'
+                    ' transaction configuration file /etc/leapp/transaction/to_remove\n'.format(
+                        outs=', '.join(event.out_pkgs.keys()),
+                        ins=', '.join(event.in_pkgs.keys()),
+                        action=event.action.name,
+                        to_or_by='by' if event.action == 'Replaced' else 'to',
+                        is_or_are='is' if len(event.in_pkgs.keys()) == 1 else 'are'
+                    )
                 )
 
     api.current_logger().debug(message)

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/libraries/redhatsignedrpmcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/libraries/redhatsignedrpmcheck.py
@@ -8,22 +8,21 @@ COMMON_REPORT_TAGS = [reporting.Tags.SANITY]
 
 
 def generate_report(packages):
-    """ Generate a report if exists packages unsigned in the system """
+    """ Generate a report if there are unsigned packages installed on the system """
     if not packages:
         return
     unsigned_packages_new_line = '\n'.join(['- ' + p for p in packages])
-    unsigned_packages = ' '.join(packages)
-    remediation = ['yum', '-y', 'remove', '{}'.format(unsigned_packages)]
-    title = 'Packages not signed by Red Hat found in the system'
-    summary = 'The following packages have not been signed by Red Hat ' \
-              'and may be removed in the upgrade process:\n{}'.format(unsigned_packages_new_line)
+    title = 'Packages not signed by Red Hat found on the system'
+    summary = ('The following packages have not been signed by Red Hat'
+               ' and may be removed during the upgrade process in case Red Hat-signed'
+               ' packages to be removed during the upgrade depend on them:\n{}'
+               .format(unsigned_packages_new_line))
     reporting.create_report([
         reporting.Title(title),
         reporting.Summary(summary),
         reporting.Severity(reporting.Severity.HIGH),
-        reporting.Tags(COMMON_REPORT_TAGS),
-        reporting.Remediation(commands=[remediation]),
-    ] + [reporting.RelatedResource('package', p) for p in packages])
+        reporting.Tags(COMMON_REPORT_TAGS)
+    ])
 
     if is_verbose():
         api.show_message(summary)

--- a/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/redhatsignedrpmcheck/tests/test_redhatsignedrpmcheck.py
@@ -45,8 +45,3 @@ def test_actor_execution_with_unsigned_data(monkeypatch):
     redhatsignedrpmcheck.generate_report(packages)
     assert reporting.create_report.called == 1
     assert 'Packages not signed by Red Hat found' in reporting.create_report.report_fields['title']
-    assert all(r['remediations']['context'][0] == 'yum' and
-               r['remediations']['context'][1] == '-y' and
-               r['remediations']['context'][2] == 'remove' and
-               'sample' in r['remediations']['context'][3]
-               for r in reporting.create_report.report_fields['remediations'])

--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/actor.py
@@ -1,6 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.repositoriesblacklist import process
 from leapp.models import RepositoriesBlacklisted, RepositoriesFacts, RepositoriesMap
+from leapp.reporting import Report
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 
@@ -11,7 +12,7 @@ class RepositoriesBlacklist(Actor):
 
     name = 'repositories_blacklist'
     consumes = (RepositoriesFacts, RepositoriesMap, )
-    produces = (RepositoriesBlacklisted,)
+    produces = (RepositoriesBlacklisted, Report)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
     def process(self):

--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/libraries/repositoriesblacklist.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/libraries/repositoriesblacklist.py
@@ -1,6 +1,11 @@
+from leapp import reporting
 from leapp.libraries.common.config import get_product_type
 from leapp.libraries.stdlib import api
-from leapp.models import RepositoriesBlacklisted, RepositoriesFacts, RepositoriesMap
+from leapp.models import (
+    RepositoriesBlacklisted,
+    RepositoriesFacts,
+    RepositoriesMap,
+)
 
 
 def _is_optional_repo(repo):
@@ -47,3 +52,26 @@ def process():
     if reposid_blacklist:
         api.current_logger().info("The optional repository is not enabled. Blacklisting the CRB repository.")
         api.produce(RepositoriesBlacklisted(repoids=reposid_blacklist))
+
+        report = [
+            reporting.Title("Excluded RHEL 8 repositories"),
+            reporting.Summary(
+                "The following repositories are not supported by "
+                "Red Hat and are excluded from the list of repositories "
+                "used during the upgrade.\n- {}".format(
+                    "\n- ".join(reposid_blacklist)
+                )
+            ),
+            reporting.Severity(reporting.Severity.INFO),
+            reporting.Tags([reporting.Tags.REPOSITORY]),
+            reporting.Flags([reporting.Flags.FAILURE]),
+            reporting.ExternalLink(
+                url=(
+                    "https://access.redhat.com/documentation/en-us/"
+                    "red_hat_enterprise_linux/8/html/package_manifest/"
+                    "codereadylinuxbuilder-repository."
+                ),
+                title="CodeReady Linux Builder repository",
+            ),
+        ]
+        reporting.create_report(report)

--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/tests/test_repositoriesblacklist.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/tests/test_repositoriesblacklist.py
@@ -1,5 +1,6 @@
 import pytest
 
+from leapp import reporting
 from leapp.libraries.actor import repositoriesblacklist
 from leapp.libraries.common.testutils import produce_mocked, CurrentActorMocked
 from leapp.libraries.stdlib import api
@@ -12,7 +13,6 @@ from leapp.models import (
     RepositoryFile,
     RepositoryMap,
 )
-from leapp.snactor.fixture import current_actor_context
 
 
 @pytest.mark.parametrize('valid_opt_repoid,product_type', [
@@ -126,11 +126,13 @@ def test_repositoriesblacklist_not_empty(monkeypatch):
     name = 'test'
     monkeypatch.setattr(repositoriesblacklist, "_get_disabled_optional_repo", lambda: [name])
     monkeypatch.setattr(api, "produce", produce_mocked())
+    monkeypatch.setattr(reporting, "create_report", produce_mocked())
 
     repositoriesblacklist.process()
     assert api.produce.called == 1
     assert isinstance(api.produce.model_instances[0], RepositoriesBlacklisted)
     assert api.produce.model_instances[0].repoids[0] == name
+    assert reporting.create_report.called == 1
 
 
 def test_repositoriesblacklist_empty(monkeypatch):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ funcsigs==1.0.2
 mock==2.0.0
 pylint
 pytest==4.6.11
-pytest-ordering==0.5
 pyudev==0.22.0
 distro==1.5.0
 ipaddress==1.0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ flake8-import-order
 funcsigs==1.0.2
 mock==2.0.0
 pylint
-# pytest is fixed at 3.6.4 because never version (3.7.*) requires scandir, which depends on gcc
-pytest==3.6.4
+pytest==4.6.11
 pytest-ordering==0.5
 pyudev==0.22.0
 distro==1.5.0


### PR DESCRIPTION
ref #544 

First MR which improves the clarity of the messages regarding unsupported repos

P.S. Bumping the requirements is required due to outdated caplog fixture + after merged #524 we are no longer restricted to pytest 3.6.4