### PR TITLE
fix wrong check if path is subpath of other path

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.utils.repository import find_repository_basedir
@@ -27,7 +28,7 @@ def pytest_collectstart(collector):
         # actor
         if "/actors/" in str(collector.fspath) and (
             not hasattr(collector.session, "current_actor_path")
-            or collector.session.current_actor_path
+            or collector.session.current_actor_path + os.sep
             not in str(collector.fspath)
         ):
             actor = None


### PR DESCRIPTION
Fixes #547 
Unblock #526 

This MR fixes the wrong implementation of the check if the path is a subpath of other path. This causes the actor context unloaded before switching to the test of another actor.