### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -13,7 +13,7 @@ py2_byte_compile "%1" "%2"}
 
 
 Name:           leapp-repository
-Version:        0.10.0
+Version:        0.11.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Upgrade handling
### Fixes
- Do not crash when the /root/temp_leapp_py3 directory exists (when upgrade is executed multiple times) (#534, rhbz#1858479)
- Do not detect grub device on the s390x architecture (ZIPL is used there) (#491)
- Consider the katello rpm being signed by Red Hat (#532)
- Omit printing grub binary data on terminal which could break terminal output (#491)
- Provide just a single remedition command in the pre-upgrade report to be compatible with Satellite and Cockpit (#540)
- Search repository files only in directories used by DNF (#525)

### Enhancements
- Changed supported upgrade paths: RHEL-ALT 7.6 -> 8.2; RHEL 7.9 -> 8.2 (#509)
- Check whether PAM modules, that are not present on RHEL 8, are used (#533)
- Inhibit upgrade when local repositories (referred by file://) are detected (#531)
- Introduced actors for migration of Authconfig to Authselect (#533)
- Support for an in-place upgrade for z15 machines - s390x architecture (#537)
- Updated list of removed drivers on RHEL 8 (#530)

## Additional changes interesting for devels
- Actor's private libraries and test files have been renamed following the new contribution guidelines (#500)
- Introduced the `CurrentActorMocked` class in the testutils library to simplify writing unit tests (#489)
- Significant improvement of test execution performance (#500, #506)
- Updated production certificates for testing upgrades to RHEL 8.3 (Beta | HTB) (#509)


