### PR TITLE
LocalReposInhibit: Check mirrorlist and metalink too

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/localreposinhibit/actor.py
@@ -27,10 +27,9 @@ class LocalReposInhibit(Actor):
         used_target_repos = next(self.consume(UsedTargetRepositories)).repos
         target_repos = next(self.consume(TMPTargetRepositoriesFacts)).repositories
         target_repo_id_to_url_map = {
-            repo.repoid: repo.baseurl
+            repo.repoid: repo.mirrorlist or repo.metalink or repo.baseurl or ""
             for repofile in target_repos
             for repo in repofile.data
-            if repo.baseurl
         }
         return any(
             target_repo_id_to_url_map[repo.repoid].startswith("file:")

--- a/repos/system_upgrade/el7toel8/actors/localreposinhibit/tests/test_unit_localreposinhibit.py
+++ b/repos/system_upgrade/el7toel8/actors/localreposinhibit/tests/test_unit_localreposinhibit.py
@@ -11,10 +11,21 @@ from leapp.snactor.fixture import ActorContext
 
 
 @pytest.mark.parametrize(
-    ("baseurl", "exp_msgs_len"),
-    [("file:///root/crb", 1), ("http://localhost/crb", 0)],
+    ("baseurl", "mirrorlist", "metalink", "exp_msgs_len"),
+    [
+        ("file:///root/crb", None, None, 1),
+        ("http://localhost/crb", None, None, 0),
+        (None, "file:///root/crb", None, 1),
+        (None, "http://localhost/crb", None, 0),
+        (None, None, "file:///root/crb", 1),
+        (None, None, "http://localhost/crb", 0),
+        ("http://localhost/crb", "file:///root/crb", None, 1),
+        ("file:///root/crb", "http://localhost/crb", None, 0),
+        ("http://localhost/crb", None, "file:///root/crb", 1),
+        ("file:///root/crb", None, "http://localhost/crb", 0),
+    ],
 )
-def test_unit_localreposinhibit(current_actor_context, baseurl, exp_msgs_len):
+def test_unit_localreposinhibit(current_actor_context, baseurl, mirrorlist, metalink, exp_msgs_len):
     """Ensure the Report is generated when local path is used as a baseurl.
 
     :type current_actor_context: ActorContext
@@ -41,7 +52,8 @@ def test_unit_localreposinhibit(current_actor_context, baseurl, exp_msgs_len):
                                 repoid="APPSTREAM",
                             ),
                             RepositoryData(
-                                name="CRB", repoid="CRB", baseurl=baseurl
+                                name="CRB", repoid="CRB", baseurl=baseurl,
+                                mirrorlist=mirrorlist, metalink=metalink
                             ),
                         ],
                     )


### PR DESCRIPTION
A repository can have an URL defined in the field `mirrorlist` or `metalink` instead of `baseurl`. Mirrorlist and metalink are mutually exclusive, though baseurl can still be present as a fallback.

Important notes:
- I'm not sure if the bug with addresses starting with `file:///` occurs when it's a metalink/mirrorlist address. Should we regard those as local repos too?
- `baseurl`, `mirrorlist` and `metalink` are all nullable fields but I could find no checks if there's not a forbidden combination of them, e.g. mirrorlist with metalink or none of these fields at all. I know such repos would be invalid, but there are many places in our codebase where they would traceback. Maybe we should check that somewhere.

Closes #580