### PR TITLE
pylint: Disable checks introduced in pylint 2.6

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -35,10 +35,12 @@ disable=
  too-many-statements,
 # new for python3 version of pylint
  useless-object-inheritance,
- consider-using-set-comprehension, # pylint3 force to use comprehension in place we don't want (py2 doesnt have these options, for inline skip)
+ consider-using-set-comprehension,  # pylint3 force to use comprehension in place we don't want (py2 doesnt have these options, for inline skip)
  unnecessary-pass,
  invalid-envvar-default,  # pylint3 warnings envvar returns str/none by default
- bad-option-value, # python 2 doesn't have import-outside-toplevel, but in some case we need to import outside toplevel
+ bad-option-value,  # python 2 doesn't have import-outside-toplevel, but in some case we need to import outside toplevel
+ super-with-arguments,  # required in python 2
+ raise-missing-from,  # no 'raise from' in python 2
 
 [FORMAT]
 # Maximum number of characters on a single line.


### PR DESCRIPTION
pylint 2.6 was released on 2020-08-20 and introduced two new checks which we cannot use due to Python 2:
  - `super-with-arguments` (R1725)
  - `raise-missing-from` (W0707)

Release notes: http://pylint.pycqa.org/en/latest/whatsnew/2.6.html

Blocks #581.