### PR TITLE
[POC] initram networking

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/addupgradebootentry.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/libraries/addupgradebootentry.py
@@ -9,7 +9,8 @@ from leapp.models import BootContent
 
 def add_boot_entry(configs=None):
     debug = 'debug' if os.getenv('LEAPP_DEBUG', '0') == '1' else ''
-
+    enable_network = os.getenv('LEAPP_INITRAM_NETWORK') in ('network-manager', 'scripts')
+    ip_arg = ' ip=on' if enable_network else ''
     kernel_dst_path, initram_dst_path = get_boot_file_paths()
     try:
         _remove_old_upgrade_boot_entry(kernel_dst_path, configs=configs)
@@ -20,7 +21,7 @@ def add_boot_entry(configs=None):
             '--title', 'RHEL-Upgrade-Initramfs',
             '--copy-default',
             '--make-default',
-            '--args', '{DEBUG} enforcing=0 rd.plymouth=0 plymouth.enable=0'.format(DEBUG=debug)
+            '--args', '{DEBUG}{NET} enforcing=0 rd.plymouth=0 plymouth.enable=0'.format(DEBUG=debug, NET=ip_arg)
         ]
         if configs:
             for config in configs:

--- a/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/module-setup.sh
+++ b/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/module-setup.sh
@@ -71,6 +71,15 @@ install() {
     # Q: Would we hack that in way of copy whole initramfs into the root, mount
     #    mount it and set envars
 
+    # Install network configuration triggers
+    if [ -f /etc/leapp-initram-network-manager ]; then
+        dracut_install /etc/leapp-initram-network-manager
+    fi
+
+    if [ -f /etc/leapp-initram-network-scripts ]; then
+        dracut_install /etc/leapp-initram-network-scripts
+    fi
+
     # install this one to ensure we are able to sync write
     inst_binary sync
 

--- a/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/libraries/modscan.py
+++ b/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/libraries/modscan.py
@@ -49,6 +49,8 @@ def _create_initram_packages():
     required_pkgs = _REQUIRED_PACKAGES
     if architecture.matches_architecture(architecture.ARCH_X86_64):
         required_pkgs.append('biosdevname')
+    if os.getenv('LEAPP_INITRAM_NETWORK', None) == 'network-manager':
+        required_pkgs.append('NetworkManager')
     return RequiredUpgradeInitramPackages(packages=required_pkgs)
 
 

--- a/repos/system_upgrade/el7toel8/actors/initramdiskgenerator/files/generate-initram.sh
+++ b/repos/system_upgrade/el7toel8/actors/initramdiskgenerator/files/generate-initram.sh
@@ -64,6 +64,19 @@ build() {
         DRACUT_MODULES_ADD=$(echo "--add $LEAPP_ADD_DRACUT_MODULES" | sed 's/,/ --add /g')
     fi
 
+    case $LEAPP_INITRAM_NETWORK in
+        network-manager)
+            DRACUT_MODULES_ADD="$DRACUT_MODULES_ADD --add network-manager"
+            touch /etc/leapp-initram-network-manager
+        ;;
+        scripts)
+            DRACUT_MODULES_ADD="$DRACUT_MODULES_ADD --add network";
+            touch /etc/leapp-initram-network-scripts
+        ;;
+        *)
+        ;;
+    esac
+
     DRACUT_INSTALL="systemd-nspawn"
     if [[ -n "$LEAPP_DRACUT_INSTALL_FILES" ]]; then
         DRACUT_INSTALL="$DRACUT_INSTALL $LEAPP_DRACUT_INSTALL_FILES"


### PR DESCRIPTION
Adding initial basic networking support for the initram phase.
Controlled by the LEAPP_INITRAM_NETWORK environment variable which must
be set to either `scripts` or `network-manager` to choose between the
legacy or NetworkManager based dracut modules.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>