### PR TITLE
Move GRUB device detection into library

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkgrubcore/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkgrubcore/actor.py
@@ -4,12 +4,15 @@ from leapp.models import FirmwareFacts, GrubDevice, UpdateGrub
 from leapp.reporting import Report, create_report
 from leapp import reporting
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.utils.deprecation import suppress_deprecation
 
 
 GRUB_SUMMARY = ('On legacy (BIOS) systems, GRUB core (located in the gap between the MBR and the '
                 'first partition) does not get automatically updated when GRUB is upgraded.')
 
 
+# TODO: remove this actor completely after the deprecation period expires
+@suppress_deprecation(GrubDevice, UpdateGrub)
 class CheckGrubCore(Actor):
     """
     Check whether we are on legacy (BIOS) system and instruct Leapp to upgrade GRUB core
@@ -32,7 +35,7 @@ class CheckGrubCore(Actor):
                 self.produce(UpdateGrub(grub_device=dev.grub_device))
                 create_report([
                     reporting.Title(
-                        'GRUB core on {} will be updated during upgrade'.format(dev.grub_device)
+                        'GRUB core will be updated during upgrade'
                     ),
                     reporting.Summary(GRUB_SUMMARY),
                     reporting.Severity(reporting.Severity.HIGH),
@@ -48,6 +51,5 @@ class CheckGrubCore(Actor):
                     reporting.Severity(reporting.Severity.HIGH),
                     reporting.Tags([reporting.Tags.BOOT]),
                     reporting.Remediation(
-                        hint='Please use "LEAPP_GRUB_DEVICE" environment variable to point Leapp to '
-                             'device where GRUB core is located'),
+                        hint='Please run "grub2-install <GRUB_DEVICE> command manually after upgrade'),
                 ])

--- a/repos/system_upgrade/el7toel8/actors/checkremovedenvvars/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkremovedenvvars/actor.py
@@ -1,0 +1,19 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkremovedenvvars
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckRemovedEnvVars(Actor):
+    """
+    Check for usage of removed environment variables and inhibit the upgrade
+    if they are used.
+    """
+
+    name = 'check_removed_envvars'
+    consumes = ()
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        checkremovedenvvars.process()

--- a/repos/system_upgrade/el7toel8/actors/checkremovedenvvars/libraries/checkremovedenvvars.py
+++ b/repos/system_upgrade/el7toel8/actors/checkremovedenvvars/libraries/checkremovedenvvars.py
@@ -1,0 +1,25 @@
+from leapp.libraries.common.config import get_all_envs
+from leapp.reporting import create_report
+from leapp import reporting
+
+DEPRECATED_VARS = ['LEAPP_GRUB_DEVICE']
+
+
+def process():
+
+    vars_to_report = []
+
+    for var in get_all_envs():
+        if var.name in DEPRECATED_VARS:
+            vars_to_report.append(var.name)
+
+    if vars_to_report:
+        vars_str = ' '.join(vars_to_report)
+        create_report([
+            reporting.Title('Leapp detected removed environment variable usage'),
+            reporting.Summary('The following Leapp related environment variable was removed: ' + vars_str),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Remediation(hint='Please do not use the reported variables'),
+            reporting.Flags(['inhibitor']),
+            reporting.Tags([reporting.Tags.UPGRADE_PROCESS]),
+        ])

--- a/repos/system_upgrade/el7toel8/actors/checkremovedenvvars/tests/test_checkremovedenvvars.py
+++ b/repos/system_upgrade/el7toel8/actors/checkremovedenvvars/tests/test_checkremovedenvvars.py
@@ -1,0 +1,25 @@
+import pytest
+
+from leapp.libraries.common.testutils import produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.libraries.actor import checkremovedenvvars
+from leapp.libraries.common.testutils import CurrentActorMocked
+
+
+def test_removed_vars(monkeypatch):
+    envars = {'LEAPP_GRUB_DEVICE': '/dev/sda'}
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars=envars))
+    monkeypatch.setattr(api.current_actor, "produce", produce_mocked())
+    checkremovedenvvars.process()
+    assert api.current_actor.produce.called == 1
+    assert 'LEAPP_GRUB_DEVICE' in api.current_actor.produce.model_instances[0].report['summary']
+    assert 'inhibitor' in api.current_actor.produce.model_instances[0].report['flags']
+
+
+def test_no_removed_vars(monkeypatch):
+    envars = {'LEAPP_SKIP_RHSM': '1'}
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(envars=envars))
+    monkeypatch.setattr(api.current_actor, "produce", produce_mocked())
+    checkremovedenvvars.process()
+    assert not api.current_actor.produce.called
+    assert not api.current_actor.produce.model_instances

--- a/repos/system_upgrade/el7toel8/actors/grubdevname/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/grubdevname/actor.py
@@ -3,8 +3,11 @@ from leapp.libraries.actor.grubdevname import get_grub_device
 from leapp.libraries.common.config import architecture
 from leapp.models import GrubDevice
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+from leapp.utils.deprecation import suppress_deprecation
 
 
+# TODO: remove this actor completely after the deprecation period expires
+@suppress_deprecation(GrubDevice)
 class Grubdevname(Actor):
     """
     Get name of block device where GRUB is located

--- a/repos/system_upgrade/el7toel8/actors/updategrubcore/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/updategrubcore/actor.py
@@ -1,6 +1,8 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.updategrubcore import update_grub_core
-from leapp.models import TransactionCompleted, UpdateGrub
+from leapp.libraries.common import grub
+from leapp.libraries.stdlib import api
+from leapp.models import TransactionCompleted, FirmwareFacts
 from leapp.reporting import Report
 from leapp.tags import RPMUpgradePhaseTag, IPUWorkflowTag
 
@@ -12,11 +14,15 @@ class UpdateGrubCore(Actor):
     """
 
     name = 'update_grub_core'
-    consumes = (TransactionCompleted, UpdateGrub)
+    consumes = (TransactionCompleted, FirmwareFacts)
     produces = (Report,)
     tags = (RPMUpgradePhaseTag, IPUWorkflowTag)
 
     def process(self):
-        dev = next(self.consume(UpdateGrub), None)
-        if dev:
-            update_grub_core(dev.grub_device)
+        ff = next(self.consume(FirmwareFacts), None)
+        if ff and ff.firmware == 'bios':
+            grub_dev = grub.get_grub_device()
+            if grub_dev:
+                update_grub_core(grub_dev)
+            else:
+                api.current_logger().warning('Leapp could not detect GRUB on {}'.format(grub_dev))

--- a/repos/system_upgrade/el7toel8/libraries/grub.py
+++ b/repos/system_upgrade/el7toel8/libraries/grub.py
@@ -1,0 +1,68 @@
+import os
+
+from leapp.libraries.stdlib import run, api, CalledProcessError
+from leapp.exceptions import StopActorExecution
+
+
+def has_grub(blk_dev):
+    """
+    Check whether GRUB is present on block device
+    """
+    try:
+        blk = os.open(blk_dev, os.O_RDONLY)
+        mbr = os.read(blk, 512)
+    except OSError:
+        api.current_logger().warning(
+            'Could not read first sector of {} in order to identify the bootloader'.format(blk_dev)
+        )
+        raise StopActorExecution()
+    os.close(blk)
+    return 'GRUB' in mbr
+
+
+def blk_dev_from_partition(partition):
+    """
+    Find parent device of /boot partition
+    """
+    try:
+        result = run(['lsblk', '-spnlo', 'name', partition])
+    except CalledProcessError:
+        api.current_logger().warn(
+            'Could not get parent device of {} partition'.format(partition)
+        )
+        raise StopActorExecution()
+    # lsblk "-s" option prints dependencies in inverse order, so the parent device will always
+    # be the last or the only device.
+    # Command result example:
+    # 'result', {'signal': 0, 'pid': 3872, 'exit_code': 0, 'stderr': u'', 'stdout': u'/dev/vda1\n/dev/vda\n'}
+    return result['stdout'].strip().split()[-1]
+
+
+def get_boot_partition():
+    """
+    Get /boot partition name
+    """
+    try:
+        # call grub2-probe to identify /boot partition
+        result = run(['grub2-probe', '--target=device', '/boot'])
+    except CalledProcessError:
+        api.current_logger().warn(
+            'Could not get name of underlying /boot partition'
+        )
+        raise StopActorExecution()
+    boot_partition = result['stdout'].strip()
+    api.current_logger().info('/boot is on {}'.format(boot_partition))
+    return boot_partition
+
+
+def get_grub_device():
+    """
+    Get block device where GRUB is located. We assume GRUB is on the same device
+    as /boot partition is.
+
+    """
+    boot_partition = get_boot_partition()
+    grub_dev = blk_dev_from_partition(boot_partition)
+    api.current_logger().info('GRUB is installed on {}'.format(grub_dev))
+    # if has_grub(grub_dev):
+    return grub_dev if has_grub(grub_dev) else None

--- a/repos/system_upgrade/el7toel8/libraries/tests/grub_invalid
+++ b/repos/system_upgrade/el7toel8/libraries/tests/grub_invalid
@@ -1,0 +1,1 @@
+Nothing to see here!

--- a/repos/system_upgrade/el7toel8/libraries/tests/grub_valid
+++ b/repos/system_upgrade/el7toel8/libraries/tests/grub_valid
@@ -1,0 +1,1 @@
+GRUB GeomHard DiskRead Error

--- a/repos/system_upgrade/el7toel8/libraries/tests/test_grub.py
+++ b/repos/system_upgrade/el7toel8/libraries/tests/test_grub.py
@@ -1,0 +1,104 @@
+import os
+
+import pytest
+
+from leapp.exceptions import StopActorExecution
+from leapp.libraries.common import grub
+from leapp.libraries.stdlib import CalledProcessError, api
+from leapp.libraries.common.testutils import logger_mocked
+
+BOOT_PARTITION = '/dev/vda1'
+BOOT_DEVICE = '/dev/vda'
+
+VALID_DD = b'GRUB GeomHard DiskRead Error'
+INVALID_DD = b'Nothing to see here!'
+
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def raise_call_error(args=None):
+    raise CalledProcessError(
+        message='A Leapp Command Error occured.',
+        command=args,
+        result={'signal': None, 'exit_code': 1, 'pid': 0, 'stdout': 'fake', 'stderr': 'fake'}
+    )
+
+
+class RunMocked(object):
+
+    def __init__(self, raise_err=False):
+        self.called = 0
+        self.args = None
+        self.raise_err = raise_err
+
+    def __call__(self, args, encoding=None):
+        self.called += 1
+        self.args = args
+        if self.raise_err:
+            raise_call_error(args)
+
+        if self.args == ['grub2-probe', '--target=device', '/boot']:
+            stdout = BOOT_PARTITION
+
+        elif self.args == ['lsblk', '-spnlo', 'name', BOOT_PARTITION]:
+            stdout = BOOT_DEVICE
+
+        return {'stdout': stdout}
+
+
+def open_mocked(fn, flags):
+    return open(
+        os.path.join(CUR_DIR, 'grub_valid') if fn == BOOT_DEVICE else os.path.join(CUR_DIR, 'grub_invalid'), 'r'
+    )
+
+
+def open_invalid(fn, flags):
+    return open(os.path.join(CUR_DIR, 'grub_invalid'), 'r')
+
+
+def read_mocked(f, size):
+    return f.read(size)
+
+
+def close_mocked(f):
+    f.close()
+
+
+def test_get_grub_device_library(monkeypatch):
+    run_mocked = RunMocked()
+    monkeypatch.setattr(grub, 'run', run_mocked)
+    monkeypatch.setattr(os, 'open', open_mocked)
+    monkeypatch.setattr(os, 'read', read_mocked)
+    monkeypatch.setattr(os, 'close', close_mocked)
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    result = grub.get_grub_device()
+    assert grub.run.called == 2
+    assert BOOT_DEVICE == result
+    assert not api.current_logger.warnmsg
+    assert 'GRUB is installed on {}'.format(result) in api.current_logger.infomsg
+
+
+def test_get_grub_device_fail_library(monkeypatch):
+    run_mocked = RunMocked(raise_err=True)
+    monkeypatch.setattr(grub, 'run', run_mocked)
+    monkeypatch.setattr(os, 'open', open_mocked)
+    monkeypatch.setattr(os, 'read', read_mocked)
+    monkeypatch.setattr(os, 'close', close_mocked)
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    with pytest.raises(StopActorExecution):
+        grub.get_grub_device()
+    assert grub.run.called == 1
+    err = 'Could not get name of underlying /boot partition'
+    assert err in api.current_logger.warnmsg
+
+
+def test_device_no_grub_library(monkeypatch):
+    run_mocked = RunMocked()
+    monkeypatch.setattr(grub, 'run', run_mocked)
+    monkeypatch.setattr(os, 'open', open_invalid)
+    monkeypatch.setattr(os, 'read', read_mocked)
+    monkeypatch.setattr(os, 'close', close_mocked)
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    result = grub.get_grub_device()
+    assert grub.run.called == 2
+    assert not result

--- a/repos/system_upgrade/el7toel8/models/grubdevice.py
+++ b/repos/system_upgrade/el7toel8/models/grubdevice.py
@@ -1,13 +1,30 @@
 from leapp.models import Model, fields
 from leapp.topics import SystemFactsTopic
+from leapp.utils.deprecation import deprecated
 
 
+@deprecated(
+    since='2020-09-01',
+    message=(
+        'The model is deprecated as the current implementation was not reliable. '
+        'We moved the GRUB device detection into grub library. '
+        'Please use get_grub_device() function instead.'
+    )
+)
 class GrubDevice(Model):
     topic = SystemFactsTopic
 
     grub_device = fields.String()
 
 
+@deprecated(
+    since='2020-09-01',
+    message=(
+        'The model is deprecated as the current implementation was not reliable. '
+        'We moved the GRUB device detection into grub library. '
+        'Please use get_grub_device() function instead.'
+    )
+)
 class UpdateGrub(Model):
     topic = SystemFactsTopic
 


### PR DESCRIPTION
We have to start detecting GRUB device at the same stage
as we update GRUB core in order to not hit issue with device
name swap.

Related BZ:

https://bugzilla.redhat.com/show_bug.cgi?id=1871162

Other info:

https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use