### PR TITLE
detectgrubconfigerror: Fix false positive on comments, add tests

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/libraries/scanner.py
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/libraries/scanner.py
@@ -10,5 +10,5 @@ def detect_config_error(conf_file):
     with open(conf_file, 'r') as f:
         config = f.read()
 
-    pattern = r'GRUB_CMDLINE_LINUX="[^"]+"(?!(\s*$)|(\s+GRUB))'
+    pattern = r'GRUB_CMDLINE_LINUX="[^"]+"(?!(\s*$)|(\s+(GRUB|#)))'
     return re.search(pattern, config) is not None

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/tests/files/grub.correct_comment
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/tests/files/grub.correct_comment
@@ -1,0 +1,8 @@
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL_OUTPUT="console"
+GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+# hi, I'm a comment
+GRUB_DISABLE_RECOVERY="true"

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/tests/files/grub.correct_puppet
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/tests/files/grub.correct_puppet
@@ -1,0 +1,27 @@
+# WARNING: This file maintained by Puppet.
+# Editing is no use unless you avoid running the Puppet agent
+
+GRUB_DEFAULT=0
+GRUB_TIMEOUT=5
+##GRUB_HIDDEN_TIMEOUT=0
+##
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+
+GRUB_CMDLINE_LINUX_RECOVERY="true"
+
+GRUB_CMDLINE_LINUX="elevator=noop"
+
+# Uncomment to disable graphical terminal (grub-pc only)
+
+#GRUB_TERMINAL="console"
+
+GRUB_GFXMODE=640x480
+GRUB_DISABLE_RECOVERY="true"
+
+
+# Set a background image
+# Image must respect various specifications
+GRUB_BACKGROUND="(hd0,0)/grub/splash.xpm.gz"
+
+# Disable OS prober
+GRUB_DISABLE_OS_PROBER="true"

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/tests/test_detectgrubconfigerror.py
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/tests/test_detectgrubconfigerror.py
@@ -8,6 +8,8 @@ CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 def test_correct_config():
     assert not detect_config_error(os.path.join(CUR_DIR, 'files/grub.correct'))
     assert not detect_config_error(os.path.join(CUR_DIR, 'files/grub.correct_trailing_space'))
+    assert not detect_config_error(os.path.join(CUR_DIR, 'files/grub.correct_comment'))
+    assert not detect_config_error(os.path.join(CUR_DIR, 'files/grub.correct_puppet'))
 
 
 def test_wrong_config():


### PR DESCRIPTION
The false positive occured when `GRUB_CMDLINE_LINUX` was followed by a comment. In a later stage, it caused the AddUpgradeBootEntry actor to break the GRUB config and the booting process.

Added tests include the `/etc/default/grub` config file on which this behavior occured, according to the bug report:

https://bugzilla.redhat.com/show_bug.cgi?id=1872356#c0