### PR TITLE
Fix run of unit tests in case on system with installed pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ test_no_lint:
 	cd repos/system_upgrade/el7toel8/; \
 	snactor workflow sanity-check ipu && \
 	cd - && \
-	pytest $(REPORT_ARG) $(ACTOR_PATH) $(LIBRARY_PATH)
+	python -m pytest $(REPORT_ARG) $(ACTOR_PATH) $(LIBRARY_PATH)
 
 test: lint test_no_lint
 


### PR DESCRIPTION
In case the host system has installed e.g. leapp or pytest already,
the host system libraries are used. In our case, different pytest,
different leapp... than we expact to use for running of unit tests.

To resolve this, do not call pytest dierectly, but load the pytest
library through python.