### PR TITLE
Do not use the deprecated logger.warn method

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkchrony/libraries/checkchrony.py
+++ b/repos/system_upgrade/el7toel8/actors/checkchrony/libraries/checkchrony.py
@@ -15,7 +15,7 @@ def is_config_default():
         result = run(['rpm', '-V', '--nomtime', 'chrony'], checked=False)
         return '/etc/chrony.conf' not in result['stdout']
     except OSError as e:
-        api.current_logger().warn("rpm verification failed: %s", str(e))
+        api.current_logger().warning("rpm verification failed: %s", str(e))
         return True
 
 

--- a/repos/system_upgrade/el7toel8/actors/checkmemcached/libraries/checkmemcached.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmemcached/libraries/checkmemcached.py
@@ -21,7 +21,7 @@ def is_sysconfig_default():
         result = run(['rpm', '-V', '--nomtime', 'memcached'], checked=False)
         return sysconfig_path not in result['stdout']
     except OSError as e:
-        api.current_logger().warn("rpm verification failed: %s", str(e))
+        api.current_logger().warning("rpm verification failed: %s", str(e))
         return True
 
 

--- a/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/libraries/rpmtransactionconfigtaskscollector.py
+++ b/repos/system_upgrade/el7toel8/actors/rpmtransactionconfigtaskscollector/libraries/rpmtransactionconfigtaskscollector.py
@@ -14,7 +14,7 @@ def load_tasks_file(path, logger):
                         not entry.strip().startswith('#')}
                 )
         except IOError as e:
-            logger.warn('Failed to open %s to load additional transaction data. Error: %s', path, str(e))
+            logger.warning('Failed to open %s to load additional transaction data. Error: %s', path, str(e))
     return []
 
 

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/spamassassinconfigupdate_spamc.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/spamassassinconfigupdate_spamc.py
@@ -35,7 +35,7 @@ def migrate_spamc_config(facts, fileops, backup_func):
         api.current_logger().info('spamc configuration file backup created at %s.'
                                   % backup_path)
     except (OSError, IOError) as e:
-        api.current_logger().warn(
+        api.current_logger().warning(
             'spamc configuration file migration will not be performed. Failed to create backup: %s' % e)
         return
     try:
@@ -43,4 +43,4 @@ def migrate_spamc_config(facts, fileops, backup_func):
         new_content = _rewrite_spamc_config(content)
         fileops.write(SPAMC_CONFIG_FILE, new_content)
     except (OSError, IOError) as e:
-        api.current_logger().warn('Failed to migrate spamc configuration file: %s' % e)
+        api.current_logger().warning('Failed to migrate spamc configuration file: %s' % e)

--- a/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/spamassassinconfigupdate_spamd.py
+++ b/repos/system_upgrade/el7toel8/actors/spamassassinconfigupdate/libraries/spamassassinconfigupdate_spamd.py
@@ -63,7 +63,7 @@ def migrate_spamd_config(facts, fileops, backup_func):
         if e.errno == errno.ENOENT:
             api.current_logger().info(nothing_to_migrate_msg)
         else:
-            api.current_logger().warn('Failed to read spamd configuration file: %s' % e)
+            api.current_logger().warning('Failed to read spamd configuration file: %s' % e)
         return
     new_content = _rewrite_spamd_config(facts, content)
     if new_content == content:
@@ -74,10 +74,10 @@ def migrate_spamd_config(facts, fileops, backup_func):
         api.current_logger().info('spamd configuration file backup created at %s.'
                                   % backup_path)
     except (OSError, IOError) as e:
-        api.current_logger().warn(
+        api.current_logger().warning(
             'spamd configuration file migration will not be performed. Failed to create backup: %s' % e)
         return
     try:
         fileops.write(utils.SYSCONFIG_SPAMASSASSIN, new_content)
     except (OSError, IOError) as e:
-        api.current_logger().warn('Failed to rewrite the spamd configuration file: %s' % e)
+        api.current_logger().warning('Failed to rewrite the spamd configuration file: %s' % e)

--- a/repos/system_upgrade/el7toel8/actors/sssdfacts/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sssdfacts/actor.py
@@ -28,7 +28,7 @@ class SSSDFacts(Actor):
             config.read('/etc/sssd/sssd.conf')
         except configparser.Error:
             # SSSD is not configured properly. Nothing to do.
-            self.log.warn('SSSD configuration unreadable.')
+            self.log.warning('SSSD configuration unreadable.')
             return
 
         self.produce(SSSDFactsLibrary(config).process())

--- a/repos/system_upgrade/el7toel8/actors/systemfacts/tests/test_systemfacts_selinux.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/tests/test_systemfacts_selinux.py
@@ -10,8 +10,9 @@ try:
     import selinux
 except ImportError:
     no_selinux = True
-    warnings.warn("Tests which uses `selinux` will be skipped "
-                  "due to library unavailability.", ImportWarning)
+    warnings.warn(
+        'Tests which uses `selinux` will be skipped'
+        ' due to library unavailability.', ImportWarning)
 
 
 reason_to_skip_msg = "Selinux is not available"

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -61,7 +61,7 @@ def _check_deprecated_rhsm_skip():
     # just log the warning now (better than nothing?); deprecation process will
     # be specified in close future
     if get_env('LEAPP_DEVEL_SKIP_RHSM', '0') == '1':
-        api.current_logger().warn(
+        api.current_logger().warning(
             'The LEAPP_DEVEL_SKIP_RHSM has been deprecated. Use'
             ' LEAPP_NO_RHSM istead or use the --no-rhsm option for'
             ' leapp. as well custom repofile has not been defined.'
@@ -88,7 +88,7 @@ class _InputData(object):
         self.rhsm_info = next(api.consume(RHSMInfo), None)
         self.rhui_info = next(api.consume(RHUIInfo), None)
         if not self.rhsm_info and not rhsm.skip_rhsm():
-            api.current_logger().warn('Could not receive RHSM information - Is this system registered?')
+            api.current_logger().warning('Could not receive RHSM information - Is this system registered?')
             raise StopActorExecution()
         if rhsm.skip_rhsm() and self.rhsm_info:
             # this should not happen. if so, raise an error as something in
@@ -236,8 +236,10 @@ def _inhibit_on_duplicate_repos(repofiles):
     if not duplicates:
         return
     list_separator_fmt = '\n    - '
-    api.current_logger().warn('The following repoids are defined multiple times:{0}{1}'
-                              .format(list_separator_fmt, list_separator_fmt.join(duplicates)))
+    api.current_logger().warning(
+        'The following repoids are defined multiple times:{0}{1}'
+        .format(list_separator_fmt, list_separator_fmt.join(duplicates))
+    )
 
     reporting.create_report([
         reporting.Title('A YUM/DNF repository defined multiple times'),

--- a/repos/system_upgrade/el7toel8/libraries/config/architecture.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/architecture.py
@@ -25,5 +25,5 @@ def matches_architecture(*match_list):
                         "but provided was {}: '{}'".format([type(e) for e in match_list], match_list))
     unsupported = set(match_list).difference(ARCH_ACCEPTED)
     if unsupported:
-        api.current_logger().warn("Unsupported architecture specified: {}".format(unsupported))
+        api.current_logger().warning("Unsupported architecture specified: {}".format(unsupported))
     return api.current_actor().configuration.architecture in match_list

--- a/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
+++ b/repos/system_upgrade/el7toel8/libraries/dnfplugin.py
@@ -94,7 +94,7 @@ def backup_debug_data(context):
         try:
             context.copytree_from('/debugdata', DNF_DEBUG_DATA_PATH)
         except OSError as e:
-            api.current_logger().warn('Failed to copy debugdata. Message: {}'.format(str(e)), exc_info=True)
+            api.current_logger().warning('Failed to copy debugdata. Message: {}'.format(str(e)), exc_info=True)
 
 
 def _transaction(context, stage, target_repoids, tasks, plugin_info, test=False, cmd_prefix=None, on_aws=False):

--- a/repos/system_upgrade/el7toel8/libraries/grub.py
+++ b/repos/system_upgrade/el7toel8/libraries/grub.py
@@ -27,7 +27,7 @@ def blk_dev_from_partition(partition):
     try:
         result = run(['lsblk', '-spnlo', 'name', partition])
     except CalledProcessError:
-        api.current_logger().warn(
+        api.current_logger().warning(
             'Could not get parent device of {} partition'.format(partition)
         )
         raise StopActorExecution()
@@ -46,7 +46,7 @@ def get_boot_partition():
         # call grub2-probe to identify /boot partition
         result = run(['grub2-probe', '--target=device', '/boot'])
     except CalledProcessError:
-        api.current_logger().warn(
+        api.current_logger().warning(
             'Could not get name of underlying /boot partition'
         )
         raise StopActorExecution()

--- a/repos/system_upgrade/el7toel8/libraries/mounting.py
+++ b/repos/system_upgrade/el7toel8/libraries/mounting.py
@@ -302,12 +302,12 @@ class MountingBase(object):
             try:
                 run(['umount', '-fl', self.target], split=False)
             except (OSError, CalledProcessError) as e:
-                api.current_logger().warn('Unmounting %s failed with: %s', self.target, str(e))
+                api.current_logger().warning('Unmounting %s failed with: %s', self.target, str(e))
         for directory in itertools.chain(self.additional_directories, (self.target,)):
             try:
                 run(['rm', '-rf', directory], split=False)
             except (OSError, CalledProcessError) as e:
-                api.current_logger().warn('Removing mount directory %s failed with: %s', directory, str(e))
+                api.current_logger().warning('Removing mount directory %s failed with: %s', directory, str(e))
 
     def mount(self):
         """ Performs the mount if MountConfig.should_create = True """
@@ -324,7 +324,7 @@ class MountingBase(object):
         try:
             run(['mount'] + self._mount_options() + [self.target], split=False)
         except (OSError, CalledProcessError) as e:
-            api.current_logger().warn('Mounting %s failed with: %s', self.target, str(e), exc_info=True)
+            api.current_logger().warning('Mounting %s failed with: %s', self.target, str(e), exc_info=True)
             raise MountError(
                 message='Mount operation with mode {} from {} to {} failed: {}'.format(
                     self._mode, self.source, self.target, str(e)),

--- a/repos/system_upgrade/el7toel8/libraries/multipathutil.py
+++ b/repos/system_upgrade/el7toel8/libraries/multipathutil.py
@@ -20,7 +20,7 @@ def read_config(path):
                 'multipath configuration file {} does not exist.'.format(path)
             )
         else:
-            api.current_logger().warn(
+            api.current_logger().warning(
                 'Failed to read multipath configuration file {}: {}'.
                 format(path, e)
             )
@@ -32,7 +32,7 @@ def write_config(path, contents):
         with open(path, 'w') as f:
             f.write(contents)
     except IOError as e:
-        api.current_logger().warn(
+        api.current_logger().warning(
             'Failed to write multipath configuration file {}: {}'.
             format(path, e)
         )

--- a/repos/system_upgrade/el7toel8/libraries/overlaygen.py
+++ b/repos/system_upgrade/el7toel8/libraries/overlaygen.py
@@ -29,7 +29,7 @@ def _get_mountpoints(storage_info):
         if os.path.isdir(entry.fs_file) and entry.fs_vfstype not in OVERLAY_DO_NOT_MOUNT:
             mount_points.add(MountPoints(entry.fs_file, entry.fs_vfstype))
         elif os.path.isdir(entry.fs_file) and entry.fs_vfstype == 'vfat':
-            api.current_logger().warn(
+            api.current_logger().warning(
                 'Ignoring vfat {} filesystem mount during upgrade process'.format(entry.fs_file)
             )
 
@@ -97,7 +97,7 @@ def _overlay_disk_size():
         disk_size = int(env_size)
     except ValueError:
         disk_size = 2048
-        api.current_logger().warn(
+        api.current_logger().warning(
             'Invalid "LEAPP_OVL_SIZE" environment variable "%s". Setting default "%d" value', env_size, disk_size
         )
     return disk_size
@@ -114,7 +114,7 @@ def cleanup_scratch(scratch_dir, mounts_dir):
             run(['/bin/umount', '-fl', mounts_dir])
             api.current_logger().debug('Unmounted mounted disk image.')
         except (OSError, CalledProcessError) as e:
-            api.current_logger().warn('Failed to umount %s - message: %s', mounts_dir, str(e))
+            api.current_logger().warning('Failed to umount %s - message: %s', mounts_dir, str(e))
     api.current_logger().debug('Recursively removing scratch directory %s.', scratch_dir)
     shutil.rmtree(scratch_dir, onerror=utils.report_and_ignore_shutil_rmtree_error)
     api.current_logger().debug('Recursively removed scratch directory %s.', scratch_dir)

--- a/repos/system_upgrade/el7toel8/libraries/persistentnetnames.py
+++ b/repos/system_upgrade/el7toel8/libraries/persistentnetnames.py
@@ -48,7 +48,7 @@ def interfaces():
         except Exception as e:  # pylint: disable=broad-except
             # FIXME(msekleta): We should probably handle errors more granularly
             # Maybe we should inhibit upgrade process at this point
-            api.current_logger().warn('Failed to gather information about network interface: ' + str(e))
+            api.current_logger().warning('Failed to gather information about network interface: ' + str(e))
             continue
 
         yield Interface(**attrs)

--- a/repos/system_upgrade/el7toel8/libraries/repofileutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/repofileutils.py
@@ -8,7 +8,7 @@ from leapp.models import RepositoryFile, RepositoryData, fields
 try:
     import dnf
 except ImportError:
-    api.current_logger().warn('repofileutils.py: failed to import dnf')
+    api.current_logger().warning('repofileutils.py: failed to import dnf')
 
 
 def _parse_repository(repoid, repo_data):

--- a/repos/system_upgrade/el7toel8/libraries/rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/rhsm.py
@@ -175,8 +175,10 @@ def _inhibit_on_duplicate_repos(repofiles):
     if not duplicates:
         return
     list_separator_fmt = '\n    - '
-    api.current_logger().warn('The following repoids are defined multiple times:{0}{1}'
-                              .format(list_separator_fmt, list_separator_fmt.join(duplicates)))
+    api.current_logger().warning(
+        'The following repoids are defined multiple times:{0}{1}'
+        .format(list_separator_fmt, list_separator_fmt.join(duplicates))
+    )
 
     reporting.create_report([
         reporting.Title('A YUM/DNF repository defined multiple times'),
@@ -327,7 +329,7 @@ def switch_certificate(context, rhsm_info, cert_path):
         try:
             context.remove(existing)
         except OSError:
-            api.current_logger().warn('Failed to remove existing certificate: %s', existing, exc_info=True)
+            api.current_logger().warning('Failed to remove existing certificate: %s', existing, exc_info=True)
 
     for path in ('/etc/pki/product', '/etc/pki/product-default'):
         if os.path.isdir(context.full_path(path)):

--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -4,6 +4,7 @@ import os
 
 from leapp.libraries.common.config import architecture
 from leapp.models import EnvVar
+from leapp.utils.deprecation import deprecated
 
 
 class produce_mocked(object):
@@ -42,6 +43,10 @@ class logger_mocked(object):
     def info(self, *args):
         self.infomsg.extend(args)
 
+    @deprecated(since='2020-09-23', message=(
+        'The logging.warn method has been deprecated since Python 3.3.'
+        'Use the warning method instead.'
+    ))
     def warn(self, *args):
         self.warnmsg.extend(args)
 

--- a/repos/system_upgrade/el7toel8/libraries/utils.py
+++ b/repos/system_upgrade/el7toel8/libraries/utils.py
@@ -97,7 +97,7 @@ def report_and_ignore_shutil_rmtree_error(func, path, exc_info):
     """
     Helper function for shutil.rmtree to only report errors but don't fail.
     """
-    api.current_logger().warn(
+    api.current_logger().warning(
         'While trying to remove directories: %s failed at %s with an exception %s message: %s',
         func.__name__, path, exc_info[0].__name__, exc_info[1]
     )
@@ -154,7 +154,7 @@ def clean_guard(cleanup_function):
                 except Exception:  # pylint: disable=broad-except
                     # Broad exception handler to handle all cases however, swallowed, to avoid loosing the original
                     # error. Logging for debuggability.
-                    api.current_logger().warn('Caught and swallowed an exception during cleanup.', exc_info=True)
+                    api.current_logger().warning('Caught and swallowed an exception during cleanup.', exc_info=True)
                 raise  # rethrow original exception
 
         return wrapper

--- a/repos/system_upgrade/el7toel8/libraries/vsftpdutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/vsftpdutils.py
@@ -32,7 +32,7 @@ def get_config_contents(path, read_func=read_file):
         return read_func(path)
     except IOError as e:
         if e.errno != errno.ENOENT:
-            api.current_logger().warn('Failed to read vsftpd configuration file: %s' % e)
+            api.current_logger().warning('Failed to read vsftpd configuration file: %s' % e)
         return None
 
 


### PR DESCRIPTION
The logger.warn method has been deprecated since Python 3.3.
Developers are supposed to use the logger.warning method instead.
See:
    https://github.com/python/cpython/blob/3.3/Lib/logging/__init__.py#L1252-L1253
    https://bugs.python.org/issue13235

Deprecates:
    produce_mocked.warn from leapp.libraries.common.testutils