### PR TITLE
Inhibit upgrade if multiple kernel-debug pkgs are installed

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddebugkernels/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddebugkernels/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.models import InstalledRedHatSignedRPM
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+from leapp.reporting import Report
+from leapp.libraries.actor import checkinstalleddebugkernels
+
+
+class CheckInstalledDebugKernels(Actor):
+    """
+    Inhibit IPU (in-place upgrade) when multiple debug kernels are installed.
+
+    Because of an issue in DNF, the transaction can't be validated if there's
+    more than one package named kernel-debug. Therefore, in this case, we
+    inhibit the upgrade with a clearer remediation.
+    """
+
+    name = 'check_installed_debug_kernels'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        checkinstalleddebugkernels.process()

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddebugkernels/libraries/checkinstalleddebugkernels.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddebugkernels/libraries/checkinstalleddebugkernels.py
@@ -12,24 +12,24 @@ def get_kernel_rpm_release(rpm):
     return int(rpm.release.split('.')[0])
 
 
-def get_kernel_devel_rpms():
+def get_kernel_debug_rpms():
     """
-    Get all installed kernel-devel packages ordered by release number (ascending).
+    Get all installed kernel-debug packages ordered by release number (ascending).
     """
     rpms = next(api.consume(InstalledRedHatSignedRPM), InstalledRedHatSignedRPM())
-    return sorted([pkg for pkg in rpms.items if pkg.name == 'kernel-devel'], key=get_kernel_rpm_release)
+    return sorted([pkg for pkg in rpms.items if pkg.name == 'kernel-debug'], key=get_kernel_rpm_release)
 
 
 def process():
-    pkgs = get_kernel_devel_rpms()
+    pkgs = get_kernel_debug_rpms()
     if len(pkgs) > 1:
-        title = 'Multiple devel kernels installed'
+        title = 'Multiple debug kernels installed'
         summary = ('DNF cannot produce a valid upgrade transaction when'
-                   ' multiple kernel-devel packages are installed.')
-        hint = ('Remove all but one kernel-devel packages before running Leapp again.')
-        all_but_latest_kernel_devel = pkgs[:-1]
+                   ' multiple kernel-debug packages are installed.')
+        hint = ('Remove all but one kernel-debug packages before running Leapp again.')
+        all_but_latest_kernel_debug = pkgs[:-1]
         packages = ['{n}-{v}-{r}'.format(n=pkg.name, v=pkg.version, r=pkg.release)
-                    for pkg in all_but_latest_kernel_devel]
+                    for pkg in all_but_latest_kernel_debug]
         commands = [['yum', '-y', 'remove'] + packages]
         reporting.create_report([
             reporting.Title(title),
@@ -38,5 +38,5 @@ def process():
             reporting.Tags([reporting.Tags.KERNEL]),
             reporting.Flags([reporting.Flags.INHIBITOR]),
             reporting.Remediation(hint=hint, commands=commands),
-            reporting.RelatedResource('package', 'kernel-devel')
+            reporting.RelatedResource('package', 'kernel-debug')
         ])

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddebugkernels/tests/unit_test_checkinstalleddebugkernels.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalleddebugkernels/tests/unit_test_checkinstalleddebugkernels.py
@@ -1,0 +1,36 @@
+import pytest
+
+from leapp.models import InstalledRedHatSignedRPM, RPM, Report
+from leapp.snactor.fixture import current_actor_context
+
+
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+
+ballast1 = [
+    RPM(name='b1', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='kernel', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='b2', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s')
+]
+ballast2 = [
+    RPM(name='b3', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='kernel', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='b4', version='1', release='1', epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s')
+]
+debug_kernels = [
+    RPM(name='kernel-debug', version='3.10.0', release='957.27.4.el7',
+        epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='kernel-debug', version='3.10.0', release='957.35.1.el7',
+        epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s'),
+    RPM(name='kernel-debug', version='3.10.0', release='957.43.1.el7',
+        epoch='1', packager=RH_PACKAGER, arch='noarch', pgpsig='s')
+]
+
+
+@pytest.mark.parametrize('n', [0, 1, 2, 3])
+def test_process_debug_kernels(current_actor_context, n):
+    current_actor_context.feed(InstalledRedHatSignedRPM(items=ballast1+debug_kernels[:n]+ballast2))
+    current_actor_context.run()
+    if n < 2:
+        assert not current_actor_context.consume(Report)
+    else:
+        assert current_actor_context.consume(Report)


### PR DESCRIPTION
When multiple **kernel-debug** packages are present, leapp can't process the transaction in some cases, so we inhibit the upgrade and present the user with hints on removing the surplus debug kernels.

Note that the added actor is basically a search-and-replace copy of **CheckInstalledDevelKernels**, which solves the same problem for a different package. I don't see many reasons to merge them into one.

Derived from: commit 2ce678fe8613c0d96ff720b7374466695aa6dc42 (#457)