### PR TITLE
realtime: respect kernel-rt rpm

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/tests/unit_test_checkinstalledkernels.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkinstalledkernels/tests/unit_test_checkinstalledkernels.py
@@ -9,43 +9,40 @@ from leapp.models import RPM, InstalledRedHatSignedRPM
 
 RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
 
+# Do not make sense to run any tests when the module is not accessible
+pytest.importorskip("rpm")
 
-def mocked_consume(pkgs):  # pkgs = [(name, version-number)]
-    installed_rpms = []
+
+def create_rpm(
+            version,
+            release,
+            name='kernel',
+            packager=RH_PACKAGER,
+            pgpsig='SOME_OTHER_SIG_X',
+            epoch='0',
+            ):
+    return RPM(
+        name=name,
+        arch=release.split('.')[-1],
+        version=version,
+        release='.'.join(release.split('.')[0:-1]),
+        epoch='0',
+        packager=RH_PACKAGER,
+        pgpsig='SOME_OTHER_SIG_X',
+    )
+
+
+def create_rpms(pkgs):
+    installed_rpms = InstalledRedHatSignedRPM()
     for pkg in pkgs:
-        installed_rpms.append(
-            RPM(
-                name=pkg[0],
-                arch='noarch',
-                version=pkg[1],
-                release='{}.sm01'.format(pkg[2]),
-                epoch='0',
-                packager=RH_PACKAGER,
-                pgpsig='SOME_OTHER_SIG_X',
-            )
-        )
-
-    def f(*a):
-        yield InstalledRedHatSignedRPM(items=installed_rpms)
-
-    return f
-
-
-@pytest.mark.parametrize('version,expected', [
-    ([], [0, 0, 0]),
-    ([1], [1, 0, 0]),
-    ([1, 2], [1, 2, 0]),
-    ([1, 2, 3], [1, 2, 3]),
-    ([1, 2, 3, 4], [1, 2, 3]),
-    ([1, 2, 3, 4, 5], [1, 2, 3])
-])
-def test_normalize(version, expected):
-    assert checkinstalledkernels._normalize_version(version) == expected
+        installed_rpms.items.append(
+            create_rpm(name=pkg[0], version=pkg[1], release=pkg[2]))
+    return installed_rpms
 
 
 @pytest.mark.parametrize('vra,version,release', [
-    ('3.10.0-1234.21.1.el7.x86_64', (3, 10, 0), 1234),
-    ('5.8.8-100.fc31.x86_64', (5, 8, 8), 100),
+    ('3.10.0-1234.21.1.el7.x86_64', '3.10.0', '1234.21.1.el7.x86_64'),
+    ('5.8.8-100.fc31.x86_64', '5.8.8', '100.fc31.x86_64'),
 ])
 def test_current_kernel(monkeypatch, vra, version, release):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=vra))
@@ -53,98 +50,159 @@ def test_current_kernel(monkeypatch, vra, version, release):
     assert release == checkinstalledkernels.get_current_kernel_release()
 
 
-@pytest.mark.parametrize('version_string, release_string, version, release', [
-    ('3.10.0', '1234.21.1.el7', (3, 10, 0), 1234),
-    ('5.8.8', '100.fc31', (5, 8, 8), 100),
-])
-def test_kernel_rpm(version_string, release_string, version, release):
-    rpm = RPM(
-        name='kernel',
-        arch='noarch',
-        version=version_string,
-        release=release_string,
-        epoch='0',
-        packager=RH_PACKAGER,
-        pgpsig='SOME_OTHER_SIG_X',
-    )
-    assert version == checkinstalledkernels.get_kernel_rpm_version(rpm)
-    assert release == checkinstalledkernels.get_kernel_rpm_release(rpm)
-
-
-s390x_pkgs_single = [('kernel', '3.10.0', 957), ('something', '3.10.0', 957), ('kernel-something', '3.10.0', 957)]
-s390x_pkgs_multi = [('kernel', '3.10.0', 957), ('something', '3.10.0', 957), ('kernel', '3.10.0', 956)]
+s390x_pkgs_single = [
+    ('kernel', '3.10.0', '957.43.1.el7.s390x'),
+    ('something', '3.10.0', '957.43.1.el7.s390x'),
+    ('kernel-something', '3.10.0', '957.43.1.el7.s390x')
+]
+s390x_pkgs_multi = [
+    ('kernel', '3.10.0', '957.43.1.el7.s390x'),
+    ('something', '3.10.0', '957.43.1.el7.s390x'),
+    ('kernel', '3.10.0', '956.43.1.el7.s390x')
+]
 
 
 def test_single_kernel_s390x(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
-    monkeypatch.setattr(api, 'current_logger', logger_mocked())
-    monkeypatch.setattr(api, 'consume', mocked_consume(s390x_pkgs_single))
+    msgs = [create_rpms(s390x_pkgs_single)]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        arch=architecture.ARCH_S390X,
+        msgs=msgs,
+        kernel='3.10.0-957.43.1.el7.s390x'),
+    )
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-    checkinstalledkernels.process()
-    assert not reporting.create_report.called
-
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X))
-    monkeypatch.setattr(api, 'consume', mocked_consume(s390x_pkgs_single))
     checkinstalledkernels.process()
     assert not reporting.create_report.called
 
 
 def test_multi_kernel_s390x(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
-    monkeypatch.setattr(api, 'current_logger', logger_mocked())
-    monkeypatch.setattr(api, 'consume', mocked_consume(s390x_pkgs_multi))
+    msgs = [create_rpms(s390x_pkgs_multi)]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        arch=architecture.ARCH_S390X,
+        msgs=msgs,
+        kernel='3.10.0-957.43.1.el7.s390x'),
+    )
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-    checkinstalledkernels.process()
-    assert not reporting.create_report.called
-
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X))
-    monkeypatch.setattr(api, 'consume', mocked_consume(s390x_pkgs_multi))
     checkinstalledkernels.process()
     assert reporting.create_report.called
     assert reporting.create_report.report_fields['title'] == 'Multiple kernels installed'
 
 
-versioned_kernel_pkgs = [('kernel', '3.10.0', 456), ('kernel', '3.10.0', 789), ('kernel', '3.10.0', 1234)]
+versioned_kernel_pkgs = [
+    ('kernel', '3.10.0', '456.43.1.el7.x86_64'),
+    ('kernel', '3.10.0', '789.35.2.el7.x86_64'),
+    ('kernel', '3.10.0', '1234.21.1.el7.x86_64')
+]
 
 
-def test_newest_kernel(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='3.10.0-1234.21.1.el7.x86_64'))
-    monkeypatch.setattr(api, 'current_logger', logger_mocked())
-    monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
+@pytest.mark.parametrize('expect_report,msgs,curr_kernel', [
+    (False, [create_rpms(versioned_kernel_pkgs)], '3.10.0-1234.21.1.el7.x86_64'),
+    (True, [create_rpms(versioned_kernel_pkgs)], '3.10.0-456.43.1.el7.x86_64'),
+    (True, [create_rpms(versioned_kernel_pkgs)], '3.10.0-789.35.2.el7.x86_64'),
+])
+def test_newest_kernel(monkeypatch, expect_report, msgs, curr_kernel):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=curr_kernel, msgs=msgs))
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkinstalledkernels.process()
-    assert not reporting.create_report.called
+    if expect_report:
+        assert reporting.create_report.called
+        assert reporting.create_report.report_fields['title'] == 'Newest installed kernel not in use'
+    else:
+        assert not reporting.create_report.called
 
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='3.10.0-456.43.1.el7.x86_64'))
-    monkeypatch.setattr(api, 'current_logger', logger_mocked())
-    monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
+
+# put the kernel in the middle of the list so that its position doesn't guarantee its rank
+versioned_kernel_pkgs.insert(2, ('kernel', '4.14.0', '115.29.1.el7.x86_64'))
+
+
+@pytest.mark.parametrize('expect_report,msgs,curr_kernel', [
+    (True, [create_rpms(versioned_kernel_pkgs)], '3.10.0-1234.21.1.el7.x86_64'),
+    (False, [create_rpms(versioned_kernel_pkgs)], '4.14.0-115.29.1.el7.x86_64'),
+])
+def test_newest_kernel_more_versions(monkeypatch, expect_report, msgs, curr_kernel):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=curr_kernel, msgs=msgs))
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkinstalledkernels.process()
-    assert reporting.create_report.called
-    assert reporting.create_report.report_fields['title'] == 'Newest installed kernel not in use'
+    if expect_report:
+        assert reporting.create_report.called
+        assert reporting.create_report.report_fields['title'] == 'Newest installed kernel not in use'
+    else:
+        assert not reporting.create_report.called
 
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='3.10.0-789.35.2.el7.x86_64'))
-    monkeypatch.setattr(api, 'current_logger', logger_mocked())
-    monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
+
+@pytest.mark.parametrize('evr', [
+    ('', '3.10.0', '1234.21.1.el7.x86_64'),
+    ('', '3.10.0', '456.43.1.el7.x86_64'),
+    ('', '3.10.0', '1.1.1.1.1.1.1.2.el7x86_64'),
+    ('', '4.10.4', '1234.21.1.el7.x86_64'),
+    ('', '6.6.6', '1234.56.rt78.el9.x86_64'),
+])
+def test_get_evr(monkeypatch, evr):
+    pkg = create_rpm(version=evr[1], release=evr[2])
+    assert checkinstalledkernels.get_EVR(pkg) == evr
+
+
+versioned_kernel_rt_pkgs = [
+    ('kernel-rt', '3.10.0', '789.35.2.rt56.1133.el7.x86_64'),
+    ('kernel-rt', '3.10.0', '789.35.2.rt57.1133.el7.x86_64'),
+    ('kernel-rt', '3.10.0', '789.35.2.rt101.1133.el7.x86_64'),
+    ('kernel-rt', '3.10.0', '790.35.2.rt666.1133.el7.x86_64'),
+]
+
+
+@pytest.mark.parametrize('msgs,num,name', [
+    ([create_rpms(versioned_kernel_rt_pkgs)], 4, 'kernel-rt'),
+    ([create_rpms(versioned_kernel_rt_pkgs[0:-1])], 3, 'kernel-rt'),
+    ([create_rpms(versioned_kernel_rt_pkgs[0:-2])], 2, 'kernel-rt'),
+    ([create_rpms(versioned_kernel_rt_pkgs[0:-3])], 1, 'kernel-rt'),
+    ([create_rpms(versioned_kernel_rt_pkgs)], 0, 'kernel'),
+    ([create_rpms(versioned_kernel_rt_pkgs)], 0, 'smth'),
+    ([create_rpms(versioned_kernel_pkgs)], 0, 'kernel-rt'),
+    ([create_rpms(versioned_kernel_pkgs + versioned_kernel_rt_pkgs)], 4, 'kernel-rt'),
+    ([create_rpms(versioned_kernel_pkgs + versioned_kernel_rt_pkgs)], 4, 'kernel'),
+])
+def test_get_pkgs(monkeypatch, msgs, num, name):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    pkgs = checkinstalledkernels.get_pkgs(name)
+    assert len(pkgs) == num
+
+
+@pytest.mark.parametrize('expect_report,msgs,curr_kernel', [
+    # kernel-rt only
+    (True, [create_rpms(versioned_kernel_rt_pkgs)], '3.10.0-789.35.2.rt56.1133.el7.x86_64'),
+    (True, [create_rpms(versioned_kernel_rt_pkgs)], '3.10.0-789.35.2.rt57.1133.el7.x86_64'),
+    (True, [create_rpms(versioned_kernel_rt_pkgs)], '3.10.0-789.35.2.rt101.1133.el7.x86_64'),
+    (False, [create_rpms(versioned_kernel_rt_pkgs)], '3.10.0-790.35.2.rt666.1133.el7.x86_64'),
+    (False, [create_rpms(versioned_kernel_rt_pkgs[0:-1])], '3.10.0-789.35.2.rt101.1133.el7.x86_64'),
+    (False, [create_rpms(versioned_kernel_rt_pkgs[0:1])], '3.10.0-789.35.2.rt56.1133.el7.x86_64'),
+
+    # mix of kernel-rt + kernel
+    (
+        True,
+        [create_rpms(versioned_kernel_rt_pkgs + versioned_kernel_pkgs)],
+        '3.10.0-789.35.2.rt101.1133.el7.x86_64'
+    ),
+    (
+        False,
+        [create_rpms(versioned_kernel_rt_pkgs + versioned_kernel_pkgs)],
+        '3.10.0-790.35.2.rt666.1133.el7.x86_64'
+    ),
+    (
+        True,
+        [create_rpms(versioned_kernel_rt_pkgs + versioned_kernel_pkgs)],
+        '3.10.0-1234.21.1.el7.x86_64'
+    ),
+    (
+        False,
+        [create_rpms(versioned_kernel_rt_pkgs + versioned_kernel_pkgs)],
+        '4.14.0-115.29.1.el7.x86_64'
+    ),
+])
+def test_newest_kernel_realtime(monkeypatch, expect_report, msgs, curr_kernel):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=curr_kernel, msgs=msgs))
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkinstalledkernels.process()
-    assert reporting.create_report.called
-    assert reporting.create_report.report_fields['title'] == 'Newest installed kernel not in use'
-
-    # put the kernel in the middle of the list so that its position doesn't guarantee its rank
-    versioned_kernel_pkgs.insert(2, ('kernel', '4.14.0', 115))
-
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='4.14.0-115.29.1.el7a.ppc64le'))
-    monkeypatch.setattr(api, 'current_logger', logger_mocked())
-    monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
-    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-    checkinstalledkernels.process()
-    assert not reporting.create_report.called
-
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel='3.10.0-1234.21.1.el7.x86_64'))
-    monkeypatch.setattr(api, 'current_logger', logger_mocked())
-    monkeypatch.setattr(api, 'consume', mocked_consume(versioned_kernel_pkgs))
-    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-    checkinstalledkernels.process()
-    assert reporting.create_report.called
-    assert reporting.create_report.report_fields['title'] == 'Newest installed kernel not in use'
+    if expect_report:
+        assert reporting.create_report.called
+        assert reporting.create_report.report_fields['title'] == 'Newest installed kernel not in use'
+    else:
+        assert not reporting.create_report.called

--- a/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/actor.py
@@ -8,7 +8,10 @@ class ScanInstalledTargetKernelVersion(Actor):
     """
     Scan for the version of the newly installed kernel
 
-    This actor will query rpm for all kernel packages and reports the first matching el8 kernel RPM version.
+    This actor will query rpm for all kernel packages and reports the first
+    matching el8 kernel RPM. In case the RHEL Real Time has been detected on
+    the original system, the kernel-rt rpm is searched. If the rpm is missing,
+    fallback for standard kernel RPM.
     """
 
     name = 'scan_installed_target_kernel_version'

--- a/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/libraries/scankernel.py
+++ b/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/libraries/scankernel.py
@@ -1,12 +1,51 @@
-from leapp.libraries import stdlib
-from leapp.libraries.stdlib import api
+from leapp.libraries.common.config.version import is_rhel_realtime
+from leapp.libraries.stdlib import api, CalledProcessError, run
 from leapp.models import InstalledTargetKernelVersion
 
 
-def process():
-    kernels = stdlib.run(["rpm", "-q", "kernel"], split=True)["stdout"]
+def _get_kernel_version(kernel_name):
+    try:
+        kernels = run(['rpm', '-q', kernel_name], split=True)['stdout']
+    except CalledProcessError:
+        return ''
+
     for kernel in kernels:
-        version = kernel.split("-", 1)[1]
-        if "el8" in version:
+        # name-version-release - we want the last two fields only
+        version = '-'.join(kernel.split('-')[-2:])
+        if 'el8' in version:
+            return version
+    return ''
+
+
+def process():
+    # pylint: disable=no-else-return  - false positive
+    # TODO: should we take care about stuff of kernel-rt and kernel in the same
+    # time when both are present? or just one? currently, handle only one
+    # of these during the upgrade. kernel-rt has higher prio when original sys
+    # was realtime
+
+    if is_rhel_realtime():
+        version = _get_kernel_version('kernel-rt')
+        if version:
             api.produce(InstalledTargetKernelVersion(version=version))
-            break
+            return
+        else:
+            api.current_logger().warning(
+                'The kernel-rt rpm from RHEL 8 has not been detected. Switching to non-preemptive kernel.')
+            # TODO: create report with instructions to install kernel-rt manually
+            # - attach link to article if any
+            # - this possibly happens just in case the repository with kernel-rt
+            # # is not enabled during the upgrade.
+
+    # standard (non-preemptive) kernel
+    version = _get_kernel_version('kernel')
+    if version:
+        api.produce(InstalledTargetKernelVersion(version=version))
+    else:
+        # This is very unexpected situation. At least one kernel has to be
+        # installed always. Some actors consuming the InstalledTargetKernelVersion
+        # will crash without the created message. I am keeping kind of original
+        # behaviour in this case, but at least the let me log the error msg
+        #
+        api.current_logger().error('Cannot detect any kernel RPM')
+        # StopActorExecutionError('Cannot detect any RHEL 8 kernel RPM.')

--- a/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/tests/test_scaninstalledkernel_scaninstalledtargetkernelversion.py
+++ b/repos/system_upgrade/el7toel8/actors/scaninstalledtargetkernelversion/tests/test_scaninstalledkernel_scaninstalledtargetkernelversion.py
@@ -1,31 +1,76 @@
+import pytest
+
 from leapp.libraries import stdlib
 from leapp.libraries.actor import scankernel
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
 from leapp.libraries.stdlib import api
 
 TARGET_KERNEL_VERSION = '1.2.3-4.el8.x86_64'
+TARGET_RT_KERNEL_VERSION = '1.2.3-4.rt56.7.el8.x86_64'
 TARGET_KERNEL = 'kernel-{}'.format(TARGET_KERNEL_VERSION)
+TARGET_RT_KERNEL = 'kernel-{}'.format(TARGET_RT_KERNEL_VERSION)
 OLD_KERNEL = 'kernel-0.1.2-3.el7.x86_64'
+OLD_RT_KERNEL = 'kernel-rt-0.1.2-3.rt4.5.el7.x86_64'
 
 
-def mocked_run_with_target_kernel(*args, **kwargs):
-    return {'stdout': [TARGET_KERNEL, OLD_KERNEL]}
+class MockedRun(object):
+
+    def __init__(self, stdouts):
+        # stdouts should be dict of list of strings: { str: [str1,str2,...]}
+        self._stdouts = stdouts
+
+    def __call__(self, *args, **kwargs):
+        for key in ('kernel', 'kernel-rt'):
+            if key in args[0]:
+                return {'stdout': self._stdouts.get(key, [])}
+        return {'stdout': []}
 
 
-def mocked_run_without_target_kernel(*args, **kwargs):
-    return {'stdout': [OLD_KERNEL]}
-
-
-def test_scaninstalledkernel(monkeypatch):
+@pytest.mark.parametrize('is_rt,exp_version,stdouts', [
+    (False, TARGET_KERNEL_VERSION, {'kernel': [OLD_KERNEL, TARGET_KERNEL]}),
+    (False, TARGET_KERNEL_VERSION, {'kernel': [TARGET_KERNEL, OLD_KERNEL]}),
+    (False, TARGET_KERNEL_VERSION, {
+        'kernel': [TARGET_KERNEL, OLD_KERNEL],
+        'kernel-rt': [TARGET_RT_KERNEL, OLD_RT_KERNEL],
+    }),
+    (True, TARGET_RT_KERNEL_VERSION, {'kernel-rt': [OLD_RT_KERNEL, TARGET_RT_KERNEL]}),
+    (True, TARGET_RT_KERNEL_VERSION, {'kernel-rt': [TARGET_RT_KERNEL, OLD_RT_KERNEL]}),
+    (True, TARGET_RT_KERNEL_VERSION, {
+        'kernel': [TARGET_KERNEL, OLD_KERNEL],
+        'kernel-rt': [TARGET_RT_KERNEL, OLD_RT_KERNEL],
+    }),
+])
+def test_scaninstalledkernel(monkeypatch, is_rt, exp_version, stdouts):
     result = []
-    monkeypatch.setattr(stdlib, 'run', mocked_run_with_target_kernel)
+    old_kver = '0.1.2-3.rt4.5.el7.x86_64' if is_rt else 'kernel-0.1.2-3.el7.x86_64'
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=old_kver))
     monkeypatch.setattr(api, 'produce', result.append)
+    monkeypatch.setattr(scankernel, 'run', MockedRun(stdouts))
     scankernel.process()
-    assert result and result[0].version == TARGET_KERNEL_VERSION
+    assert len(result) == 1 and result[0].version == exp_version
+
+
+def test_scaninstalledkernel_missing_rt(monkeypatch):
+    result = []
+    old_kver = '0.1.2-3.rt4.5.el7.x86_64'
+    stdouts = {'kernel': [TARGET_KERNEL], 'kernel-rt': [OLD_RT_KERNEL]}
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=old_kver))
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(api, 'produce', result.append)
+    monkeypatch.setattr(scankernel, 'run', MockedRun(stdouts))
+    scankernel.process()
+    assert api.current_logger.warnmsg
+    assert len(result) == 1 and result[0].version == TARGET_KERNEL_VERSION
 
 
 def test_scaninstalledkernel_missing(monkeypatch):
     result = []
-    monkeypatch.setattr(stdlib, 'run', mocked_run_without_target_kernel)
+    old_kver = '0.1.2-3.rt4.5.el7.x86_64'
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=old_kver))
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'produce', result.append)
+    monkeypatch.setattr(scankernel, 'run', MockedRun({}))
     scankernel.process()
+    assert api.current_logger.warnmsg
+    assert api.current_logger.errmsg
     assert not result

--- a/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/tests/test_version.py
@@ -103,3 +103,15 @@ def test_is_supported_version(monkeypatch, result, is_alt, src_ver, saphana):
     monkeypatch.setattr(version, 'SUPPORTED_VERSIONS', {'rhel': ['7.8'], 'rhel-alt': ['7.6'], 'rhel-saphana': ['7.7']})
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver=src_ver))
     assert version.is_supported_version() == result
+
+
+@pytest.mark.parametrize('result,kernel,release_id', [
+    (False, '3.10.0-790.el7.x86_64', 'rhel'),
+    (False, '3.10.0-790.el7.x86_64', 'fedora'),
+    (False, '3.10.0-790.35.2.rt666.1133.el7.x86_64', 'fedora'),
+    (True, '3.10.0-790.35.2.rt666.1133.el7.x86_64', 'rhel'),
+])
+def test_is_rhel_realtime(monkeypatch, result, kernel, release_id):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver='7.9', kernel=kernel,
+                                                                 release_id=release_id))
+    assert version.is_rhel_realtime() == result

--- a/repos/system_upgrade/el7toel8/libraries/config/version.py
+++ b/repos/system_upgrade/el7toel8/libraries/config/version.py
@@ -173,6 +173,25 @@ def is_rhel_alt():
     return conf.os_release.release_id == 'rhel' and conf.kernel[0] == '4'
 
 
+def is_rhel_realtime():
+    """
+    Check whether the original system is RHEL Real Time.
+
+    Currently the check is based on the release of the original booted kernel.
+    In case of RHEL, we are sure the release contains the ".rt" string and
+    non-realtime kernels don't. Let's use this minimalistic check for now.
+    In future, we could detect whether the system is preemptive or not based
+    on properties of the kernel (e.g. uname -a tells that information).
+
+    :return: `True` if the orig system is RHEL RT and `False` otherwise.
+    :rtype: bool
+    """
+    conf = api.current_actor().configuration
+    if conf.os_release.release_id != 'rhel':
+        return False
+    return '.rt' in conf.kernel.split('-')[1]
+
+
 def is_supported_version():
     """
     Verify if the current system version is supported for the upgrade.


### PR DESCRIPTION
RHEL Real Time (RT) systems boot using kernel-rt rpm. But still,
even a kernel rpm can be installed. So now, detect whether we are
booted via kernel-rt or not and based on that:

- do the comparison of the newest installed and booted kernel(-rt)
- detect the target installed kernel(-rt) version

## TODO
- [x] detect target kernel-rt version when original sys was RHEL RT 
- [x] handle correctly default boot - boot into kernel-rt when RHEL RT

## Comparison of kernel versions changes
Unfortunately, this make comparisons between releases more difficult
as we need to check the whole release, including alphanumeric
characters in release, e.g.:

-        kernel-rt-3.10.0-1160.2.1.rt56.1133.el7.x86_64

Previously we worked just with numbers. To make the check valid and
more robust, let's use rpm.labelCompare(). We are sure this library
is on every RHEL 7 system as dnf requires it (and probably yum too).
Let's use it as it resolves all our current troubles right now and
makes whole comparison more reliable.

In this implementation I am skipping comparison with epoch as
there is no (and will not be) kernel with bumped epoch.

## How postupgrade phases are affected

Actors working with bootloader and iniramfss needs to refer to specific kernel always. Currently, we are going to set the default boot and handle the target initramfs only for one specified kernel. If the original system was Real Time, work with `kernel-rt` related stuff. If the `kernel-rt` RHEL 8 rpm is not discovered (not installed), fallback to standard non-preemptive kernel. This is possible if user do not attach all expected RHEL 8 repositories (in this case, e.g. `rhel-8-for-x86_64-rt-rpms`).

If the original system is not real time (not booted with preemptive kernel) act as before. No change is visible in that case.