### PR TITLE
Feature/add actor checkpcidrivers

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkpcidrivers/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkpcidrivers/actor.py
@@ -1,0 +1,32 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.checkpcidrivers import checkpcidrivers_main
+from leapp.models import PCIDevices, RestrictedPCIDevices
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag, ExperimentalTag
+
+
+class CheckPCIDrivers(Actor):
+    """
+    Check if host PCI devices drivers has restrictions on target system.
+
+    If driver is restricted this means it is either unsupported or unavailable
+    in some set of newer RHEL versions.
+
+    If the driver is unavailable on a target system - then the upgrade will
+        be inhibited
+    If the driver is available, but not supported - then the upgrade will
+        continue, but the relevant report will be generated
+    If the driver is available and supported - then the upgrade will continue
+        normally
+    """
+
+    name = "check_pci_drivers"
+    consumes = (
+        PCIDevices,
+        RestrictedPCIDevices,
+    )
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag, ExperimentalTag)
+
+    def process(self):
+        checkpcidrivers_main()

--- a/repos/system_upgrade/el7toel8/actors/checkpcidrivers/libraries/checkpcidrivers.py
+++ b/repos/system_upgrade/el7toel8/actors/checkpcidrivers/libraries/checkpcidrivers.py
@@ -1,0 +1,191 @@
+"""
+TODOs:
+1. consider the idea to compare data sources timestamp in order to decide
+   if the source is actual or not
+"""
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp.models import PCIDevices, RestrictedPCIDevices
+from leapp.reporting import create_report
+
+
+def render_report(
+    restricted_driver_names_on_host,
+    restricted_pci_ids_on_host,
+    restricted_devices_drivers,
+    restricted_devices_pcis,
+    inhibit_upgrade=False,
+):
+    """
+    Render the report for restricted PCI devices in use.
+
+    :param inhibit_upgrade: if True, the report will have Inhibitor flag and
+        the upgrade will be inhibited.
+    """
+    # Prefilter needed data for the report
+    unavailable_driver_names = tuple(
+        driver
+        for driver in restricted_driver_names_on_host
+        if restricted_devices_drivers[driver].available_rhel8 == 0
+    )
+    unavailable_pci_ids = tuple(
+        pci_id
+        for pci_id in restricted_pci_ids_on_host
+        if restricted_devices_pcis[pci_id].available_rhel8 == 0
+    )
+    unsupported_driver_names = tuple(
+        driver
+        for driver in restricted_driver_names_on_host
+        if restricted_devices_drivers[driver].supported_rhel8 == 0
+    )
+    unsupported_pci_ids = tuple(
+        pci_id
+        for pci_id in restricted_pci_ids_on_host
+        if restricted_devices_pcis[pci_id].supported_rhel8 == 0
+    )
+
+    # Render the report entities
+    title = "Detected PCI drivers that are restricted on RHEL8."
+
+    # Prepare summary
+    summary_partial = "The following drivers are restricted on RHEL 8 system:"
+    # Process unavailable devices
+    if unavailable_driver_names or unavailable_pci_ids:
+        summary_partial += "\n\t Unavailable in RHEL8:"
+        if unavailable_driver_names:
+            summary_partial += "\n\t\t- driver names:\n"
+            summary_partial += "\t\t\t- " + "\n\t\t\t- ".join(
+                unavailable_driver_names
+            )
+        if unavailable_pci_ids:
+            summary_partial += "\n\t\t- pci ids:\n"
+            summary_partial += "\t\t\t- " + "\n\t\t\t- ".join(
+                unavailable_pci_ids
+            )
+
+    # Process unsupported devices
+    if unsupported_driver_names or unsupported_pci_ids:
+        summary_partial += "\n\t Unsupported in RHEL8:"
+        if unsupported_driver_names:
+            summary_partial += "\n\t\t- driver names:\n"
+            summary_partial += "\t\t\t- " + "\n\t\t\t- ".join(
+                unsupported_driver_names
+            )
+        if unsupported_pci_ids:
+            summary_partial += "\n\t\t- pci ids:\n"
+            summary_partial += "\t\t\t- " + "\n\t\t\t- ".join(
+                unsupported_pci_ids
+            )
+
+    reports = [
+        reporting.Title(title),
+        reporting.Summary(summary_partial),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Tags([reporting.Tags.KERNEL, reporting.Tags.DRIVERS]),
+    ]
+    if inhibit_upgrade:
+        reports += [reporting.Flags([reporting.Flags.INHIBITOR])]
+    return reports
+
+
+def create_dict_lookup(driver_names, key):
+    """
+    Creates a dict lookup from the list of Models.
+
+    :param driver_names: List[leapp.models.Model[K, V]]
+    :param key: a key value, that will be used as a primary key to generate a
+        result Dict
+    :return: Dict[leapp.models.Model[K,V].key, leapp.models.Model[K,V]]
+    :raises ValueError: if there are duplicates of leapp.models.Model[K,V].key
+    :raises AttributeError: if key not in K (Model attributes)
+
+    Example:
+    >>> create_dict_lookup([Model(a=1, b=2), Model(a=2, b=3)], key="b") == {
+    >>>     2: Model(a=1, b=2),
+    >>>     3: Model(a=2, b=3),
+    >>> }
+    """
+    lookup = {getattr(item, key): item for item in driver_names}
+    if len(lookup) != len(driver_names):
+        raise ValueError("A duplicated key(s) found")
+    return lookup
+
+
+def checkpcidrivers_main():
+    """Main entrypoint of the CheckPCIDrivers Actor."""
+    try:
+        pci_devs = next(api.consume(PCIDevices))
+        restricted_pci_devs = next(api.consume(RestrictedPCIDevices))
+    except StopIteration:
+        raise StopActorExecutionError(
+            message=(
+                "At least one of the needed messages is empty. "
+                "Required messages are PCIDevices, RestrictedPCIDevices."
+            )
+        )
+    else:
+        # get set of drivers-names/pci-ids presented on host
+        driver_names_on_host = set(dev.driver for dev in pci_devs.devices)
+        pci_ids_on_host = set(dev.pci_id for dev in pci_devs.devices)
+
+        # get restricted driver_names and pci_ids dict lookups
+        try:
+            restricted_devices_drivers = create_dict_lookup(
+                restricted_pci_devs.driver_names, key="driver_name"
+            )
+            restricted_devices_pcis = create_dict_lookup(
+                restricted_pci_devs.pci_ids, key="pci_id"
+            )
+        except (AttributeError, ValueError) as err:
+            raise StopActorExecutionError(message=str(err))
+        # get set of restricted driver-names/pci-ids presented on host
+        restricted_driver_names_on_host = driver_names_on_host & set(
+            restricted_devices_drivers
+        )
+        restricted_pci_ids_on_host = pci_ids_on_host & set(
+            restricted_devices_pcis
+        )
+
+        # check if at least one driver on host is not available on RHEL8
+        if any(
+            restricted_devices_drivers[driver_name].available_rhel8 == 0
+            for driver_name in restricted_driver_names_on_host
+        ) or any(
+            restricted_devices_pcis[pci].available_rhel8 == 0
+            for pci in restricted_pci_ids_on_host
+        ):
+            api.current_logger().critical(
+                "Some of the host drivers are unavailable on the RHEL 8 "
+                "system. Inhibiting the upgrade...",
+            )
+            create_report(
+                render_report(
+                    restricted_driver_names_on_host,
+                    restricted_pci_ids_on_host,
+                    restricted_devices_drivers,
+                    restricted_devices_pcis,
+                    inhibit_upgrade=True,
+                )
+            )
+        # check if at least one driver on host is not supported on RHEL8
+        elif any(
+            restricted_devices_drivers[driver_name].supported_rhel8 == 0
+            for driver_name in restricted_driver_names_on_host
+        ) or any(
+            restricted_devices_pcis[pci].supported_rhel8 == 0
+            for pci in restricted_pci_ids_on_host
+        ):
+            api.current_logger().warning(
+                "Some of the host drivers are unsupported on the RHEL 8 "
+                "system. Warning the user...",
+            )
+            create_report(
+                render_report(
+                    restricted_driver_names_on_host,
+                    restricted_pci_ids_on_host,
+                    restricted_devices_drivers,
+                    restricted_devices_pcis,
+                )
+            )

--- a/repos/system_upgrade/el7toel8/actors/checkpcidrivers/tests/unit_test_checkpcidrivers.py
+++ b/repos/system_upgrade/el7toel8/actors/checkpcidrivers/tests/unit_test_checkpcidrivers.py
@@ -1,0 +1,367 @@
+import itertools
+import logging
+from functools import partial
+
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor.checkpcidrivers import (
+    checkpcidrivers_main,
+    create_dict_lookup,
+    render_report,
+)
+from leapp.libraries.common.testutils import (
+    CurrentActorMocked,
+    create_report_mocked,
+    produce_mocked,
+)
+from leapp.libraries.stdlib import api
+from leapp.models import (
+    Model,
+    PCIDevice,
+    PCIDevices,
+    RestrictedPCIDevice,
+    RestrictedPCIDevices,
+    fields,
+)
+from leapp.topics.systeminfo import SystemInfoTopic
+
+logger = logging.getLogger(__name__)
+
+pci_devices = PCIDevices(
+    devices=[
+        PCIDevice(
+            slot="00:00.0",
+            driver="",
+            dev_cls="Host bridge",
+            vendor="Intel Corporation",
+            name="440FX - 82441FX PMC [Natoma]",
+            subsystem_vendor="Red Hat, Inc.",
+            subsystem_name="Qemu virtual machine",
+            pci_id="",
+            rev="02",
+        ),
+        PCIDevice(
+            slot="00:01.0",
+            dev_cls="ISA bridge",
+            vendor="Intel Corporation",
+            name="82371SB PIIX3 ISA [Natoma/Triton II]",
+            subsystem_vendor="Red Hat, Inc.",
+            pci_id="15b560:0739",
+            subsystem_name="Qemu virtual machine",
+        ),
+        PCIDevice(
+            slot="00:01.1",
+            dev_cls="IDE interface",
+            vendor="Intel Corporation",
+            name="82371SB PIIX3 IDE [Natoma/Triton II]",
+            subsystem_vendor="Red Hat, Inc.",
+            subsystem_name="Qemu virtual machine",
+            pci_id="15b560:0739",
+            progif="80",
+        ),
+    ]
+)
+
+restricted_pci_devices = RestrictedPCIDevices(
+    driver_names=[
+        RestrictedPCIDevice(
+            pci_id="nan",
+            driver_name="3w-9xxx",
+            device_name="3w-9xxx",
+            available_rhel7=1,
+            supported_rhel7=1,
+            available_rhel8=0,
+            supported_rhel8=0,
+            available_rhel9=0,
+            supported_rhel9=0,
+            comment="nan",
+        ),
+        RestrictedPCIDevice(
+            pci_id="nan",
+            driver_name="3w-sas",
+            device_name="3w-sas",
+            available_rhel7=1,
+            supported_rhel7=1,
+            available_rhel8=1,
+            supported_rhel8=0,
+            available_rhel9=0,
+            supported_rhel9=0,
+            comment="nan",
+        ),
+        RestrictedPCIDevice(
+            pci_id="nan",
+            driver_name="acard-ahci",
+            device_name="acard-ahci",
+            available_rhel7=1,
+            supported_rhel7=1,
+            available_rhel8=1,
+            supported_rhel8=1,
+            available_rhel9=0,
+            supported_rhel9=0,
+            comment="nan",
+        ),
+    ],
+    pci_ids=[
+        RestrictedPCIDevice(
+            pci_id="0x1000:0x0060",
+            driver_name="megaraid_sas",
+            device_name="SAS1078R",
+            available_rhel7=1,
+            supported_rhel7=1,
+            available_rhel8=0,
+            supported_rhel8=0,
+            available_rhel9=0,
+            supported_rhel9=0,
+            comment="nan",
+        ),
+        RestrictedPCIDevice(
+            pci_id="0x1000:0x0064",
+            driver_name="mpt2sas",
+            device_name="SAS2116_1",
+            available_rhel7=1,
+            supported_rhel7=1,
+            available_rhel8=1,
+            supported_rhel8=0,
+            available_rhel9=0,
+            supported_rhel9=0,
+            comment="nan",
+        ),
+        RestrictedPCIDevice(
+            pci_id="0x1000:0x0065",
+            driver_name="mpt2sas",
+            device_name="SAS2116_2",
+            available_rhel7=1,
+            supported_rhel7=1,
+            available_rhel8=1,
+            supported_rhel8=1,
+            available_rhel9=0,
+            supported_rhel9=0,
+            comment="nan",
+        ),
+    ],
+)
+
+
+@pytest.mark.parametrize(
+    (
+        "driver_name",
+        "pci_id",
+        "inhibit_upgrade",
+        "num_msgs",
+    ),
+    [
+        (
+            "good driver name",
+            "good pci id",
+            None,
+            0,
+        ),
+        (
+            "3w-9xxx",
+            "good pci id",
+            True,
+            1,
+        ),
+        (
+            "3w-sas",
+            "good pci id",
+            None,
+            1,
+        ),
+        (
+            "acard-ahci",
+            "good pci id",
+            None,
+            0,
+        ),
+        (
+            "good driver name",
+            "0x1000:0x0060",
+            True,
+            1,
+        ),
+        (
+            "good driver name",
+            "0x1000:0x0064",
+            None,
+            1,
+        ),
+        (
+            "good driver name",
+            "0x1000:0x0065",
+            None,
+            0,
+        ),
+    ],
+)
+def test_basic_checkpcidrivers(
+    monkeypatch,
+    driver_name,
+    pci_id,
+    inhibit_upgrade,
+    num_msgs,
+):
+    """Check the main actor function."""
+    pci_devices.devices[0].driver = driver_name
+    pci_devices.devices[0].pci_id = pci_id
+    monkeypatch.setattr(
+        api,
+        "current_actor",
+        CurrentActorMocked(msgs=[pci_devices, restricted_pci_devices]),
+    )
+    monkeypatch.setattr(
+        reporting,
+        "create_report",
+        create_report_mocked(),
+    )
+    monkeypatch.setattr(
+        CurrentActorMocked,
+        "produce",
+        produce_mocked(),
+    )
+    checkpcidrivers_main()
+    if inhibit_upgrade:
+        assert len(CurrentActorMocked.produce.model_instances) == 1
+        assert CurrentActorMocked.produce.model_instances[0].report[
+            "flags"
+        ] == ["inhibitor"]
+    if num_msgs and not inhibit_upgrade:
+        assert (
+            "flags" not in CurrentActorMocked.produce.model_instances[0].report
+        )
+    assert len(CurrentActorMocked.produce.model_instances) == num_msgs
+
+
+RestrictedPCIDevicePrefilled = partial(
+    RestrictedPCIDevice,
+    pci_id="",
+    driver_name="",
+    device_name="",
+    comment="",
+    available_rhel7=1,
+    available_rhel9=0,
+    supported_rhel7=1,
+    supported_rhel9=0,
+)
+
+
+def get_test_case_for_testing_report(
+    devices, available_rhel8, supported_rhel8
+):
+    return devices, {
+        d: RestrictedPCIDevicePrefilled(
+            available_rhel8=available_rhel8,
+            supported_rhel8=supported_rhel8,
+        )
+        for d in devices
+    }
+
+
+@pytest.mark.parametrize(
+    (
+        "restricted_driver_names_on_host",
+        "restricted_devices_drivers",
+        "restricted_pci_ids_on_host",
+        "restricted_devices_pcis",
+        "inhibit_upgrade",
+        "exp_line_length",
+    ),
+    [
+        get_test_case_for_testing_report(("d1", "d2"), 0, 0)
+        + get_test_case_for_testing_report(("p1", "p2"), 0, 0)
+        + (True, 15),
+        get_test_case_for_testing_report(("d1", "d2"), 1, 0)
+        + get_test_case_for_testing_report(("p1", "p2"), 1, 0)
+        + (True, 8),
+        get_test_case_for_testing_report(("d1", "d2"), 0, 1)
+        + get_test_case_for_testing_report(("p1", "p2"), 0, 1)
+        + (True, 8),
+        get_test_case_for_testing_report(("d1", "d2"), 1, 0)
+        + get_test_case_for_testing_report(("p1", "p2"), 0, 1)
+        + (True, 9),
+    ],
+)
+def test_render_report(
+    monkeypatch,
+    restricted_driver_names_on_host,
+    restricted_pci_ids_on_host,
+    restricted_devices_drivers,
+    restricted_devices_pcis,
+    inhibit_upgrade,
+    exp_line_length,
+    caplog,
+):
+    """Check report appearance."""
+    monkeypatch.setattr(
+        reporting,
+        "create_report",
+        create_report_mocked(),
+    )
+    reporting.create_report(
+        render_report(
+            restricted_driver_names_on_host=restricted_driver_names_on_host,
+            restricted_pci_ids_on_host=restricted_pci_ids_on_host,
+            restricted_devices_drivers=restricted_devices_drivers,
+            restricted_devices_pcis=restricted_devices_pcis,
+            inhibit_upgrade=inhibit_upgrade,
+        )
+    )
+    logger.info(reporting.create_report.report_fields["summary"])
+    assert sum(len(m.split("\n")) for m in caplog.messages) == exp_line_length
+
+
+class M(Model):
+    """A model just for the purpose of further test."""
+
+    topic = SystemInfoTopic
+
+    a = fields.Integer(default=0)
+    b = fields.Integer(default=0)
+
+
+@pytest.mark.parametrize(
+    ("driver_names", "key", "exp", "exception"),
+    [
+        # Normal case
+        (
+            [M(a=1, b=2), M(a=1, b=3)],
+            "b",
+            {2: M(a=1, b=2), 3: M(a=1, b=3)},
+            None,
+        ),
+        # Not existing attribute
+        (
+            [M(a=1, b=2), M(a=1, b=3)],
+            "c",
+            None,
+            AttributeError,
+        ),
+        # Not existing attribute, empty Ms
+        (
+            [M(), M()],
+            "c",
+            None,
+            AttributeError,
+        ),
+        # Duplicated attribute values
+        (
+            [M(a=1, b=2), M(a=1, b=2)],
+            "b",
+            None,
+            ValueError,
+        ),
+    ],
+)
+def test_create_dict_lookup_fn(driver_names, key, exp, exception):
+    if exception:
+        with pytest.raises(exception):
+            create_dict_lookup(driver_names, key)
+    else:
+        assert create_dict_lookup(driver_names, key) == exp
+
+
+def test_checkpcidrivers_no_restricted_devs(current_actor_context):
+    """Test if actor works well when no messages provided."""
+    current_actor_context.run()
+    assert current_actor_context._messaging.errors()

--- a/repos/system_upgrade/el7toel8/actors/kernel/checkkerneldrivers/tests/unit_test_checkkerneldrivers.py
+++ b/repos/system_upgrade/el7toel8/actors/kernel/checkkerneldrivers/tests/unit_test_checkkerneldrivers.py
@@ -2,24 +2,23 @@ import pytest
 
 from leapp.models import PCIDevice, PCIDevices, KernelModuleParameter
 from leapp.reporting import Report
-from leapp.snactor.fixture import current_actor_context
 
 
 devices_ok = [
-    PCIDevice(slot="00:00.0", dev_cls="foo", vendor="bar", name="foobar", driver="i915"),
-    PCIDevice(slot="00:01.0", dev_cls="foo", vendor="bar", name="foobar", driver="serial"),
-    PCIDevice(slot="00:02.0", dev_cls="foo", vendor="bar", name="foobar", driver="pcieport"),
-    PCIDevice(slot="00:03.0", dev_cls="foo", vendor="bar", name="foobar", driver="nvme")
+    PCIDevice(slot="00:00.0", dev_cls="foo", vendor="bar", name="foobar", driver="i915", pci_id="some id"),
+    PCIDevice(slot="00:01.0", dev_cls="foo", vendor="bar", name="foobar", driver="serial", pci_id="some id"),
+    PCIDevice(slot="00:02.0", dev_cls="foo", vendor="bar", name="foobar", driver="pcieport", pci_id="some id"),
+    PCIDevice(slot="00:03.0", dev_cls="foo", vendor="bar", name="foobar", driver="nvme", pci_id="some id")
 ]
 devices_driverless = [
-    PCIDevice(slot="00:04.0", dev_cls="foo", vendor="bar", name="foobar", driver=""),
-    PCIDevice(slot="00:05.0", dev_cls="foo", vendor="bar", name="foobar", driver="")
+    PCIDevice(slot="00:04.0", dev_cls="foo", vendor="bar", name="foobar", driver="", pci_id="some id"),
+    PCIDevice(slot="00:05.0", dev_cls="foo", vendor="bar", name="foobar", driver="", pci_id="some id")
 ]
 devices_removed = [
-    PCIDevice(slot="00:06.0", dev_cls="foo", vendor="bar", name="foobar", driver="floppy"),
-    PCIDevice(slot="00:07.0", dev_cls="foo", vendor="bar", name="foobar", driver="initio"),
-    PCIDevice(slot="00:08.0", dev_cls="foo", vendor="bar", name="foobar", driver="pata_acpi"),
-    PCIDevice(slot="00:09.0", dev_cls="foo", vendor="bar", name="foobar", driver="iwl4965")
+    PCIDevice(slot="00:06.0", dev_cls="foo", vendor="bar", name="foobar", driver="floppy", pci_id="some id"),
+    PCIDevice(slot="00:07.0", dev_cls="foo", vendor="bar", name="foobar", driver="initio", pci_id="some id"),
+    PCIDevice(slot="00:08.0", dev_cls="foo", vendor="bar", name="foobar", driver="pata_acpi", pci_id="some id"),
+    PCIDevice(slot="00:09.0", dev_cls="foo", vendor="bar", name="foobar", driver="iwl4965", pci_id="some id")
 ]
 
 

--- a/repos/system_upgrade/el7toel8/actors/pcidevicesscanner/libraries/pcidevicesscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/pcidevicesscanner/libraries/pcidevicesscanner.py
@@ -1,8 +1,15 @@
+import re
+
 from leapp.libraries.stdlib import api, run
-from leapp.models import PCIDevices, PCIDevice
+from leapp.models import PCIDevice, PCIDevices
+
+# Regex to capture Vendor, Device and SVendor and SDevice values
+PCI_ID_REG = re.compile(r"(?<=Vendor:\t|Device:\t)\w+")
 
 
-def parse_pci_device(block):
+# TODO this could be solved more efficiently and error prune via python re
+#   and groupdict
+def parse_pci_device(textual_block, numeric_block):
     """ Parse one block from lspci output describing one PCI device """
     device = {
         'Slot': '',
@@ -18,7 +25,7 @@ def parse_pci_device(block):
         'Module': [],
         'NUMANode': ''
     }
-    for line in block.split('\n'):
+    for line in textual_block.split('\n'):
         key, value = line.split(':\t')
 
         if key in device:
@@ -46,12 +53,20 @@ def parse_pci_device(block):
         progif=device['ProgIf'],
         driver=device['Driver'],
         modules=device['Module'],
-        numa_node=device['NUMANode'])
+        numa_node=device['NUMANode'],
+        pci_id=":".join(PCI_ID_REG.findall(numeric_block))
+    )
 
 
-def parse_pci_devices(output):
+def parse_pci_devices(pci_textual, pci_numeric):
     """ Parse lspci output and return a list of PCI devices """
-    return [parse_pci_device(block) for block in output.split('\n\n')[:-1]]
+    return [
+        parse_pci_device(*block) for block
+        in zip(
+            pci_textual.split('\n\n')[:-1],
+            pci_numeric.split('\n\n')[:-1]
+        )
+    ]
 
 
 def produce_pci_devices(producer, devices):
@@ -61,6 +76,7 @@ def produce_pci_devices(producer, devices):
 
 def scan_pci_devices(producer):
     """ Scan system PCI Devices """
-    output = run(['lspci', '-vmmk'], checked=False)['stdout']
-    devices = parse_pci_devices(output)
+    pci_textual = run(['lspci', '-vmmk'], checked=False)['stdout']
+    pci_numeric = run(['lspci', '-vmmkn'], checked=False)['stdout']
+    devices = parse_pci_devices(pci_textual, pci_numeric)
     produce_pci_devices(producer, devices)

--- a/repos/system_upgrade/el7toel8/actors/restrictedpcisscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/restrictedpcisscanner/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import restrictedpcisscanner
+from leapp.models import RestrictedPCIDevices
+from leapp.tags import ExperimentalTag, FactsPhaseTag, IPUWorkflowTag
+
+
+class RestrictedPCIsScanner(Actor):
+    """
+    Provides data about restricted (unsupported or/and unavailable) devices.
+
+    The data sources priority set up is as following:
+    1. The actor tries to get the data from /etc/leapp/files
+    2. Then from the online service
+    """
+
+    name = "restricted_pcis_scanner"
+    consumes = ()
+    produces = (RestrictedPCIDevices,)
+    tags = (IPUWorkflowTag, FactsPhaseTag, ExperimentalTag)
+
+    def process(self):
+        restrictedpcisscanner.produce_restricted_pcis()

--- a/repos/system_upgrade/el7toel8/actors/restrictedpcisscanner/libraries/restrictedpcisscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/restrictedpcisscanner/libraries/restrictedpcisscanner.py
@@ -1,0 +1,170 @@
+import errno
+import json
+import os
+
+import urllib3
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config import get_env
+from leapp.libraries.stdlib import api
+from leapp.models import RestrictedPCIDevices
+from leapp.models.fields import ModelViolationError
+
+
+try:
+    # python3
+    from json import JSONDecodeError  # pylint: disable=ungrouped-imports
+except ImportError:
+    # python2
+    JSONDecodeError = ValueError
+
+REQUEST_TIMEOUT = 0.5  # TODO Consider moving it to the leapp env var
+UNSUPPORTED_DRIVER_NAMES_GLOBAL_FILE = os.path.join(
+    "/etc/leapp/files", "unsupported_driver_names.json"
+)
+UNSUPPORTED_PCI_IDS_GLOBAL_FILE = os.path.join(
+    "/etc/leapp/files", "unsupported_pci_ids.json"
+)
+
+# TODO Once the microservice for providing the data about removed hardware
+#   will be provisioned to the Red Hat costumers, then this variable default
+#   value should be overwritten
+PCIS_HOST_DEFAULT = ""
+API_VERSION = "v1"
+
+
+def get_restricted_pcis(http):
+    """
+    Get data about restricted driver names and unsupported pci_ids online.
+
+    The function makes API call to the web service, which provides
+    these data.
+
+    :param urllib3.PoolManager http: pool manager instance
+    :returns: Tuple[dict, dict]
+    """
+    # TODO this constant should be above the scope of this func.
+    #   However due to the way how actor tested with CurrentActorMocked
+    #   we can't do this.
+    API_URL = "http://{host_port}/api/{api_version}/".format(
+        host_port=get_env(
+            "LEAPP_DEVEL_PCIS_HOST",
+            default=PCIS_HOST_DEFAULT,
+        ),
+        api_version=API_VERSION,
+    )
+    unsupported_driver_names = http.request(
+        "GET",
+        API_URL + "unsupported_driver_names/",
+        timeout=REQUEST_TIMEOUT,
+        headers={},
+    )
+    unsupported_pci_ids = http.request(
+        "GET",
+        API_URL + "unsupported_pci_ids/",
+        timeout=REQUEST_TIMEOUT,
+        headers={},
+    )
+
+    unsupported_driver_names = json.loads(
+        unsupported_driver_names.data.decode("utf-8")
+    )
+    unsupported_pci_ids = json.loads(unsupported_pci_ids.data.decode("utf-8"))
+    return unsupported_driver_names, unsupported_pci_ids
+
+
+def get_restricted_pcis_offline(driver_names_file, pci_ids_file, _open=open):
+    """
+    Get data about restricted driver names and unsupported pci_ids offline.
+
+    The function takes the data from locally stored json files in the given
+    location.
+
+    :param _open: made to make the testing easy
+    """
+    with _open(driver_names_file) as f:
+        unsupported_driver_names = json.load(f)
+    with _open(pci_ids_file) as f:
+        unsupported_pci_ids = json.load(f)
+    return unsupported_driver_names, unsupported_pci_ids
+
+
+def produce_restricted_pcis():
+    """
+    Produce RestrictedPCIDevice message from the online or offline sources.
+
+    The data sources preference order is the following:
+    1. We try to get the data from the /etc/leapp/files
+    2. We try to get the data from the only web service
+    """
+    unsupported_driver_names = {"devices": {}}
+    unsupported_pci_ids = {"devices": {}}
+    # trying get data in leapp files
+    try:
+        api.current_logger().info(
+            "Trying get restricted PCI data from the /etc/leapp/files..."
+        )
+        unsupported_driver_names, unsupported_pci_ids = get_restricted_pcis_offline(
+            driver_names_file=UNSUPPORTED_DRIVER_NAMES_GLOBAL_FILE,
+            pci_ids_file=UNSUPPORTED_PCI_IDS_GLOBAL_FILE,
+        )
+        api.current_logger().info("Data received from /etc/leapp/files.")
+    # no files
+    except EnvironmentError as e:
+        if e.errno == errno.ENOENT and not (
+            os.path.islink(UNSUPPORTED_DRIVER_NAMES_GLOBAL_FILE)
+            or os.path.islink(UNSUPPORTED_PCI_IDS_GLOBAL_FILE)
+        ):
+            # trying to get files online
+            try:
+                api.current_logger().info(
+                    "Trying get restricted PCI data online..."
+                )
+                http = urllib3.PoolManager()
+                (
+                    unsupported_driver_names,
+                    unsupported_pci_ids,
+                ) = get_restricted_pcis(http)
+                api.current_logger().info(
+                    "Data received from the online source."
+                )
+            # mcs is not available or return a bad json format
+            except (urllib3.exceptions.MaxRetryError, JSONDecodeError):
+                raise StopActorExecutionError(
+                    message=(
+                        "Can't get the data about restricted PCI devices "
+                        "from any available sources."
+                    )
+                )
+        else:
+            raise StopActorExecutionError(
+                "The required files are presented in the /etc/leapp/files. "
+                "However, they can't be read by the system (i.e. "
+                "broken symlink, IO error)."
+            )
+    # files exists, but bad json format
+    except (JSONDecodeError, UnicodeDecodeError):
+        raise StopActorExecutionError(
+            "The required files are presented in the /etc/leapp/files. "
+            "However, they have invalid JSON format and can't be decoded."
+        )
+    finally:
+        # trying to produce the message from received data
+        try:
+            api.produce(
+                RestrictedPCIDevices.create(
+                    {
+                        "driver_names": tuple(
+                            unsupported_driver_names["devices"].values()
+                        ),
+                        "pci_ids": tuple(
+                            unsupported_pci_ids["devices"].values()
+                        ),
+                    },
+                )
+            )
+        # bad data format
+        except (KeyError, AttributeError, ModelViolationError):
+            raise StopActorExecutionError(
+                "Can't produce RestrictedPCIDevices message. The data are incompatible."
+            )

--- a/repos/system_upgrade/el7toel8/actors/restrictedpcisscanner/tests/unit_test_restricted_pcis_scanner.py
+++ b/repos/system_upgrade/el7toel8/actors/restrictedpcisscanner/tests/unit_test_restricted_pcis_scanner.py
@@ -1,0 +1,284 @@
+import errno
+from functools import partial
+
+import mock
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import restrictedpcisscanner
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import RestrictedPCIDevice, RestrictedPCIDevices
+
+
+try:
+    # python3
+    from unittest.mock import mock_open
+except ImportError:
+    # python2
+    from mock import mock_open  # pylint: disable=ungrouped-imports
+
+    FileNotFoundError = IOError  # pylint: disable=redefined-builtin
+
+unsupported_driver_names_example = {
+    "devices": {
+        "3w-9xxx": {
+            "pci_id": "nan",
+            "driver_name": "3w-9xxx",
+            "device_name": "3w-9xxx",
+            "available_rhel7": 1,
+            "supported_rhel7": 0,
+            "available_rhel8": 0,
+            "supported_rhel8": 0,
+            "available_rhel9": 0,
+            "supported_rhel9": 0,
+            "comment": "nan",
+        },
+        "3w-sas": {
+            "pci_id": "nan",
+            "driver_name": "3w-sas",
+            "device_name": "3w-sas",
+            "available_rhel7": 1,
+            "supported_rhel7": 0,
+            "available_rhel8": 0,
+            "supported_rhel8": 0,
+            "available_rhel9": 0,
+            "supported_rhel9": 0,
+            "comment": "nan",
+        },
+    }
+}
+
+
+unsupported_pci_ids_example = {
+    "devices": {
+        "0x1000:0x0060": {
+            "pci_id": "0x1000:0x0060",
+            "driver_name": "megaraid_sas",
+            "device_name": "SAS1078R",
+            "available_rhel7": 1,
+            "supported_rhel7": 1,
+            "available_rhel8": 0,
+            "supported_rhel8": 0,
+            "available_rhel9": 0,
+            "supported_rhel9": 0,
+            "comment": "nan",
+        },
+        "0x1000:0x0064": {
+            "pci_id": "0x1000:0x0064",
+            "driver_name": "mpt2sas",
+            "device_name": "SAS2116_1",
+            "available_rhel7": 1,
+            "supported_rhel7": 1,
+            "available_rhel8": 0,
+            "supported_rhel8": 0,
+            "available_rhel9": 0,
+            "supported_rhel9": 0,
+            "comment": "nan",
+        },
+    }
+}
+
+some_very_bad_data = {"bad": "data"}
+some_bad_data = {"devices": "not here"}
+
+
+def blank_fn(should_return, *args, **kwargs):
+    """
+    Just a blank fn which accepts anything and returns what should_return.
+    """
+    return should_return
+
+
+def json_loads_mock_gen(returns_first, returns_second):
+    """
+    Generator used for mocking the json.loads call.
+
+    :param returns_first: defines which data will be returned by the json.loads when called first time
+    :param returns_second: defines which data will be returned by the json.loads when called the second time
+
+    It is needed to make it possible returning two different values when
+    called json.loads first and the second time.
+    """
+    yield partial(blank_fn, returns_first)
+    yield partial(blank_fn, returns_second)
+
+
+@pytest.mark.parametrize(
+    (
+        "mcs_socket",
+        "mcs_available",
+        "global_files_exists",
+        "bad_data",
+        "json_returns_first",
+        "json_returns_second",
+    ),
+    [
+        # Should use global files
+        (
+            "not existing host of the mcs",
+            False,
+            True,
+            False,
+            unsupported_driver_names_example,
+            unsupported_pci_ids_example,
+        ),
+        # Should use global files (because it is preferred)
+        (
+            "existing host",
+            True,
+            True,
+            False,
+            unsupported_driver_names_example,
+            unsupported_pci_ids_example,
+        ),
+        # Should use mcs (calls are mocked)
+        (
+            "existing host",
+            True,
+            False,
+            False,
+            unsupported_driver_names_example,
+            unsupported_pci_ids_example,
+        ),
+        # Should raise StopActorExecutionError
+        (
+            "not existing host",
+            False,
+            False,
+            True,
+            unsupported_driver_names_example,
+            unsupported_pci_ids_example,
+        ),
+        # Should use global files, which has bad data. Should raise StopActorExecutionError
+        (
+            "not existing host of the mcs",
+            False,
+            True,
+            True,
+            some_very_bad_data,
+            some_very_bad_data,
+        ),
+        # Should use global files, which has bad data. Should raise StopActorExecutionError
+        (
+            "not existing host of the mcs",
+            False,
+            True,
+            True,
+            some_bad_data,
+            some_bad_data,
+        ),
+        # Should use mcs, which has bad data. Should raise StopActorExecutionError
+        (
+            "existing host",
+            True,
+            False,
+            True,
+            some_very_bad_data,
+            some_very_bad_data,
+        ),
+        # Should use mcs, which has bad data. Should raise StopActorExecutionError
+        (
+            "existing host",
+            True,
+            False,
+            True,
+            some_bad_data,
+            some_bad_data,
+        ),
+    ],
+)
+def test_basic_restricted_pci_scanner(
+    monkeypatch,
+    mcs_socket,
+    mcs_available,
+    global_files_exists,
+    bad_data,
+    json_returns_first,
+    json_returns_second,
+):
+    """Test main actor function."""
+    monkeypatch.setattr(
+        api,
+        "current_actor",
+        CurrentActorMocked(
+            envars={
+                "LEAPP_DEVEL_PCIS_HOST": mcs_socket,
+            }
+        ),
+    )
+    monkeypatch.setattr(api, "produce", produce_mocked())
+    if global_files_exists:
+        json_loads_mock = json_loads_mock_gen(
+            json_returns_first, json_returns_second
+        )
+        monkeypatch.setattr(
+            restrictedpcisscanner.json,
+            "load",
+            value=next(json_loads_mock),
+        )
+        monkeypatch.setattr(
+            restrictedpcisscanner,
+            "get_restricted_pcis_offline",
+            value=partial(
+                restrictedpcisscanner.get_restricted_pcis_offline,
+                # no need to provide any data, because we mocked the
+                #   json.loads
+                _open=mock_open(read_data=""),
+            ),
+        )
+        if bad_data:
+            with pytest.raises(StopActorExecutionError):
+                restrictedpcisscanner.produce_restricted_pcis()
+            return
+        restrictedpcisscanner.produce_restricted_pcis()
+
+    if not global_files_exists and mcs_available:
+        pool_manager_mock = mock.Mock()
+        get_restricted_pcis_offline = mock.Mock(
+            side_effect=FileNotFoundError()
+        )
+        json_loads_mock = json_loads_mock_gen(
+            json_returns_first, json_returns_second
+        )
+        # even though FileNotFoundError raised as side effect, the error
+        # number is None (should be 2), so we have to mock the ENOENT
+        monkeypatch.setattr(errno, "ENOENT", value=None)
+
+        monkeypatch.setattr(
+            restrictedpcisscanner.urllib3,
+            "PoolManager",
+            value=pool_manager_mock,
+        )
+        monkeypatch.setattr(
+            restrictedpcisscanner.json,
+            "loads",
+            value=next(json_loads_mock),
+        )
+        monkeypatch.setattr(
+            restrictedpcisscanner,
+            "get_restricted_pcis_offline",
+            value=get_restricted_pcis_offline,
+        )
+
+        if bad_data:
+            with pytest.raises(StopActorExecutionError):
+                restrictedpcisscanner.produce_restricted_pcis()
+            return
+        restrictedpcisscanner.produce_restricted_pcis()
+
+        pool_manager_mock.assert_called_once()
+    if not global_files_exists and not mcs_available:
+        with pytest.raises(StopActorExecutionError):
+            restrictedpcisscanner.produce_restricted_pcis()
+        return
+    assert len(api.produce.model_instances) == 1
+    assert isinstance(api.produce.model_instances[0], RestrictedPCIDevices)
+    assert isinstance(
+        api.produce.model_instances[0].driver_names[0],
+        RestrictedPCIDevice,
+    )
+    assert isinstance(
+        api.produce.model_instances[0].pci_ids[0],
+        RestrictedPCIDevice,
+    )

--- a/repos/system_upgrade/el7toel8/models/pcidevices.py
+++ b/repos/system_upgrade/el7toel8/models/pcidevices.py
@@ -3,7 +3,8 @@ from leapp.topics import SystemInfoTopic
 
 
 class PCIDevice(Model):
-    """Model to represent a PCI Device.
+    """
+    Model to represent a PCI Device.
 
     There is the following match between model parameters and
     the fields of the output of a shell command `lspci -vmmk`
@@ -64,3 +65,64 @@ class PCIDevices(Model):
     topic = SystemInfoTopic
 
     devices = fields.List(fields.Model(PCIDevice))
+
+
+class RestrictedPCIDevice(Model):
+    """
+    Model to represent knwon restrictions of the given PCI devices.
+
+
+    pci_id - unsupported pci_ids. It has the following
+        structure: {Vendor}:{Device}:{SVendor}:{SDevice}, where all these 4
+        parameters are numeric ids (see shell command spci -vmmkn). If SVendor
+        and SDevice fields do not exist, then pci_id has the following structure:
+        {Vendor}:{Device}.
+    driver_name - the name of restricted driver
+    device_name - the name of restricted device
+    supported_{rhel_version} - 1 is supported on the given RHEL, 0 - not
+        supported
+    available_{rhel_version} - 1 is available on the given RHEL, 0 - not
+        available. it could be the driver is available, but not supported
+    comments - the field for comments
+    """
+    topic = SystemInfoTopic
+
+    pci_id = fields.Nullable(fields.String())
+    driver_name = fields.Nullable(fields.String())
+    device_name = fields.Nullable(fields.String())
+    available_rhel7 = fields.Integer()
+    supported_rhel7 = fields.Integer()
+    available_rhel8 = fields.Integer()
+    supported_rhel8 = fields.Integer()
+    available_rhel9 = fields.Integer()
+    supported_rhel9 = fields.Integer()
+    comment = fields.Nullable(fields.String())
+
+
+class RestrictedPCIDevices(Model):
+    """
+    Model to represent all known restricted PCI devices.
+
+    Restricted devices might be restricted based on either
+     - pci id (each particular device)
+     - driver name (all the family of the devices being served by the
+        particular driver).
+
+    However the data type, which represents how the pci id or driver name is
+    restricted is identical.
+
+    Thus both attributes has the same data type.
+
+    driver_names - is a container with the devices, which are restricted by
+        the driver name identifier
+    pci_ids - is a container with the devices, which are restricted by
+        the pci_id identifier
+    """
+    topic = SystemInfoTopic
+
+    driver_names = fields.List(
+        fields.Model(RestrictedPCIDevice),
+    )
+    pci_ids = fields.List(
+        fields.Model(RestrictedPCIDevice),
+    )

--- a/repos/system_upgrade/el7toel8/models/pcidevices.py
+++ b/repos/system_upgrade/el7toel8/models/pcidevices.py
@@ -3,6 +3,46 @@ from leapp.topics import SystemInfoTopic
 
 
 class PCIDevice(Model):
+    """Model to represent a PCI Device.
+
+    There is the following match between model parameters and
+    the fields of the output of a shell command `lspci -vmmk`
+
+    slot - 'Slot',
+    dev_cls - 'Class',
+    vendor - 'Vendor',
+    name - 'Device',
+    subsystem_vendor - 'SVendor',
+    subsystem_name - 'SDevice',
+    physical_slot - 'PhySlot',
+    rev - 'Rev',
+    progif - 'ProgIf',
+    driver - 'Driver',
+    modules - 'Module',
+    numa_node - 'NUMANode',
+
+    pci_id - represents the numeric identification of the device, formed as
+        string concatenating of the numeric device identifiers for fields
+        Vendor, Device, SVendor, SDevice (output
+        of a shell command `lspci -vmmkn`) with the `:` delimiter.
+        For example:
+        one device from output of `lspci -vmmkn` is:
+
+        ```
+        Slot:	04:00.0
+        Class:	0880
+        Vendor:	8086
+        Device:	15bf
+        SVendor:	17aa
+        SDevice:	2279
+        Rev:	01
+        Driver:	thunderbolt
+        Module:	thunderbolt
+        ```
+
+        then
+        pci_id == "8086:15bf:17aa:2279"
+    """
     topic = SystemInfoTopic
 
     slot = fields.String()
@@ -17,6 +57,7 @@ class PCIDevice(Model):
     driver = fields.Nullable(fields.String())
     modules = fields.Nullable(fields.List(fields.String()))
     numa_node = fields.Nullable(fields.String())
+    pci_id = fields.String()
 
 
 class PCIDevices(Model):


### PR DESCRIPTION
Add a set of actors which checks the host system PCI devices, If any of them is restricted on rhel8 os, then the actor notifies the user via a report message. In case the device is not available on the target system, then the upgrade is inhibited

 The data sources priority set up is as follows:
        1. The actor tries to get the data from /etc/leapp/files
        2. Then from the online service
        3. As a fallback mechanism the data comes from the locally stored
            copy

Closes #596

Example of reports:
```
============================================================
                     UPGRADE INHIBITED                      
============================================================

Upgrade has been inhibited due to the following problems:
    1. Inhibitor: Detected PCI drivers that are restricted on RHEL8.
Consult the pre-upgrade report for details and possible remediation.

============================================================
                     UPGRADE INHIBITED                      
============================================================
```
```
----------------------------
Risk Factor: high (inhibitor) 
Title: Detected PCI drivers that are restricted on RHEL8. 
Summary: The following drivers are restricted on RHEL 8 system:
Unsupported in RHEL8:
	- driver names:
		- d2
		- d1
	- pci ids:
		- p1
		- p2
-------------------------------