### PR TITLE
Drop events with identical initial releases and input packages

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test_peseventsscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/tests/unit_test_peseventsscanner.py
@@ -187,8 +187,10 @@ def test_resolve_conflicting_requests(monkeypatch):
     monkeypatch.setattr(peseventsscanner, 'filter_out_pkgs_in_blacklisted_repos', lambda x: x)
 
     events = [
-        Event(Action.split, {'sip-devel': 'repo'}, {'python3-sip-devel': 'repo', 'sip': 'repo'}, (7, 6), (8, 0), []),
-        Event(Action.split, {'sip': 'repo'}, {'python3-pyqt5-sip': 'repo', 'python3-sip': 'repo'}, (7, 6), (8, 0), [])]
+        Event(1, Action.split, {'sip-devel': 'repo'}, {'python3-sip-devel': 'repo', 'sip': 'repo'},
+              (7, 6), (8, 0), []),
+        Event(2, Action.split, {'sip': 'repo'}, {'python3-pyqt5-sip': 'repo', 'python3-sip': 'repo'},
+              (7, 6), (8, 0), [])]
     installed_pkgs = {'sip', 'sip-devel'}
 
     tasks = process_events([(8, 0)], events, installed_pkgs)
@@ -231,16 +233,16 @@ def test_process_events(monkeypatch):
     monkeypatch.setattr(peseventsscanner, 'get_repositories_blacklisted', get_repos_blacklisted_mocked(set()))
 
     events = [
-        Event(Action.split, {'original': 'rhel7-repo'}, {'split01': 'rhel8-repo', 'split02': 'rhel8-repo'},
+        Event(1, Action.split, {'original': 'rhel7-repo'}, {'split01': 'rhel8-repo', 'split02': 'rhel8-repo'},
               (7, 6), (8, 0), []),
-        Event(Action.removed, {'removed': 'rhel7-repo'}, {}, (7, 6), (8, 0), []),
-        Event(Action.present, {'present': 'rhel8-repo'}, {}, (7, 6), (8, 0), []),
+        Event(2, Action.removed, {'removed': 'rhel7-repo'}, {}, (7, 6), (8, 0), []),
+        Event(3, Action.present, {'present': 'rhel8-repo'}, {}, (7, 6), (8, 0), []),
         # this package is present at the start, gets removed and then reintroduced
-        Event(Action.removed, {'reintroduced': 'rhel7-repo'}, {}, (7, 6), (8, 0), []),
-        Event(Action.present, {'reintroduced': 'rhel8-repo'}, {}, (8, 0), (8, 1), []),
+        Event(4, Action.removed, {'reintroduced': 'rhel7-repo'}, {}, (7, 6), (8, 0), []),
+        Event(5, Action.present, {'reintroduced': 'rhel8-repo'}, {}, (8, 0), (8, 1), []),
         # however, this package was never there
-        Event(Action.removed, {'neverthere': 'rhel7-repo'}, {}, (7, 6), (8, 0), []),
-        Event(Action.present, {'neverthere': 'rhel8-repo'}, {}, (8, 0), (8, 1), [])]
+        Event(6, Action.removed, {'neverthere': 'rhel7-repo'}, {}, (7, 6), (8, 0), []),
+        Event(7, Action.present, {'neverthere': 'rhel8-repo'}, {}, (8, 0), (8, 1), [])]
     installed_pkgs = {'original', 'removed', 'present', 'reintroduced'}
     tasks = process_events([(8, 0), (8, 1)], events, installed_pkgs)
 
@@ -279,10 +281,10 @@ def test_pes_data_not_found(monkeypatch):
 
 def test_add_output_pkgs_to_transaction_conf():
     events = [
-        Event(Action.split, {'split_in': 'repo'}, {'split_out1': 'repo', 'split_out2': 'repo'}, (7, 6), (8, 0), []),
-        Event(Action.merged, {'merged_in1': 'repo', 'merged_in2': 'repo'}, {'merged_out': 'repo'}, (7, 6), (8, 0), []),
-        Event(Action.renamed, {'renamed_in': 'repo'}, {'renamed_out': 'repo'}, (7, 6), (8, 0), []),
-        Event(Action.replaced, {'replaced_in': 'repo'}, {'replaced_out': 'repo'}, (7, 6), (8, 0), []),
+        Event(1, Action.split, {'split_in': 'repo'}, {'split_out1': 'repo', 'split_out2': 'repo'}, (7, 6), (8, 0), []),
+        Event(2, Action.merged, {'merge_in1': 'repo', 'merge_in2': 'repo'}, {'merge_out': 'repo'}, (7, 6), (8, 0), []),
+        Event(3, Action.renamed, {'renamed_in': 'repo'}, {'renamed_out': 'repo'}, (7, 6), (8, 0), []),
+        Event(4, Action.replaced, {'replaced_in': 'repo'}, {'replaced_out': 'repo'}, (7, 6), (8, 0), []),
     ]
 
     conf_empty = RpmTransactionTasks()
@@ -293,13 +295,13 @@ def test_add_output_pkgs_to_transaction_conf():
     add_output_pkgs_to_transaction_conf(conf_split, events)
     assert sorted(conf_split.to_remove) == ['split_in', 'split_out1', 'split_out2']
 
-    conf_merged_incomplete = RpmTransactionTasks(to_remove=['merged_in1'])
+    conf_merged_incomplete = RpmTransactionTasks(to_remove=['merge_in1'])
     add_output_pkgs_to_transaction_conf(conf_merged_incomplete, events)
-    assert conf_merged_incomplete.to_remove == ['merged_in1']
+    assert conf_merged_incomplete.to_remove == ['merge_in1']
 
-    conf_merged = RpmTransactionTasks(to_remove=['merged_in1', 'merged_in2'])
+    conf_merged = RpmTransactionTasks(to_remove=['merge_in1', 'merge_in2'])
     add_output_pkgs_to_transaction_conf(conf_merged, events)
-    assert sorted(conf_merged.to_remove) == ['merged_in1', 'merged_in2', 'merged_out']
+    assert sorted(conf_merged.to_remove) == ['merge_in1', 'merge_in2', 'merge_out']
 
     conf_renamed = RpmTransactionTasks(to_remove=['renamed_in'])
     add_output_pkgs_to_transaction_conf(conf_renamed, events)
@@ -312,10 +314,10 @@ def test_add_output_pkgs_to_transaction_conf():
 
 def test_filter_events_by_architecture():
     events = [
-        Event(Action.present, {'pkg1': 'repo'}, {}, (7, 6), (8, 0), ['arch1']),
-        Event(Action.present, {'pkg2': 'repo'}, {}, (7, 6), (8, 0), ['arch2', 'arch1', 'arch3']),
-        Event(Action.present, {'pkg3': 'repo'}, {}, (7, 6), (8, 0), ['arch2', 'arch3', 'arch4']),
-        Event(Action.present, {'pkg4': 'repo'}, {}, (7, 6), (8, 0), [])
+        Event(1, Action.present, {'pkg1': 'repo'}, {}, (7, 6), (8, 0), ['arch1']),
+        Event(2, Action.present, {'pkg2': 'repo'}, {}, (7, 6), (8, 0), ['arch2', 'arch1', 'arch3']),
+        Event(3, Action.present, {'pkg3': 'repo'}, {}, (7, 6), (8, 0), ['arch2', 'arch3', 'arch4']),
+        Event(4, Action.present, {'pkg4': 'repo'}, {}, (7, 6), (8, 0), [])
     ]
 
     filtered = filter_events_by_architecture(events, 'arch1')
@@ -327,11 +329,11 @@ def test_filter_events_by_architecture():
 
 def test_filter_events_by_releases():
     events = [
-        Event(Action.present, {'pkg1': 'repo'}, {}, (7, 6), (7, 7), []),
-        Event(Action.present, {'pkg2': 'repo'}, {}, (7, 7), (7, 8), []),
-        Event(Action.present, {'pkg3': 'repo'}, {}, (7, 8), (8, 0), []),
-        Event(Action.present, {'pkg4': 'repo'}, {}, (8, 0), (8, 1), []),
-        Event(Action.present, {'pkg5': 'repo'}, {}, (8, 1), (8, 2), [])
+        Event(1, Action.present, {'pkg1': 'repo'}, {}, (7, 6), (7, 7), []),
+        Event(2, Action.present, {'pkg2': 'repo'}, {}, (7, 7), (7, 8), []),
+        Event(3, Action.present, {'pkg3': 'repo'}, {}, (7, 8), (8, 0), []),
+        Event(4, Action.present, {'pkg4': 'repo'}, {}, (8, 0), (8, 1), []),
+        Event(5, Action.present, {'pkg5': 'repo'}, {}, (8, 1), (8, 2), [])
     ]
 
     filtered = filter_events_by_releases(events, [(7, 6), (7, 7), (8, 0), (8, 3)])
@@ -346,3 +348,25 @@ def test_filter_releases_by_target():
     releases = [(7, 6), (7, 7), (7, 8), (7, 9), (8, 0), (8, 1), (8, 2), (8, 3), (9, 0), (9, 1)]
     filtered_releases = filter_releases_by_target(releases, (8, 1))
     assert filtered_releases == [(7, 6), (7, 7), (7, 8), (7, 9), (8, 0), (8, 1)]
+
+
+def drop_conflicting_release_events(events):
+    conflict1a = Event(1, Action.present, {'pkg1': 'repo'}, {}, (7, 6), (8, 0), [])
+    conflict1b = Event(2, Action.replacement, {'pkg1': 'repo'}, {}, (7, 6), (8, 2), [])
+    conflict1c = Event(3, Action.removal, {'pkg1': 'repo'}, {}, (7, 6), (8, 1), [])
+    conflict2a = Event(4, Action.removal, {'pkg2a': 'repo'}, {}, (7, 6), (8, 0), [])
+    conflict2b = Event(5, Action.replacement, {'pkg2a': 'repo', 'pkg2b': 'repo'}, {}, (7, 6), (8, 1), [])
+    # two input packages
+    conflict3a = Event(6, Action.merge, {'pkg3a': 'repo', 'pkg3b': 'repo'}, {'pkg3c': 'repo'}, (7, 6), (8, 0), [])
+    conflict3b = Event(7, Action.merge, {'pkg3a': 'repo', 'pkg3b': 'repo'}, {'pkg3d': 'repo'}, (7, 6), (8, 1), [])
+    # these two can't be chained, don't remove anything
+    okay1a = Event(8, Action.replacement, {'pkg4a': 'repo'}, {'pkg4b': 'repo'}, (7, 6), (8, 0), [])
+    okay1b = Event(9, Action.replacement, {'pkg4b': 'repo'}, {'pkg4c': 'repo'}, (8, 0), (8, 1), [])
+
+    events = [conflict1a, conflict1b, conflict1c, conflict2a, conflict2b, conflict3a, conflict3b, okay1a, okay1b]
+    drop_conflicting_release_events(events)
+
+    for event in [conflict1b, conflict2b, conflict3b, okay1a, okay1b]:
+        assert event in events
+    for event in [conflict1a, conflict1c, conflict2a, conflict3a]:
+        assert event not in events


### PR DESCRIPTION
Some package transitions have to be represented via events that have the same initial release and the same set of input packages. In such a conflict, keep the event with the highest target release or ID and drop the rest.