### PR TITLE
Provide also a hint to check if repomap file is up-to-date

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -387,7 +387,7 @@ def gather_target_repositories(context, indata):
                 ' ensure the custom repository file is provided regarding the documentation with'
                 ' properly defined repositories or in case repositories are already defined'
                 ' in any repofiles under /etc/yum.repos.d/ directory, use the --enablerepo option'
-                ' for leapp'
+                ' for leapp. Also make sure "/etc/leapp/files/repomap.csv" file is up-to-date.'
                 ).format(version=api.current_actor().configuration.version.target)
             }
         )


### PR DESCRIPTION
In order to enable upgrades on RHUI we need an updated repomap file. It can happen users have an old one from previous upgrades and thus missing the needed mapping.