### PR TITLE
Release 0.12.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -13,7 +13,7 @@ py2_byte_compile "%1" "%2"}
 
 
 Name:           leapp-repository
-Version:        0.11.0
+Version:        0.12.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Packaging
- Require new leapp framework capability 1.3
- Fix python macro error in spec file

## Upgrade handling
### Fixes
- Fix traceback on repos with a mirrorlist or metalink
- Make sure "default.target.wants" dir exists
- Do not remove java from the upgrade transaction
- authselect: Fix mkhomedir issues after authselect conversion
- Fix handling of events with same initial releases and input packages
- Fix storing of logs from initramfs
- Do not inhibit if winbind or wins is used in nsswitch.conf (as the issue is fixed in RHEL 8.2)

### Enhancements
- Enable upgrades on AWS and Azure
- Check usage of removed/deprecated leapp env vars
- Improve remediation instructions for HA clusters