### PR TITLE
Move actor which removes "leapp-resume" service into After phase

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/removeresumeservice/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeresumeservice/actor.py
@@ -18,7 +18,7 @@ class RemoveSystemdResumeService(Actor):
     name = 'remove_systemd_resume_service'
     consumes = ()
     produces = (Report,)
-    tags = (FirstBootPhaseTag, IPUWorkflowTag)
+    tags = (FirstBootPhaseTag.After, IPUWorkflowTag)
 
     def process(self):
         service_name = 'leapp_resume.service'


### PR DESCRIPTION
In order to avoid killing (by removal) the "leapp-resume" service
and at the same time trying to reload systemd daemon by other
services, we move the actor which removes "leapp-resume" service
into FirstBootPhase.After phase.

https://bugzilla.redhat.com/show_bug.cgi?id=1883218