### PR TITLE
Docstring refactoring: use quotes instead of apostrophe

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/libraries/scanner.py
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/libraries/scanner.py
@@ -2,11 +2,11 @@ import re
 
 
 def detect_config_error(conf_file):
-    '''
+    """
     Check grub configuration for syntax error in GRUB_CMDLINE_LINUX value.
 
     :return: Function returns True if error was detected, otherwise False.
-    '''
+    """
     with open(conf_file, 'r') as f:
         config = f.read()
 

--- a/repos/system_upgrade/el7toel8/actors/multipathconfcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfcheck/actor.py
@@ -6,13 +6,13 @@ from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
 class MultipathConfCheck(Actor):
-    '''
+    """
     Checks whether the multipath configuration can be updated to RHEL-8.
     Specifically, it checks if the path_checker/checker option is set to
     something other than tur in the defaults section. If so, non-trivial
     changes may be required in the multipath.conf file, and it is not
     possible to auto-update it.
-    '''
+    """
 
     name = 'multipath_conf_check'
     consumes = (MultipathConfFacts,)

--- a/repos/system_upgrade/el7toel8/actors/multipathconfread/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfread/actor.py
@@ -5,10 +5,10 @@ from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
 class MultipathConfRead(Actor):
-    '''
+    """
     Reads multipath configuration files (multipath.conf, and any files in
     the multipath config directory) and extracts the necessary information
-    '''
+    """
 
     name = 'multipath_conf_read'
     consumes = (InstalledRedHatSignedRPM,)

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/actor.py
@@ -5,7 +5,7 @@ from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
 
 
 class MultipathConfUpdate(Actor):
-    '''
+    """
     Modifies multipath configuration files on the target RHEL-8 system so that
     they will run properly. This is done in three ways
     1. commenting out lines for options that no longer exist, or whose value
@@ -13,7 +13,7 @@ class MultipathConfUpdate(Actor):
     2. Migrating any options in an devices section with all_devs to an
        overrides setions
     3. Rename options that have changed names
-    '''
+    """
 
     name = 'multipath_conf_update'
     consumes = (MultipathConfFacts,)

--- a/repos/system_upgrade/el7toel8/actors/pcidevicesscanner/libraries/pcidevicesscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/pcidevicesscanner/libraries/pcidevicesscanner.py
@@ -3,7 +3,7 @@ from leapp.models import PCIDevices, PCIDevice
 
 
 def parse_pci_device(block):
-    ''' Parse one block from lspci output describing one PCI device '''
+    """ Parse one block from lspci output describing one PCI device """
     device = {
         'Slot': '',
         'Class': '',
@@ -50,17 +50,17 @@ def parse_pci_device(block):
 
 
 def parse_pci_devices(output):
-    ''' Parse lspci output and return a list of PCI devices '''
+    """ Parse lspci output and return a list of PCI devices """
     return [parse_pci_device(block) for block in output.split('\n\n')[:-1]]
 
 
 def produce_pci_devices(producer, devices):
-    ''' Produce a Leapp message with all PCI devices '''
+    """ Produce a Leapp message with all PCI devices """
     producer(PCIDevices(devices=devices))
 
 
 def scan_pci_devices(producer):
-    ''' Scan system PCI Devices '''
+    """ Scan system PCI Devices """
     output = run(['lspci', '-vmmk'], checked=False)['stdout']
     devices = parse_pci_devices(output)
     produce_pci_devices(producer, devices)

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/actor.py
@@ -11,13 +11,13 @@ WORKING_DIRECTORY = '/tmp/selinux/'
 
 
 class SELinuxApplyCustom(Actor):
-    '''
+    """
     Re-apply SELinux customizations from RHEL-7 installation
 
     Re-apply SELinux policy customizations (custom policy modules and changes
     introduced by semanage). Any changes (due to incompatiblity with RHEL-8
     SELinux policy) are reported to user.
-    '''
+    """
     name = 'selinuxapplycustom'
     consumes = (SELinuxCustom, SELinuxModules)
     produces = ()

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/actor.py
@@ -5,14 +5,14 @@ from leapp.libraries.actor import selinuxcontentscanner
 
 
 class SELinuxContentScanner(Actor):
-    '''
+    """
     Scan the system for any SELinux customizations
 
     Find SELinux policy customizations (custom policy modules and changes
     introduced by semanage) and save them in SELinuxModules and SELinuxCustom
     models. Customizations that are incompatible with SELinux policy on RHEL-8
     are removed.
-    '''
+    """
 
     name = 'selinuxcontentscanner'
     consumes = (SELinuxFacts,)

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/libraries/selinuxcontentscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/libraries/selinuxcontentscanner.py
@@ -31,14 +31,14 @@ WORKING_DIRECTORY = '/tmp/selinux/'
 
 
 def check_module(name):
-    '''
+    """
     Check if given module contains one of removed types and comment out corresponding lines.
 
     The function expects a text file "$name" containing cil policy
     to be present in the current directory.
 
     Returns a list of invalid lines.
-    '''
+    """
     try:
         removed = run(['grep', '-w', '-E', "|".join(REMOVED_TYPES_), name], split=True)
         # Add ";" at the beginning of invalid lines (comment them out)
@@ -49,11 +49,11 @@ def check_module(name):
 
 
 def list_selinux_modules():
-    '''
+    """
     Produce list of SELinux policy modules
 
     Returns list of tuples (name,priority)
-    '''
+    """
     try:
         semodule = run(['semodule', '-lfull'], split=True)
     except CalledProcessError:
@@ -75,7 +75,7 @@ def list_selinux_modules():
 
 
 def get_selinux_modules():
-    '''
+    """
     Read all custom SELinux policy modules from the system
 
     Returns 3-tuple (modules, retain_rpms, install_rpms)
@@ -84,7 +84,7 @@ def get_selinux_modules():
     during the upgrade and "install_rpms" is a list of RPMs
     that should be installed during the upgrade
 
-    '''
+    """
 
     modules = list_selinux_modules()
     semodule_list = []
@@ -172,7 +172,7 @@ def get_selinux_modules():
 
 
 def get_selinux_customizations():
-    '''
+    """
     Extract local SELinux customizations introduced by semanage command
 
     Returns tuple (semanage_valid, semanage_removed)
@@ -180,7 +180,7 @@ def get_selinux_customizations():
     which should be safe to re-apply on RHEL 8 system
     and "semanage_removed" is a list of commands that
     will no longer be valid after system upgrade
-    '''
+    """
 
     semanage_removed = []
     semanage_valid = []

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/actor.py
@@ -5,13 +5,13 @@ from leapp.libraries.actor import selinuxprepare
 
 
 class SELinuxPrepare(Actor):
-    '''
+    """
     Remove selinux policy customizations before updating selinux-policy* packages
 
     RHEL-7 policy customizations could cause policy package upgrade to fail and therefore
     need to be removed. Customizations introduced by semanage are removed first,
     followed by custom policy modules gathered by SELinuxContentScanner.
-    '''
+    """
 
     name = 'selinuxprepare'
     consumes = (SELinuxCustom, SELinuxModules)

--- a/repos/system_upgrade/el7toel8/actors/sssdcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sssdcheck/actor.py
@@ -14,7 +14,7 @@ related = [
 
 
 class SSSDCheck(Actor):
-    '''
+    """
     Check SSSD configuration for changes in RHEL8 and report them.
 
     These changes are:
@@ -22,7 +22,7 @@ class SSSDCheck(Actor):
     - ldap_groups_use_matching_rule_in_chain was removed and will be ignored
     - ldap_initgroups_use_matching_rule_in_chain was removed and will be ignored
     - ldap_sudo_include_regexp changed default from true to false
-    '''
+    """
 
     name = 'sssd_check'
     consumes = (SSSDConfig,)

--- a/repos/system_upgrade/el7toel8/actors/sssdfacts/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sssdfacts/actor.py
@@ -7,7 +7,7 @@ from leapp.tags import IPUWorkflowTag, FactsPhaseTag
 
 
 class SSSDFacts(Actor):
-    '''
+    """
     Check SSSD configuration for changes in RHEL8 and report them in model.
 
     These changes are:
@@ -15,7 +15,7 @@ class SSSDFacts(Actor):
     - ldap_groups_use_matching_rule_in_chain was removed and will be ignored
     - ldap_initgroups_use_matching_rule_in_chain was removed and will be ignored
     - ldap_sudo_include_regexp changed default from true to false
-    '''
+    """
 
     name = 'sssd_facts'
     consumes = ()

--- a/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/el7toel8/actors/systemfacts/libraries/systemfacts.py
@@ -16,7 +16,7 @@ from leapp.models import SysctlVariablesFacts, SysctlVariable, ActiveKernelModul
 
 
 def aslist(f):
-    ''' Decorator used to convert generator to list '''
+    """ Decorator used to convert generator to list """
     @functools.wraps(f)
     def inner(*args, **kwargs):
         return list(f(*args, **kwargs))
@@ -24,7 +24,7 @@ def aslist(f):
 
 
 def anyendswith(value, ends):
-    ''' Check if `value` ends with one of the possible `ends` '''
+    """ Check if `value` ends with one of the possible `ends` """
     for end in ends:
         if value.endswith(end):
             return True
@@ -32,7 +32,7 @@ def anyendswith(value, ends):
 
 
 def anyhasprefix(value, prefixes):
-    ''' Check if `value` starts with on of the possible `prefixes` '''
+    """ Check if `value` starts with on of the possible `prefixes` """
     for p in prefixes:
         if value.startswith(p):
             return True
@@ -51,7 +51,7 @@ def _get_system_users():
 
 
 def get_system_users_status():
-    ''' Get a list of users from `/etc/passwd` '''
+    """ Get a list of users from `/etc/passwd` """
     return UsersFacts(users=_get_system_users())
 
 
@@ -66,7 +66,7 @@ def _get_system_groups():
 
 
 def get_system_groups_status():
-    ''' Get a list of groups from `/etc/groups` '''
+    """ Get a list of groups from `/etc/groups` """
     return GroupsFacts(groups=_get_system_groups())
 
 
@@ -127,7 +127,7 @@ def _get_active_kernel_modules(logger):
 
 
 def get_active_kernel_modules_status(logger):
-    ''' Get a list of active kernel modules '''
+    """ Get a list of active kernel modules """
     return ActiveKernelModulesFacts(kernel_modules=_get_active_kernel_modules(logger))
 
 
@@ -157,7 +157,7 @@ def _get_sysctls():
 
 
 def get_sysctls_status():
-    r''' Get a list of stable `sysctls` variables
+    r""" Get a list of stable `sysctls` variables
 
         Note that some variables are inherently unstable and we need to blacklist
         them:
@@ -166,17 +166,17 @@ def get_sysctls_status():
                 | grep -E '^\+[a-z]'\
                 | cut -d' ' -f1\
                 | cut -d+ -f2
-    '''
+    """
     return SysctlVariablesFacts(sysctl_variables=_get_sysctls())
 
 
 def get_repositories_status():
-    ''' Get a basic information about YUM repositories installed in the system '''
+    """ Get a basic information about YUM repositories installed in the system """
     return RepositoriesFacts(repositories=repofileutils.get_parsed_repofiles())
 
 
 def get_selinux_status():
-    ''' Get SELinux status information '''
+    """ Get SELinux status information """
     # will be None if something went wrong or contain SELinuxFacts otherwise
     res = None
     try:
@@ -209,7 +209,7 @@ def get_selinux_status():
 
 
 def get_firewalls_status():
-    ''' Get firewalld status information '''
+    """ Get firewalld status information """
     logger = logging.getLogger('get_firewalld_status')
 
     def _get_firewall_status(service_name):

--- a/repos/system_upgrade/el7toel8/actors/tcpwrappersconfigread/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/tcpwrappersconfigread/actor.py
@@ -5,9 +5,9 @@ from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
 class TcpWrappersConfigRead(Actor):
-    '''
+    """
     Parse tcp_wrappers configuration files /etc/hosts.{allow,deny}.
-    '''
+    """
 
     name = 'tcp_wrappers_config_read'
     consumes = ()

--- a/repos/system_upgrade/el7toel8/actors/updateetcsysconfigkernel/libraries/updateetcsysconfigkernel.py
+++ b/repos/system_upgrade/el7toel8/actors/updateetcsysconfigkernel/libraries/updateetcsysconfigkernel.py
@@ -2,7 +2,7 @@ from leapp.libraries.stdlib import run
 
 
 def update_kernel_config(path):
-    ''' Update DEFAULTKERNEL entry at provided config file '''
+    """ Update DEFAULTKERNEL entry at provided config file """
     run(['/bin/sed',
          '-i',
          's/^DEFAULTKERNEL=kernel$/DEFAULTKERNEL=kernel-core/g',

--- a/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/vsftpdconfigread/actor.py
@@ -5,9 +5,9 @@ from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
 class VsftpdConfigRead(Actor):
-    '''
+    """
     Reads vsftpd configuration files (/etc/vsftpd/*.conf) and extracts necessary information.
-    '''
+    """
 
     name = 'vsftpd_config_read'
     consumes = (InstalledRedHatSignedRPM,)

--- a/repos/system_upgrade/el7toel8/files/rhel_upgrade.py
+++ b/repos/system_upgrade/el7toel8/files/rhel_upgrade.py
@@ -33,9 +33,9 @@ class RhelUpgradeCommand(dnf.cli.Command):
         parser.add_argument('filename')
 
     def _process_packages(self, pkg_set, op):
-        '''
+        """
         Adds list of packages for given operation to the transaction
-        '''
+        """
         pkgs_notfound = []
 
         for pkg_spec in pkg_set:

--- a/repos/system_upgrade/el7toel8/libraries/tcpwrappersutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/tcpwrappersutils.py
@@ -65,7 +65,7 @@ def _daemon_list_matches_daemon(daemon_list, daemon, recursion_depth):
 
 
 def config_applies_to_daemon(facts, daemon):
-    '''
+    """
     Returns True if the specified tcp_wrappers configuration applies to the specified daemon.
     Otherwise returns False.
 
@@ -75,7 +75,7 @@ def config_applies_to_daemon(facts, daemon):
 
     :param facts: A TcpWrappersFacts representation of the tcp_wrappers configuration
     :param daemon: The daemon name
-    '''
+    """
     for daemon_list in facts.daemon_lists:
         value = [item.lower() for item in daemon_list.value]
         if _daemon_list_matches_daemon(value, daemon, 0):

--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -158,22 +158,22 @@ class CurrentActorMocked(object):  # pylint:disable=R0904
 
 
 def make_IOError(error):
-    '''
+    """
     Create an IOError instance
 
     Create an IOError instance with the given error number.
 
     :param error: the error number, e.g. errno.ENOENT
-    '''
+    """
     return IOError(error, os.strerror(error))
 
 
 def make_OSError(error):
-    '''
+    """
     Create an OSError instance
 
     Create an OSError instance with the given error number.
 
     :param error: the error number, e.g. errno.ENOENT
-    '''
+    """
     return OSError(error, os.strerror(error))

--- a/repos/system_upgrade/el7toel8/libraries/vsftpdutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/vsftpdutils.py
@@ -10,24 +10,24 @@ TCP_WRAPPERS = 'tcp_wrappers'
 
 
 def read_file(path):
-    '''
+    """
     Read a file in text mode and return the contents.
 
     :param path: File path
-    '''
+    """
     with open(path, 'r') as f:
         return f.read()
 
 
 def get_config_contents(path, read_func=read_file):
-    '''
+    """
     Try to read a vsftpd configuration file
 
     Try to read a vsftpd configuration file, log a warning if an error happens.
     :param path: File path
     :param read_func: Function to use to read the file. This is meant to be overriden in tests.
     :return: File contents or None, if the file could not be read
-    '''
+    """
     try:
         return read_func(path)
     except IOError as e:
@@ -37,12 +37,12 @@ def get_config_contents(path, read_func=read_file):
 
 
 def get_default_config_hash(read_func=read_file):
-    '''
+    """
     Read the default vsftpd configuration file (/etc/vsftpd/vsftpd.conf) and return its hash.
 
     :param read_func: Function to use to read the file. This is meant to be overriden in tests.
     :return SHA1 hash of the configuration file, or None if the file could not be read.
-    '''
+    """
     content = get_config_contents(VSFTPD_DEFAULT_CONFIG_PATH, read_func=read_func)
     if content is None:
         return None

--- a/repos/system_upgrade/el7toel8/models/multipathconffacts.py
+++ b/repos/system_upgrade/el7toel8/models/multipathconffacts.py
@@ -3,7 +3,7 @@ from leapp.topics import SystemInfoTopic
 
 
 class MultipathConfigOption(Model):
-    '''Model representing information about a multipath configuration option'''
+    """Model representing information about a multipath configuration option"""
     topic = SystemInfoTopic
 
     name = fields.String(default='')
@@ -11,24 +11,24 @@ class MultipathConfigOption(Model):
 
 
 class MultipathConfig(Model):
-    '''Model representing information about a multipath configuration file'''
+    """Model representing information about a multipath configuration file"""
     topic = SystemInfoTopic
 
     pathname = fields.String()
-    '''Config file path name'''
+    """Config file path name"""
 
     default_path_checker = fields.Nullable(fields.String())
     config_dir = fields.Nullable(fields.String())
-    '''Values of path_checker and config_dir in the defaults section.
-       None if not set'''
+    """Values of path_checker and config_dir in the defaults section.
+       None if not set"""
 
     default_retain_hwhandler = fields.Nullable(fields.Boolean())
     default_detect_prio = fields.Nullable(fields.Boolean())
     default_detect_checker = fields.Nullable(fields.Boolean())
     reassign_maps = fields.Nullable(fields.Boolean())
-    '''True if retain_attached_hw_handler, detect_prio, detect_path_checker,
+    """True if retain_attached_hw_handler, detect_prio, detect_path_checker,
        or reassign_maps is set to "yes" in the defaults section. False
-       if set to "no". None if not set.'''
+       if set to "no". None if not set."""
 
     hw_str_match_exists = fields.Boolean(default=False)
     ignore_new_boot_devs_exists = fields.Boolean(default=False)
@@ -39,21 +39,21 @@ class MultipathConfig(Model):
     overrides_pg_timeout_exists = fields.Boolean(default=False)
     queue_if_no_path_exists = fields.Boolean(default=False)
     all_devs_section_exists = fields.Boolean(default=False)
-    '''True if hw_str_match, ignore_new_boot_devs, new_bindings_in_boot,
+    """True if hw_str_match, ignore_new_boot_devs, new_bindings_in_boot,
        detect_path_checker, or unpriv_sgio is set in any section,
        if queue_if_no_path is included in the features line in any
        section or if hardware_handler or pg_timeout is set in the
-       overrides section. False otherwise'''
+       overrides section. False otherwise"""
 
     all_devs_options = fields.List(fields.Model(MultipathConfigOption),
                                    default=[])
-    '''options in an all_devs device configuration section to be converted to
-       an overrides section'''
+    """options in an all_devs device configuration section to be converted to
+       an overrides section"""
 
 
 class MultipathConfFacts(Model):
-    '''Model representing information from multipath configuration files'''
+    """Model representing information from multipath configuration files"""
     topic = SystemInfoTopic
 
     configs = fields.List(fields.Model(MultipathConfig), default=[])
-    '''List of multipath configuration files'''
+    """List of multipath configuration files"""

--- a/repos/system_upgrade/el7toel8/models/tcpwrappersfacts.py
+++ b/repos/system_upgrade/el7toel8/models/tcpwrappersfacts.py
@@ -3,22 +3,22 @@ from leapp.topics import SystemInfoTopic
 
 
 class DaemonList(Model):
-    '''
+    """
     A split up representation of a daemon_list (see host_access(5)). Example value of the
     'value' attribute: ["ALL", "EXCEPT", "in.fingerd"]
-    '''
+    """
     topic = SystemInfoTopic
 
     value = fields.List(fields.String())
 
 
 class TcpWrappersFacts(Model):
-    '''
+    """
     A representation of tcp_wrappers configuration. Currently it only contains a list
     of daemon lists that are present in the tcp_wrappers configuration files. From this
     you can extract information on whether there is any configuration that applies to
     a specific daemon (see leapp.libraries.common.tcpwrappersutils.config_applies_to_daemon()).
-    '''
+    """
     topic = SystemInfoTopic
 
     daemon_lists = fields.List(fields.Model(DaemonList))

--- a/repos/system_upgrade/el7toel8/models/vsftpdfacts.py
+++ b/repos/system_upgrade/el7toel8/models/vsftpdfacts.py
@@ -3,7 +3,7 @@ from leapp.topics import SystemInfoTopic
 
 
 class VsftpdConfig(Model):
-    '''
+    """
     Model representing some aspects of a vsftpd configuration file.
 
     The attributes representing the state of configuration options are nullable, so that
@@ -11,21 +11,21 @@ class VsftpdConfig(Model):
     in the configuration file, the corresponding attribute is set to True; if the option
     is set to NO, the attribute is set to False; if the option is not present in the config
     file at all, the attribute is set to None.
-    '''
+    """
     topic = SystemInfoTopic
 
     path = fields.String()
-    '''Path to the vsftpd configuration file'''
+    """Path to the vsftpd configuration file"""
     strict_ssl_read_eof = fields.Nullable(fields.Boolean())
-    '''Represents the state of the strict_ssl_read_eof option in the config file'''
+    """Represents the state of the strict_ssl_read_eof option in the config file"""
     tcp_wrappers = fields.Nullable(fields.Boolean())
-    '''Represents the state of the tcp_wrappers option in the config file'''
+    """Represents the state of the tcp_wrappers option in the config file"""
 
 
 class VsftpdFacts(Model):
     topic = SystemInfoTopic
 
     default_config_hash = fields.Nullable(fields.String())
-    '''SHA1 hash of the /etc/vsftpd/vsftpd.conf file, if it exists, None otherwise'''
+    """SHA1 hash of the /etc/vsftpd/vsftpd.conf file, if it exists, None otherwise"""
     configs = fields.List(fields.Model(VsftpdConfig))
-    '''List of vsftpd configuration files'''
+    """List of vsftpd configuration files"""


### PR DESCRIPTION
In case of docstring, quotes should be used always, officialy.
Replace apostrophes by quotes in case of docstrings.

Ref: https://www.python.org/dev/peps/pep-0257