### PR TITLE
Added "-y" option to yum remove ipa-server in actor

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkipaserver/libraries/checkipaserver.py
+++ b/repos/system_upgrade/el7toel8/actors/checkipaserver/libraries/checkipaserver.py
@@ -54,7 +54,7 @@ def ipa_warn_pkg_installed(ipainfo):
         reporting.Summary(summary),
         reporting.Remediation(
             hint="Remove unused ipa-server package",
-            commands=[["yum", "remove", "ipa-server"]],
+            commands=[["yum", "remove", "-y", "ipa-server"]],
         ),
         reporting.ExternalLink(
             url=MIGRATION_GUIDE, title="Migrating IdM from RHEL 7 to 8",


### PR DESCRIPTION
Automated remediation fails as yum remove is expecting input. Added the "-y" option to fix