### PR TITLE
verifydialogs: Pass a unique Key to the create_report

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkhacluster/tests/test_check_ha_cluster_checkhacluster.py
+++ b/repos/system_upgrade/el7toel8/actors/checkhacluster/tests/test_check_ha_cluster_checkhacluster.py
@@ -1,5 +1,5 @@
 from leapp.reporting import Report
-from leapp.libraries.actor.checkhacluster import COROSYNC_CONF_LOCATION
+from leapp.libraries.actor.checkhacluster import COROSYNC_CONF_LOCATION, CIB_LOCATION
 
 
 def assert_inhibits(reports, node_type):
@@ -16,7 +16,9 @@ def test_no_inhibit_when_no_ha_cluster(monkeypatch, current_actor_context):
 
 
 def test_inhibits_when_cluster_node(monkeypatch, current_actor_context):
-    monkeypatch.setattr("os.path.isfile", lambda path: True)
+    # NOTE(ivasilev) Limiting here the paths to mock not to cause unexpected side-effects
+    # (original test had path: True)
+    monkeypatch.setattr("os.path.isfile", lambda path: path in (COROSYNC_CONF_LOCATION, CIB_LOCATION))
     current_actor_context.run()
     assert_inhibits(current_actor_context.consume(Report), "node")
 
@@ -31,9 +33,11 @@ def test_inhibits_when_cluster_node_no_cib(monkeypatch, current_actor_context):
 
 
 def test_inhibits_when_cluster_remote_node(monkeypatch, current_actor_context):
+    # NOTE(ivasilev) Limiting here the paths to mock not to cause unexpected side-effects
+    # (original test had path: path != COROSYNC_CONF_LOCATION)
     monkeypatch.setattr(
         "os.path.isfile",
-        lambda path: path != COROSYNC_CONF_LOCATION
+        lambda path: path == CIB_LOCATION
     )
     current_actor_context.run()
     assert_inhibits(current_actor_context.consume(Report), "remote node")

--- a/repos/system_upgrade/el7toel8/actors/verifydialogs/libraries/verifydialogs.py
+++ b/repos/system_upgrade/el7toel8/actors/verifydialogs/libraries/verifydialogs.py
@@ -19,5 +19,6 @@ def check_dialogs(inhibit_if_no_userchoice=True):
                        reporting.Severity(reporting.Severity.HIGH),
                        reporting.Summary(summary.format('\n'.join(sections))),
                        reporting.Flags([reporting.Flags.INHIBITOR] if inhibit_if_no_userchoice else []),
-                       reporting.Remediation(hint=dialogs_remediation, commands=cmd_remediation)]
+                       reporting.Remediation(hint=dialogs_remediation, commands=cmd_remediation),
+                       reporting.Key(dialog.key)]
         reporting.create_report(report_data + dialog_resources)


### PR DESCRIPTION
This final touch to stable id generation will make reports from
the same actor but with different dialogs have different ids.

Depends-On: https://github.com/oamg/leapp/pull/669