### PR TITLE
Add an "AND_IF" after /dev/mapper check

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -14,7 +14,7 @@ export LEAPP3_BIN=$LEAPPHOME/leapp3
 export NEWROOT=${NEWROOT:-"/sysroot"}
 
 NSPAWN_OPTS="--capability=all --bind=/sys --bind=/dev --bind=/dev/pts --bind=/run/systemd --bind=/proc"
-[ -d /dev/mapper ] NSPAWN_OPTS="$NSPAWN_OPTS --bind=/dev/mapper"
+[ -d /dev/mapper ] && NSPAWN_OPTS="$NSPAWN_OPTS --bind=/dev/mapper"
 export NSPAWN_OPTS="$NSPAWN_OPTS --bind=/run/udev --keep-unit --register=no --timezone=off --resolv-conf=off"
 
 


### PR DESCRIPTION
Otherwise we get "[: missing `]" error.