### PR TITLE
A humble attempt to respect framework dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ install:
 jobs:
   include:
     - script:
-        - docker run --rm -ti -v ${PWD}:/payload --env=PYTHON_VENV leapp-tests
+        - docker run --env CI=$CI --rm -ti -v ${PWD}:/payload --env=PYTHON_VENV leapp-tests
       env: PYTHON_VENV=python2.7
     - script:
-        - docker run --rm -ti -v ${PWD}:/payload --env=PYTHON_VENV leapp-tests
+        - docker run --env CI=$CI --rm -ti -v ${PWD}:/payload --env=PYTHON_VENV leapp-tests
       env: PYTHON_VENV=python3.6
     - stage: deploy
-      script: 
-        - docker run --rm -ti -v ${PWD}:/payload --entrypoint "/bin/bash" leapp-tests -c "make install-deps && make dashboard_data"
+      script:
+        - docker run --env CI=$CI --rm -ti -v ${PWD}:/payload --entrypoint "/bin/bash" leapp-tests -c "make install-deps && make dashboard_data"
         - bash ./utils/update_dashboard.sh
       if: branch = master AND type = push

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,13 @@ TIMESTAMP:=$${__TIMESTAMP:-$(shell /bin/date -u "+%Y%m%d%H%MZ")}
 SHORT_SHA=`git rev-parse --short HEAD`
 BRANCH=`git rev-parse --abbrev-ref HEAD | tr -- '-/' '_'`
 
+# The dependent framework PR connection will be taken from the top commit's depends-on message.
+REQ_LEAPP_PR=$(shell git log master..HEAD | grep -m1 -iE '^[[:space:]]*Depends-On:[[:space:]]*.*[[:digit:]]+[[:space:]]*$$' | grep -Eo '*[[:digit:]]*')
+# NOTE(ivasilev) In case of travis relying on top commit is a no go as a top commit will be a merge commit.
+ifdef CI
+	REQ_LEAPP_PR=$(shell git log master..HEAD | grep -m1 -iE '^[[:space:]]*Depends-On:[[:space:]]*.*[[:digit:]]+[[:space:]]*$$' | grep -Eo '[[:digit:]]*')
+endif
+
 # In case anyone would like to add any other suffix, just make it possible
 _SUFFIX=`if test -n "$$SUFFIX"; then echo ".$${SUFFIX}"; fi; `
 
@@ -203,8 +210,14 @@ install-deps:
 	case $(_PYTHON_VENV) in python3*) yum install gcc -y; esac
 	virtualenv --system-site-packages -p /usr/bin/$(_PYTHON_VENV) $(VENVNAME); \
 	. $(VENVNAME)/bin/activate; \
+	pip install -U pip; \
 	pip install --upgrade setuptools; \
-	pip install --upgrade -r requirements.txt
+	pip install --upgrade -r requirements.txt \
+	# In case the top commit Depends-On some yet unmerged framework patch - override master leapp with the proper version
+	if [[ ! -z "$(REQ_LEAPP_PR)" ]] ; then \
+		echo "Leapp-repository depends on the yet unmerged pr of the framework #$(REQ_LEAPP_PR), installing it.." && \
+		$(VENVNAME)/bin/pip install -U "git+https://github.com/oamg/leapp.git@refs/pull/$(REQ_LEAPP_PR)/head"; \
+	fi
 	python utils/install_actor_deps.py --actor=$(ACTOR)
 
 install-deps-fedora:
@@ -219,8 +232,14 @@ install-deps-fedora:
 	@# Prepare the virtual environment
 	virtualenv --system-site-packages --python /usr/bin/python $(VENVNAME)
 	. $(VENVNAME)/bin/activate ; \
+	pip install -U pip; \
 	pip install --upgrade setuptools; \
 	pip install --upgrade -r requirements.txt; \
+	# In case the top commit Depends-On some yet unmerged framework patch - override master leapp with the proper version
+	if [[ ! -z "$(REQ_LEAPP_PR)" ]] ; then \
+		echo "Leapp-repository depends on the yet unmerged pr of the framework #$(REQ_LEAPP_PR), installing it.." && \
+		$(VENVNAME)/bin/pip install -U "git+https://github.com/oamg/leapp.git@refs/pull/$(REQ_LEAPP_PR)/head"; \
+	fi
 
 lint:
 	. $(VENVNAME)/bin/activate; \

--- a/utils/docker-tests/Dockerfile
+++ b/utils/docker-tests/Dockerfile
@@ -5,5 +5,11 @@ VOLUME /payload
 RUN yum update -y && \
     yum install python-virtualenv make git -y
 
+# NOTE(ivasilev) Unless we upgrade pip an obsolete v 9 will be on the system
+# and we need at least 10.0.1 to install a not-yet-merged framework pr in case
+# it's necessary
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" && \
+    python get-pip.py
+
 WORKDIR /payload
 ENTRYPOINT make install-deps && make test


### PR DESCRIPTION
If the top commit in a branch has a Depends-On comment,
then the corresponding PR of the framework is checked whether
or not it has been already merged, and in case it's still open
the proper version of leapp will be installed into the venv
as part of the install-deps-* target.