### PR TITLE
If msgs is None, make sure mocked consume works

### DIFF
--- a/repos/system_upgrade/el7toel8/libraries/testutils.py
+++ b/repos/system_upgrade/el7toel8/libraries/testutils.py
@@ -71,7 +71,7 @@ class CurrentActorMocked(object):  # pylint:disable=R0904
         self.configuration = namedtuple(
             'configuration', ['architecture', 'kernel', 'leapp_env_vars', 'os_release', 'version']
         )(arch, kernel, envarsList, release, version)
-        self._msgs = msgs
+        self._msgs = msgs or []
 
     def __call__(self):
         return self


### PR DESCRIPTION
The real api.consume returns empty iterator when
no messages were fed. However in the mocked api.consume
version, this leads to an error.

This is fixed now