### PR TITLE
Ensure --enablerepo are not blacklisted + better reporting

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/actor.py
@@ -1,17 +1,34 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.repositoriesblacklist import process
-from leapp.models import RepositoriesBlacklisted, RepositoriesFacts, RepositoriesMap
+from leapp.models import (
+    CustomTargetRepository,
+    RepositoriesBlacklisted,
+    RepositoriesFacts,
+    RepositoriesMap,
+)
 from leapp.reporting import Report
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
 class RepositoriesBlacklist(Actor):
     """
-    Generate list of repository IDs that should be ignored by Leapp during upgrade process
+    Exclude target repositories provided by Red Hat without support.
+
+    Conditions to exclude:
+    - there are not such repositories already enabled on the source system
+      (e.g. "Optional" repositories)
+    - such repositories are not required for the upgrade explicitly by the user
+      (e.g. via the --enablerepo option or via the /etc/leapp/files/leapp_upgrade_repositories.repo file)
+
+    E.g. CRB repository is provided by Red Hat but it is without the support.
     """
 
-    name = 'repositories_blacklist'
-    consumes = (RepositoriesFacts, RepositoriesMap, )
+    name = "repositories_blacklist"
+    consumes = (
+        CustomTargetRepository,
+        RepositoriesFacts,
+        RepositoriesMap,
+    )
     produces = (RepositoriesBlacklisted, Report)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 

--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/libraries/repositoriesblacklist.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/libraries/repositoriesblacklist.py
@@ -2,10 +2,52 @@ from leapp import reporting
 from leapp.libraries.common.config import get_product_type
 from leapp.libraries.stdlib import api
 from leapp.models import (
+    CustomTargetRepository,
     RepositoriesBlacklisted,
     RepositoriesFacts,
     RepositoriesMap,
 )
+
+
+def _report_using_unsupported_repos(repos):
+    report = [
+        reporting.Title("Using repository not supported by Red Hat"),
+        reporting.Summary(
+            "The following repositories have been used for the "
+            "upgrade, but they are not supported by the Red Hat.:\n"
+            "- {}".format("\n - ".join(repos))
+        ),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Tags([reporting.Tags.REPOSITORY]),
+    ]
+    reporting.create_report(report)
+
+
+def _report_excluded_repos(repos):
+    api.current_logger().info(
+        "The optional repository is not enabled. Excluding %r "
+        "from the upgrade",
+        repos,
+    )
+
+    report = [
+        reporting.Title("Excluded RHEL 8 repositories"),
+        reporting.Summary(
+            "The following repositories are not supported by "
+            "Red Hat and are excluded from the list of repositories "
+            "used during the upgrade.\n- {}".format("\n- ".join(repos))
+        ),
+        reporting.Severity(reporting.Severity.INFO),
+        reporting.Tags([reporting.Tags.REPOSITORY]),
+        reporting.Flags([reporting.Flags.FAILURE]),
+        reporting.Remediation(
+            hint=(
+                "If you still require to use the excluded repositories "
+                "during the upgrade, execute leapp with the following options: {}."
+            ).format(" ".join(["--enablerepo {}".format(repo) for repo in repos])),
+        ),
+    ]
+    reporting.create_report(report)
 
 
 def _is_optional_repo(repo):
@@ -16,62 +58,77 @@ def _is_optional_repo(repo):
     return repo.from_repoid.endswith(suffix)
 
 
-def _get_list_of_optional_repos():
+def _get_manually_enabled_repos():
     """
-    Return a dict of optional repositories based on RepositoriesMap: { 'from_repoid' : 'to_repoid'}
+    Get set of repo that are manually enabled.
 
-    It consumes RepositoriesMap messages and create map (dict) of optional repositories
-    on RHEL 7 system to CRB repositories on RHEL 8. See the RepositoriesMap model..
+    manually enabled means (
+        specified by --enablerepo option of the leapp command or
+        inside the /etc/leapp/files/leapp_upgrade_repositories.repo),
+    )
+    :rtype: set [repoid]
     """
-    opt_repo = {}
+    try:
+        return {repo.repoid for repo in api.consume(CustomTargetRepository)}
+    except StopIteration:
+        return set()
+
+
+def _get_optional_repo_mapping():
+    """
+    Get a mapping of RHEL 7 Optional repos to corresponding RHEL 8 repos.
+
+    It consumes RepositoriesMap messages and creates a mapping of 'Optional' repositories
+    from RHEL 7 to CRB repositories on RHEL 8.
+    It returns the mapping as a dict {'from_repoid' : 'to_repoid'}.
+    """
+    opt_repo_mapping = {}
     repo_map = next(api.consume(RepositoriesMap), None)
     if repo_map:
         for repo in repo_map.repositories:
             if _is_optional_repo(repo):
-                opt_repo[repo.from_repoid] = repo.to_repoid
-    return opt_repo
+                opt_repo_mapping[repo.from_repoid] = repo.to_repoid
+    return opt_repo_mapping
 
 
-def _get_disabled_optional_repo():
+def _get_repos_to_exclude():
     """
-    Return a list of disabled optional repositories available on the system.
+    Get a set of repoids to not use during the upgrade.
+
+    These are such RHEL 8 repositories that are mapped from disabled
+    RHEL 7 Optional repositories.
+    :rtype: set [repoids]
     """
-    opt_repos = _get_list_of_optional_repos()
-    repos_blacklist = []
-    repo_map = next(api.consume(RepositoriesFacts), None)
-    for repo_file in repo_map.repositories:
-        for repo in repo_file.data:
-            if repo.repoid in opt_repos and not repo.enabled:
-                repos_blacklist.append(opt_repos[repo.repoid])
-    return repos_blacklist
+    opt_repo_mapping = _get_optional_repo_mapping()
+    repos_to_exclude = []
+    repos_on_system = next(api.consume(RepositoriesFacts), None)
+    if repos_on_system:
+        for repo_file in repos_on_system.repositories:
+            for repo in repo_file.data:
+                if repo.repoid in opt_repo_mapping and not repo.enabled:
+                    repos_to_exclude.append(opt_repo_mapping[repo.repoid])
+    return set(repos_to_exclude)
 
 
 def process():
-    # blacklist CRB repo if optional repo is not enabled
-    reposid_blacklist = _get_disabled_optional_repo()
-    if reposid_blacklist:
-        api.current_logger().info("The optional repository is not enabled. Blacklisting the CRB repository.")
-        api.produce(RepositoriesBlacklisted(repoids=reposid_blacklist))
+    """
+    Exclude target repositories provided by Red Hat without support.
 
-        report = [
-            reporting.Title("Excluded RHEL 8 repositories"),
-            reporting.Summary(
-                "The following repositories are not supported by "
-                "Red Hat and are excluded from the list of repositories "
-                "used during the upgrade.\n- {}".format(
-                    "\n- ".join(reposid_blacklist)
-                )
-            ),
-            reporting.Severity(reporting.Severity.INFO),
-            reporting.Tags([reporting.Tags.REPOSITORY]),
-            reporting.Flags([reporting.Flags.FAILURE]),
-            reporting.ExternalLink(
-                url=(
-                    "https://access.redhat.com/documentation/en-us/"
-                    "red_hat_enterprise_linux/8/html/package_manifest/"
-                    "codereadylinuxbuilder-repository."
-                ),
-                title="CodeReady Linux Builder repository",
-            ),
-        ]
-        reporting.create_report(report)
+    Conditions to exclude:
+    - there are not such repositories already enabled on the source system
+      (e.g. "Optional" repositories)
+    - such repositories are not required for the upgrade explicitly by the user
+      (e.g. via the --enablerepo option or via the /etc/leapp/files/leapp_upgrade_repositories.repo file)
+
+    E.g. CRB repository is provided by Red Hat but it is without the support.
+    """
+    repos_to_exclude = _get_repos_to_exclude()
+    manually_enabled_repos = _get_manually_enabled_repos() & repos_to_exclude
+
+    overriden_repos_to_exclude = repos_to_exclude - manually_enabled_repos
+
+    if manually_enabled_repos:
+        _report_using_unsupported_repos(manually_enabled_repos)
+    if overriden_repos_to_exclude:
+        _report_excluded_repos(overriden_repos_to_exclude)
+        api.produce(RepositoriesBlacklisted(repoids=list(overriden_repos_to_exclude)))

--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/tests/test_repositoriesblacklist.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/tests/test_repositoriesblacklist.py
@@ -2,9 +2,14 @@ import pytest
 
 from leapp import reporting
 from leapp.libraries.actor import repositoriesblacklist
-from leapp.libraries.common.testutils import produce_mocked, CurrentActorMocked
+from leapp.libraries.common.testutils import (
+    CurrentActorMocked,
+    create_report_mocked,
+    produce_mocked,
+)
 from leapp.libraries.stdlib import api
 from leapp.models import (
+    CustomTargetRepository,
     EnvVar,
     RepositoriesBlacklisted,
     RepositoriesFacts,
@@ -52,7 +57,7 @@ def test_with_optionals(monkeypatch, valid_opt_repoid, product_type):
     monkeypatch.setattr(api, "consume", repositories_mock)
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
         envars={'LEAPP_DEVEL_SOURCE_PRODUCT_TYPE': product_type}))
-    optionals = set(repositoriesblacklist._get_list_of_optional_repos().keys())
+    optionals = set(repositoriesblacklist._get_optional_repo_mapping())
     assert {valid_opt_repoid} == optionals
     assert not non_opt_repoids & optionals
 
@@ -83,7 +88,7 @@ def test_without_optionals(monkeypatch):
 
     monkeypatch.setattr(api, "consume", repositories_mock)
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
-    assert not repositoriesblacklist._get_list_of_optional_repos()
+    assert not repositoriesblacklist._get_optional_repo_mapping()
 
 
 def test_with_empty_optional_repo(monkeypatch):
@@ -92,9 +97,9 @@ def test_with_empty_optional_repo(monkeypatch):
         repos_files = [RepositoryFile(file='/etc/yum.repos.d/redhat.repo', data=repos_data)]
         yield RepositoriesFacts(repositories=repos_files)
 
-    monkeypatch.setattr(repositoriesblacklist, "_get_list_of_optional_repos", lambda: {})
+    monkeypatch.setattr(repositoriesblacklist, "_get_optional_repo_mapping", lambda: {})
     monkeypatch.setattr(api, "consume", repositories_mock)
-    assert not repositoriesblacklist._get_disabled_optional_repo()
+    assert not repositoriesblacklist._get_repos_to_exclude()
 
 
 def test_with_repo_disabled(monkeypatch):
@@ -103,10 +108,10 @@ def test_with_repo_disabled(monkeypatch):
         repos_files = [RepositoryFile(file='/etc/yum.repos.d/redhat.repo', data=repos_data)]
         yield RepositoriesFacts(repositories=repos_files)
 
-    monkeypatch.setattr(repositoriesblacklist, "_get_list_of_optional_repos",
+    monkeypatch.setattr(repositoriesblacklist, "_get_optional_repo_mapping",
                         lambda: {'rhel-7-optional-rpms': 'rhel-7'})
     monkeypatch.setattr(api, "consume", repositories_mock)
-    disabled = repositoriesblacklist._get_disabled_optional_repo()
+    disabled = repositoriesblacklist._get_repos_to_exclude()
     assert 'rhel-7' in disabled
 
 
@@ -116,15 +121,16 @@ def test_with_repo_enabled(monkeypatch):
         repos_files = [RepositoryFile(file='/etc/yum.repos.d/redhat.repo', data=repos_data)]
         yield RepositoriesFacts(repositories=repos_files)
 
-    monkeypatch.setattr(repositoriesblacklist, "_get_list_of_optional_repos",
+    monkeypatch.setattr(repositoriesblacklist, "_get_optional_repo_mapping",
                         lambda: {'rhel-7-optional-rpms': 'rhel-7'})
     monkeypatch.setattr(api, "consume", repositories_mock)
-    assert not repositoriesblacklist._get_disabled_optional_repo()
+    assert not repositoriesblacklist._get_repos_to_exclude()
 
 
 def test_repositoriesblacklist_not_empty(monkeypatch):
     name = 'test'
-    monkeypatch.setattr(repositoriesblacklist, "_get_disabled_optional_repo", lambda: [name])
+    monkeypatch.setattr(repositoriesblacklist, "_get_repos_to_exclude", lambda: {name})
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     monkeypatch.setattr(api, "produce", produce_mocked())
     monkeypatch.setattr(reporting, "create_report", produce_mocked())
 
@@ -136,9 +142,60 @@ def test_repositoriesblacklist_not_empty(monkeypatch):
 
 
 def test_repositoriesblacklist_empty(monkeypatch):
-    monkeypatch.setattr(repositoriesblacklist, "_get_disabled_optional_repo", lambda: [])
+    monkeypatch.setattr(repositoriesblacklist, "_get_repos_to_exclude", lambda: set())  # pylint:disable=W0108
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     monkeypatch.setattr(api, "produce", produce_mocked())
 
     repositoriesblacklist.process()
     assert api.produce.called == 0
+
+
+@pytest.mark.parametrize(
+    ("enabled_repo", "exp_report_title", "message_produced"),
+    [
+        ("codeready-builder-for-rhel-8-x86_64-rpms", "Using repository not supported by Red Hat", False),
+        ("some_other_enabled_repo", "Excluded RHEL 8 repositories", True),
+        (None, "Excluded RHEL 8 repositories", True),
+    ],
+)
+def test_enablerepo_option(monkeypatch, enabled_repo, exp_report_title, message_produced):
+    repos_data = [
+        RepositoryData(
+            repoid="rhel-7-server-optional-rpms",
+            name="RHEL 7 Server",
+            enabled=False,
+        )
+    ]
+    repos_files = [
+        RepositoryFile(file="/etc/yum.repos.d/redhat.repo", data=repos_data)
+    ]
+    msgs_to_feed = [
+            RepositoriesMap(
+                repositories=(
+                    [
+                        RepositoryMap(
+                            to_pes_repo="rhel-7-server-optional-rpms",
+                            from_repoid="rhel-7-server-optional-rpms",
+                            to_repoid="codeready-builder-for-rhel-8-x86_64-rpms",
+                            from_minor_version="all",
+                            to_minor_version="all",
+                            arch="x86_64",
+                            repo_type="rpm",
+                        ),
+                    ]
+                )
+            ),
+            RepositoriesFacts(repositories=repos_files),
+    ]
+
+    if enabled_repo:
+        msgs_to_feed.append(CustomTargetRepository(repoid=enabled_repo))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs_to_feed))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    repositoriesblacklist.process()
+    assert reporting.create_report.report_fields["title"] == exp_report_title
+    if message_produced:
+        assert isinstance(api.produce.model_instances[0], RepositoriesBlacklisted)
+    else:
+        assert not api.produce.model_instances


### PR DESCRIPTION
With this feature all manually enabled repos [1]
are not blacklisted anymore.

[1] manually enabled means (
         specified by --enablerepo option of the leapp command or
         inside the /etc/leapp/files/leapp_upgrade_repositories.repo),
     )