### PR TITLE
to_remove: Add initial-setup

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -1,1 +1,3 @@
 ### List of packages (each on new line) to be removed from the upgrade transaction
+# Removing initial-setup package to avoid it asking for EULA acceptance during upgrade - OAMG-1531
+initial-setup


### PR DESCRIPTION
Previously if the initial-setup package was installed on a system, the
upgrade caused that the user was asked to accept the EULA and other
questions, during the first boot into the upgraded system. This causes
the system to stop the startup and it gets stuck on this point unless
someone interactively answers these questions.

This patch adds the initial-setup package to the list of rpms to be
removed during the upgrade transaction to ensure that this is no longer
happening.

Issue: OAMG-1531
Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>