### PR TITLE
Check if grub.cfg is in /boot/efi

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/addupgradebootentry/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/addupgradebootentry/actor.py
@@ -34,6 +34,6 @@ class AddUpgradeBootEntry(Actor):
 
         # related to issue with hybrid BIOS and UEFI images
         # https://bugzilla.redhat.com/show_bug.cgi?id=1667028
-        if ff.firmware == 'bios' and os.path.ismount('/boot/efi'):
+        if ff.firmware == 'bios' and os.path.ismount('/boot/efi') and os.path.isfile('/boot/efi/EFI/redhat/grub.cfg'):
             configs = ['/boot/grub2/grub.cfg', '/boot/efi/EFI/redhat/grub.cfg']
         add_boot_entry(configs)


### PR DESCRIPTION
There are cases when /boot/efi is mounted but grub.cfg is not there as
EFI is not used. In that case leapp will fail with the following error

Details: Command ['/usr/sbin/grubby', '--remove-kernel',
'/boot/vmlinuz-upgrade.x86_64', '-c', '/boot/efi/EFI/redhat/grub.cfg']
failed with exit code 1.: error opening /boot/efi/EFI/redhat/grub.cfg
for read: No such file or directory

This patch adds file check to condition to allow leapp to skip such
cases

BZ-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1905247