### PR TITLE
Introduce check_multiple_package_version actor

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkmultiplepackageversions/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmultiplepackageversions/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.checkmultiplepackageversions import check
+from leapp.models import InstalledRPM
+from leapp.reporting import Report
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+
+
+class CheckMultiplePackageVersions(Actor):
+    """
+    Check for problematic 32bit packages installed together with 64bit ones.
+
+    If a known problematic 32bit package is found, the upgrade will be inhibited with the detailed
+    report how to solve the problem if such a remedy exists.
+    """
+
+    name = 'multiple_package_versions'
+    consumes = (InstalledRPM,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        check()

--- a/repos/system_upgrade/el7toel8/actors/checkmultiplepackageversions/libraries/checkmultiplepackageversions.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmultiplepackageversions/libraries/checkmultiplepackageversions.py
@@ -18,10 +18,10 @@ def check():
         name, arch = package.split('.')
         if has_package(InstalledRPM, name, arch) and has_package(InstalledRPM, name, 'x86_64'):
             actual_problems.append(package)
-        # generate RelatedResources for the report
-        related_resources.append(RelatedResource('package', package))
-        if details['bugzilla']:
-            related_resources.append(RelatedResource('bugzilla', details['bugzilla']))
+            # generate RelatedResources for the report
+            related_resources.append(RelatedResource('package', package))
+            if details['bugzilla']:
+                related_resources.append(RelatedResource('bugzilla', details['bugzilla']))
 
     if actual_problems:
         remediation = ["yum", "remove", "-y"] + actual_problems

--- a/repos/system_upgrade/el7toel8/actors/checkmultiplepackageversions/libraries/checkmultiplepackageversions.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmultiplepackageversions/libraries/checkmultiplepackageversions.py
@@ -1,0 +1,37 @@
+from leapp.libraries.common.rpms import has_package
+from leapp.models import InstalledRPM
+from leapp.reporting import create_report, Title, Summary, Severity, Flags, Remediation, RelatedResource
+
+# package_name: remedy information
+PROBLEM_PACKAGE_MAP = {
+    'brlapi.i686': {'bugzilla': None},
+    'gnome-online-accounts-devel.i686': {
+        'bugzilla': 'https://bugzilla.redhat.com/show_bug.cgi?id=1765627'},
+    'geocode-glib-devel.i686': {
+        'bugzilla': 'https://bugzilla.redhat.com/show_bug.cgi?id=1765629'}}
+
+
+def check():
+    actual_problems = []
+    related_resources = []
+    for package, details in PROBLEM_PACKAGE_MAP.items():
+        name, arch = package.split('.')
+        if has_package(InstalledRPM, name, arch) and has_package(InstalledRPM, name, 'x86_64'):
+            actual_problems.append(package)
+        # generate RelatedResources for the report
+        related_resources.append(RelatedResource('package', package))
+        if details['bugzilla']:
+            related_resources.append(RelatedResource('bugzilla', details['bugzilla']))
+
+    if actual_problems:
+        remediation = ["yum", "remove", "-y"] + actual_problems
+        # create a single report entry for all problematic packages
+        create_report([
+            Title('Some packages have both 32bit and 64bit version installed which are known '
+                  'to cause rpm transaction test to fail'),
+            Summary('The following packages have both 32bit and 64bit version installed which are known '
+                    'to cause rpm transaction test to fail:\n{}'.format(
+                        '\n'.join(['- {}'.format(a) for a in actual_problems]))),
+            Severity(Severity.HIGH),
+            Flags([Flags.INHIBITOR]),
+            Remediation(commands=[remediation])] + related_resources)

--- a/repos/system_upgrade/el7toel8/actors/checkmultiplepackageversions/tests/test_multiplepackageversions.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmultiplepackageversions/tests/test_multiplepackageversions.py
@@ -30,6 +30,24 @@ def test_x32_x64(current_actor_context):
            {'brlapi.i686', 'gnome-online-accounts-devel.i686', 'geocode-glib-devel.i686'}
 
 
+def test_1_package(current_actor_context):
+    pkg = 'geocode-glib-devel'
+    problem_rpms = [
+       RPM(name=pkg, version='0.1', release='1.sm01', epoch='1',
+           packager="RH_PACKAGER", arch='x86_64', pgpsig='SOME_OTHER_SIG_X'),
+       RPM(name=pkg, version='0.1', release='1.sm01', epoch='1', packager="RH_PACKAGER",
+           arch='i686',
+           pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 5326810137017186')
+    ]
+    current_actor_context.feed(InstalledRPM(items=problem_rpms))
+    current_actor_context.run()
+    report = current_actor_context.consume(Report)[0].report
+    assert report['title'] == ('Some packages have both 32bit and 64bit version installed which are known to'
+                               ' cause rpm transaction test to fail')
+    assert {p['title'] for p in report['detail']['related_resources'] if p['scheme'] == 'package'} == \
+           {'{}.i686'.format(pkg)}
+
+
 def test_x64_only(current_actor_context):
     ok_rpms = [
        RPM(name='brlapi', version='0.1', release='1.sm01', epoch='1', packager="RH_PACKAGER", arch='x86_64',

--- a/repos/system_upgrade/el7toel8/actors/checkmultiplepackageversions/tests/test_multiplepackageversions.py
+++ b/repos/system_upgrade/el7toel8/actors/checkmultiplepackageversions/tests/test_multiplepackageversions.py
@@ -1,0 +1,61 @@
+import mock
+
+from leapp.actors import Actor
+from leapp.models import InstalledRPM, Report, RPM
+
+
+def test_x32_x64(current_actor_context):
+    problem_rpms = [
+       RPM(name='brlapi', version='0.1', release='1.sm01', epoch='1', packager="RH_PACKAGER", arch='i686',
+           pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51'),
+       RPM(name='gnome-online-accounts-devel', version='0.1', release='1.sm01', epoch='1',
+           packager="RH_PACKAGER", arch='i686', pgpsig='SOME_OTHER_SIG_X'),
+       RPM(name='geocode-glib-devel', version='0.1', release='1.sm01', epoch='1', packager="RH_PACKAGER",
+           arch='i686', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 5326810137017186'),
+       RPM(name='brlapi', version='0.1', release='1.sm01', epoch='1', packager="RH_PACKAGER", arch='x86_64',
+           pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51'),
+       RPM(name='gnome-online-accounts-devel', version='0.1', release='1.sm01', epoch='1',
+           packager="RH_PACKAGER", arch='x86_64', pgpsig='SOME_OTHER_SIG_X'),
+       RPM(name='geocode-glib-devel', version='0.1', release='1.sm01', epoch='1', packager="RH_PACKAGER",
+           arch='x86_64',
+           pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 5326810137017186')
+       ]
+
+    current_actor_context.feed(InstalledRPM(items=problem_rpms))
+    current_actor_context.run()
+    report = current_actor_context.consume(Report)[0].report
+    assert report['title'] == ('Some packages have both 32bit and 64bit version installed which are known to'
+                               ' cause rpm transaction test to fail')
+    assert {p['title'] for p in report['detail']['related_resources'] if p['scheme'] == 'package'} == \
+           {'brlapi.i686', 'gnome-online-accounts-devel.i686', 'geocode-glib-devel.i686'}
+
+
+def test_x64_only(current_actor_context):
+    ok_rpms = [
+       RPM(name='brlapi', version='0.1', release='1.sm01', epoch='1', packager="RH_PACKAGER", arch='x86_64',
+           pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51'),
+       RPM(name='gnome-online-accounts-devel', version='0.1', release='1.sm01', epoch='1',
+           packager="RH_PACKAGER", arch='x86_64', pgpsig='SOME_OTHER_SIG_X'),
+       RPM(name='geocode-glib-devel', version='0.1', release='1.sm01', epoch='1', packager="RH_PACKAGER",
+           arch='x86_64',
+           pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 5326810137017186')
+       ]
+
+    current_actor_context.feed(InstalledRPM(items=ok_rpms))
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+
+
+def test_x32_only(current_actor_context):
+    ok_rpms = [
+       RPM(name='brlapi', version='0.1', release='1.sm01', epoch='1', packager="RH_PACKAGER", arch='i686',
+           pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51'),
+       RPM(name='gnome-online-accounts-devel', version='0.1', release='1.sm01', epoch='1',
+           packager="RH_PACKAGER", arch='i686', pgpsig='SOME_OTHER_SIG_X'),
+       RPM(name='geocode-glib-devel', version='0.1', release='1.sm01', epoch='1', packager="RH_PACKAGER",
+           arch='i686', pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 5326810137017186'),
+       ]
+
+    current_actor_context.feed(InstalledRPM(items=ok_rpms))
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)

--- a/repos/system_upgrade/el7toel8/actors/postgresqlcheck/libraries/postgresqlcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/postgresqlcheck/libraries/postgresqlcheck.py
@@ -78,8 +78,8 @@ def report_installed_packages(_context=api):
     Additionally, create another report if the postgresql-contrib rpm
     is installed.
     """
-    has_server = has_package(InstalledRedHatSignedRPM, 'postgresql-server', _context)
-    has_contrib = has_package(InstalledRedHatSignedRPM, 'postgresql-contrib', _context)
+    has_server = has_package(InstalledRedHatSignedRPM, 'postgresql-server', context=_context)
+    has_contrib = has_package(InstalledRedHatSignedRPM, 'postgresql-contrib', context=_context)
 
     if has_server:
         # postgresql-server

--- a/repos/system_upgrade/el7toel8/actors/tcpwrapperscheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/tcpwrapperscheck/actor.py
@@ -54,7 +54,7 @@ class TcpWrappersCheck(Actor):
             )
 
         # Convert installed packages message to list
-        packages = create_lookup(InstalledRedHatSignedRPM, field='items', key='name')
+        packages = create_lookup(InstalledRedHatSignedRPM, field='items', keys=('name',))
 
         found_packages = config_affects_daemons(tcp_wrappers_facts, packages, DAEMONS)
 


### PR DESCRIPTION
Upgrade should be inhibited if both x32 and x64 version of certain packages
are simultaneously present on the machine.
The actor will check for those packages and produce a Report with a bugzilla
link (if any is present for the problematic package).
The implementation also enhances the create_lookup library function allowing it
to create multi-parameter lookups.

TBD:
- create_lookup tests in test_redhatsignedrpmscanner.py appear to be completely
meaningless and need to be refactored & updated.
- check_multiple_package_version tests

OAMG-4097