### PR TITLE
Exclude SR-IOV VF devices from physical devices

### DIFF
--- a/repos/system_upgrade/el7toel8/libraries/persistentnetnames.py
+++ b/repos/system_upgrade/el7toel8/libraries/persistentnetnames.py
@@ -1,3 +1,4 @@
+import os
 import pyudev
 
 from leapp.models import PCIAddress, Interface
@@ -11,7 +12,14 @@ def physical_interfaces():
     Returns a list of pyudev.Device objects for all physical network interfaces
     """
     enumerator = pyudev.Enumerator(udev_context).match_subsystem('net')
-    return [d for d in enumerator if not d.device_path.startswith('/devices/virtual/')]
+    dev_list = []
+    for d in enumerator:
+        if d.device_path.startswith('/devices/virtual/'):
+            continue
+        if os.path.exists(os.path.join(d.sys_path, 'device/physfn')):
+            continue
+        dev_list.append(d)
+    return dev_list
 
 
 def pci_info(path):

--- a/repos/system_upgrade/el7toel8/libraries/persistentnetnames.py
+++ b/repos/system_upgrade/el7toel8/libraries/persistentnetnames.py
@@ -1,4 +1,5 @@
 import os
+
 import pyudev
 
 from leapp.models import PCIAddress, Interface


### PR DESCRIPTION
Fixes: https://github.com/oamg/leapp-repository/issues/630

Exclude SR-IOV VF devices from the persistent list as it has to be created on every reboot.

Relate BZ - [#1866372](https://bugzilla.redhat.com/show_bug.cgi?id=1866372#c5)