### PR TITLE
storagescanner: Inhibit if any CIFS entries found in /etc/fstab

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkcifs/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkcifs/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.checkcifs import checkcifs
+from leapp.models import StorageInfo
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckCIFS(Actor):
+    """
+    Check if CIFS filesystem is in use. If yes, inhibit the upgrade process.
+
+    Actor looks for CIFS in /ets/fstab.
+    If there is a CIFS entry, the upgrade is inhibited.
+    """
+    name = "check_cifs"
+    consumes = (StorageInfo,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        checkcifs(self.consume(StorageInfo))

--- a/repos/system_upgrade/el7toel8/actors/checkcifs/libraries/checkcifs.py
+++ b/repos/system_upgrade/el7toel8/actors/checkcifs/libraries/checkcifs.py
@@ -1,0 +1,19 @@
+from leapp import reporting
+from leapp.reporting import create_report
+
+
+def checkcifs(storage_info):
+    for storage in storage_info:
+        if any(entry.fs_vfstype == "cifs" for entry in storage.fstab):
+            create_report([
+                reporting.Title("Use of CIFS detected. Upgrade can't proceed"),
+                reporting.Summary("CIFS is currently not supported by the inplace upgrade."),
+                reporting.Severity(reporting.Severity.HIGH),
+                reporting.Tags([
+                        reporting.Tags.FILESYSTEM,
+                        reporting.Tags.NETWORK
+                ]),
+                reporting.Remediation(hint='Comment out CIFS entries to proceed with the upgrade.'),
+                reporting.Flags([reporting.Flags.INHIBITOR]),
+                reporting.RelatedResource('file', '/etc/fstab')
+            ])

--- a/repos/system_upgrade/el7toel8/actors/checkcifs/tests/test_checkcifs.py
+++ b/repos/system_upgrade/el7toel8/actors/checkcifs/tests/test_checkcifs.py
@@ -1,0 +1,34 @@
+from leapp.snactor.fixture import current_actor_context
+from leapp.models import StorageInfo, FstabEntry
+from leapp.reporting import Report
+
+
+def test_actor_with_fstab_entry(current_actor_context):
+    with_fstab_entry = [FstabEntry(fs_spec="//10.20.30.42/share1", fs_file="/mnt/win_share1",
+                                   fs_vfstype="cifs",
+                                   fs_mntops="credentials=/etc/win-credentials,file_mode=0755,dir_mode=0755",
+                                   fs_freq="0", fs_passno="0"),
+                        FstabEntry(fs_spec="//10.20.30.42/share2", fs_file="/mnt/win_share2",
+                                   fs_vfstype="cifs",
+                                   fs_mntops="credentials=/etc/win-credentials,file_mode=0755,dir_mode=0755",
+                                   fs_freq="0", fs_passno="0"),
+                        FstabEntry(fs_spec="/dev/mapper/fedora-home", fs_file="/home",
+                                   fs_vfstype="ext4",
+                                   fs_mntops="defaults,x-systemd.device-timeout=0",
+                                   fs_freq="1", fs_passno="2")]
+    current_actor_context.feed(StorageInfo(fstab=with_fstab_entry))
+    current_actor_context.run()
+    report_fields = current_actor_context.consume(Report)[0].report
+    assert 'inhibitor' in report_fields['flags']
+    assert report_fields['severity'] == 'high'
+    assert report_fields['title'] == "Use of CIFS detected. Upgrade can't proceed"
+
+
+def test_actor_no_cifs(current_actor_context):
+    with_fstab_entry = [FstabEntry(fs_spec="/dev/mapper/fedora-home", fs_file="/home",
+                                   fs_vfstype="ext4",
+                                   fs_mntops="defaults,x-systemd.device-timeout=0",
+                                   fs_freq="1", fs_passno="2")]
+    current_actor_context.feed(StorageInfo(fstab=with_fstab_entry))
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)


### PR DESCRIPTION
Due to networking not available in initramfs phase CIFS upgrade attempt
with CIFS entries in the /etc/fstab has to be inhibited for now.
Also changed a behavior of error reporting in _get_fstab_info
function, instead of find-first-error-and-report-it now all errors
of the same type will be reported under a single report entry.

OAMG-4107