### PR TITLE
Fix XFS ftype=0 workaround for "non-XFS" rootfs

### DIFF
--- a/repos/system_upgrade/el7toel8/libraries/overlaygen.py
+++ b/repos/system_upgrade/el7toel8/libraries/overlaygen.py
@@ -63,7 +63,7 @@ def _prepare_required_mounts(scratch_dir, mounts_dir, mount_points, xfs_info):
 
     mount_names = [mount_point.fs_file for mount_point in mount_points]
 
-    for mountpoint in xfs_info.mountpoints_without_ftype:
+    for mountpoint in set(xfs_info.mountpoints_without_ftype + ['/']):
         if mountpoint in mount_names:
             image = _create_mount_disk_image(disk_images_directory, mountpoint)
             result[mountpoint] = mounting.LoopMount(source=image, target=_mount_dir(mounts_dir, mountpoint))


### PR DESCRIPTION
We have realized that in case the /var/lib/leapp is on partition
with XFS ftype=0, we need to treat rootfs partition as the XFS ftype=0 one,
doesn't matter what actual FS is used for rootfs.

This implementation treat rootfs like that always if any XFS ftype=0
has been detected (just to save time now). It's even possible, the
root cause had a bigger scope and we will need to treat any FS with
our workaround in future. But this will definitely fix the bug for
now.

rhbz: #1911802