### PR TITLE
ziplconvertoblcfg: Ensure we won't delete /boot

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/ziplconverttoblscfg/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/ziplconverttoblscfg/actor.py
@@ -38,7 +38,9 @@ class ZiplConvertToBLSCFG(Actor):
         # replace the original boot directory inside the container by the host one
         # - as we cannot use zipl* pointing anywhere else than default directory
         # - no, --bls-directory is not solution
-        with mounting.BindMount(source='/boot', target=os.path.join(userspace.path, 'boot')):
+        with mounting.BindMount(source='/boot',
+                                target=os.path.join(userspace.path, 'boot'),
+                                config=mounting.MountConfig.AttachOnly):
             userspace_zipl_conf = os.path.join(userspace.path, 'etc', 'zipl.conf')
             if os.path.exists(userspace_zipl_conf):
                 os.remove(userspace_zipl_conf)


### PR DESCRIPTION
During the conversiion of zipl bootmanager configuration to the BLS
format, we bind mount /boot into the target userspace. Previously, the
bind mount cleanup removed everything from the mounted /boot directory.
This patch fixes the problem by making it avoid running cleanup actors
before and after mount operations.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>