### PR TITLE
Fix syntax error in do-upgrade.sh

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/el7toel8/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -14,7 +14,7 @@ export LEAPP3_BIN=$LEAPPHOME/leapp3
 export NEWROOT=${NEWROOT:-"/sysroot"}
 
 NSPAWN_OPTS="--capability=all --bind=/sys --bind=/dev --bind=/dev/pts --bind=/run/systemd --bind=/proc"
-[ -d /dev/mapper ] NSPAWN_OPTS="$NSPAWN_OPTS --bind=/dev/mapper"
+[ -d /dev/mapper ] && NSPAWN_OPTS="$NSPAWN_OPTS --bind=/dev/mapper"
 export NSPAWN_OPTS="$NSPAWN_OPTS --bind=/run/udev --keep-unit --register=no --timezone=off --resolv-conf=off"
 
 


### PR DESCRIPTION
Missing of "&&" causes following error:
upgrade[683]: //lib/dracut/hooks/upgrade/50-do-upgrade.sh: line 17: [: missing `]'

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>