### PR TITLE
persistentnetnamesdisable: Fix the issue when 1 eth nic in multiple n…

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/persistentnetnamesdisable/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/persistentnetnamesdisable/actor.py
@@ -38,7 +38,7 @@ class PersistentNetNamesDisable(Actor):
 
         if self.single_eth0(interfaces):
             self.disable_persistent_naming()
-        elif len(interfaces) > 1 and self.ethX_count(interfaces) > 0:
+        elif len(interfaces) > 1 and self.ethX_count(interfaces) > 1:
             create_report([
                 reporting.Title('Unsupported network configuration'),
                 reporting.Summary(

--- a/repos/system_upgrade/el7toel8/actors/persistentnetnamesdisable/tests/test_persistentnetnamesdisable.py
+++ b/repos/system_upgrade/el7toel8/actors/persistentnetnamesdisable/tests/test_persistentnetnamesdisable.py
@@ -49,5 +49,4 @@ def test_actor_ethX_and_not_ethX(current_actor_context):
                            devpath="/devices/hidraw/hidraw0")]
     current_actor_context.feed(PersistentNetNamesFacts(interfaces=interface))
     current_actor_context.run()
-    assert current_actor_context.consume(Report)
-    assert 'inhibitor' in current_actor_context.consume(Report)[0].report['flags']
+    assert not current_actor_context.consume(Report)


### PR DESCRIPTION
…ics env

We should only inhibit the upgrade when multiple eth nics exist.
Neverthless, for 1 eth nic in multiple nics env, we should not
fail the upgrade.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>