### PR TITLE
Check the FSTAB file for the deprecated / removed XFS mount options.

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkfstabxfsoptions/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfstabxfsoptions/actor.py
@@ -1,0 +1,27 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkfstabxfsoptions
+from leapp.models import StorageInfo
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckFstabXFSOptions(Actor):
+    """
+    Check the FSTAB file for the deprecated / removed XFS mount options.
+
+    Some mount options for XFS have been deprecated on RHEL 7 and already
+    removed on RHEL 8. If any such an option is present in the FSTAB,
+    it's impossible to boot the RHEL 8 system without the manual update of the
+    file.
+
+    Check whether any of these options are present in the FSTAB file
+    and inhibit the upgrade in such a case.
+    """
+
+    name = 'checkfstabxfsoptions'
+    consumes = (StorageInfo,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        checkfstabxfsoptions.process()

--- a/repos/system_upgrade/el7toel8/actors/checkfstabxfsoptions/libraries/checkfstabxfsoptions.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfstabxfsoptions/libraries/checkfstabxfsoptions.py
@@ -1,0 +1,59 @@
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp.models import StorageInfo
+
+# man 5 xfs
+REMOVED_XFS_OPTIONS = set([
+    # removed from kernel in 4.0
+    'nodelaylog',
+    'delaylog',
+    'ihashsize',
+    'irixsgid',
+    'osyncisdsync',
+    'osyncisosync',
+    # removed from kernel in 4.19
+    'nobarrier',
+    'barrier',
+])
+
+
+def _get_storage_data():
+    storage = next(api.consume(StorageInfo), None)
+    if not storage:
+        raise StopActorExecutionError('The StorageInfo message is not available.')
+    if not storage.fstab:
+        raise StopActorExecutionError('Data from the /etc/fstab file is missing.')
+    return storage
+
+
+def process():
+    storage = _get_storage_data()
+    used_removed_options = set()
+    for entry in storage.fstab:
+        if entry.fs_vfstype == 'xfs':
+            # NOTE: some opts could have a value, like ihashsize=4096 - we want
+            # just the name of the option (that's why the double-split)
+            options = set([opt.split('=')[0] for opt in entry.fs_mntops.split(',')])
+            used_removed_options.update(options.intersection(REMOVED_XFS_OPTIONS))
+
+    if not used_removed_options:
+        return
+
+    list_separator_fmt = '\n    - '
+    reporting.create_report([
+        reporting.Title('Deprecated XFS mount options present in FSTAB.'),
+        reporting.Summary(
+            'Some XFS mount options are not supported on RHEL 8 and prevent'
+            ' system from booting correctly if any of the reported XFS options are used.'
+            ' filesystem:{}{}.'.format(
+                list_separator_fmt,
+                list_separator_fmt.join(list(REMOVED_XFS_OPTIONS)))),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Flags([reporting.Flags.INHIBITOR]),
+        reporting.Tags([reporting.Tags.FILESYSTEM]),
+        reporting.RelatedResource('file', '/etc/fstab'),
+        reporting.Remediation(hint=(
+            'Drop the following mount options from the /etc/fstab file for any'
+            ' XFS filesystem: {}.'.format(', '.join(used_removed_options)))),
+    ])

--- a/repos/system_upgrade/el7toel8/actors/checkfstabxfsoptions/tests/test_checkfstabxfsoptions.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfstabxfsoptions/tests/test_checkfstabxfsoptions.py
@@ -1,0 +1,68 @@
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import checkfstabxfsoptions
+from leapp.models import FstabEntry, StorageInfo
+from leapp.reporting import Report
+from leapp.snactor.fixture import current_actor_context
+
+
+def _myint_gen():
+    i = 0
+    while True:
+        yield i
+        i += 1
+
+
+def _gen_fs_ent(fstype='ext4', mntops='auto', val=_myint_gen()):
+    return FstabEntry(
+        fs_spec='/path/spec/{}'.format(next(val)),
+        fs_file='/path/file/{}'.format(next(val)),
+        fs_vfstype=fstype,
+        fs_mntops=mntops,
+        fs_freq='1',
+        fs_passno='1',
+    )
+
+
+@pytest.mark.parametrize('fstab', [
+    [_gen_fs_ent()],
+    [_gen_fs_ent() for dummy in range(4)],
+    [_gen_fs_ent(), _gen_fs_ent('ext4', 'auto,quota,huge_file')],
+    # checking that problematic options are ignored for non-xfs FS
+    [_gen_fs_ent(), _gen_fs_ent('ext4', 'auto,barier,huge_file')],
+    [_gen_fs_ent('ext4', i) for i in checkfstabxfsoptions.REMOVED_XFS_OPTIONS],
+    [_gen_fs_ent(i, 'nobarrier') for i in ('ext4', 'ext3', 'vfat', 'btrfs')],
+])
+def test_no_xfs_option(fstab, current_actor_context):
+    current_actor_context.feed(StorageInfo(fstab=fstab))
+    current_actor_context.run()
+    report = current_actor_context.consume(Report)
+    assert not report
+
+
+# each item == one fstab
+problematic_fstabs = [[_gen_fs_ent('xfs', ','.join(checkfstabxfsoptions.REMOVED_XFS_OPTIONS))]]
+for opt in checkfstabxfsoptions.REMOVED_XFS_OPTIONS:
+    problematic_fstabs.append([_gen_fs_ent('xfs', opt)])
+    problematic_fstabs.append([_gen_fs_ent(), _gen_fs_ent('xfs', opt)])
+    problematic_fstabs.append([_gen_fs_ent(), _gen_fs_ent('xfs', opt), _gen_fs_ent()])
+    pre_opts = '{},auto,quota'.format(opt)
+    in_opts = 'auto,{},quota'.format(opt)
+    post_opts = 'auto,quota,{}'.format(opt)
+    problematic_fstabs.append([_gen_fs_ent(), _gen_fs_ent('xfs', pre_opts)])
+    problematic_fstabs.append([_gen_fs_ent(), _gen_fs_ent('xfs', in_opts)])
+    problematic_fstabs.append([_gen_fs_ent(), _gen_fs_ent('xfs', post_opts)])
+# ensure we catch even cases when a value is expected to be specified; we know just this
+# one case, so it should be representative it's working like that..
+problematic_fstabs.append([_gen_fs_ent(), _gen_fs_ent('xfs', 'defaults,ihashsize=4096')])
+problematic_fstabs.append([_gen_fs_ent(), _gen_fs_ent('xfs', 'defaults,ihashsize=4096,auto')])
+
+
+@pytest.mark.parametrize('fstab', problematic_fstabs)
+def test_removed_xfs_option(fstab, current_actor_context):
+    current_actor_context.feed(StorageInfo(fstab=fstab))
+    current_actor_context.run()
+    report = current_actor_context.consume(Report)
+    assert report and len(report) == 1
+    assert 'inhibitor' in report[0].report['flags']


### PR DESCRIPTION
Some mount options for XFS have been deprecated on RHEL 7 and already
removed on RHEL 8. If any such an option is present in the FSTAB,
it's impossible to boot the RHEL 8 system without the manual update
of the file.

Check whether any of these options are present in the FSTAB file
and inhibit the upgrade in such a case.