### PR TITLE
s390 inhibit if /boot is not on a separate partition

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checknonmountboots390/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checknonmountboots390/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checknonmountboots390
+from leapp.models import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckNonMountBootS390(Actor):
+    """
+    Inhibits on s390 when /boot is NOT on a separate partition.
+
+    Due to some problems, if /boot is not on a separate partition, leapp is deleting the content of /boot.
+    To avoid this from happening, we are inhibiting the upgrade process until this problem has been solved.
+    """
+
+    name = 'check_non_mount_boot_s390'
+    consumes = ()
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        checknonmountboots390.perform_check()

--- a/repos/system_upgrade/el7toel8/actors/checknonmountboots390/libraries/checknonmountboots390.py
+++ b/repos/system_upgrade/el7toel8/actors/checknonmountboots390/libraries/checknonmountboots390.py
@@ -1,0 +1,27 @@
+import os
+
+from leapp import reporting
+from leapp.libraries.common.config import architecture
+
+
+def perform_check():
+    if not architecture.matches_architecture(architecture.ARCH_S390X):
+        return
+
+    if os.path.ismount('/boot'):
+        return
+
+    data = [
+        reporting.Title('Leapp detected known issue related to /boot on s390x architecture'),
+        reporting.Summary((
+            'Due to a bug in the Leapp code, there is a situation when the upgrade process'
+            ' removes content of /boot when the directory is not on a separate partition and'
+            ' the system is running on S390x architecture. To avoid this from happening, we'
+            ' are inhibiting the upgrade process in this release until the issue has been fixed.'
+        )),
+        reporting.Flags([reporting.Flags.INHIBITOR]),
+        reporting.Tags([reporting.Tags.FILESYSTEM, reporting.Tags.UPGRADE_PROCESS, reporting.Tags.BOOT]),
+        reporting.Severity(reporting.Severity.HIGH),
+    ]
+
+    reporting.create_report(data)

--- a/repos/system_upgrade/el7toel8/actors/checknonmountboots390/tests/test_checknonmountboots390.py
+++ b/repos/system_upgrade/el7toel8/actors/checknonmountboots390/tests/test_checknonmountboots390.py
@@ -1,0 +1,30 @@
+import pytest
+
+from leapp.libraries.actor import checknonmountboots390
+
+
+class CheckNonMountBootS390ReportCreated(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    'matches_arch,ismount,should_report', (
+        (True, True, False),
+        (True, False, True),
+        (False, True, False),
+        (False, False, False),
+    )
+)
+def test_checknonmountboots390_perform_check(monkeypatch, matches_arch, ismount, should_report):
+    def _create_report(data):
+        raise CheckNonMountBootS390ReportCreated()
+
+    monkeypatch.setattr(checknonmountboots390.architecture, 'matches_architecture', lambda x: matches_arch)
+    monkeypatch.setattr(checknonmountboots390.os.path, 'ismount', lambda x: ismount)
+    monkeypatch.setattr(checknonmountboots390.reporting, 'create_report', _create_report)
+
+    if should_report:
+        with pytest.raises(CheckNonMountBootS390ReportCreated):
+            checknonmountboots390.perform_check()
+    else:
+        checknonmountboots390.perform_check()


### PR DESCRIPTION
Previously, when the upgrade is performed on a s390x machine with zipl
and /boot is not on a separate partition, the content of /boot got
deleted during the upgrade process. Since the potential solution for
this problem turned out to fail the upgrade for all s390 upgrades, it
has been decided to create an actor that inhibits the upgrade for the
detected scenario that caused the deletion of the /boot content.

This patch introduces a new check actor that inhibits the upgrade when:
- The architecture is s390X
- /boot is not a mounted partition

In case all of the above is true, the upgrade is inhibited with a
report.