### PR TITLE
Bump the required framework version regarding reporting.Key

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -30,7 +30,7 @@ Requires:       leapp-repository-dependencies = 5
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' this instead of the real framework rpm version.
-Requires:       leapp-framework >= 1.3, leapp-framework < 2
+Requires:       leapp-framework >= 1.4, leapp-framework < 2
 Requires:       python2-leapp
 
 # That's temporary to ensure the obsoleted subpackage is not installed


### PR DESCRIPTION
Regarding the rquired reporting.Key functionality, leapp-repository
should require higher version of the leapp framework to ensure the
correct version of the leapp is installed.

Depends-On: https://github.com/oamg/leapp/pull/684