### PR TITLE
Release 0.13.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -13,7 +13,7 @@ py2_byte_compile "%1" "%2"}
 
 
 Name:           leapp-repository
-Version:        0.12.0
+Version:        0.13.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Packaging
- Bump required leapp-framework capability to 1.4 (#642)

## Upgrade handling
### Fixes
- Fix comparison of the newest installed and booted kernel (#600)
- Fix remediation command for ipa-server removal (#617)
- Fix crash due to missing network interfaces during upgrade phases (#625)
- Fix error with /boot/efi existing on non-EFI systems (#627)
- Fix false positive detection of issue in /etc/default/grub that led into GRUB prompt (#587)
- Fix syntax error in upgrade script (#619)
- Inhibit upgrade with mount options in fstab that break mounting on RHEL 8 (#639)
- Inhibit upgrade on s390x machines with /boot on a separate partition (#641)
- Inhibit upgrade if multiple kernel-debug pkgs are installed (#599)
- Remove the initial-setup package to avoid it asking for EULA acceptance during upgrade (#626)
- Remove the *leapp-resume* service after the *FirstBoot* phase to prevent kill of the leapp process on `systemctl daemon-reload` (#611)

### Enhancements
- Add upgrade support for SAP HANA (own upgrade path) (#503)
- Allow upgrade with SCA enabled manifest (#615)
- Add actors to migrate Quagga to FRR (#467)
- Add stable uniq Key id for every dialog (#618)
- Respect the *kernel-rt* package (#600) 

## Additional changes interesting for devels
- Add a possibility to overwrite virtualenv name using `$VENVNAME` (#613)
- Update product certificates for RHEL 8.3 GA and 8.4 Beta/HTB (#624)

Related leapp release: https://github.com/oamg/leapp/releases/tag/v0.12.0