### PR TITLE
Make pylint 2.7.0 and 2.7.1 happy again

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -41,6 +41,7 @@ disable=
  bad-option-value,  # python 2 doesn't have import-outside-toplevel, but in some case we need to import outside toplevel
  super-with-arguments,  # required in python 2
  raise-missing-from,  # no 'raise from' in python 2
+ use-a-generator, # cannot be modified because of Python2 support
 
 [FORMAT]
 # Maximum number of characters on a single line.

--- a/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/tests/test_forcedefaultboot_forcedefaultboottotargetkernelversion.py
+++ b/repos/system_upgrade/el7toel8/actors/forcedefaultboottotargetkernelversion/tests/test_forcedefaultboot_forcedefaultboottotargetkernelversion.py
@@ -99,7 +99,7 @@ class MockedRun(object):
     def __call__(self, cmd, *args, **kwargs):
         if cmd and cmd[0] == 'grubby':
             target = getattr(self, 'grubby_{}'.format(cmd[1].strip('--').replace('-', '_')), None)
-            assert target and 'Unsupport grubby command called'
+            assert target and 'Unsupport grubby command called'  # pylint: disable=simplifiable-condition
             return target(cmd)  # pylint: disable=not-callable
         if cmd and cmd[0] == '/usr/sbin/zipl':
             self.called_zipl = True

--- a/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
+++ b/repos/system_upgrade/el7toel8/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
@@ -37,7 +37,7 @@ def mocked_consume_no_args(*models):
 def mocked_consume_no_version(*models):
     if InstalledTargetKernelVersion in models:
         return iter(())
-    assert False and 'this should not be called'
+    assert False and 'this should not be called'  # pylint: disable=condition-evals-to-constant
     return iter(())
 
 

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/tests/component_test_selinuxapplycustom.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxapplycustom/tests/component_test_selinuxapplycustom.py
@@ -29,6 +29,7 @@ def _run_cmd(cmd, logmsg="", split=True):
     except CalledProcessError as e:
         if logmsg:
             api.current_logger().warning("%s: %s", logmsg, str(e.stderr))
+    return None
 
 
 def find_module_semodule(semodule_lfull, name, priority):

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/component_test_selinuxcontentscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxcontentscanner/tests/component_test_selinuxcontentscanner.py
@@ -33,6 +33,7 @@ def _run_cmd(cmd, logmsg="", split=False):
         # This way expected failures are not reported.
         if logmsg:
             api.current_logger().warning("%s: %s", logmsg, str(e.stderr))
+    return None
 
 
 @pytest.fixture(scope="function")

--- a/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/component_test_selinuxprepare.py
+++ b/repos/system_upgrade/el7toel8/actors/selinux/selinuxprepare/tests/component_test_selinuxprepare.py
@@ -32,6 +32,7 @@ def _run_cmd(cmd, logmsg="", split=False):
     except CalledProcessError as e:
         if logmsg:
             api.current_logger().warning("%s: %s", logmsg, str(e.stderr))
+    return None
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
List of changes

- disable `use-a-generator` - cannot be fixed because the wanted change is incompatible with Python2
- update `_run_cmd` in selinux actors to set the return statement expicitly (the mock function looks weird, but let's ignore it)
- disable `R1726` & `R1727` in affected actors; the pylint's report is correct, however I guess that in this case the weird asserts have documentation purposes (@vinzenz  ?)
