### PR TITLE
Fixing FRR configuration after rebase in 8.4

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/quaggatofrr/tests/files/bgpd.conf
+++ b/repos/system_upgrade/el7toel8/actors/quaggatofrr/tests/files/bgpd.conf
@@ -1,0 +1,33 @@
+hostname BGP_Seed
+password test
+!
+router bgp 65000
+ bgp router-id 127.0.0.1
+ network 10.0.0.0/24
+ neighbor 127.0.0.1 remote-as 65001
+ neighbor 127.0.0.1 route-map RMAPpsklenar in
+ neighbor 127.0.0.1 route-map RMAPpsklenar out
+!
+! ACCEPT ECOMMUNITY
+ip extcommunity-list standard xuser permit rt 65001:80
+!
+route-map RMAPbrno permit 20
+ match extcommunity psklenar
+ set local-preference 80
+!
+log file /var/log/quagga/bgpd.log debugging
+!
+!route-map SetAttr permit 10
+! set community 65000:1 additive
+! set extcommunity rt 65000:1
+! set aggregator as 65002 1.2.3.4
+! set as-path prepend 1 2 3 4
+! set atomic-aggregate
+! set metric 20
+! set originator-id 1.2.3.4
+!
+line vty
+ no login
+!
+access-list CONF permit 10.0.0.0/24
+!end


### PR DESCRIPTION
Configuration of extcommunity-list command in bgpd hase changed in RHEL-8.4. If used in default bgpd.conf in /etc/frr, this update will fix the command syntax.