### PR TITLE
Freeze pip on version 20.3.4 and pylitn and peseventsscanner

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/quaggatofrr/tests/test_unit_quaggatofrr.py
+++ b/repos/system_upgrade/el7toel8/actors/quaggatofrr/tests/test_unit_quaggatofrr.py
@@ -38,7 +38,7 @@ def _create_mock_files():
         shutil.rmtree(TO_DIR)
 
 
-class MockedFilePointer():
+class MockedFilePointer(object):
     def __init__(self, orig_open, fname, mode='r'):
         self._orig_open = orig_open
         self.fname = fname
@@ -70,7 +70,7 @@ class MockedFilePointer():
             self.written += data
 
 
-class MockedOpen():
+class MockedOpen(object):
     """
     This is mock for the open function. When called it creates
     the MockedFilePointer object.

--- a/utils/docker-tests/Dockerfile
+++ b/utils/docker-tests/Dockerfile
@@ -8,7 +8,7 @@ RUN yum update -y && \
 # NOTE(ivasilev) Unless we upgrade pip an obsolete v 9 will be on the system
 # and we need at least 10.0.1 to install a not-yet-merged framework pr in case
 # it's necessary
-RUN easy_install pip
+RUN easy_install pip==20.3.4
 
 WORKDIR /payload
 ENTRYPOINT make install-deps && make test


### PR DESCRIPTION
The current pip v21 is written for Python 3.6+ only. No idea how
it happened the py3 code appeared inside Python 2.7.9 repositories
and not sure whether it will be fixed in future.

And make pylint happy again:
- C1001 error (old-style-class) in quaggatofrr
- C0103 (invalid-name) in peseventsscanner (attributes in classes used lower case instead of upper case)