### PR TITLE
CI: travis: fix docker pull limit (centos registry)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os: linux
 dist: xenial
 env:
   global:
-    - CONTAINER=centos:7
+    - CONTAINER=registry.centos.org/centos:7
 services:
   - docker
 

--- a/utils/docker-tests/Dockerfile
+++ b/utils/docker-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM registry.centos.org/centos:7
 
 VOLUME /payload
 


### PR DESCRIPTION
Regarding the pull rate limit from the docker.io hub (100 pulls / 6h),
let's look at alternatives. There are two ways (see two commits) how
to achieve this.

1) Use the docker but pull from centos registry instead of from docker.io:
-  registry.centos.org/centos:7

This can be a little bit annoying when you want to remove an image and you
cannot write just "centos:7" but has to write all other stuff. (passed)

2) start to use podman, as docker is over. From my point that's better solution as docker is kind of history now. (failed, see comments)

Note: Tested in my VM. Now waiting for results on travis. Once the tests passes for the first commit, I will push the second one.