### PR TITLE
Release 0.14.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -13,7 +13,7 @@ py2_byte_compile "%1" "%2"}
 
 
 Name:           leapp-repository
-Version:        0.13.0
+Version:        0.14.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Packaging
- Added dependency on python-requests on RHEL 7

## Upgrade handling
### Fixes
- Fix migration of Quagga to FRR on 8.4

### Enhancements
- Changed supported upgrade paths:
    RHEL-ALT 7.6 -> 8.4
    RHEL 7.9 -> 8.4
    RHEL with SAP 7.7 -> 8.2 (unchanged)
- Download the leapp data from cloud.redhat.com automatically
  when no data are present locally (and system is registered)
- Inhibit the upgrade if the system uses any drivers dropped
  from the target system

## Additional changes interesting for devels
- added possibility of dumping leapp archive via serial console
  (undocumented yet)
- Add the fetch shared library
- Add PCIDevice model representing PCI devices
- Add RestrictedPCIDevices representing restricted PCI devices