### PR TITLE
[WIP] [completely broken now] Refactoring & fixing the fetching of data and PCI stuff

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkpcidrivers/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkpcidrivers/actor.py
@@ -7,17 +7,14 @@ from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 class CheckPCIDrivers(Actor):
     """
-    Check if host PCI devices drivers has restrictions on target system.
+    Check if detected PCI devices are supported on a target system.
 
-    If driver is restricted this means it is either unsupported or unavailable
-    in some set of newer RHEL versions.
+    Inhibit the ugprade if any detected drivers are unavailable on the target
+    system.
 
-    If the driver is unavailable on a target system - then the upgrade will
-        be inhibited
-    If the driver is available, but not supported - then the upgrade will
-        continue, but the relevant report will be generated
-    If the driver is available and supported - then the upgrade will continue
-        normally
+    In case that all drivers are present on the target system but some of them
+    becomes unsupported on the target system, create just report without the
+    inhibitor.
     """
 
     name = "check_pci_drivers"

--- a/repos/system_upgrade/el7toel8/actors/checkpcidrivers/libraries/checkpcidrivers.py
+++ b/repos/system_upgrade/el7toel8/actors/checkpcidrivers/libraries/checkpcidrivers.py
@@ -1,9 +1,3 @@
-"""
-TODOs:
-1. consider the idea to compare data sources timestamp in order to decide
-   if the source is actual or not
-"""
-
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.stdlib import api

--- a/repos/system_upgrade/el7toel8/actors/restrictedpcisscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/restrictedpcisscanner/actor.py
@@ -9,11 +9,12 @@ class RestrictedPCIsScanner(Actor):
     Provides data about restricted (unsupported or/and unavailable) devices.
 
     The data sources priority set up is as following:
-    1. The actor tries to get the data from /etc/leapp/files
-    2. Then from the online service
+      1. The actor tries to get the data from /etc/leapp/files
+      2. If not present then try to fetch them from the online service
+    Raise the StopActorExecutionError if the valid data cannot be obtained
     """
 
-    name = "restricted_pcis_scanner"
+    name = 'restricted_pcis_scanner'
     consumes = ()
     produces = (RestrictedPCIDevices,)
     tags = (IPUWorkflowTag, FactsPhaseTag)


### PR DESCRIPTION
## Summary

The current implementation around fetching of data and especially around PCI stuff is not fulfilling our needs as:
* it can be used on RHEL 7 only now
* it's not generic - it cannot be used in the multiple repositories in the same time; the code duplication and modification is required now
* the proposed models around restricted PCIs, reflecting the real data structure, is not usable and suitable to use for a generic processing
* the code is not python2 & python3 compatible
* ...etc

The goal of this PR is to create **clean code** that will be generic for the use in upgrades.


## TODOs etc.
- [ ] propose new model design for the restricted PCI devices with which we could work in reasonabe way
- [ ] Update the fetch function to return expected output on python2 & python3
  - now it returns different stuff on py2 & py3 which breaks actors... 
- [ ] Update the restrictedPCIscanner actor properly to address the changes in models
- [ ] ...

