### PR TITLE
Fix the pip installation in Dockerfile for unit-tests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -41,7 +41,9 @@ disable=
  bad-option-value,  # python 2 doesn't have import-outside-toplevel, but in some case we need to import outside toplevel
  super-with-arguments,  # required in python 2
  raise-missing-from,  # no 'raise from' in python 2
- use-a-generator, # cannot be modified because of Python2 support
+ use-a-generator,  # cannot be modified because of Python2 support
+ consider-using-with,  # on bunch spaces we cannot change that...
+ duplicate-string-formatting-argument,  # TMP: will be fixed in close future
 
 [FORMAT]
 # Maximum number of characters on a single line.

--- a/utils/docker-tests/Dockerfile
+++ b/utils/docker-tests/Dockerfile
@@ -5,10 +5,18 @@ VOLUME /payload
 RUN yum update -y && \
     yum install python-virtualenv python-setuptools make git -y
 
-# NOTE(ivasilev) Unless we upgrade pip an obsolete v 9 will be on the system
-# and we need at least 10.0.1 to install a not-yet-merged framework pr in case
-# it's necessary
-RUN easy_install pip==20.3.4
+# NOTE(ivasilev,pstodulk) We need at least pip v10.0.1, however centos:7
+# provides just v8.1.2 (via EPEL). So do this: install epel repos -> install
+# python2-pip -> use pip to update to specific pip version we require. period
+# NOTE(pstodulk) I see we take care about pip for py3 inside the Makefile,
+# however I am afraid of additional possible troubles in future because of the
+# archaic pip3 version (v9.0.1). As we want to run tests for Py2 and Py3 in ci
+# always anyway, let's put py3 installation here as well..
+
+RUN yum -y install epel-release && \
+    yum -y install python2-pip python3-pip && \
+    python2 -m pip install --upgrade pip==20.3.4 && \
+    python3 -m pip install --upgrade pip==20.3.4
 
 WORKDIR /payload
 ENTRYPOINT make install-deps && make test


### PR DESCRIPTION
The easy_install script is not usable anymore since the html page
changed the format and the script is not able to discover required
python packages anymore. Instead of that, install pip from centos
(includes installation of the EPEL repository), update it to version
we require and continue..

As well, to omit possible additional problems in future with pip for
Python3, let's install in the container python3-pip and update it
to the very same version (v20.3.4) too.