### PR TITLE
Use Packit CI for building of packages 

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,82 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: packaging/leapp-repository.spec
+# name in upstream package repository/registry (e.g. in PyPI)
+upstream_package_name: leapp-repository
+downstream_package_name: leapp-repository
+upstream_tag_template: 'v{version}'
+
+# This is just for the build from the CLI - all other builds for jobs use own
+# actions
+actions:
+  create-archive:
+  - bash -c "rm -f packaging/deps-pkgs.tar.gz"
+  - bash -c "make source"
+  - bash -c "mv packaging/sources/*.gz packaging/"
+  - bash -c "find packaging/*.gz -type f"
+  fix-spec-file:
+  - bash -c "sed -i -r \"0,/Release:/ s/Release:(\s*)\S*/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" packaging/leapp-repository.spec"
+  post-upstream-clone:
+  # builds from PRs should have lower NVR than those from master branch
+  - bash -c "sed -i \"s/1%{?dist}/0%{?dist}/g\" packaging/leapp-repository.spec"
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    owner: "@oamg"
+    project: leapp
+    targets:
+    - epel-7-x86_64
+    - epel-8-x86_64
+  actions:
+    create-archive:
+    - bash -c "rm -f packaging/deps-pkgs.tar.gz"
+    - bash -c "make source"
+    - bash -c "mv packaging/sources/*.gz packaging/"
+    - bash -c "find packaging/*.gz -type f"
+    fix-spec-file:
+    - bash -c "sed -i -r \"0,/Release:/ s/Release:(\s*)\S*/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" packaging/leapp-repository.spec"
+    post-upstream-clone:
+    # builds from PRs should have lower NVR than those from master branch
+    - bash -c "sed -i \"s/1%{?dist}/0%{?dist}/g\" packaging/leapp-repository.spec"
+- job: copr_build
+  trigger: commit
+  metadata:
+    branch: master
+    owner: "@oamg"
+    project: leapp
+    targets:
+    - epel-7-x86_64
+    - epel-8-x86_64
+  actions:
+    create-archive:
+    - bash -c "rm -f packaging/deps-pkgs.tar.gz"
+    - bash -c "make source"
+    - bash -c "mv packaging/sources/*.gz packaging/"
+    - bash -c "find packaging/*.gz -type f"
+    fix-spec-file:
+    - bash -c "sed -i -r \"0,/Release:/ s/Release:(\s*)\S*/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" packaging/leapp-repository.spec"
+    post-upstream-clone:
+    # builds from master branch should start with 100 release, to have high priority
+    - bash -c "sed -i \"s/1%{?dist}/100%{?dist}/g\" packaging/leapp-repository.spec"
+- job: copr_build
+  trigger: release
+  metadata:
+    owner: "@oamg"
+    project: leapp
+    targets:
+    - epel-7-x86_64
+    - epel-8-x86_64
+  actions:
+    create-archive:
+    - bash -c "rm -f packaging/deps-pkgs.tar.gz"
+    - bash -c "make source"
+    - bash -c "mv packaging/sources/*.gz packaging/"
+    - bash -c "find packaging/*.gz -type f"
+    fix-spec-file:
+    - bash -c "sed -i -r \"0,/Release:/ s/Release:(\s*)\S*/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" packaging/leapp-repository.spec"
+    post-upstream-clone:
+    # builds from master branch should start with 100 release, to have high priority
+    - bash -c "sed -i \"s/1%{?dist}/100%{?dist}/g\" packaging/leapp-repository.spec"

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ clean:
 	@echo "--- Clean repo ---"
 	@rm -rf packaging/{sources,SRPMS,tmp,BUILD,BUILDROOT,RPMS}/
 	@rm -rf build/ dist/ *.egg-info .pytest_cache/
+	@rm -f *src.rpm packaging/*tar.gz
 	@find . -name 'leapp.db' | grep "\.leapp/leapp.db" | xargs rm -f
 	@find . -name '__pycache__' -exec rm -fr {} +
 	@find . -name '*.pyc' -exec rm -f {} +


### PR DESCRIPTION
Added .packit.yaml file for packit to build automatically packages
in the public COPR repo. The Makefile is updated to clean SRPMs
and tarballs created by packit.

Some notes:
- the release ID format created by Packit is different from the
  one we used before.
- to create tarballs from the CLI via Packit:
     $ packit source
- to create SRPM from the CLI via Packit:
     $ packit srpm
- using packit from the CLI modifies the SPEC file, be aware about
  that to be sure the SPEC file is not commited with unwanted
  changes
