### PR TITLE
The Modularity integration

### DIFF
--- a/repos/system_upgrade/common/actors/filterrpmtransactionevents/actor.py
+++ b/repos/system_upgrade/common/actors/filterrpmtransactionevents/actor.py
@@ -1,7 +1,10 @@
 from leapp.actors import Actor
-from leapp.models import (FilteredRpmTransactionTasks,
-                          InstalledRedHatSignedRPM, PESRpmTransactionTasks,
-                          RpmTransactionTasks)
+from leapp.models import (
+    FilteredRpmTransactionTasks,
+    InstalledRedHatSignedRPM,
+    PESRpmTransactionTasks,
+    RpmTransactionTasks
+)
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
@@ -29,11 +32,15 @@ class FilterRpmTransactionTasks(Actor):
         to_remove = set()
         to_keep = set()
         to_upgrade = set()
+        modules_to_enable = {}
+        modules_to_reset = {}
         for event in self.consume(RpmTransactionTasks, PESRpmTransactionTasks):
             local_rpms.update(event.local_rpms)
             to_install.update(event.to_install)
             to_remove.update(installed_pkgs.intersection(event.to_remove))
             to_keep.update(installed_pkgs.intersection(event.to_keep))
+            modules_to_enable.update({'{}:{}'.format(m.name, m.stream): m for m in event.modules_to_enable})
+            modules_to_reset.update({'{}:{}'.format(m.name, m.stream): m for m in event.modules_to_reset})
 
         to_remove.difference_update(to_keep)
 
@@ -45,4 +52,6 @@ class FilterRpmTransactionTasks(Actor):
             to_install=list(to_install),
             to_remove=list(to_remove),
             to_keep=list(to_keep),
-            to_upgrade=list(to_upgrade)))
+            to_upgrade=list(to_upgrade),
+            modules_to_reset=list(modules_to_reset.values()),
+            modules_to_enable=list(modules_to_enable.values())))

--- a/repos/system_upgrade/common/actors/filterrpmtransactionevents/tests/test_filterrpmtransactionevents.py
+++ b/repos/system_upgrade/common/actors/filterrpmtransactionevents/tests/test_filterrpmtransactionevents.py
@@ -1,6 +1,5 @@
+from leapp.models import FilteredRpmTransactionTasks, InstalledRedHatSignedRPM, Module, RPM, RpmTransactionTasks
 from leapp.snactor.fixture import current_actor_context
-from leapp.models import RPM, InstalledRedHatSignedRPM, FilteredRpmTransactionTasks, RpmTransactionTasks
-
 
 RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
 
@@ -16,13 +15,31 @@ def test_actor_execution_with_sample_data(current_actor_context):
             pgpsig='SOME_PGP_SIG'),
         RPM(name='sample02', version='0.1', release='1.sm01', epoch='1', packager=RH_PACKAGER, arch='noarch',
             pgpsig='SOME_PGP_SIG')]
+    modules_to_enable = [Module(name='enable', stream='1'), Module(name='enable', stream='2')]
+    modules_to_reset = [Module(name='reset', stream='1'), Module(name='reset', stream='2')]
     current_actor_context.feed(InstalledRedHatSignedRPM(items=installed_rpm))
     current_actor_context.feed(RpmTransactionTasks(
         to_remove=[rpm.name for rpm in installed_rpm],
-        to_keep=[installed_rpm[0].name]
+        to_keep=[installed_rpm[0].name],
+        modules_to_enable=modules_to_enable,
+        modules_to_reset=modules_to_reset,
+    ))
+    current_actor_context.feed(RpmTransactionTasks(
+        modules_to_enable=modules_to_enable,
+        modules_to_reset=modules_to_reset,
     ))
     current_actor_context.run()
     result = current_actor_context.consume(FilteredRpmTransactionTasks)
     assert len(result) == 1
     assert result[0].to_keep == [installed_rpm[0].name]
     assert result[0].to_remove == [installed_rpm[1].name]
+
+    assert len(result[0].modules_to_enable) == 2
+    assert all(m.name == 'enable' for m in result[0].modules_to_enable)
+    assert '1' in {m.stream for m in result[0].modules_to_enable}
+    assert '2' in {m.stream for m in result[0].modules_to_enable}
+
+    assert len(result[0].modules_to_reset) == 2
+    assert all(m.name == 'reset' for m in result[0].modules_to_reset)
+    assert '1' in {m.stream for m in result[0].modules_to_reset}
+    assert '2' in {m.stream for m in result[0].modules_to_reset}

--- a/repos/system_upgrade/common/actors/getenabledmodules/actor.py
+++ b/repos/system_upgrade/common/actors/getenabledmodules/actor.py
@@ -1,0 +1,19 @@
+from leapp.actors import Actor
+from leapp.libraries.common.module import get_enabled_modules
+from leapp.models import EnabledModules, Module
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class GetEnabledModules(Actor):
+    """
+    Provides data about which module streams are enabled on the source system.
+    """
+
+    name = 'get_enabled_modules'
+    consumes = ()
+    produces = (EnabledModules,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        modules = [Module(name=m.getName(), stream=m.getStream()) for m in get_enabled_modules()]
+        self.produce(EnabledModules(modules=modules))

--- a/repos/system_upgrade/common/actors/peseventsscanner/actor.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/actor.py
@@ -1,13 +1,14 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.peseventsscanner import pes_events_scanner
 from leapp.models import (
+    EnabledModules,
     InstalledRedHatSignedRPM,
     PESRpmTransactionTasks,
     RepositoriesBlacklisted,
     RepositoriesFacts,
     RepositoriesMapping,
     RepositoriesSetupTasks,
-    RpmTransactionTasks,
+    RpmTransactionTasks
 )
 from leapp.reporting import Report
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
@@ -15,7 +16,7 @@ from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 class PesEventsScanner(Actor):
     """
-    Provides data about packages events from Package Evolution Service.
+    Provides data about package events from Package Evolution Service.
 
     After collecting data from a provided JSON file containing Package Evolution Service events, a
     message with relevant data will be produced to help DNF Upgrade transaction calculation.
@@ -23,6 +24,7 @@ class PesEventsScanner(Actor):
 
     name = 'pes_events_scanner'
     consumes = (
+        EnabledModules,
         InstalledRedHatSignedRPM,
         RepositoriesBlacklisted,
         RepositoriesFacts,

--- a/repos/system_upgrade/common/actors/peseventsscanner/tests/files/sample04.json
+++ b/repos/system_upgrade/common/actors/peseventsscanner/tests/files/sample04.json
@@ -1,0 +1,48 @@
+{
+  "packageinfo": [
+    {
+      "id": 1,
+      "action": 4,
+      "in_packageset": { "set_id": 1, "package": [{ "name": "original", "repository": "repo", "modulestreams": [null, { "name": "module", "stream": "stream_in" }] }] },
+      "out_packageset": {
+        "set_id": 2,
+        "package": [
+          {
+            "name": "split01",
+            "repository": "repo",
+            "modulestreams": [null, { "name": "module", "stream": "stream_out" }]
+          },
+          {
+            "name": "split02",
+            "repository": "repo",
+            "modulestreams": [null, { "name": "module", "stream": "stream_out" }]
+          }
+        ]
+      },
+      "modulestream_maps": [
+        {
+          "in_modulestream": null,
+          "out_modulestream": {
+            "name": "module",
+            "stream": "stream_out"
+          }
+        },
+        {
+          "in_modulestream": {
+            "name": "module",
+            "stream": "stream_in"
+          },
+          "out_modulestream": null
+        }
+      ],
+      "release": { "z_stream": null, "major_version": 8, "tag": null, "os_name": "RHEL", "minor_version": 0 }
+    },
+    {
+      "id": 2,
+      "action": 1,
+      "in_packageset": { "set_id": 3, "package": [{ "name": "removed", "repository": "repo" }] },
+      "out_packageset": null,
+      "release": { "z_stream": null, "major_version": 8, "tag": null, "os_name": "RHEL", "minor_version": 0 }
+    }
+  ]
+}

--- a/repos/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py
+++ b/repos/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py
@@ -1,13 +1,22 @@
+import functools
 import os
 import subprocess
-import functools
 
 import pyudev
 
-from leapp.models import StorageInfo, PartitionEntry, FstabEntry, MountEntry, LsblkEntry, \
-    PvsEntry, VgsEntry, LvdisplayEntry, SystemdMountEntry
 from leapp import reporting
 from leapp.libraries.stdlib import api
+from leapp.models import (
+    FstabEntry,
+    LsblkEntry,
+    LvdisplayEntry,
+    MountEntry,
+    PartitionEntry,
+    PvsEntry,
+    StorageInfo,
+    SystemdMountEntry,
+    VgsEntry
+)
 
 
 def aslist(f):

--- a/repos/system_upgrade/common/actors/storagescanner/tests/unit_test_storagescanner.py
+++ b/repos/system_upgrade/common/actors/storagescanner/tests/unit_test_storagescanner.py
@@ -1,5 +1,5 @@
-import os
 import functools
+import os
 
 import pyudev
 
@@ -7,9 +7,16 @@ from leapp import reporting
 from leapp.libraries.actor import storagescanner
 from leapp.libraries.common.testutils import create_report_mocked, logger_mocked
 from leapp.libraries.stdlib import api
-from leapp.models import (FstabEntry, LsblkEntry, LvdisplayEntry, MountEntry, PartitionEntry, PvsEntry,
-                          SystemdMountEntry, VgsEntry, )
-
+from leapp.models import (
+    FstabEntry,
+    LsblkEntry,
+    LvdisplayEntry,
+    MountEntry,
+    PartitionEntry,
+    PvsEntry,
+    SystemdMountEntry,
+    VgsEntry
+)
 
 CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 

--- a/repos/system_upgrade/common/libraries/config/version.py
+++ b/repos/system_upgrade/common/libraries/config/version.py
@@ -35,6 +35,16 @@ def get_major_version(version):
     return version.split('.')[0]
 
 
+def get_source_version():
+    """
+    Return the version of the source system.
+
+    :rtype: str
+    :returns: The version of the source system.
+    """
+    return api.current_actor().configuration.version.source
+
+
 def get_source_major_version():
     """
     Return the major version of the source (original) system.
@@ -44,7 +54,17 @@ def get_source_major_version():
     :rtype: str
     :returns: The major version of the source system.
     """
-    return get_major_version(api.current_actor().configuration.version.source)
+    return get_major_version(get_source_version())
+
+
+def get_target_version():
+    """
+    Return the version of the target system.
+
+    :rtype: str
+    :returns: The version of the target system.
+    """
+    return api.current_actor().configuration.version.target
 
 
 def get_target_major_version():
@@ -56,7 +76,7 @@ def get_target_major_version():
     :rtype: str
     :returns: The major version of the target system.
     """
-    return get_major_version(api.current_actor().configuration.version.target)
+    return get_major_version(get_target_version())
 
 
 class _SupportedVersionsDict(dict):
@@ -186,8 +206,7 @@ def matches_source_version(*match_list):
     :param match_list: specification of versions to check against
     :type match_list: strings, for details see argument ``match_list`` of function :func:`matches_version`.
     """
-    source_version = api.current_actor().configuration.version.source
-    return matches_version(match_list, source_version)
+    return matches_version(match_list, get_source_version())
 
 
 def matches_target_version(*match_list):
@@ -197,8 +216,7 @@ def matches_target_version(*match_list):
     :param match_list: specification of versions to check against
     :type match_list: strings, for details see argument ``match_list`` of function :func:`matches_version`.
     """
-    target_version = api.current_actor().configuration.version.target
-    return matches_version(match_list, target_version)
+    return matches_version(match_list, get_target_version())
 
 
 def matches_release(allowed_releases, release):

--- a/repos/system_upgrade/common/libraries/dnfplugin.py
+++ b/repos/system_upgrade/common/libraries/dnfplugin.py
@@ -6,7 +6,11 @@ import shutil
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import dnfconfig, guards, mounting, overlaygen, rhsm, utils
-from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
+from leapp.libraries.common.config.version import (
+    get_source_major_version,
+    get_target_major_version,
+    get_target_version
+)
 from leapp.libraries.stdlib import api, CalledProcessError, config
 
 DNF_PLUGIN_NAME = 'rhel_upgrade.py'
@@ -83,7 +87,9 @@ def build_plugin_data(target_repoids, debug, test, tasks, on_aws):
             'local_rpms': [os.path.join('/installroot', pkg.lstrip('/')) for pkg in tasks.local_rpms],
             'to_install': tasks.to_install,
             'to_remove': tasks.to_remove,
-            'to_upgrade': tasks.to_upgrade
+            'to_upgrade': tasks.to_upgrade,
+            'modules_to_enable': ['{}:{}'.format(m.name, m.stream) for m in tasks.modules_to_enable],
+            'modules_to_reset': ['{}:{}'.format(m.name, m.stream) for m in tasks.modules_to_reset],
         },
         'dnf_conf': {
             'allow_erasing': True,
@@ -93,7 +99,7 @@ def build_plugin_data(target_repoids, debug, test, tasks, on_aws):
             'enable_repos': target_repoids,
             'gpgcheck': False,
             'platform_id': 'platform:el{}'.format(get_target_major_version()),
-            'releasever': api.current_actor().configuration.version.target,
+            'releasever': get_target_version(),
             'installroot': '/installroot',
             'test_flag': test
         },

--- a/repos/system_upgrade/common/libraries/module.py
+++ b/repos/system_upgrade/common/libraries/module.py
@@ -1,0 +1,71 @@
+import warnings
+
+try:
+    import dnf
+except ImportError:
+    dnf = None
+    warnings.warn('Could not import the `dnf` python module.', ImportWarning)
+
+try:
+    import hawkey
+except ImportError:
+    hawkey = None
+    warnings.warn('Could not import the `hawkey` python module.', ImportWarning)
+
+
+def _create_or_get_dnf_base(base=None):
+    if not base:
+        base = dnf.Base()
+        base.read_all_repos()
+        base.fill_sack()
+    return base
+
+
+def get_modules(base=None):
+    """
+    Return info about all module streams as a list of libdnf.module.ModulePackage objects.
+    """
+    if not dnf:
+        return []
+    base = _create_or_get_dnf_base(base)
+
+    module_base = dnf.module.module_base.ModuleBase(base)
+    # this method is absent on RHEL 7, in which case there are no modules anyway
+    if not hasattr(module_base, 'get_modules'):
+        return []
+    return module_base.get_modules('*')[0]
+
+
+def get_enabled_modules():
+    """
+    Return currently enabled module streams as a list of libdnf.module.ModulePackage objects.
+    """
+    if not dnf:
+        return []
+
+    base = _create_or_get_dnf_base()
+    modules = get_modules(base)
+
+    # if modules are not supported (RHEL 7), base.sack._moduleContainer won't exist
+    # luckily in that case modules are empty and the element won't even be accessed
+    return [m for m in modules if base.sack._moduleContainer.isEnabled(m)]
+
+
+def map_installed_rpms_to_modules():
+    """
+    Map installed modular packages to the module streams they come from.
+    """
+    modules = get_modules()
+    # empty on RHEL 7 because of no modules
+    if not modules:
+        return {}
+    # create a reverse mapping from the RPMS to module streams
+    # key: tuple of 4 strings representing a NVRA (name, version, release, arch) of an RPM
+    # value: tuple of 2 strings representing a module and its stream
+    rpm_streams = {}
+    for module in modules:
+        for rpm in module.getArtifacts():
+            nevra = hawkey.split_nevra(rpm)
+            rpm_key = (nevra.name, nevra.version, nevra.release, nevra.arch)
+            rpm_streams[rpm_key] = (module.getName(), module.getStream())
+    return rpm_streams

--- a/repos/system_upgrade/common/libraries/persistentnetnames.py
+++ b/repos/system_upgrade/common/libraries/persistentnetnames.py
@@ -1,7 +1,7 @@
 import pyudev
 
-from leapp.models import PCIAddress, Interface
 from leapp.libraries.stdlib import api
+from leapp.models import Interface, PCIAddress
 
 udev_context = pyudev.Context()
 

--- a/repos/system_upgrade/common/libraries/tests/test_dnfplugin.py
+++ b/repos/system_upgrade/common/libraries/tests/test_dnfplugin.py
@@ -1,0 +1,216 @@
+from collections import namedtuple
+
+import pytest
+
+import leapp.models
+from leapp.libraries.common import dnfplugin
+from leapp.libraries.common.config.version import get_major_version
+from leapp.models.fields import Boolean
+from leapp.topics import Topic
+
+
+class DATADnfPluginDataTopic(Topic):
+    name = 'data_dnf_plugin_data'
+
+
+fields = leapp.models.fields
+
+TaskData = namedtuple('TaskData', 'expected initdata')
+
+TEST_INSTALL_PACKAGES = TaskData(
+    expected=('install1', 'install2'),
+    initdata=('install1', 'install2')
+)
+TEST_REMOVE_PACKAGES = TaskData(
+    expected=('remove1', 'remove2'),
+    initdata=('remove1', 'remove2'),
+)
+TEST_UPGRADE_PACKAGES = TaskData(
+    expected=('upgrade1', 'upgrade2'),
+    initdata=('upgrade1', 'upgrade2'),
+)
+TEST_ENABLE_MODULES = TaskData(
+    expected=('enable1:stream1', 'enable2:stream2'),
+    initdata=(
+        leapp.models.Module(name='enable1', stream='stream1'),
+        leapp.models.Module(name='enable2', stream='stream2'),
+    )
+)
+TEST_RESET_MODULES = TaskData(
+    expected=('reset1:stream1', 'reset2:stream2'),
+    initdata=(
+        leapp.models.Module(name='reset1', stream='stream1'),
+        leapp.models.Module(name='reset2', stream='stream2'),
+    )
+)
+
+
+class DATADnfPluginDataPkgsInfo(leapp.models.Model):
+    topic = DATADnfPluginDataTopic
+    local_rpms = fields.List(fields.String())
+    to_install = fields.List(fields.StringEnum(choices=TEST_INSTALL_PACKAGES.expected))
+    to_remove = fields.List(fields.StringEnum(choices=TEST_REMOVE_PACKAGES.expected))
+    to_upgrade = fields.List(fields.StringEnum(choices=TEST_UPGRADE_PACKAGES.expected))
+    modules_to_enable = fields.List(fields.StringEnum(choices=TEST_ENABLE_MODULES.expected))
+    modules_to_reset = fields.List(fields.StringEnum(choices=TEST_RESET_MODULES.expected))
+
+
+TEST_ENABLE_REPOS_CHOICES = ('enabled_repo', 'BASEOS', 'APPSTREAM')
+
+
+class BooleanEnum(fields.EnumMixin, Boolean):
+    pass
+
+
+class DATADnfPluginDataDnfConf(leapp.models.Model):
+    topic = DATADnfPluginDataTopic
+    allow_erasing = BooleanEnum(choices=[True])
+    best = BooleanEnum(choices=[True])
+    debugsolver = fields.Boolean()
+    disable_repos = BooleanEnum(choices=[True])
+    enable_repos = fields.List(fields.StringEnum(choices=TEST_ENABLE_REPOS_CHOICES))
+    gpgcheck = BooleanEnum(choices=[False])
+    platform_id = fields.StringEnum(choices=['platform:el8', 'platform:el9'])
+    releasever = fields.String()
+    installroot = fields.StringEnum(choices=['/installroot'])
+    test_flag = fields.Boolean()
+
+
+class DATADnfPluginDataRHUIAWS(leapp.models.Model):
+    topic = DATADnfPluginDataTopic
+    on_aws = fields.Boolean()
+    region = fields.Nullable(fields.String())
+
+
+class DATADnfPluginDataRHUI(leapp.models.Model):
+    topic = DATADnfPluginDataTopic
+    aws = fields.Model(DATADnfPluginDataRHUIAWS)
+
+
+class DATADnfPluginData(leapp.models.Model):
+    topic = DATADnfPluginDataTopic
+    pkgs_info = fields.Model(DATADnfPluginDataPkgsInfo)
+    dnf_conf = fields.Model(DATADnfPluginDataDnfConf)
+    rhui = fields.Model(DATADnfPluginDataRHUI)
+
+
+# Delete those models from leapp.models to 'unpolute' the module
+del leapp.models.DATADnfPluginDataPkgsInfo
+del leapp.models.DATADnfPluginDataDnfConf
+del leapp.models.DATADnfPluginDataRHUI
+del leapp.models.DATADnfPluginDataRHUIAWS
+del leapp.models.DATADnfPluginData
+
+
+def _mocked_get_target_major_version(version):
+    def impl():
+        return version
+    return impl
+
+
+def _mocked_api_get_file_path(name):
+    return 'some/random/file/path/{}'.format(name)
+
+
+_CONFIG_BUILD_TEST_DEFINITION = (
+    #   Parameter, Input Data, Expected Fields with data
+    ('debug', False, ('dnf_conf', 'debugsolver'), False),
+    ('debug', True, ('dnf_conf', 'debugsolver'), True),
+    ('target_repoids', TEST_ENABLE_REPOS_CHOICES, ('dnf_conf', 'enable_repos'), list(TEST_ENABLE_REPOS_CHOICES)),
+    ('target_repoids', TEST_ENABLE_REPOS_CHOICES[0:1],
+     ('dnf_conf', 'enable_repos'), list(TEST_ENABLE_REPOS_CHOICES[0:1])),
+    ('target_repoids', TEST_ENABLE_REPOS_CHOICES[1:],
+     ('dnf_conf', 'enable_repos'), list(TEST_ENABLE_REPOS_CHOICES[1:])),
+    ('target_repoids', TEST_ENABLE_REPOS_CHOICES[2:],
+     ('dnf_conf', 'enable_repos'), list(TEST_ENABLE_REPOS_CHOICES[2:])),
+    ('test', False, ('dnf_conf', 'test_flag'), False),
+    ('test', True, ('dnf_conf', 'test_flag'), True),
+)
+
+
+@pytest.mark.parametrize('used_target_version', ['8.4', '8.5', '9.0', '9.1'])
+@pytest.mark.parametrize('parameter,input_value,test_path,expected_value', _CONFIG_BUILD_TEST_DEFINITION)
+def test_build_plugin_data_variations(
+    monkeypatch,
+    used_target_version,
+    parameter,
+    input_value,
+    test_path,
+    expected_value,
+):
+    used_target_major_version = get_major_version(used_target_version)
+    monkeypatch.setattr(dnfplugin, 'get_target_version', _mocked_get_target_major_version(used_target_version))
+    monkeypatch.setattr(dnfplugin, 'get_target_major_version',
+                        _mocked_get_target_major_version(used_target_major_version))
+    inputs = {
+        'target_repoids': ['BASEOS', 'APPSTREAM'],
+        'debug': True,
+        'test': True,
+        'on_aws': False,
+        'tasks': leapp.models.FilteredRpmTransactionTasks(
+            to_install=TEST_INSTALL_PACKAGES.initdata,
+            to_remove=TEST_REMOVE_PACKAGES.initdata,
+            to_upgrade=TEST_UPGRADE_PACKAGES.initdata,
+            modules_to_enable=TEST_ENABLE_MODULES.initdata,
+            modules_to_reset=TEST_RESET_MODULES.initdata
+            )
+    }
+    inputs[parameter] = input_value
+    created = DATADnfPluginData.create(
+        dnfplugin.build_plugin_data(
+            **inputs
+        )
+    )
+    assert created.dnf_conf.platform_id == 'platform:el{}'.format(used_target_major_version)
+    assert created.dnf_conf.releasever == used_target_version
+    value = created
+    for path in test_path:
+        value = getattr(value, path)
+    assert value == expected_value
+
+
+def test_build_plugin_data(monkeypatch):
+    monkeypatch.setattr(dnfplugin, 'get_target_version', _mocked_get_target_major_version('8.4'))
+    monkeypatch.setattr(dnfplugin, 'get_target_major_version', _mocked_get_target_major_version('8'))
+    # Use leapp to validate format and data
+    created = DATADnfPluginData.create(
+        dnfplugin.build_plugin_data(
+            target_repoids=['BASEOS', 'APPSTREAM'],
+            debug=True,
+            test=True,
+            on_aws=False,
+            tasks=leapp.models.FilteredRpmTransactionTasks(
+                to_install=TEST_INSTALL_PACKAGES.initdata,
+                to_remove=TEST_REMOVE_PACKAGES.initdata,
+                to_upgrade=TEST_UPGRADE_PACKAGES.initdata,
+                modules_to_enable=TEST_ENABLE_MODULES.initdata,
+                modules_to_reset=TEST_RESET_MODULES.initdata
+                )
+            )
+    )
+    assert created.dnf_conf.debugsolver is True
+    assert created.dnf_conf.test_flag is True
+    assert created.rhui.aws.on_aws is False
+    assert created.pkgs_info.modules_to_reset == list(TEST_RESET_MODULES.expected)
+
+    with pytest.raises(fields.ModelViolationError):
+        DATADnfPluginData.create(
+            dnfplugin.build_plugin_data(
+                target_repoids=['BASEOS', 'APPSTREAM'],
+                debug=True,
+                test=True,
+                on_aws=False,
+                tasks=leapp.models.FilteredRpmTransactionTasks(
+                    to_install=TEST_INSTALL_PACKAGES.initdata,
+                    to_remove=TEST_REMOVE_PACKAGES.initdata,
+                    to_upgrade=TEST_UPGRADE_PACKAGES.initdata,
+                    modules_to_enable=TEST_ENABLE_MODULES.initdata,
+                    # Enforcing the failure
+                    modules_to_reset=(
+                        leapp.models.Module(
+                            name='broken', stream=None
+                        ),
+                    ),
+                )
+            )
+        )

--- a/repos/system_upgrade/common/libraries/tests/test_persistentnetnames_library.py
+++ b/repos/system_upgrade/common/libraries/tests/test_persistentnetnames_library.py
@@ -1,6 +1,6 @@
 from leapp.libraries.common import persistentnetnames
-from leapp.libraries.stdlib import api
 from leapp.libraries.common.testutils import produce_mocked
+from leapp.libraries.stdlib import api
 
 
 class AttributesTest(object):

--- a/repos/system_upgrade/common/libraries/tests/test_utils_logging_handler.py
+++ b/repos/system_upgrade/common/libraries/tests/test_utils_logging_handler.py
@@ -2,8 +2,8 @@
 import os.path
 import sys
 
-from leapp.libraries.common.utils import logging_handler, config
-from leapp.libraries.stdlib.call import STDOUT, STDERR
+from leapp.libraries.common.utils import config, logging_handler
+from leapp.libraries.stdlib.call import STDERR, STDOUT
 
 
 def test_logging_handler(capfdbinary, monkeypatch):

--- a/repos/system_upgrade/common/libraries/utils.py
+++ b/repos/system_upgrade/common/libraries/utils.py
@@ -6,7 +6,7 @@ import six
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import mounting
-from leapp.libraries.stdlib import STDOUT, CalledProcessError, api, config, run
+from leapp.libraries.stdlib import api, CalledProcessError, config, run, STDOUT
 
 
 def parse_config(cfg=None, strict=True):

--- a/repos/system_upgrade/common/models/module.py
+++ b/repos/system_upgrade/common/models/module.py
@@ -1,0 +1,20 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemFactsTopic
+
+
+class Module(Model):
+    """
+    A single DNF module indentified by its name and stream.
+    """
+    topic = SystemFactsTopic
+    name = fields.String()
+    stream = fields.String()
+
+
+class EnabledModules(Model):
+    """
+    DNF modules enabled on the source system.
+    """
+    topic = SystemFactsTopic
+
+    modules = fields.List(fields.Model(Module), default=[])

--- a/repos/system_upgrade/common/models/rpmtransactiontasks.py
+++ b/repos/system_upgrade/common/models/rpmtransactiontasks.py
@@ -1,4 +1,4 @@
-from leapp.models import Model, fields
+from leapp.models import fields, Model, Module
 from leapp.topics import TransactionTopic
 
 
@@ -10,6 +10,8 @@ class RpmTransactionTasks(Model):
     to_keep = fields.List(fields.String(), default=[])
     to_remove = fields.List(fields.String(), default=[])
     to_upgrade = fields.List(fields.String(), default=[])
+    modules_to_enable = fields.List(fields.Model(Module), default=[])
+    modules_to_reset = fields.List(fields.Model(Module), default=[])
 
 
 class FilteredRpmTransactionTasks(RpmTransactionTasks):

--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/libraries/repositoriesblacklist.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/libraries/repositoriesblacklist.py
@@ -2,12 +2,7 @@ from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
 from leapp.libraries.stdlib import api
-from leapp.models import (
-    CustomTargetRepository,
-    RepositoriesBlacklisted,
-    RepositoriesFacts,
-    RepositoriesMapping
-)
+from leapp.models import CustomTargetRepository, RepositoriesBlacklisted, RepositoriesFacts, RepositoriesMapping
 
 # {OS_MAJOR_VERSION: PESID}
 UNSUPPORTED_PESIDS = {
@@ -39,7 +34,7 @@ def _report_excluded_repos(repos):
     )
 
     report = [
-        reporting.Title("Excluded RHEL 8 repositories"),
+        reporting.Title("Excluded target system repositories"),
         reporting.Summary(
             "The following repositories are not supported by "
             "Red Hat and are excluded from the list of repositories "

--- a/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/tests/test_repositoriesblacklist.py
+++ b/repos/system_upgrade/el7toel8/actors/repositoriesblacklist/tests/test_repositoriesblacklist.py
@@ -2,22 +2,18 @@ import pytest
 
 from leapp import reporting
 from leapp.libraries.actor import repositoriesblacklist
-from leapp.libraries.common.testutils import (
-    CurrentActorMocked,
-    create_report_mocked,
-    produce_mocked,
-)
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, produce_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import (
     CustomTargetRepository,
     EnvVar,
+    PESIDRepositoryEntry,
+    RepoMapEntry,
     RepositoriesBlacklisted,
     RepositoriesFacts,
-    RepositoryData,
-    RepositoryFile,
     RepositoriesMapping,
-    PESIDRepositoryEntry,
-    RepoMapEntry
+    RepositoryData,
+    RepositoryFile
 )
 
 
@@ -190,8 +186,8 @@ def test_repositoriesblacklist_empty(monkeypatch, repofacts_opts_disabled, repom
     ("enabled_repo", "exp_report_title", "message_produced"),
     [
         ("codeready-builder-for-rhel-8-x86_64-rpms", "Using repository not supported by Red Hat", False),
-        ("some_other_enabled_repo", "Excluded RHEL 8 repositories", True),
-        (None, "Excluded RHEL 8 repositories", True),
+        ("some_other_enabled_repo", "Excluded target system repositories", True),
+        (None, "Excluded target system repositories", True),
     ],
 )
 def test_enablerepo_option(monkeypatch,


### PR DESCRIPTION
    This patch introduces support for modularity.

    PES events will drive what module streams are going to be enabled and
    reset. Additionally users can now request module streams to be enabled
    or reset via the `RPMTransactionTasks` message by filling the
    `modules_to_enable` or `modules_to_reset` respectively.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>

NOTE(pirat89): the reset of module-streams is not working yet and has been commented out in this pr from our upgrade dnf plugin. The fix will be delivered in a following PR