### PR TITLE
xfsinfoscanner: Do not use systemd-mount data

### DIFF
--- a/repos/system_upgrade/common/actors/xfsinfoscanner/libraries/xfsinfoscanner.py
+++ b/repos/system_upgrade/common/actors/xfsinfoscanner/libraries/xfsinfoscanner.py
@@ -20,15 +20,6 @@ def scan_xfs_mount(data):
     return mountpoints
 
 
-def scan_xfs_systemdmount(data):
-    mountpoints = set()
-    for entry in data:
-        if entry.fs_type == "xfs":
-            mountpoints.add(entry.path)
-
-    return mountpoints
-
-
 def is_xfs_without_ftype(mp):
     for l in run(['/usr/sbin/xfs_info', '{}'.format(mp)], split=True)['stdout']:
         if 'ftype=0' in l:
@@ -46,13 +37,11 @@ def scan_xfs():
 
     fstab_data = set()
     mount_data = set()
-    systemdmount_data = set()
     if storage_info:
         fstab_data = scan_xfs_fstab(storage_info.fstab)
         mount_data = scan_xfs_mount(storage_info.mount)
-        systemdmount_data = scan_xfs_systemdmount(storage_info.systemdmount)
 
-    mountpoints = fstab_data | mount_data | systemdmount_data
+    mountpoints = fstab_data | mount_data
     mountpoints_ftype0 = list(filter(is_xfs_without_ftype, mountpoints))
 
     # By now, we only have XFS mountpoints and check whether or not it has ftype = 0

--- a/repos/system_upgrade/common/actors/xfsinfoscanner/tests/unit_test_xfsinfoscanner.py
+++ b/repos/system_upgrade/common/actors/xfsinfoscanner/tests/unit_test_xfsinfoscanner.py
@@ -85,32 +85,6 @@ def test_scan_xfs_mount(monkeypatch):
     assert mountpoints == {"/boot"}
 
 
-def test_scan_xfs_systemdmount(monkeypatch):
-    systemdmount_data_no_xfs = {
-        "node": "/dev/sda1",
-        "path": "pci-0000:00:17.0-ata-2",
-        "model": "TOSHIBA_THNSNJ512GDNU_A",
-        "wwn": "0x500080d9108e8753",
-        "fs_type": "ext4",
-        "label": "n/a",
-        "uuid": "5675d309-eff7-4eb1-9c27-58bc5880ec72"}
-
-    mountpoints = xfsinfoscanner.scan_xfs_systemdmount([SystemdMountEntry(**systemdmount_data_no_xfs)])
-    assert not mountpoints
-
-    systemdmount_data_xfs = {
-        "node": "/dev/sda1",
-        "path": "/var",
-        "model": "n/a",
-        "wwn": "n/a",
-        "fs_type": "xfs",
-        "label": "n/a",
-        "uuid": "n/a"}
-
-    mountpoints = xfsinfoscanner.scan_xfs_systemdmount([SystemdMountEntry(**systemdmount_data_xfs)])
-    assert mountpoints == {"/var"}
-
-
 def test_is_xfs_without_ftype(monkeypatch):
     monkeypatch.setattr(xfsinfoscanner, "run", run_mocked())
 


### PR DESCRIPTION

The data from systemd-mount is not relevant for the xfsinfoscanner. All
the parititions mounted are reported through /proc/mounts and the output
as is from systemd-mount --list is not giving us any additionally useful
output. It rather caused problems by having PCI addresses as mount
paths, which caused failures when we tried to get the information if the
xfs partition has ftype=0.