### PR TITLE
Replace action tag with sha in PR welcome msg action

### DIFF
--- a/.github/workflows/pr-welcome-msg.yml
+++ b/.github/workflows/pr-welcome-msg.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |


### PR DESCRIPTION
Change made after discussion with @Rezney, to be safer with unverified action. (more [here](https://julienrenaux.fr/2019/12/20/github-actions-security-risk/))

Action needs to be enabled in organization settings, see [docs](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#managing-github-actions-permissions-for-your-organization).