### PR TITLE
tests: Start using github actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,25 @@
+name: Unit Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Run unit tests in containers
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - python3.6
+          - python2.7
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run tests @ ${{matrix.python}}
+        run: script -e -c /bin/bash -c 'TERM=xterm docker build -t leapp-tests -f utils/docker-tests/Dockerfile utils/docker-tests && PYTHON_VENV=${{matrix.python}}  docker run --rm -ti -v ${PWD}:/payload --env=PYTHON_VENV leapp-tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,6 @@ install:
 
 jobs:
   include:
-    - script:
-        - docker run --env CI=$CI --rm -ti -v ${PWD}:/payload --env=PYTHON_VENV leapp-tests
-      env: PYTHON_VENV=python2.7
-    - script:
-        - docker run --env CI=$CI --rm -ti -v ${PWD}:/payload --env=PYTHON_VENV leapp-tests
-      env: PYTHON_VENV=python3.6
     - stage: deploy
       script:
         - docker run --env CI=$CI --rm -ti -v ${PWD}:/payload --entrypoint "/bin/bash" leapp-tests -c "make install-deps && make dashboard_data"


### PR DESCRIPTION
Previously we did use travis, however since we are being now required to
subscribe to a paid plan to cover our tests we will switch to GitHub
Actions.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>