### PR TITLE
FIX: Add missing SYSTEMD_SECCOMP environment variable

### DIFF
--- a/repos/system_upgrade/common/libraries/dnfplugin.py
+++ b/repos/system_upgrade/common/libraries/dnfplugin.py
@@ -242,7 +242,11 @@ def install_initramdisk_requirements(packages, target_userspace_info, used_repos
             cmd.append('-v')
         if rhsm.skip_rhsm():
             cmd += ['--disableplugin', 'subscription-manager']
-        context.call(cmd)
+        env = {}
+        if get_target_major_version() == '9':
+            # allow handling new RHEL 9 syscalls by systemd-nspawn
+            env = {'SYSTEMD_SECCOMP': '0'}
+        context.call(cmd, env=env)
 
 
 def perform_transaction_install(target_userspace_info, storage_info, used_repos, tasks, plugin_info):


### PR DESCRIPTION
During the improvements for RHEL9 compatibility we added the
SYSTEMD_SECCOMP environment variable for calls to DNF. This
positively impacts DNS resolution.
In case of the installation of additional packages for the initramfs
we did overlook this and it resulted in DNF not being able to resolve
the hostnames.
This patchs adds the SYSTEMD_SECCOMP environment variable also for the
DNF call do install additional packages.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>