### PR TITLE
Add detection of enabled yum plugins.

### DIFF
--- a/repos/system_upgrade/common/actors/checkyumpluginsenabled/actor.py
+++ b/repos/system_upgrade/common/actors/checkyumpluginsenabled/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.checkyumpluginsenabled import check_required_yum_plugins_enabled
+from leapp.models import YumConfig
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckYumPluginsEnabled(Actor):
+    """
+    Checks that the required yum plugins are enabled.
+    """
+
+    name = 'check_yum_plugins_enabled'
+    consumes = (YumConfig,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        yum_config = next(self.consume(YumConfig))
+        check_required_yum_plugins_enabled(yum_config)

--- a/repos/system_upgrade/common/actors/checkyumpluginsenabled/libraries/checkyumpluginsenabled.py
+++ b/repos/system_upgrade/common/actors/checkyumpluginsenabled/libraries/checkyumpluginsenabled.py
@@ -1,0 +1,72 @@
+import os
+
+from leapp import reporting
+from leapp.libraries.common.config.version import get_source_major_version
+from leapp.libraries.common.rhsm import skip_rhsm
+
+# If LEAPP_NO_RHSM is set, subscription-manager and product-id will not be
+# considered as required when checking whether the required plugins are enabled.
+REQUIRED_YUM_PLUGINS = {'subscription-manager', 'product-id'}
+FMT_LIST_SEPARATOR = '\n    - '
+
+
+def check_required_yum_plugins_enabled(yum_config):
+    """
+    Checks whether the yum plugins required by the IPU are enabled.
+
+    If they are not enabled, a report is produced informing the user about it.
+
+    :param yum_config: YumConfig
+    """
+
+    missing_required_plugins = REQUIRED_YUM_PLUGINS - set(yum_config.enabled_plugins)
+
+    if skip_rhsm():
+        missing_required_plugins -= {'subscription-manager', 'product-id'}
+
+    if missing_required_plugins:
+        missing_required_plugins_text = ''
+        for missing_plugin in missing_required_plugins:
+            missing_required_plugins_text += '{0}{1}'.format(FMT_LIST_SEPARATOR, missing_plugin)
+
+        if get_source_major_version() == '7':
+            pkg_manager = 'YUM'
+            pkg_manager_config_path = '/etc/yum.conf'
+            plugin_configs_dir = '/etc/yum/pluginconf.d'
+        else:
+            # On RHEL8+ the yum package might not be installed
+            pkg_manager = 'DNF'
+            pkg_manager_config_path = '/etc/dnf/dnf.conf'
+            plugin_configs_dir = '/etc/dnf/plugins'
+
+        # pkg_manager_config_path - enable/disable plugins globally
+        # subscription_manager_plugin_conf, product_id_plugin_conf - plugins can be disabled individually
+        subscription_manager_plugin_conf = os.path.join(plugin_configs_dir, 'subscription-manager.conf')
+        product_id_plugin_conf = os.path.join(plugin_configs_dir, 'product-id.conf')
+
+        remediation_commands = [
+            'sed -i \'s/^plugins=0/plugins=1/\' \'{0}\''.format(pkg_manager_config_path),
+            'sed -i \'s/^enabled=0/enabled=1/\' \'{0}\''.format(subscription_manager_plugin_conf),
+            'sed -i \'s/^enabled=0/enabled=1/\' \'{0}\''.format(product_id_plugin_conf)
+        ]
+
+        reporting.create_report([
+            reporting.Title('Required {0} plugins are not being loaded.'.format(pkg_manager)),
+            reporting.Summary(
+                'The following {0} plugins are not being loaded: {1}'.format(pkg_manager,
+                                                                             missing_required_plugins_text)
+            ),
+            reporting.Remediation(
+                hint='If you have yum plugins globally disabled, please enable them by editing the {0}. '
+                     'Individually, the {1} plugins can be enabled in their corresponding configurations found at: {2}'
+                     .format(pkg_manager_config_path, pkg_manager, plugin_configs_dir),
+                # Provide all commands as one due to problems with satellites
+                commands=[['bash', '-c', '"{0}"'.format('; '.join(remediation_commands))]]
+            ),
+            reporting.RelatedResource('file', pkg_manager_config_path),
+            reporting.RelatedResource('file', subscription_manager_plugin_conf),
+            reporting.RelatedResource('file', product_id_plugin_conf),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.Tags([reporting.Tags.REPOSITORY]),
+        ])

--- a/repos/system_upgrade/common/actors/checkyumpluginsenabled/tests/test_checkyumpluginsenabled.py
+++ b/repos/system_upgrade/common/actors/checkyumpluginsenabled/tests/test_checkyumpluginsenabled.py
@@ -1,0 +1,39 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor.checkyumpluginsenabled import check_required_yum_plugins_enabled
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import YumConfig
+
+
+def test_report_when_missing_required_plugins(monkeypatch):
+    """Test whether a report entry is created when any of the required YUM plugins are missing."""
+    yum_config = YumConfig(enabled_plugins=['product-id', 'some-user-plugin'])
+
+    actor_reports = create_report_mocked()
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(reporting, 'create_report', actor_reports)
+
+    check_required_yum_plugins_enabled(yum_config)
+
+    assert actor_reports.called, 'Report wasn\'t created when required a plugin is missing.'
+
+    fail_description = 'The missing required plugin is not mentioned in the report.'
+    assert 'subscription-manager' in actor_reports.report_fields['summary'], fail_description
+
+    fail_description = 'The upgrade should be inhibited when plugins are not enabled.'
+    assert 'inhibitor' in actor_reports.report_fields['flags'], fail_description
+
+
+def test_nothing_is_reported_when_rhsm_disabled(monkeypatch):
+    actor_mocked = CurrentActorMocked(envars={'LEAPP_NO_RHSM': '1'})
+
+    monkeypatch.setattr(api, 'current_actor', actor_mocked)
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+
+    yum_config = YumConfig(enabled_plugins=[])
+    check_required_yum_plugins_enabled(yum_config)
+
+    assert not reporting.create_report.called, 'Report was created even if LEAPP_NO_RHSM was set'

--- a/repos/system_upgrade/common/actors/yumconfigscanner/actor.py
+++ b/repos/system_upgrade/common/actors/yumconfigscanner/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.yumconfigscanner import scan_yum_config
+from leapp.models import YumConfig
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class YumConfigScanner(Actor):
+    """
+    Scans the configuration of the YUM package manager.
+    """
+
+    name = 'yum_config_scanner'
+    consumes = ()
+    produces = (YumConfig,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        scan_yum_config()

--- a/repos/system_upgrade/common/actors/yumconfigscanner/libraries/yumconfigscanner.py
+++ b/repos/system_upgrade/common/actors/yumconfigscanner/libraries/yumconfigscanner.py
@@ -1,0 +1,82 @@
+import re
+
+from leapp.libraries.common.config.version import get_source_major_version
+from leapp.libraries.stdlib import api, run
+from leapp.models import YumConfig
+
+# When the output spans multiple lines, each of the lines after the first one
+# start with a '    <SPACES>    : '
+YUM_LOADED_PLUGINS_NEXT_LINE_START = ' +: '
+
+
+def _parse_loaded_plugins(yum_output):
+    """
+    Retrieves a list of plugins that are being loaded when calling yum.
+
+    :param dict yum_output: The result of running the yum command.
+    :rtype: list
+    :returns: A list of plugins that are being loaded when calling yum.
+    """
+    # YUM might break the information about loaded plugins into multiple lines,
+    # we need to concaternate the list ourselves
+    loaded_plugins_str = ''
+    for line in yum_output['stdout']:
+        if line.startswith('Loaded plugins:'):
+            # We have found the first line that contains the plugins
+            plugins_on_this_line = line[16:]  # Remove the `Loaded plugins: ` part
+
+            if plugins_on_this_line[-1] == ',':
+                plugins_on_this_line += ' '
+
+            loaded_plugins_str += plugins_on_this_line
+            continue
+
+        if loaded_plugins_str:
+            if re.match(YUM_LOADED_PLUGINS_NEXT_LINE_START, line):
+                # The list of plugins continues on this line
+                plugins_on_this_line = line.lstrip(' :')  # Remove the leading spaces and semicolon
+
+                # Plugins are separated by ', ', however the space at the end of line might get dropped, add it
+                # so we can split it by ', ' later
+                if plugins_on_this_line[-1] == ',':
+                    plugins_on_this_line += ' '
+
+                loaded_plugins_str += plugins_on_this_line
+            else:
+                # The list of loaded plugins ended
+                break
+
+    return loaded_plugins_str.split(', ')
+
+
+def scan_enabled_yum_plugins():
+    """
+    Runs the `yum` command and parses its output for enabled/loaded plugins.
+
+    :return: A list of enabled plugins.
+    :rtype: List
+    """
+
+    # We rely on yum itself to report what plugins are used when it is invoked.
+    # An alternative approach would be to check /usr/lib/yum-plugins/ (install
+    # path for yum plugins) and parse corresponding configurations from
+    # /etc/yum/pluginconf.d/
+
+    if get_source_major_version() == '7':
+        yum_cmd = ['yum']
+    else:
+        yum_cmd = ['dnf', '-v']  # On RHEL8 we need to supply an extra switch
+
+    yum_output = run(yum_cmd, split=True, checked=False)  # The yum command will certainly fail (does not matter).
+
+    return _parse_loaded_plugins(yum_output)
+
+
+def scan_yum_config():
+    """
+    Scans the YUM configuration and produces :class:`YumConfig` message with the information found.
+    """
+    config = YumConfig()
+    config.enabled_plugins = scan_enabled_yum_plugins()
+
+    api.produce(config)

--- a/repos/system_upgrade/common/actors/yumconfigscanner/tests/test_yumconfigscanner.py
+++ b/repos/system_upgrade/common/actors/yumconfigscanner/tests/test_yumconfigscanner.py
@@ -1,0 +1,83 @@
+import pytest
+
+from leapp.libraries.actor import yumconfigscanner
+
+CMD_YUM_OUTPUT = '''Loaded plugins: langpacks, my plugin, subscription-manager, product-id
+Usage: yum [options] COMMAND
+'''
+CMD_YUM_OUTPUT_MULTILINE_BREAK_ON_HYPHEN = '''Loaded plugins: langpacks, my plugin, subscription-
+              : manager, product-id
+Usage: yum [options] COMMAND
+'''
+CMD_YUM_OUTPUT_MULTILINE_BREAK_ON_WHITESPACE = '''Loaded plugins: langpacks, my plugin,
+              : subscription-manager, product-id
+Usage: yum [options] COMMAND
+'''
+
+
+def assert_plugins_identified_as_enabled(expected_plugins, identified_plugins):
+    fail_description = 'Failed to parse a plugin from the yum output.'
+    for expected_enabled_plugin in expected_plugins:
+        assert expected_enabled_plugin in identified_plugins, fail_description
+
+
+@pytest.mark.parametrize(
+    ('source_major_version', 'yum_command'),
+    [
+        ('7', ['yum']),
+        ('8', ['dnf', '-v']),
+    ]
+)
+def test_scan_enabled_plugins(monkeypatch, source_major_version, yum_command):
+    """Tests whether the enabled plugins are correctly retrieved from the yum output."""
+
+    def run_mocked(cmd, **kwargs):
+        if cmd == yum_command:
+            return {
+                'stdout': CMD_YUM_OUTPUT.split('\n'),
+                'stderr': 'You need to give some command',
+                'exit_code': 1
+            }
+        raise ValueError('Tried to run an unexpected command.')
+
+    def get_source_major_version_mocked():
+        return source_major_version
+
+    # The library imports `run` all the way into its namespace (from ...stdlib import run),
+    # we must overwrite it there then:
+    monkeypatch.setattr(yumconfigscanner, 'run', run_mocked)
+    monkeypatch.setattr(yumconfigscanner, 'get_source_major_version', get_source_major_version_mocked)
+
+    enabled_plugins = yumconfigscanner.scan_enabled_yum_plugins()
+    assert_plugins_identified_as_enabled(
+        ['langpacks', 'my plugin', 'subscription-manager', 'product-id'],
+        enabled_plugins
+    )
+
+
+@pytest.mark.parametrize(
+    ('yum_output',),
+    [
+        (CMD_YUM_OUTPUT,),
+        (CMD_YUM_OUTPUT_MULTILINE_BREAK_ON_HYPHEN,),
+        (CMD_YUM_OUTPUT_MULTILINE_BREAK_ON_WHITESPACE,)
+    ])
+def test_yum_loaded_plugins_multiline_output(yum_output, monkeypatch):
+    """Tests whether the library correctly handles yum plugins getting reported on multiple lines."""
+    def run_mocked(cmd, **kwargs):
+        return {
+            'stdout': yum_output.split('\n'),
+            'stderr': 'You need to give some command',
+            'exit_code': 1
+        }
+
+    monkeypatch.setattr(yumconfigscanner, 'run', run_mocked)
+    monkeypatch.setattr(yumconfigscanner, 'get_source_major_version', lambda: '7')
+
+    enabled_plugins = yumconfigscanner.scan_enabled_yum_plugins()
+
+    assert len(enabled_plugins) == 4, 'Identified more yum plugins than available in the mocked yum output.'
+    assert_plugins_identified_as_enabled(
+        ['langpacks', 'my plugin', 'subscription-manager', 'product-id'],
+        enabled_plugins
+    )

--- a/repos/system_upgrade/common/models/yumconfig.py
+++ b/repos/system_upgrade/common/models/yumconfig.py
@@ -1,0 +1,8 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemFactsTopic
+
+
+class YumConfig(Model):
+    topic = SystemFactsTopic
+
+    enabled_plugins = fields.List(fields.String(), default=[])


### PR DESCRIPTION
The IPU requires `subscription-manager` and `product-id` yum plugins to be enabled in order to proceed without errors about no enabled target repositories. This PR adds the necessary infrastructure for the detection and reporting when the required plugins are not being loaded by yum.

The introduced changes consist of:
- add a new model `YumConfig` that carries the information about detected `enabled_plugins`,
- add a new actor `YumConfigScanner` that takes care of extracting the current yum configuration from the system,
- add a new actor `CheckYumPluginsEnabled` that checks that the plugins are loaded (available), and if not, informs the user about this fact, along with information where to enable them.

Relates: https://bugzilla.redhat.com/show_bug.cgi?id=1913829