### PR TITLE
Add name parameter to the tft request

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -90,7 +90,8 @@ jobs:
             "api_key": "${{ secrets.TF_API_KEY }}",
             "test": {"fmf": {
               "url": "https://gitlab.cee.redhat.com/oamg/tmt-plans",
-              "ref": "master"
+              "ref": "master",
+              "name": "morf-leapp|integration|e2e"
             }},
             "environments": [{
               "arch": "x86_64",


### PR DESCRIPTION
As tmt-plans repository now contains morf tests for convert2rhel this
is needed to filter out tests that make no sense for leapp.