### PR TITLE
rpmscanner: fix loading of data about module streams with DNF

### DIFF
--- a/repos/system_upgrade/common/actors/rpmscanner/libraries/rpmscanner.py
+++ b/repos/system_upgrade/common/actors/rpmscanner/libraries/rpmscanner.py
@@ -47,6 +47,8 @@ def _get_package_repository_data_dnf():
     pkg_repos = {}
 
     try:
+        # NOTE: currently we do not initialize/load DNF plugins here as we are
+        # working just with the local stuff (load_system_repo=True)
         dnf_base.fill_sack(load_system_repo=True, load_available_repos=False)
         for pkg in dnf_base.sack.query():
             pkg_repos[pkg.name] = pkg._from_repo.lstrip('@')
@@ -85,7 +87,11 @@ def get_modules():
         return []
 
     base = dnf.Base()
+    base.init_plugins()
     base.read_all_repos()
+    # e.g. the amazon-id plugin requires loaded repositories
+    # for the proper configuration.
+    base.configure_plugins()
     base.fill_sack()
 
     module_base = dnf.module.module_base.ModuleBase(base)


### PR DESCRIPTION
The original solution worked just in case no DNF plugins habe been
required to load available repositories metadata. However e.g. in
case of RHUI, we need plugins to get such a data as baseurls of
repositories usually contain REGION substring that is expected to
be replaced by the Amazon-id plugin.

Added initilisation and configuration of DNF plugins as expected.