### PR TITLE
Disable pylint warnings about missing open() encoding parameter.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -22,6 +22,7 @@ disable=
  unsubscriptable-object,
  unused-argument,
  unused-import,
+ unspecified-encoding,
 # "C" Coding convention violations
  bad-continuation,
  missing-docstring,
@@ -37,6 +38,8 @@ disable=
  too-many-locals,
  too-many-statements,
  consider-using-from-import,
+ use-list-literal,
+ use-dict-literal,
 # new for python3 version of pylint
  useless-object-inheritance,
  consider-using-set-comprehension,  # pylint3 force to use comprehension in place we don't want (py2 doesnt have these options, for inline skip)


### PR DESCRIPTION
The new version of `pylint` adds a new warning that warns about not
specifying encoding when opening a file. This option was introduced
mostly to support better compatibility when running Python packages on
Windows, where the usage of the implicit encoding causes trouble.

Also adding two stylistic options to the disabled ones: `use-dict-literal`
and `use-list-literal`, both suggesting to use `[]`/`{}` instead of calling
`list()` or `dict()`.