### PR TITLE
targetuserspacecreator: Improve the error msg when custom repos missing

### DIFF
--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -418,17 +418,20 @@ def gather_target_repositories(context, indata):
     if missing_custom_repoids:
         raise StopActorExecutionError(
             message='Some required custom target repositories are not available.',
-            details={'hint': (
-                ' The most probably you are using custom or third party actor'
-                ' that produces CustomTargetRepository message or you did a typo'
-                ' in one of repoids specified on command line for the leapp --enablerepo'
-                ' option.'
-                ' Inside the upgrade container, we are not able to find such'
-                ' repository inside any repository file. Consider use of the'
-                ' custom repository file regarding the official upgrade'
-                ' documentation or check whether you did not do a typo in any'
-                ' repoids you specified for the --enablerepo option of leapp.'
-                )
+            details={
+                'hint': (
+                    ' The most probably you are using custom or third party actor'
+                    ' that produces CustomTargetRepository message or you did a typo'
+                    ' in one of repoids specified on command line for the leapp --enablerepo'
+                    ' option.'
+                    ' Inside the upgrade container, we are not able to find such'
+                    ' repository inside any repository file. Consider use of the'
+                    ' custom repository file regarding the official upgrade'
+                    ' documentation or check whether you did not do a typo in any'
+                    ' repoids you specified for the --enablerepo option of leapp.'
+                    ' Check the leapp logs to see the list of all available repositories.'
+                ),
+                'missing_custom_repositories': '"{}"'.format('", "'.join(missing_custom_repoids)),
             }
         )
 


### PR DESCRIPTION
We have found that people has troubles to realize where the problem
exactly is when they require specific repositories using the
--enablerepo option.

e.g. sometimes they do not have access to a Satellite server so they
cannot check what repositories are provided for the target system
and they do not know we print the list of available repositories
in the logs.

Additionally, it's taking a time to find which repositories are missing
or which contain a typo. So we print the list of missing repositories
to make this clean on what people should focus.

As the list of all available target repositories could be pretty long,
we do not print the list in the error message, but point people they
can find the list in the logs, so they are aware they have this
information available from us.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2002347

## Example

```
# leapp preupgrade --debug --enablerepo some-repoid --enablerepo rhel-8-for-x86_64-baseos-rpms --enablerepo rhel-8-for-x86_64-appstream-rpm
 
============================================================
                           ERRORS                           
============================================================

2021-09-08 18:45:32.936527 [ERROR] Actor: target_userspace_creator
Message: Some required custom target repositories are not available.
Summary:
    Missing_custom_repositories: "some-repoid", "rhel-8-for-x86_64-appstream-rpm"
    Hint:  The most probably you are using custom or third party actor that produces CustomTargetRepository message or you did a typo in one of repoids specified on command line for the leapp --enablerepo option. Inside the upgrade container, we are not able to find such repository inside any repository file. Consider use of the custom repository file regarding the official upgrade documentation or check whether you did not do a typo in any repoids you specified for the --enablerepo option of leapp. Check the leapp logs to see the list of all available repositories.

============================================================
                       END OF ERRORS                        
============================================================

```