### PR TITLE
upgrade: Restore leapp environment variables on --resume

### DIFF
--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -53,7 +53,7 @@ def upgrade(args):
             os.environ['LEAPP_VERBOSE'] = '1'
         else:
             os.environ['LEAPP_VERBOSE'] = '0'
-
+        util.restore_leapp_env_vars(context)
         skip_phases_until = util.get_last_phase(context)
     else:
         e = Execution(context=context, kind='upgrade', configuration=configuration)

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -8,9 +8,19 @@ from datetime import datetime
 from leapp.config import get_config
 from leapp.exceptions import CommandError
 from leapp.repository.scan import find_and_scan_repositories
-from leapp.utils.audit import get_connection, get_checkpoints
+from leapp.utils.audit import get_connection, get_checkpoints, get_messages
 from leapp.utils.output import report_unsupported
 from leapp.utils.report import fetch_upgrade_report_messages, generate_report_file
+
+
+def restore_leapp_env_vars(context):
+    """
+    Restores leapp environment variables from the `IPUConfig` message.
+    """
+    messages = get_messages(('IPUConfig',), context)
+    leapp_env_vars = json.loads((messages or [{}])[0].get('message', {}).get('data', '{}')).get('leapp_env_vars', {})
+    for entry in leapp_env_vars:
+        os.environ[entry['name']] = entry['value']
 
 
 def archive_logfiles():


### PR DESCRIPTION
This patch will restore leapp environment variables from the IPUConfig
message. This will allow to easier and more naturally access environment
from actors during the upgrade even after reboot etc.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>