### PR TITLE
actor: Check the existence of the custom network-scripts

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/checkcustomnetworkscripts/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/checkcustomnetworkscripts/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import customnetworkscripts
+from leapp.models import Report
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class CheckCustomNetworkScripts(Actor):
+    """
+    Check the existence of custom network-scripts and warn user about possible
+    manual intervention requirements.
+    """
+
+    name = "check_custom_network_scripts"
+    produces = (Report,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        customnetworkscripts.process()

--- a/repos/system_upgrade/el8toel9/actors/checkcustomnetworkscripts/libraries/customnetworkscripts.py
+++ b/repos/system_upgrade/el8toel9/actors/checkcustomnetworkscripts/libraries/customnetworkscripts.py
@@ -1,0 +1,58 @@
+import os
+
+from leapp import reporting
+
+CUSTOM_NETWORK_SCRIPTS = [
+    "/sbin/ifup-local",
+    "/sbin/ifup-pre-local",
+    "/sbin/ifdown-local",
+    "/sbin/ifdown-pre-local",
+]
+DOC_URL = "https://red.ht/upgrading-RHEL-8-to-RHEL-9-network-scripts"
+
+
+def generate_report(existing_custom_network_scripts):
+    """ Generate reports informing user about possible manual intervention required """
+
+    # Show documentation url if custom network-scripts detected
+    title = "custom network-scripts detected"
+    summary = (
+        "RHEL 9 does not support the legacy network-scripts package that was"
+        " deprecated in RHEL 8. Custom network-scripts have been detected."
+    )
+
+    reporting.create_report(
+        [
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Remediation(
+                hint=(
+                    "Migrate the custom network-scripts to NetworkManager dispatcher"
+                    " scripts manually before the ugprade. Follow instructions in the"
+                    " official documentation."
+                )
+            ),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.Tags([reporting.Tags.NETWORK, reporting.Tags.SERVICES]),
+            reporting.ExternalLink(
+                title=(
+                    "Upgrading from RHEL 8 to 9 - migrating custom network-scripts to"
+                    " NetworkManager dispatcher scripts"
+                ),
+                url=DOC_URL,
+            ),
+        ]
+        + [
+            reporting.RelatedResource("file", fname)
+            for fname in existing_custom_network_scripts
+        ]
+    )
+
+
+def process():
+    existing_custom_network_scripts = [
+        fname for fname in CUSTOM_NETWORK_SCRIPTS if os.path.isfile(fname)
+    ]
+    if existing_custom_network_scripts:
+        generate_report(existing_custom_network_scripts)

--- a/repos/system_upgrade/el8toel9/actors/checkcustomnetworkscripts/tests/unit_test_customnetworkscripts.py
+++ b/repos/system_upgrade/el8toel9/actors/checkcustomnetworkscripts/tests/unit_test_customnetworkscripts.py
@@ -1,0 +1,19 @@
+import os
+
+from leapp import reporting
+from leapp.libraries.actor import customnetworkscripts
+from leapp.libraries.common import testutils
+
+
+def test_customnetworkscripts_exists(monkeypatch):
+    monkeypatch.setattr(os.path, "isfile", lambda dummy: True)
+    monkeypatch.setattr(reporting, "create_report", testutils.create_report_mocked())
+    customnetworkscripts.process()
+    assert reporting.create_report.called
+
+
+def test_customnetworkscripts_not_found(monkeypatch):
+    monkeypatch.setattr(os.path, "isfile", lambda dummy: False)
+    monkeypatch.setattr(reporting, 'create_report', testutils.create_report_mocked())
+    customnetworkscripts.process()
+    assert not reporting.create_report.called


### PR DESCRIPTION
RHEL 9 does not support the legacy network-scripts package that was
deprecated in RHEL 8. As a result, if the local scripts of network
scripts are detected on the system, user should move these custom
scripts to the user local directory (e.g. /opt or /usr/local/sbin) in
order to proceed with the upgrade into RHEL 9.

Signed-off-by: Wen Liang <liangwen12year@gmail.com>