### PR TITLE
Add sssd el8toel9 actor

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/sssdcheck/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/sssdcheck/actor.py
@@ -1,0 +1,60 @@
+from leapp.actors import Actor
+from leapp.models import SSSDConfig8to9
+from leapp import reporting
+from leapp.reporting import Report, create_report
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+
+
+COMMON_REPORT_TAGS = [reporting.Tags.AUTHENTICATION, reporting.Tags.SECURITY]
+
+related = [
+    reporting.RelatedResource('package', 'sssd'),
+    reporting.RelatedResource('file', '/etc/sssd/sssd.conf')
+]
+
+
+class SSSDCheck8to9(Actor):
+    """
+    Check SSSD configuration for changes in RHEL9 and report them in model.
+
+    Implicit files domain is disabled by default. This may affect local
+    smartcard authentication if there is not explicit files domain created.
+
+    If there is no files domain and smartcard authentication is enabled,
+    we will notify the administrator.
+    """
+
+    name = 'sssd_check_8to9'
+    consumes = (SSSDConfig8to9,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        model = next(self.consume(SSSDConfig8to9), None)
+        if not model:
+            return
+
+        # enable_files_domain is set explicitly, change of default has no effect
+        if model.enable_files_domain_set:
+            return
+
+        # there is explicit files domain, implicit files domain has no effect
+        if model.explicit_files_domain:
+            return
+
+        # smartcard authentication is disabled, implicit files domain has no effect
+        if not model.pam_cert_auth:
+            return
+
+        create_report([
+            reporting.Title('SSSD implicit files domain is now disabled by default.'),
+            reporting.Summary('Default value of [sssd]/enable_files_domain has '
+                              'changed from true to false.'),
+            reporting.Tags(COMMON_REPORT_TAGS),
+            reporting.Remediation(
+                hint='If you use smartcard authentication for local users, '
+                     'set this option to true explicitly and call '
+                     '"authselect enable-feature with-files-domain".'
+            ),
+            reporting.Severity(reporting.Severity.MEDIUM)
+        ] + related)

--- a/repos/system_upgrade/el8toel9/actors/sssdfacts/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/sssdfacts/actor.py
@@ -1,0 +1,34 @@
+from six.moves import configparser
+
+from leapp.actors import Actor
+from leapp.libraries.actor.sssdfacts8to9 import SSSDFactsLibrary
+from leapp.models import SSSDConfig8to9
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+
+
+class SSSDFacts8to9(Actor):
+    """
+    Check SSSD configuration for changes in RHEL9 and report them in model.
+
+    Implicit files domain is disabled by default. This may affect local
+    smartcard authentication if there is not explicit files domain created.
+
+    If there is no files domain and smartcard authentication is enabled,
+    we will notify the administrator.
+    """
+
+    name = 'sssd_facts_8to9'
+    consumes = ()
+    produces = (SSSDConfig8to9,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        try:
+            config = configparser.RawConfigParser()
+            config.read('/etc/sssd/sssd.conf')
+        except configparser.Error:
+            # SSSD is not configured properly. Nothing to do.
+            self.log.warning('SSSD configuration unreadable.')
+            return
+
+        self.produce(SSSDFactsLibrary(config).process())

--- a/repos/system_upgrade/el8toel9/actors/sssdfacts/libraries/sssdfacts8to9.py
+++ b/repos/system_upgrade/el8toel9/actors/sssdfacts/libraries/sssdfacts8to9.py
@@ -1,0 +1,43 @@
+from leapp.models import SSSDConfig8to9
+
+
+class SSSDFactsLibrary(object):
+    """
+    Helper library from SSSDFacts actor to allow unit testing.
+    """
+    def __init__(self, config):
+        self.config = config
+
+    def process(self):
+        """
+        Check SSSD configuration for the following options:
+
+        - sssd/enable_files_domain
+        - pam/pam_cert_auth
+        - explicit files provider domain present
+        """
+        facts = SSSDConfig8to9(
+            enable_files_domain_set=False,
+            explicit_files_domain=False,
+            pam_cert_auth=False,
+        )
+
+        facts.enable_files_domain_set = self.config.has_option('sssd', 'enable_files_domain')
+        facts.pam_cert_auth = self.config.getboolean('pam', 'pam_cert_auth', fallback=False)
+
+        # Lookup domain with id_provider == files
+        for section in self.config.sections():
+            # Not a domain config.
+            if not section.startswith('domain/'):
+                continue
+
+            # Malformed config?
+            if not self.config.has_option(section, 'id_provider'):
+                continue
+
+            val = self.config.get(section, 'id_provider', fallback=None)
+            if val == 'files':
+                facts.explicit_files_domain = True
+                break
+
+        return facts

--- a/repos/system_upgrade/el8toel9/actors/sssdfacts/tests/unit_test_sssdfacts_8to9.py
+++ b/repos/system_upgrade/el8toel9/actors/sssdfacts/tests/unit_test_sssdfacts_8to9.py
@@ -1,0 +1,167 @@
+import textwrap
+
+from six import StringIO
+
+from leapp.libraries.actor.sssdfacts8to9 import SSSDFactsLibrary
+from leapp.libraries.common import utils
+
+
+def get_config(content):
+    return utils.parse_config(StringIO(textwrap.dedent(content)))
+
+
+def test_empty_config():
+    config = utils.parse_config()
+    facts = SSSDFactsLibrary(config).process()
+
+    assert not facts.enable_files_domain_set
+    assert not facts.explicit_files_domain
+    assert not facts.pam_cert_auth
+
+
+def test_enable_files_domain_set__notset():
+    config = get_config("""
+    [sssd]
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert not facts.enable_files_domain_set
+    assert not facts.explicit_files_domain
+    assert not facts.pam_cert_auth
+
+
+def test_enable_files_domain_set__set_true():
+    config = get_config("""
+    [sssd]
+    enable_files_domain = true
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert facts.enable_files_domain_set
+    assert not facts.explicit_files_domain
+    assert not facts.pam_cert_auth
+
+
+def test_enable_files_domain_set__set_false():
+    config = get_config("""
+    [sssd]
+    enable_files_domain = false
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert facts.enable_files_domain_set
+    assert not facts.explicit_files_domain
+    assert not facts.pam_cert_auth
+
+
+def test_enable_files_domain_set__nodomain():
+    config = get_config("""
+    [sssd]
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert not facts.enable_files_domain_set
+    assert not facts.explicit_files_domain
+    assert not facts.pam_cert_auth
+
+
+def test_explicit_files_domain__notset():
+    config = get_config("""
+    [sssd]
+    domains = ldap
+
+    [domain/ldap]
+    id_provider = ldap
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert not facts.enable_files_domain_set
+    assert not facts.explicit_files_domain
+    assert not facts.pam_cert_auth
+
+
+def test_explicit_files_domain__set():
+    config = get_config("""
+    [sssd]
+    domains = files
+
+    [domain/files]
+    id_provider = files
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert not facts.enable_files_domain_set
+    assert facts.explicit_files_domain
+    assert not facts.pam_cert_auth
+
+
+def test_pam_cert_auth__notset():
+    config = get_config("""
+    [pam]
+    pam_gssapi_services = sudo
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert not facts.enable_files_domain_set
+    assert not facts.explicit_files_domain
+    assert not facts.pam_cert_auth
+
+
+def test_pam_cert_auth__true():
+    config = get_config("""
+    [pam]
+    pam_gssapi_services = sudo
+    pam_cert_auth = true
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert not facts.enable_files_domain_set
+    assert not facts.explicit_files_domain
+    assert facts.pam_cert_auth
+
+
+def test_pam_cert_auth__false():
+    config = get_config("""
+    [pam]
+    pam_gssapi_services = sudo
+    pam_cert_auth = false
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert not facts.enable_files_domain_set
+    assert not facts.explicit_files_domain
+    assert not facts.pam_cert_auth
+
+
+def test_complex_config():
+    config = get_config("""
+    [sssd]
+    user = root
+    services = nss, pam, sudo
+    domain = ldap, files
+
+    [pam]
+    pam_cert_auth = true
+
+    [domain/ldap]
+    id_provider = ldap
+    ldap_groups_use_matching_rule_in_chain = True
+
+    [domain/files]
+    id_provider = files
+    """)
+
+    facts = SSSDFactsLibrary(config).process()
+
+    assert not facts.enable_files_domain_set
+    assert facts.explicit_files_domain
+    assert facts.pam_cert_auth

--- a/repos/system_upgrade/el8toel9/models/sssd.py
+++ b/repos/system_upgrade/el8toel9/models/sssd.py
@@ -1,0 +1,24 @@
+from leapp.models import Model, fields
+from leapp.topics import SystemInfoTopic
+
+
+class SSSDConfig8to9(Model):
+    """
+    SSSD configuration that is related to the upgrade process.
+    """
+    topic = SystemInfoTopic
+
+    enable_files_domain_set = fields.Boolean()
+    """
+    True if [sssd]/enable_files_domain is explicitly set.
+    """
+
+    explicit_files_domain = fields.Boolean()
+    """
+    True if a domain with id_provider=files exist.
+    """
+
+    pam_cert_auth = fields.Boolean()
+    """
+    True if [pam]/pam_cert_auth is set to True.
+    """


### PR DESCRIPTION
Check SSSD configuration for changes in RHEL9 and report them in model.

Implicit files domain is disabled by default. This may affect local
smartcard authentication if there is not explicit files domain created.

If there is no files domain and smartcard authentication is enabled,
we will notify the administrator.