### PR TITLE
Enhance calculation of the free space on the disk

### DIFF
--- a/repos/system_upgrade/common/actors/addupgradebootentry/actor.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/actor.py
@@ -2,7 +2,7 @@ import os
 
 from leapp.actors import Actor
 from leapp.libraries.actor.addupgradebootentry import add_boot_entry, fix_grub_config_error
-from leapp.models import BootContent, GrubConfigError, FirmwareFacts
+from leapp.models import BootContent, GrubConfigError, FirmwareFacts, TransactionDryRun
 from leapp.exceptions import StopActorExecutionError
 from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
 
@@ -15,7 +15,7 @@ class AddUpgradeBootEntry(Actor):
     """
 
     name = 'add_upgrade_boot_entry'
-    consumes = (BootContent, GrubConfigError, FirmwareFacts)
+    consumes = (BootContent, GrubConfigError, FirmwareFacts, TransactionDryRun)
     produces = ()
     tags = (IPUWorkflowTag, InterimPreparationPhaseTag)
 

--- a/repos/system_upgrade/common/actors/dnfdryrun/actor.py
+++ b/repos/system_upgrade/common/actors/dnfdryrun/actor.py
@@ -1,0 +1,51 @@
+from leapp.actors import Actor
+from leapp.libraries.common import dnfplugin
+from leapp.models import (
+    DNFPluginTask,
+    FilteredRpmTransactionTasks,
+    RHUIInfo,
+    StorageInfo,
+    TargetUserSpaceInfo,
+    TransactionDryRun,
+    UsedTargetRepositories,
+    XFSPresence,
+)
+from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
+
+
+class DnfDryRun(Actor):
+    """
+    Actor that invokes DNF to download the RPMs required for the upgrade transaction.
+
+    This actor uses the rhel-upgrade plugin to perform the download of RPM for the transaction and performing the
+    transaction test, that is something like a dry run trying to determine the success of the upgrade.
+    """
+
+    name = 'dnf_dry_run'
+    consumes = (
+        DNFPluginTask,
+        FilteredRpmTransactionTasks,
+        RHUIInfo,
+        StorageInfo,
+        TargetUserSpaceInfo,
+        UsedTargetRepositories,
+        XFSPresence,
+    )
+    produces = (TransactionDryRun,)
+    tags = (IPUWorkflowTag, InterimPreparationPhaseTag)
+
+    def process(self):
+        xfs_info = next(self.consume(XFSPresence), XFSPresence())
+        storage_info = next(self.consume(StorageInfo), StorageInfo())
+        used_repos = self.consume(UsedTargetRepositories)
+        plugin_info = list(self.consume(DNFPluginTask))
+        tasks = next(self.consume(FilteredRpmTransactionTasks), FilteredRpmTransactionTasks())
+        target_userspace_info = next(self.consume(TargetUserSpaceInfo), None)
+        rhui_info = next(self.consume(RHUIInfo), None)
+        on_aws = bool(rhui_info and rhui_info.provider == 'aws')
+
+        dnfplugin.perform_dry_run(
+            tasks=tasks, used_repos=used_repos, target_userspace_info=target_userspace_info,
+            xfs_info=xfs_info, storage_info=storage_info, plugin_info=plugin_info, on_aws=on_aws
+        )
+        self.produce(TransactionDryRun())

--- a/repos/system_upgrade/common/models/transactioncompleted.py
+++ b/repos/system_upgrade/common/models/transactioncompleted.py
@@ -4,3 +4,7 @@ from leapp.topics import TransactionTopic
 
 class TransactionCompleted(Model):
     topic = TransactionTopic
+
+
+class TransactionDryRun(Model):
+    topic = TransactionTopic


### PR DESCRIPTION
In the original solution, the part of the upgrade process has
this order:
```
        dnftransactioncheck (TargetTransactionChecksPhase)
                ↓
        dnfpackagedownload  (DownloadPhase)
                ↓
        upgradeinitramfsgenerator (InterimPreparationPhase)
                ↓
        dnfupgradetransaction (RPMUpgradePhase)
```

Usually, in case there is not enough space on disk to proceed the
DNF transaction, the issue is discovered during the DownloadPhase
inside the dnfpackagedownload actor. However, in some cases the IPU
can crashed on insufficient disk space during the execution of the
DNF transaction (RPMUpgradePhase), which very critical moment of the
upgrade and system ends in emergency console. This is not common
situation, but we realized it's caused by the order of execution:
  1. download rpms and do dry-run of the DNF transaction
  2. download and install additional rpms inside the targetuserspace
     container and build the upgrade initramfs
  3. execute the DNF transaction

The step 2 could take additional 200-300+ MBs which in some cases
causes enough space on the disk. The solution could be to exchange
the order of dnfpackagedownload and upgradeinitramfsgenerator actors,
however that would require changes in the IPUWorkflow and also,
it would waste additional time before the upgrade process is stopped
because of discovered problem.

So instead, we add the DnfDryRun actor that is executed after the
upgrade initramfs is generated and before the changes in the bootloader
configuration, so we calculate the needed disk space after all space
changes are done, before any configuration is touched.

For this purpose, the subcommand for the rhel-upgrade plugin has
been introduced: dry-run, which basically behaves like the download
sub-cmd, however do not download anything, just work with the cached
data (so it's something between 'download' and 'upgrade' sub-cmds).

Also the TransactionDryRun has been introduced, to ensure the
actor configuring bootloader is executed after the dnf dry run
is performed.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1976932