### PR TITLE
[inhibitwhenluks] Allow OS upgrade if luks volumes are only Ceph OSDs

### DIFF
--- a/repos/system_upgrade/common/actors/cephvolumescan/actor.py
+++ b/repos/system_upgrade/common/actors/cephvolumescan/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import cephvolumescan
+from leapp.models import CephInfo, InstalledRPM
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CephVolumeScan(Actor):
+
+    """
+    Retrieves the list of encrypted Ceph OSD
+    """
+
+    name = 'cephvolumescan'
+    consumes = (InstalledRPM,)
+    produces = (CephInfo,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        output = cephvolumescan.encrypted_osds_list()
+        self.produce(CephInfo(encrypted_volumes=output))

--- a/repos/system_upgrade/common/actors/cephvolumescan/libraries/cephvolumescan.py
+++ b/repos/system_upgrade/common/actors/cephvolumescan/libraries/cephvolumescan.py
@@ -1,0 +1,62 @@
+import json
+import os
+import re
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import CalledProcessError, run
+from leapp.models import InstalledRPM
+
+CEPH_CONF = "/etc/ceph/ceph.conf"
+CONTAINER = "ceph-osd"
+
+
+def select_osd_container(engine):
+    container_name = ""
+    try:
+        output = run([engine, 'ps'])
+    except CalledProcessError as cpe:
+        raise StopActorExecutionError(
+            'Could not retrieve running containers list',
+            details={'details': 'An exception raised during containers listing {}'.format(str(cpe))}
+        )
+    for line in output['stdout'].splitlines():
+        container_name = line.split()[-1]
+        if re.match(CONTAINER, container_name):
+            return container_name
+    return container_name
+
+
+def get_ceph_lvm_list():
+    base_cmd = ['ceph-volume', 'lvm', 'list', '--format', 'json']
+    container_binary = 'podman' if has_package(InstalledRPM, 'podman') else \
+        'docker' if has_package(InstalledRPM, 'docker') else ''
+    if container_binary == '':
+        cmd_ceph_lvm_list = base_cmd
+    else:
+        container_name = select_osd_container(container_binary)
+        cmd_ceph_lvm_list = [container_binary, 'exec', container_name]
+        cmd_ceph_lvm_list.extend(base_cmd)
+    try:
+        output = run(cmd_ceph_lvm_list)
+    except CalledProcessError as cpe:
+        raise StopActorExecutionError(
+            'Could not retrieve the ceph volumes list',
+            details={'details': 'An exception raised while retrieving ceph volumes {}'.format(str(cpe))}
+        )
+    try:
+        json_output = json.loads(output['stdout'])
+    except ValueError as jve:
+        raise StopActorExecutionError(
+            'Could not load json file containing ceph volume list',
+            details={'details': 'json file wrong format {}'.format(str(jve))}
+        )
+    return json_output
+
+
+def encrypted_osds_list():
+    result = []
+    if os.path.isfile(CEPH_CONF):
+        output = get_ceph_lvm_list()
+        result = [output[key][0]['lv_uuid'] for key in output if output[key][0]['tags']['ceph.encrypted']]
+    return result

--- a/repos/system_upgrade/common/actors/cephvolumescan/tests/test_cephvolumescan.py
+++ b/repos/system_upgrade/common/actors/cephvolumescan/tests/test_cephvolumescan.py
@@ -1,0 +1,85 @@
+import pytest
+from mock import Mock, patch
+
+from leapp.libraries.actor import cephvolumescan
+from leapp.models import InstalledRPM, LsblkEntry, RPM, StorageInfo
+from leapp.reporting import Report
+
+CONT_PS_COMMAND_OUTPUT = {
+    "stdout":
+    """CONTAINER ID IMAGE COMMAND CREATED STATUS PORTS NAMES
+    50d96fe72019 registry.redhat.io/rhceph/rhceph-4-rhel8:latest "/opt/ceph-contain..." \
+        2 weeks ago Up 2 weeks ceph-osd-0
+    f93c17b49c40 registry.redhat.io/rhceph/rhceph-4-rhel8:latest "/opt/ceph-contain..." \
+        2 weeks ago Up 2 weeks ceph-osd-1
+    0669880c52dc registry.redhat.io/rhceph/rhceph-4-rhel8:latest "/opt/ceph-contain..." \
+        2 weeks ago Up 2 weeks ceph-mgr-ceph4-standalone
+    d7068301294e registry.redhat.io/rhceph/rhceph-4-rhel8:latest "/opt/ceph-contain..." \
+        2 weeks ago Up 2 weeks ceph-mon-ceph4-standalone
+    63de6d00f241 registry.redhat.io/openshift4/ose-prometheus-alertmanager:4.1 "/bin/alertmanager..." \
+        2 weeks ago Up 2 weeks alertmanager
+    28ed65960c80 registry.redhat.io/rhceph/rhceph-4-dashboard-rhel8:4 "/run.sh" \
+        2 weeks ago Up 2 weeks grafana-server
+    f4b300d7a11f registry.redhat.io/openshift4/ose-prometheus-node-exporter:v4.1 "/bin/node_exporte..." \
+        2 weeks ago Up 2 weeks node-exporter
+    95a03700b3ff registry.redhat.io/openshift4/ose-prometheus:4.1 "/bin/prometheus -..." \
+        2 weeks ago Up 2 weeks prometheus"""
+    }
+
+CEPH_VOLUME_OUTPUT = {
+    "stdout": """{
+        "0":[
+            {
+                "devices":[
+                    "/dev/sda"
+                ],
+                "lv_name":"osd-block-c5215ba7-517b-45c7-88df-37a03eeaa0e9",
+                "lv_uuid":"Tyc0TH-RDxr-ebAF-9mWF-Kh5R-YnvJ-cEcGVn",
+                "tags":{
+                    "ceph.encrypted":"1"
+                },
+                "type":"block",
+                "vg_name":"ceph-a696c40d-6b1d-448d-a40e-fadca22b64bc"
+            }
+        ]
+    }"""
+}
+
+CEPH_LVM_LIST = {
+    '0': [{'devices': ['/dev/sda'],
+           'lv_name': 'osd-block-c5215ba7-517b-45c7-88df-37a03eeaa0e9',
+           'lv_uuid': 'Tyc0TH-RDxr-ebAF-9mWF-Kh5R-YnvJ-cEcGVn',
+           'tags': {'ceph.encrypted': '1'},
+           'type': 'block',
+           'vg_name': 'ceph-a696c40d-6b1d-448d-a40e-fadca22b64bc'}]
+    }
+
+
+@patch('leapp.libraries.actor.cephvolumescan.run')
+def test_select_osd_container(m_run):
+
+    m_run.return_value = CONT_PS_COMMAND_OUTPUT
+
+    assert cephvolumescan.select_osd_container('docker') == "ceph-osd-0"
+
+
+@patch('leapp.libraries.actor.cephvolumescan.has_package')
+@patch('leapp.libraries.actor.cephvolumescan.select_osd_container')
+@patch('leapp.libraries.actor.cephvolumescan.run')
+def test_get_ceph_lvm_list(m_run, m_osd_container, m_has_package):
+
+    m_has_package.return_value = True
+    m_osd_container.return_value = 'podman'
+    m_run.return_value = CEPH_VOLUME_OUTPUT
+
+    assert cephvolumescan.get_ceph_lvm_list() == CEPH_LVM_LIST
+
+
+@patch('leapp.libraries.actor.cephvolumescan.os.path.isfile')
+@patch('leapp.libraries.actor.cephvolumescan.get_ceph_lvm_list')
+def test_encrypted_osds_list(m_get_ceph_lvm_list, m_isfile):
+
+    m_get_ceph_lvm_list.return_value = CEPH_LVM_LIST
+    m_isfile.return_value = True
+
+    assert cephvolumescan.encrypted_osds_list() == ['Tyc0TH-RDxr-ebAF-9mWF-Kh5R-YnvJ-cEcGVn']

--- a/repos/system_upgrade/common/actors/inhibitwhenluks/tests/test_inhibitwhenluks.py
+++ b/repos/system_upgrade/common/actors/inhibitwhenluks/tests/test_inhibitwhenluks.py
@@ -1,4 +1,4 @@
-from leapp.models import LsblkEntry, StorageInfo
+from leapp.models import CephInfo, LsblkEntry, StorageInfo
 from leapp.reporting import Report
 from leapp.snactor.fixture import current_actor_context
 from leapp.utils.report import is_inhibitor
@@ -14,6 +14,17 @@ def test_actor_with_luks(current_actor_context):
     assert current_actor_context.consume(Report)
     report_fields = current_actor_context.consume(Report)[0].report
     assert is_inhibitor(report_fields)
+
+
+def test_actor_with_luks_ceph_only(current_actor_context):
+    with_luks = [LsblkEntry(name='luks-132', maj_min='253:0', rm='0',
+                            size='10G', ro='0', tp='crypt', mountpoint=''
+                            )]
+    ceph_volume = ['luks-132']
+    current_actor_context.feed(StorageInfo(lsblk=with_luks))
+    current_actor_context.feed(CephInfo(encrypted_volumes=ceph_volume))
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
 
 
 def test_actor_without_luks(current_actor_context):

--- a/repos/system_upgrade/common/models/cephinfo.py
+++ b/repos/system_upgrade/common/models/cephinfo.py
@@ -1,0 +1,8 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class CephInfo(Model):
+    topic = SystemInfoTopic
+
+    encrypted_volumes = fields.List(fields.String(), default=[])


### PR DESCRIPTION
The presence of even one encryted disks prevents
the OS update. This addition permits the upgrade
if all the disks are Ceph encrypted OSDs as it
shouldn't impact the OS update

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1885335

Signed-off-by: Teoman ONAY <tonay@redhat.com>