### PR TITLE
Enable support for SAP upgrades on AWS using RHUI

### DIFF
--- a/repos/system_upgrade/common/actors/cloud/checkrhui/actor.py
+++ b/repos/system_upgrade/common/actors/cloud/checkrhui/actor.py
@@ -62,7 +62,8 @@ class CheckRHUI(Actor):
                         reporting.Remediation(commands=[['yum', 'install', '-y', info['leapp_pkg']]])
                     ])
                     return
-                if provider == 'aws':
+                # there are several "variants" related to the *AWS* provider (aws, aws-sap)
+                if provider.startswith('aws'):
                     # We have to disable Amazon-id plugin in the initramdisk phase as the network
                     # is down at the time
                     self.produce(DNFPluginTask(name='amazon-id', disable_in=['upgrade']))

--- a/repos/system_upgrade/common/actors/dnfpackagedownload/actor.py
+++ b/repos/system_upgrade/common/actors/dnfpackagedownload/actor.py
@@ -41,7 +41,8 @@ class DnfPackageDownload(Actor):
         tasks = next(self.consume(FilteredRpmTransactionTasks), FilteredRpmTransactionTasks())
         target_userspace_info = next(self.consume(TargetUserSpaceInfo), None)
         rhui_info = next(self.consume(RHUIInfo), None)
-        on_aws = bool(rhui_info and rhui_info.provider == 'aws')
+        # there are several "variants" related to the *AWS* provider (aws, aws-sap)
+        on_aws = bool(rhui_info and rhui_info.provider.startswith('aws'))
 
         dnfplugin.perform_rpm_download(
             tasks=tasks, used_repos=used_repos, target_userspace_info=target_userspace_info,

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -2,12 +2,18 @@ import os
 
 from leapp.libraries.stdlib import api
 
-
 AWS_MAP = {
     'el7_pkg': 'rh-amazon-rhui-client',
     'el8_pkg': 'rh-amazon-rhui-client',
     'leapp_pkg': 'leapp-rhui-aws',
     'leapp_pkg_repo': 'leapp-aws.repo'
+}
+
+AWS_MAP_SAP = {
+    'el7_pkg': 'rh-amazon-rhui-client-sap-bundle',
+    'el8_pkg': 'rh-amazon-rhui-client-sap-bundle-e4s',
+    'leapp_pkg': 'leapp-rhui-aws-sap-e4s',
+    'leapp_pkg_repo': 'leapp-aws-sap-e4s.repo'
 }
 
 AZURE_MAP = {
@@ -18,24 +24,29 @@ AZURE_MAP = {
     'leapp_pkg_repo': 'leapp-azure.repo'
 }
 
+
 # for the moment the only difference in RHUI package naming is on ARM
 AWS_MAP_AARCH64 = dict(AWS_MAP, el7_pkg='rh-amazon-rhui-client-arm')
 
 RHUI_CLOUD_MAP = {
     'x86_64': {
         'aws': AWS_MAP,
+        'aws-sap-e4s': AWS_MAP_SAP,
         'azure': AZURE_MAP,
     },
     'aarch64': {
         'aws': AWS_MAP_AARCH64,
+        'aws-sap-e4s': AWS_MAP_SAP,
         'azure': AZURE_MAP,
     },
     'ppc64le': {
         'aws': AWS_MAP,
+        'aws-sap-e4s': AWS_MAP_SAP,
         'azure': AZURE_MAP,
     },
     's390x': {
         'aws': AWS_MAP,
+        'aws-sap-e4s': AWS_MAP_SAP,
         'azure': AZURE_MAP,
     },
 }
@@ -70,6 +81,15 @@ def gen_rhui_files_map():
             ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
             (AWS_DNF_PLUGIN_NAME, DNF_PLUGIN_PATH),
             (RHUI_CLOUD_MAP[arch]['aws']['leapp_pkg_repo'], YUM_REPOS_PATH)
+        ],
+        'aws-sap-e4s': [
+            ('rhui-client-config-server-8-sap-bundle.crt', RHUI_PKI_PRODUCT_DIR),
+            ('rhui-client-config-server-8-sap-bundle.key', RHUI_PKI_DIR),
+            ('content-rhel8-sap.crt', RHUI_PKI_PRODUCT_DIR),
+            ('content-rhel8-sap.key', RHUI_PKI_DIR),
+            ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
+            (AWS_DNF_PLUGIN_NAME, DNF_PLUGIN_PATH),
+            (RHUI_CLOUD_MAP[arch]['aws-sap-e4s']['leapp_pkg_repo'], YUM_REPOS_PATH)
         ],
         'azure': [
             ('content.crt', RHUI_PKI_PRODUCT_DIR),


### PR DESCRIPTION
Adds RHUI specific data needed for RHEL 7 > RHEL 8 upgrade using RHUI. Special "leapp-rhui-aws-sap-e4s" package is needed in the RHEL 7 client repository.