### PR TITLE
Enable support for SAP upgrades on Azure using RHUI

### DIFF
--- a/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
+++ b/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
@@ -63,8 +63,10 @@ class RedHatSignedRpmScanner(Actor):
             arch = self.configuration.architecture
 
             el7_pkg = rhui.RHUI_CLOUD_MAP[arch]['azure']['el7_pkg']
+            el7_pkg_sap = rhui.RHUI_CLOUD_MAP[arch]['azure-sap']['el7_pkg']
             el8_pkg = rhui.RHUI_CLOUD_MAP[arch]['azure']['el8_pkg']
-            return pkg.name in [el7_pkg, el8_pkg]
+            el8_pkg_sap = rhui.RHUI_CLOUD_MAP[arch]['azure-sap']['el8_pkg']
+            return pkg.name in [el7_pkg, el7_pkg_sap, el8_pkg, el8_pkg_sap]
 
         for rpm_pkgs in self.consume(InstalledRPM):
             for pkg in rpm_pkgs.items:

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -24,6 +24,13 @@ AZURE_MAP = {
     'leapp_pkg_repo': 'leapp-azure.repo'
 }
 
+AZURE_MAP_SAP = {
+    'el7_pkg': 'rhui-azure-rhel7-base-sap-ha',
+    'el8_pkg': 'rhui-azure-rhel8-sap-ha',
+    'agent_pkg': 'WALinuxAgent',
+    'leapp_pkg': 'leapp-rhui-azure-sap',
+    'leapp_pkg_repo': 'leapp-azure-sap.repo'
+}
 
 # for the moment the only difference in RHUI package naming is on ARM
 AWS_MAP_AARCH64 = dict(AWS_MAP, el7_pkg='rh-amazon-rhui-client-arm')
@@ -33,21 +40,25 @@ RHUI_CLOUD_MAP = {
         'aws': AWS_MAP,
         'aws-sap-e4s': AWS_MAP_SAP,
         'azure': AZURE_MAP,
+        'azure-sap': AZURE_MAP_SAP,
     },
     'aarch64': {
         'aws': AWS_MAP_AARCH64,
         'aws-sap-e4s': AWS_MAP_SAP,
         'azure': AZURE_MAP,
+        'azure-sap': AZURE_MAP_SAP,
     },
     'ppc64le': {
         'aws': AWS_MAP,
         'aws-sap-e4s': AWS_MAP_SAP,
         'azure': AZURE_MAP,
+        'azure-sap': AZURE_MAP_SAP,
     },
     's390x': {
         'aws': AWS_MAP,
         'aws-sap-e4s': AWS_MAP_SAP,
         'azure': AZURE_MAP,
+        'azure-sap': AZURE_MAP_SAP,
     },
 }
 
@@ -95,7 +106,12 @@ def gen_rhui_files_map():
             ('content.crt', RHUI_PKI_PRODUCT_DIR),
             ('key.pem', RHUI_PKI_PRIVATE_DIR),
             (RHUI_CLOUD_MAP[arch]['azure']['leapp_pkg_repo'], YUM_REPOS_PATH)
-        ]
+        ],
+        'azure-sap': [
+            ('content-rhel8-sap-ha.crt', RHUI_PKI_PRODUCT_DIR),
+            ('key-rhel8-sap-ha.pem', RHUI_PKI_DIR),
+            (RHUI_CLOUD_MAP[arch]['azure-sap']['leapp_pkg_repo'], YUM_REPOS_PATH)
+        ],
     }
 
 


### PR DESCRIPTION
Adds RHUI specific data needed for RHEL 7 > RHEL 8 upgrade using RHUI. Special "leapp-rhui-azure-sap" package is needed in the RHEL 7 client repository.