### PR TITLE
Disable database sync before reboot by default

### DIFF
--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -31,6 +31,7 @@ from leapp.utils.output import beautify_actor_exception, report_errors, report_i
              default=get_config().get('report', 'schema'))
 @breadcrumbs.produces_breadcrumbs
 def preupgrade(args, breadcrumbs):
+    util.disable_database_sync()
     context = str(uuid.uuid4())
     cfg = get_config()
     util.handle_output_level(args)

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -67,6 +67,7 @@ def upgrade(args, breadcrumbs):
         util.restore_leapp_env_vars(context)
         skip_phases_until = util.get_last_phase(context)
     else:
+        util.disable_database_sync()
         configuration = util.prepare_configuration(args)
         e = Execution(context=context, kind='upgrade', configuration=configuration)
         e.store()


### PR DESCRIPTION
This patch sets the LEAPP_DEVEL_DATABASE_SYNC_OFF by default for
`preupgrade` and for `upgrade` for the pre-reboot part of the upgrade,
unless the environment variable has been set already by the user.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>