### PR TITLE
Modify the supported upgrade path for RHEL 7.9 systems running SAP HANA

### DIFF
--- a/repos/system_upgrade/common/actors/ipuworkflowconfig/libraries/ipuworkflowconfig.py
+++ b/repos/system_upgrade/common/actors/ipuworkflowconfig/libraries/ipuworkflowconfig.py
@@ -25,7 +25,7 @@ upgrade_paths_map = {
     # expected upgrade paths for RHEL 7
     ('7.6', LEAPP_UPGRADE_FLAVOUR_DEFAULT): '8.4',
     ('7.9', LEAPP_UPGRADE_FLAVOUR_DEFAULT): '8.4',
-    ('7.9', LEAPP_UPGRADE_FLAVOUR_SAP_HANA): '8.4',
+    ('7.9', LEAPP_UPGRADE_FLAVOUR_SAP_HANA): '8.2',
 
     # expected upgrade paths for RHEL 8
     ('8.6', LEAPP_UPGRADE_FLAVOUR_DEFAULT): '9.0',

--- a/repos/system_upgrade/el7toel8/actors/checksaphana/libraries/checksaphana.py
+++ b/repos/system_upgrade/el7toel8/actors/checksaphana/libraries/checksaphana.py
@@ -5,11 +5,11 @@ from leapp import reporting
 
 
 # SAP HANA Compatibility
-# Requirement is SAP HANA 2.00 rev 55 which is the minimal supported revision for both RHEL 7.9 and RHEL 8.4
+# Requirement is SAP HANA 2.00 rev 54 which is the minimal supported revision for both RHEL 7.9 and RHEL 8.2
 
 SAP_HANA_MINIMAL_MAJOR_VERSION = 2
-SAP_HANA_RHEL8_REQUIRED_PATCH_LEVELS = ((5, 55, 0),)
-SAP_HANA_MINIMAL_VERSION_STRING = 'HANA 2.0 SPS05 rev 55 or later'
+SAP_HANA_RHEL8_REQUIRED_PATCH_LEVELS = ((5, 54, 0),)
+SAP_HANA_MINIMAL_VERSION_STRING = 'HANA 2.0 SPS05 rev 54 or later'
 
 
 def _manifest_get(manifest, key, default_value=None):


### PR DESCRIPTION
Modify the supported upgrade path for RHEL 7.9 systems running SAP HANA from RHEL 8.4 to RHEL 8.2