### PR TITLE
Fix: Random crashes during the output decoding of dnf commands

### DIFF
--- a/repos/system_upgrade/common/libraries/tests/panagrams
+++ b/repos/system_upgrade/common/libraries/tests/panagrams
@@ -1,0 +1,21 @@
+Vypätá dcéra grófa Maxwella s IQ nižším ako kôň núti čeľaď hrýzť hŕbu jabĺk.
+
+Nechť již hříšné saxofony ďáblů rozezvučí síň úděsnými tóny waltzu, tanga a quickstepu.
+
+صِف خَلقَ خَودِ كَمِثلِ الشَمسِ إِذ بَزَغَت — يَحظى الضَجيعُ بِها نَجلاءَ مِعطارِ
+
+Ах чудна българска земьо, полюшвай цъфтящи жита.
+
+Albert osti fagotin ja töräytti puhkuvan melodian.
+
+Falsches Üben von Xylophonmusik quält jeden größeren Zwerg
+
+Ταχίστη αλώπηξ βαφής ψημένη γη, δρασκελίζει υπέρ νωθρού κυνός Takhístè alôpèx vaphês psèménè gè, draskelízei ypér nòthroý kynós
+
+דג סקרן שט בים מאוכזב ולפתע מצא חברה
+
+ऋषियों को सताने वाले दुष्ट राक्षसों के राजा रावण का सर्वनाश करने वाले विष्णुवतार भगवान श्रीराम, अयोध्या के महाराज दशरथ के बड़े सपुत्र थे।
+
+Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
+
+Эх, чужак, общий съём цен шляп (юфть) – вдрызг! 

--- a/repos/system_upgrade/common/libraries/tests/test_utils_logging_handler.py
+++ b/repos/system_upgrade/common/libraries/tests/test_utils_logging_handler.py
@@ -1,0 +1,49 @@
+# -*- coding: UTF-8 -*-
+import os.path
+import sys
+
+from leapp.libraries.common.utils import logging_handler, config
+from leapp.libraries.stdlib.call import STDOUT, STDERR
+
+
+def test_logging_handler(capfdbinary, monkeypatch):
+    debug_on = False
+    monkeypatch.setattr(config, 'is_debug', lambda: debug_on)
+    panagrams_path = os.path.join(os.path.dirname(__file__), 'panagrams')
+    with open(panagrams_path, 'rb') as f:
+        test_data = f.read()
+
+    bin_test_data = test_data
+    if isinstance(test_data, str) and str is not bytes:
+        bin_test_data = test_data.encode()
+    # Should not log anything
+    for c in range(0, len(bin_test_data)):
+        logging_handler((None, STDERR), bin_test_data[c:c+1])
+    debug_on = True
+    for c in range(0, len(bin_test_data)):
+        logging_handler((None, STDERR), bin_test_data[c:c+1])
+    for c in range(0, len(bin_test_data)):
+        logging_handler((None, STDOUT), bin_test_data[c:c+1])
+    captured = capfdbinary.readouterr()
+    assert captured.out == bin_test_data
+    assert captured.err == bin_test_data
+
+
+def test_logging_handler_arrow(capfdbinary, monkeypatch):
+    debug_on = False
+    monkeypatch.setattr(config, 'is_debug', lambda: debug_on)
+    # → => '\xe2\x86\x92'
+    if sys.version_info > (3, 0):
+        buf = b'\xe2\x86\x92'
+    else:
+        buf = '\xe2\x86\x92'
+
+    for i in range(0, len(buf)):
+        debug_on = False
+        logging_handler((None, STDERR), buf[i:i+1])
+        debug_on = True
+        logging_handler((None, STDERR), buf[i:i+1])
+        logging_handler((None, STDOUT), buf[i:i+1])
+    captured = capfdbinary.readouterr()
+    assert captured.err == buf
+    assert captured.out == buf

--- a/repos/system_upgrade/common/libraries/utils.py
+++ b/repos/system_upgrade/common/libraries/utils.py
@@ -1,4 +1,5 @@
 import functools
+import os
 import sys
 
 import six
@@ -75,14 +76,13 @@ def logging_handler(fd_info, buf):
     Custom log handler to always show stdout to console and stderr only in DEBUG mode
     """
     (_unused, fd_type) = fd_info
-
-    if isinstance(buf, bytes) and str is not bytes:
-        buf = buf.decode('utf-8')
-    if fd_type == STDOUT:
-        sys.stdout.write(buf)
+    if fd_type != STDOUT and not config.is_debug():
+        return
+    target = sys.stdout if fd_type == STDOUT else sys.stderr
+    if sys.version_info > (3, 0):
+        os.writev(target.fileno(), [buf])
     else:
-        if config.is_debug():
-            sys.stderr.write(buf)
+        target.write(buf)
 
 
 def reinstall_leapp_repository_hint():


### PR DESCRIPTION
Previously the output of DNF causes crashes during the upgrade.
This was caused by incomplete UTF-8 byte sequences being decoded on the
fly, for this purpose we're now starting to use an incremental decoder,
that should solve the problem.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>