### PR TITLE
Release 0.15.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -41,7 +41,7 @@ py2_byte_compile "%1" "%2"}
 # RHEL 8+ packages to be consistent with other leapp projects in future.
 
 Name:           leapp-repository
-Version:        0.14.0
+Version:        0.15.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Packaging
- Add dependency on `dnf-command(config-manager)` (#701)
- Added a dependency on leapp as the new rpm provides leapp commands (#701, #)
- Bumped leapp-repository-dependencies to 6 (#701)
- Provides the leapp-upgrade capability, so users can install all packages just by the `yum install leapp-upgrade` command (#701)
- Support building on RHEL 8 systems: leapp-upgrade-el8toel9 (#701)
- The leapp-repository rpm has been renamed to leapp-upgrade-el7toel8 for RHEL 7 (#701)

## Upgrade handling
### Fixes
- Check all devices (not only PCI devices) for possible removed drivers (#666)
- Do not exclude repoids enabled via the --enablerepo option (#623)
- Enforce the `en_US.urf-8` locale when running leapp to prevent various issues when a different locale is used on the system (#706)
- Enhance the check of required free space on disk for the upgrade (#734)
- Fix XFS ftype=0 workaround when "non-XFS" rootfs is present (#674)
- Fix detection of XFS partitions without ftype (#678)
- Fix handling of /etc/yum.repos.d directory for RHUI (#730)
- Fix handling of issues when fetching leapp data files
- Fix incorrect mapping of RHEL repositories (#714)
- Fix invalid detection of RHEL-ALT on RHEL 8 systems
- Fix the detection of NFS partitions in /etc/fstab (#712)
- Fix the report message when multiple NICs with ethX names are present (#640)
- Introduce the LEAPP_NO_NETWORK_RENAMING environment variable to leave management of NICs names on user when set to '1'; fixes e.g. problems with bonding configuration (#721)
- Various Python3 compatibility fixes in regards to prepare for IPU 8 -> 9 (#680, #679, #681, #688)

### Enhancements
- Changed supported upgrade path for RHEL with SAP: RHEL with SAP 7.9 -> 8.2
- Add PostgresqlCheck actor for basic reporting about PostgresSQL changes (#136)
- Add multiple attempts to fetch data from server and increased the timeout to improve the experience on systems with unstable network connection
- Add possibility to influence creation of targetuserspace container, upgrade initramfs, and target initramfs (#517)
- Add the scandasd actor to check if DASD is used on s390x arch (#517)
- Enable upgrades for SAP on AWS & Azure using RHUI (#736, #739)
- Generate /etc/migration-results upon leapp preupgrade / upgrade execution to inform about status of the migration (#719)
- Improve the report message when BTRFS is detected (#727)
- Inhibit the upgrade if any CIFS entries found in /etc/fstab (#632)
- Inhibit the upgrade if any deprecated OpenSSH configuration options / directives are detected (#695)
- Inhibit the upgrade when multiple rescue boot entries exist on s390x (#700)
- Inhibit the upgrade when x32b and x64b versions of packages are installed (#628)
- Introduce hard preservation of leapp packages during the IPU (#701)
- Introduce new system of automatic mapping of RHEL repositories for the in-place upgrade based on the repomap.json file (#714)
- Introduce the --channel CLI option to specify the channel (e.g. eus) supposed to be used for the upgrade (#728)
- Report the problems with target repositories using inhibitors instead of error messages (#731)
- Restore the leapp environment variables on --resume execution after the reboot of the system (#724)
- Update the /etc/{yum,dnf}/var/releasever file if exists or RHUI is detected (#720)

## Additional changes interesting for devels
- CLI: leapp CLI commands are now part of leapp-repository in the `commands` directory (#662)
- Drop of RepositoriesMap and RepositoryMap models as these have been replaced by new 'private' models and it was no possible to keep the original functionality connected to connected to these old models (#714)
- Dropped possibility to upgrade from/to HTB systems (HTB doesn't exist anymore)
- Introduced many changes as preparation for the IPU 8 -> 9
- Introduced the upgrade/common leapp repository: contains fundamental parts generic for all IPUs
- Introduced the upgrade/el8toel9 leapp repository: contains stuff related just for IPU 8 -> 9; depends on the upgrades/common repository
- Introduced the LEAPP_DEVEL_USE_PERSISTENT_PACKAGE_CACHE envar for development and testing purposes to speed up the process, but use of the envar could end with some issues when the cached data is not fresh
- The upgrade/el7toel8 leapp repository contains only stuff related to IPU 7 -> 8
- Makefile: introduce the `fast_lint` target to run linters just on files different from master (#722)
- The InstalledRPM model is extended by module:stream data (#667)
- config library: introduce `get_target_major_version` and `get_source_major_version` functions
- fetch library: the `fetch_or_read` function allows to specify the file encoding (#717)
- mounting library: add the remove_tree isolated action (#517)
- testutils library: CurrentActorMocked: implemented the get_actor_file_path method (#517)
- 