### PR TITLE
authselectcheck: do not create invalid answerfile (remove invalid newline in the dialog label)

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/authselectcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectcheck/actor.py
@@ -81,7 +81,7 @@ class AuthselectCheck(Actor):
     def get_confirmation(self, model, command):
         dialog = self.dialogs[0]
 
-        dialog.components[0].label += "\n{}\n".format(command)
+        dialog.components[0].label += " {}".format(command)
 
         return self.get_answers(dialog).get('confirm')
 


### PR DESCRIPTION
The original solution created invalid answertfile because the added
newline in the label statement without making the line a comment,
so the result was like:
```
# Label:              Configure PAM and nsswitch.conf with the following authselect call?
authselect select sssd with-fingerprint --force
```

Make the result to looks something like this (just one line):
```
# Label:              Configure PAM and nsswitch.conf with the following authselect call? authselect select sssd with-fingerprint --force
```

The minimal reproducer, on clean RHEL 7 system execute:
```
authconfig --update --enablesssdauth
```