### PR TITLE
Fix the rerun command regarding the --channel ....

### DIFF
--- a/commands/rerun/__init__.py
+++ b/commands/rerun/__init__.py
@@ -68,6 +68,7 @@ def rerun(args):
         verbose=args.verbose,
         reboot=False,
         no_rhsm=False,
+        channel=None,
         whitelist_experimental=[],
         enablerepo=[]))
 


### PR DESCRIPTION
With the introduction of the --channel option for the leapp upgrade
command, the rerun command has become broken as it doesn't know
anything about this option but part of the code is shared with the
upgrade command. Introduce the channel field in the `Namespace`
object that represents the "args" in case of the rerun command.