### PR TITLE
peseventsscanner: Fix the mapping of repositories (e.g. on detached

### DIFF
--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/peseventsscanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/peseventsscanner.py
@@ -13,6 +13,7 @@ from leapp.libraries.stdlib.config import is_verbose
 from leapp.exceptions import StopActorExecution, StopActorExecutionError
 from leapp.models import (
     InstalledRedHatSignedRPM,
+    PESIDRepositoryEntry,
     PESRpmTransactionTasks,
     RepositoriesBlacklisted,
     RepositoriesFacts,
@@ -145,7 +146,19 @@ def _get_repositories_mapping(target_pesids):
         peseventsscanner_repomap.DEFAULT_PESID[get_target_major_version()], None
     )
     if not representative_repo:
-        api.current_logger().warning('Cannot determine the base target repository')
+        api.current_logger().warning('Cannot determine the representative target base repository.')
+        api.current_logger().info(
+            'Fallback: Create an artificial representative PESIDRepositoryEntry for the repository mapping'
+        )
+        representative_repo = PESIDRepositoryEntry(
+            pesid=peseventsscanner_repomap.DEFAULT_PESID[get_target_major_version()],
+            arch=api.current_actor().configuration.architecture,
+            major_version=get_target_major_version(),
+            repoid='artificial-repoid',
+            repo_type='rpm',
+            channel='ga',
+            rhui='',
+        )
 
     for pesid in target_pesids:
         if pesid in exp_pesid_repos:


### PR DESCRIPTION
systems)

tl;dr; because of problems with mapping, the peseventsscanner actor
produced incorrect lists of packages expected to be installed,
kept/upgraded, and removed when the base repository is not enabled.

The current design of the peseventsscanner actor (and related actors..)
requires mapping of target PES IDs of each target packages to expected
repository IDs, as for each package that should be installed, it needs
to provide information about repository that should be used for the
upgrade. IOW, the PES data doesn't contain the information about
specific repositories, just cover a family of repositories via PES
ID, but regarding the current connection with other two actors,
we have to do the adhoc translation too. In the end, packages that
we cannot map to any specific repoid are removed from all output
lists (later used as input for our dnf plugin).

This can be problem, as for the correct translation we need some
source repositories, so we can discover the target equivalents
based on some markers, like:
 - is it RHUI?
 - what channels we should use? (ga, eus, e4s, ..?)
 - ...

To find the best candidate, we do a trick, to pick a representative
repository on the system (from Base / BaseOS family) to pick the best
matching target repository for the particular PES ID family.

But this solution is broken when the system has not enabled the
base repository. This scenario is most typical for:
  - detached systems (e.g. everything installed only via ISO)
  - systems consuming only custom repositories
  - ...

As on such a systems we usually even cannot find any DNF repository
with standard repoid at all (most typical scenario).

To handle the problem for now, when we cannot find a representative
repository, fallback to create artifical one for the search of best
candidates. This will cover now majority of cases as:
  - usually such systems do not use RHSM, so repositories have to be
    provided by user already
  - the current artificial repository points to "ga" channel, but
    customer can specify the wanted channel using the --channel CLI
    option (which is most likely to happen for IPU 7.9 -> 8.x)
  - architecture is known
  - src repoid is not important here now
  - act as non-rhui system as RHUI systems most likely will have
    enableed RHUI repositories so the fallback is not expected to
    happen on RHUI

The proper solution for the problem will be deliver with the
planned "refactoring" when we merge together several actors, so
the decision logic about target repositories will be just on one
place and we will have more free space to decide what to do.