### PR TITLE
Fix getting device attribute through udev on py3

### DIFF
--- a/repos/system_upgrade/common/libraries/persistentnetnames.py
+++ b/repos/system_upgrade/common/libraries/persistentnetnames.py
@@ -44,7 +44,9 @@ def interfaces():
             attrs['driver'] = dev['ID_NET_DRIVER']
             attrs['vendor'] = dev['ID_VENDOR_ID']
             attrs['pci_info'] = PCIAddress(**pci_info(dev['ID_PATH']))
-            attrs['mac'] = dev.attributes['address']
+            attrs['mac'] = dev.attributes.get('address')
+            if isinstance(attrs['mac'], bytes):
+                attrs['mac'] = attrs['mac'].decode()
         except Exception as e:  # pylint: disable=broad-except
             # FIXME(msekleta): We should probably handle errors more granularly
             # Maybe we should inhibit upgrade process at this point

--- a/repos/system_upgrade/common/libraries/tests/test_persistentnetnames_library.py
+++ b/repos/system_upgrade/common/libraries/tests/test_persistentnetnames_library.py
@@ -1,0 +1,57 @@
+from leapp.libraries.common import persistentnetnames
+from leapp.libraries.stdlib import api
+from leapp.libraries.common.testutils import produce_mocked
+
+
+class AttributesTest(object):
+    def __init__(self):
+        self.attributes = {
+            'address': b'fa:16:3e:cd:26:5a'
+        }
+
+    def get(self, attribute):
+        if attribute in self.attributes:
+            return self.attributes[attribute]
+        raise KeyError
+
+
+class DeviceTest(object):
+    def __init__(self):
+        self.dict_data = {
+             'ID_NET_DRIVER': 'virtio_net',
+             'ID_VENDOR_ID': '0x1af4',
+             'ID_PATH': 'pci-0000:00:03.0',
+        }
+
+    def __getitem__(self, key):
+        if key in self.dict_data:
+            return self.dict_data[key]
+        raise KeyError
+
+    @property
+    def sys_name(self):
+        return 'eth'
+
+    @property
+    def device_path(self):
+        return '/devices/pci0000:00/0000:00:03.0/virtio0/net/eth0'
+
+    @property
+    def attributes(self):
+        return AttributesTest()
+
+
+def provide_test_interfaces():
+    return [DeviceTest()]
+
+
+def test_getting_interfaces(monkeypatch):
+    monkeypatch.setattr(persistentnetnames, 'physical_interfaces', provide_test_interfaces)
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    interface = next(persistentnetnames.interfaces())
+    assert interface.name
+    assert interface.devpath
+    assert interface.driver
+    assert interface.vendor
+    assert interface.pci_info
+    assert interface.mac


### PR DESCRIPTION
On Python 3 pyudev Attribute object provides its own getter and missing
the __getitem__. Switch to use the "get" method which will work for both
py2 and py3.