### PR TITLE
unittests: Scenario based testing

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,9 +13,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python:
-          - python3.6
-          - python2.7
+        scenarios:
+          - name: Run unit tests for el8toel9 and common repositories on python 3.9
+            python: python3.9
+            repos: 'el8toel9,common'
+            container: centos8
+          - name: Run unit tests for el7toel8 and common repositories on python 3.6
+            python: python3.6
+            repos: 'el7toel8,common'
+            container: centos8
+          - name: Run unit tests for el8toel9 and common repositories on python 3.6
+            python: python3.6
+            repos: 'el8toel9,common'
+            container: centos8
+          - name: Run unit tests for el7toel8 and common repositories on python 2.7
+            python: python2.7
+            repos: 'el7toel8,common'
+            container: centos7
 
     steps:
       - name: Checkout code
@@ -29,10 +43,5 @@ jobs:
         if: github.ref != 'refs/heads/master'
         run: |
           git branch -f master origin/master
-      - name: Drop el8toel9 code for python2.7 tests
-        run: |
-          rm -rf ${PWD}/repos/system_upgrade/el8toel9
-        shell: bash
-        if: matrix.python == 'python2.7'
-      - name: Run tests @ ${{matrix.python}}
-        run: script -e -c /bin/bash -c 'TERM=xterm docker build -t leapp-tests -f utils/docker-tests/Dockerfile utils/docker-tests && PYTHON_VENV=${{matrix.python}}  docker run --rm -ti -v ${PWD}:/payload --env=PYTHON_VENV leapp-tests'
+      - name: ${{matrix.scenarios.name}}
+        run: script -e -c /bin/bash -c 'TERM=xterm docker build -t leapp-tests -f utils/docker-tests/Dockerfile.${{matrix.scenarios.container}} utils/docker-tests && PYTHON_VENV=${{matrix.scenarios.python}} REPOSITORIES=${{matrix.scenarios.repos}} docker run --rm -ti -v ${PWD}:/payload --env=PYTHON_VENV --env=REPOSITORIES leapp-tests'

--- a/repos/system_upgrade/common/actors/selinux/selinuxapplycustom/Makefile
+++ b/repos/system_upgrade/common/actors/selinux/selinuxapplycustom/Makefile
@@ -1,2 +1,5 @@
 install-deps:
-	yum install -y policycoreutils policycoreutils-python
+	yum install -y policycoreutils
+	-yum install -y policycoreutils-python
+	-yum install -y python3-policycoreutils
+

--- a/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/Makefile
+++ b/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/Makefile
@@ -1,2 +1,4 @@
 install-deps:
-	yum install -y policycoreutils policycoreutils-python
+	yum install -y policycoreutils
+	-yum install -y policycoreutils-python
+	-yum install -y python3-policycoreutils

--- a/repos/system_upgrade/common/actors/selinux/selinuxprepare/Makefile
+++ b/repos/system_upgrade/common/actors/selinux/selinuxprepare/Makefile
@@ -1,2 +1,4 @@
 install-deps:
-	yum install -y policycoreutils policycoreutils-python
+	yum install -y policycoreutils
+	-yum install -y policycoreutils-python
+	-yum install -y python3-policycoreutils

--- a/repos/system_upgrade/common/actors/systemfacts/Makefile
+++ b/repos/system_upgrade/common/actors/systemfacts/Makefile
@@ -1,3 +1,5 @@
 install-deps:
-	yum install -y kmod procps-ng policycoreutils findutils libselinux-python
+	yum install -y kmod procps-ng policycoreutils findutils
+	-yum install -y libselinux-python
+	-yum install -y python3-libselinux
 

--- a/repos/system_upgrade/common/actors/transactionworkarounds/actor.py
+++ b/repos/system_upgrade/common/actors/transactionworkarounds/actor.py
@@ -1,8 +1,7 @@
-import os
-
 from leapp.actors import Actor
 from leapp.models import RpmTransactionTasks
 from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.libraries.actor import transactionworkarounds
 
 
 class TransactionWorkarounds(Actor):
@@ -18,13 +17,4 @@ class TransactionWorkarounds(Actor):
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
     def process(self):
-        location = self.get_folder_path('bundled-rpms')
-        local_rpms = []
-        for name in os.listdir(location):
-            if name.endswith('.rpm'):
-                # It is important to put here the realpath to the files here, because
-                # symlinks cannot be resolved properly inside of the target userspace since they use the /installroot
-                # mount target
-                local_rpms.append(os.path.realpath(os.path.join(location, name)))
-        if local_rpms:
-            self.produce(RpmTransactionTasks(local_rpms=local_rpms))
+        transactionworkarounds.process()

--- a/repos/system_upgrade/common/actors/transactionworkarounds/libraries/transactionworkarounds.py
+++ b/repos/system_upgrade/common/actors/transactionworkarounds/libraries/transactionworkarounds.py
@@ -1,0 +1,17 @@
+import os
+
+from leapp.libraries.stdlib import api
+from leapp.models import RpmTransactionTasks
+
+
+def process():
+    location = api.get_folder_path('bundled-rpms')
+    local_rpms = []
+    for name in os.listdir(location):
+        if name.endswith('.rpm'):
+            # It is important to put here the realpath to the files here, because
+            # symlinks cannot be resolved properly inside of the target userspace since they use the /installroot
+            # mount target
+            local_rpms.append(os.path.realpath(os.path.join(location, name)))
+    if local_rpms:
+        api.produce(RpmTransactionTasks(local_rpms=local_rpms))

--- a/repos/system_upgrade/el7toel8/actors/migratentp/Makefile
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/Makefile
@@ -1,2 +1,2 @@
 install-deps:
-	yum install -y python-ipaddress
+	-yum install -y python-ipaddress

--- a/repos/system_upgrade/el7toel8/actors/migratesendmail/Makefile
+++ b/repos/system_upgrade/el7toel8/actors/migratesendmail/Makefile
@@ -1,2 +1,2 @@
 install-deps:
-	yum install -y python-ipaddress
+	-yum install -y python-ipaddress

--- a/utils/docker-tests/Dockerfile.centos7
+++ b/utils/docker-tests/Dockerfile.centos7
@@ -1,0 +1,22 @@
+FROM registry.centos.org/centos:7
+
+VOLUME /payload
+
+RUN yum update -y && \
+    yum install python-virtualenv python-setuptools make git -y
+
+# NOTE(ivasilev,pstodulk) We need at least pip v10.0.1, however centos:7
+# provides just v8.1.2 (via EPEL). So do this: install epel repos -> install
+# python2-pip -> use pip to update to specific pip version we require. period
+# NOTE(pstodulk) I see we take care about pip for py3 inside the Makefile,
+# however I am afraid of additional possible troubles in future because of the
+# archaic pip3 version (v9.0.1). As we want to run tests for Py2 and Py3 in ci
+# always anyway, let's put py3 installation here as well..
+
+RUN yum -y install epel-release && \
+    yum -y install python2-pip python3-pip && \
+    python2 -m pip install --upgrade pip==20.3.4 && \
+    python3 -m pip install --upgrade pip==20.3.4
+
+WORKDIR /payload
+ENTRYPOINT make install-deps && make test

--- a/utils/docker-tests/Dockerfile.centos8
+++ b/utils/docker-tests/Dockerfile.centos8
@@ -1,0 +1,9 @@
+FROM registry.centos.org/centos:8
+
+VOLUME /payload
+
+RUN dnf update -y && \
+    dnf install python3-virtualenv python3-setuptools python3-pip make git -y
+
+WORKDIR /payload
+ENTRYPOINT make install-deps && make test

--- a/utils/install_actor_deps.py
+++ b/utils/install_actor_deps.py
@@ -41,8 +41,11 @@ def install_actor_deps(actor, directory):
     error("Actor '{}' doesn't exist!\n".format(actor), 1)
 
 
-def install_all_deps(directory):
+def install_all_deps(directory, repos):
+    repos = repos.split() if repos else repos
     for root, dirs, files in os.walk(directory):
+        if repos and not any([repo in dirs for repo in repos]):
+            continue
         if 'Makefile' in files:
             install(os.path.join(root, 'Makefile'))
 
@@ -53,9 +56,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--actor", help="name of the actor for which to install dependencies")
+    parser.add_argument(
+        "--repos", help="repositories to look into")
     args = parser.parse_args()
 
     if args.actor:
         install_actor_deps(args.actor, ACTORS_DIR)
     else:
-        install_all_deps(ACTORS_DIR)
+        install_all_deps(ACTORS_DIR, args.repos)


### PR DESCRIPTION
Previously we tested all repositories all together. We didn't really
care wether it was for el7toel8 or el8toel9, we even had el8toel9
being tested with python2.7 python until we deleted the el8toel9
repository within the GitHub action as a temporary measure.

This implements the feature of allowing el7toel8 and el8toel9 testing
scenarios to be implemented properly.
This means as of this patch there are 4 unit test runs:
- Python 2.7 with system_upgrade/el7toel8 and system_upgrade/common
  repos in a CentOS7 container
- Python 3.6 with system_upgrade/el7toel8 and system_upgrade/common
  repos in a CentOS8 container
- Python 3.6 with system_upgrade/el8toel9 and system_upgrade/common
  repos in a CentOS8 container
- Python 3.9 with system_upgrade/el8toel9 and system_upgrade/common
  repos in a CentOS8 container

Additionally some tests had to be altered, which either had some
problems during the execution OR were just plain wrong from the start
and had to be rewritten in order to make them being proper tests
(looking at you transactionworkarounds actor...)

On top of that pylint is now executed with -j 8 which should use 8
paralell processes to execute, which hopefully will result in faster
results.