### PR TITLE
unit-tests: Turn off fail-fast

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,7 @@ jobs:
     name: Run unit tests in containers
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         scenarios:
           - name: Run unit tests for el8toel9 and common repositories on python 3.9


### PR DESCRIPTION
Previously we used the fail-fast default value for GitHub Actions.
This leads to all still running unit tests to be cancelled when one
fails.
With this option one can see the results for all test scenarios, even if
one fails.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>