### PR TITLE
Accommodate C1803: use-implicit-booleaness-not-comparison

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/multipathconfcheck/libraries/multipathconfcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfcheck/libraries/multipathconfcheck.py
@@ -72,7 +72,7 @@ def _check_default_detection(options):
         if options[keyword] and not options[keyword][0] and \
                 options[keyword][1] not in bad:
             bad.append(options[keyword][1])
-    if bad == []:
+    if not bad:
         return
     paths = _create_paths_str(bad)
     create_report([

--- a/repos/system_upgrade/el7toel8/actors/multipathconfupdate/libraries/multipathconfupdate.py
+++ b/repos/system_upgrade/el7toel8/actors/multipathconfupdate/libraries/multipathconfupdate.py
@@ -232,7 +232,7 @@ def _update_config(config):
             qinp_info.has_no_path_retry = has_no_path_retry
             qinp_infos.append(qinp_info)
     _comment_out_ranges(lines, all_devs_ranges)
-    if qinp_infos != []:
+    if qinp_infos:
         _remove_qinp(lines, qinp_infos)
     if config.all_devs_options != []:
         if overrides_line:


### PR DESCRIPTION
That's a nice rule, so let's fix occurrencies that violate it.