### PR TITLE
Linters: fix isort check on master and HEAD..

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,15 +261,17 @@ lint:
 		echo "--- Linting done. ---"; \
 	fi
 
-	. $(VENVNAME)/bin/activate; \
-	git diff $(MASTER_BRANCH) --name-only | xargs isort -c --diff || \
-	{ \
-		echo; \
-		echo "------------------------------------------------------------------------------"; \
-		echo "Hint: Apply the required changes."; \
-		echo "      Execute the following command to apply them automatically: make lint_fix"; \
-		exit 1; \
-	} && echo "--- isort check done. ---";
+	if [[  "`git rev-parse --abbrev-ref HEAD`" != "master" ]] && [[ -n "`git diff $(MASTER_BRANCH) --name-only`" ]]; then \
+		. $(VENVNAME)/bin/activate; \
+		git diff $(MASTER_BRANCH) --name-only | xargs isort -c --diff || \
+		{ \
+			echo; \
+			echo "------------------------------------------------------------------------------"; \
+			echo "Hint: Apply the required changes."; \
+			echo "      Execute the following command to apply them automatically: make lint_fix"; \
+			exit 1; \
+		} && echo "--- isort check done. ---"; \
+	fi
 
 lint_fix:
 	. $(VENVNAME)/bin/activate; \


### PR DESCRIPTION
When running "isort" check introduced in previous commit, it should
check only changed files. However, the check has been broken after
the merge in two possible ways:
  - all files has been checked on master (right now, it means always
    broken)
  - nothing has been discovered (HEAD or another branch) created
    without any change introduced against the master branch

Skip the isort check in such a cases