### PR TITLE
Bindmount "/sys/firmware/efi/efivars/"

### DIFF
--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -39,6 +39,7 @@ else
     # TODO(pstodulk, mreznik): Why --console=pipe? Is it ok? Discovered a weird
     # issue on IPU 8 -> 9 without that in our VMs
     NSPAWN_OPTS="$NSPAWN_OPTS --bind=/sys:/hostsys --console=pipe"
+    [ -e /sys/firmware/efi/efivars ] && NSPAWN_OPTS="$NSPAWN_OPTS --bind=/sys/firmware/efi/efivars"
 fi
 export NSPAWN_OPTS="$NSPAWN_OPTS --keep-unit --register=no --timezone=off --resolv-conf=off"
 


### PR DESCRIPTION
Bindmount "/sys/firmware/efi/efivars/" into the host container in order to avoid an issue with "efivars" special filesystem being
mounted as read-only.