### PR TITLE
actor: add inihibtor FirewalldCheckAllowZoneDrifting

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/firewalldcheckallowzonedrifting/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/firewalldcheckallowzonedrifting/actor.py
@@ -1,0 +1,51 @@
+from leapp import reporting
+from leapp.actors import Actor
+from leapp.models import FirewalldGlobalConfig, FirewallsFacts
+from leapp.reporting import create_report, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class FirewalldCheckAllowZoneDrifting(Actor):
+    """
+    This actor will check if AllowZoneDrifiting=yes in firewalld.conf. This
+    option has been removed in RHEL-9 and behavior is as if
+    AllowZoneDrifiting=no.
+    """
+
+    name = 'firewalld_check_allow_zone_drifting'
+    consumes = (FirewallsFacts, FirewalldGlobalConfig)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        # If firewalld is not enabled then don't bother the user about its
+        # configuration. This Report keys off a _default_ value and as such
+        # will trigger for all users that have not done one of the following:
+        #   - disabled firewalld
+        #   - manually set AllowZoneDrifting=no (as firewalld logs suggests)
+        #
+        for facts in self.consume(FirewallsFacts):
+            if not facts.firewalld.enabled:
+                return
+
+        for facts in self.consume(FirewalldGlobalConfig):
+            if not facts.allowzonedrifting:
+                return
+
+        create_report([
+            reporting.Title('Unsupported Firewalld Configuration In Use'),
+            reporting.Summary('Firewalld has enabled configuration option '
+                              '"{conf_key}" which has been removed in RHEL-9. '
+                              'New behavior is as if "{conf_key}" was set to "no".'.format(
+                                  conf_key='AllowZoneDrifiting')),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.SANITY, reporting.Tags.FIREWALL]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.ExternalLink(
+                url='https://access.redhat.com/articles/4855631',
+                title='Changes in firewalld related to Zone Drifting'),
+            reporting.Remediation(
+                hint='Set AllowZoneDrifting=no in /etc/firewalld/firewalld.conf',
+                commands=[['sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" '
+                           '/etc/firewalld/firewalld.conf']]),
+        ])

--- a/repos/system_upgrade/el8toel9/actors/firewalldcheckallowzonedrifting/tests/component_test_firewalldcheckallowzonedrifting.py
+++ b/repos/system_upgrade/el8toel9/actors/firewalldcheckallowzonedrifting/tests/component_test_firewalldcheckallowzonedrifting.py
@@ -1,0 +1,35 @@
+from leapp.models import FirewalldGlobalConfig, FirewallsFacts, FirewallStatus
+from leapp.reporting import Report
+
+
+def test_actor_firewalldcheckallowzonedrifting(current_actor_context):
+    status = FirewallStatus(enabled=True, active=True)
+    current_actor_context.feed(FirewallsFacts(firewalld=status,
+                                              iptables=status,
+                                              ip6tables=status))
+    current_actor_context.feed(FirewalldGlobalConfig(allowzonedrifting=True))
+
+    current_actor_context.run()
+    assert current_actor_context.consume(Report)
+
+
+def test_actor_firewalldcheckallowzonedrifting_negative(current_actor_context):
+    status = FirewallStatus(enabled=False, active=True)
+    current_actor_context.feed(FirewallsFacts(firewalld=status,
+                                              iptables=status,
+                                              ip6tables=status))
+    current_actor_context.feed(FirewalldGlobalConfig(allowzonedrifting=True))
+
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+
+
+def test_actor_firewalldcheckallowzonedrifting_negative2(current_actor_context):
+    status = FirewallStatus(enabled=True, active=True)
+    current_actor_context.feed(FirewallsFacts(firewalld=status,
+                                              iptables=status,
+                                              ip6tables=status))
+    current_actor_context.feed(FirewalldGlobalConfig(allowzonedrifting=False))
+
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)

--- a/repos/system_upgrade/el8toel9/actors/firewalldcollectglobalconfig/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/firewalldcollectglobalconfig/actor.py
@@ -1,0 +1,19 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.private_firewalldcollectglobalconfig import read_config
+from leapp.models import FirewalldGlobalConfig
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class FirewalldCollectGlobalConfig(Actor):
+    """
+    This actor reads firewalld's configuration and produces Model
+    FirewalldGlobalConfig.
+    """
+
+    name = 'firewalld_collect_global_config'
+    consumes = ()
+    produces = (FirewalldGlobalConfig,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        self.produce(read_config())

--- a/repos/system_upgrade/el8toel9/actors/firewalldcollectglobalconfig/libraries/private_firewalldcollectglobalconfig.py
+++ b/repos/system_upgrade/el8toel9/actors/firewalldcollectglobalconfig/libraries/private_firewalldcollectglobalconfig.py
@@ -1,0 +1,31 @@
+import os
+
+from leapp.models import FirewalldGlobalConfig
+
+
+def read_config():
+    default_conf = FirewalldGlobalConfig()
+
+    path = '/etc/firewalld/firewalld.conf'
+    if not os.path.exists(path):
+        return default_conf
+
+    conf_dict = {}
+    with open(path) as conf_file:
+        for line in conf_file:
+            (key, _unused, value) = line.partition('=')
+            if not value:
+                continue
+
+            value = value.lower().strip()
+            if value in ['yes', 'true']:
+                value = True
+            if value in ['no', 'false']:
+                value = False
+
+            # Only worry about config used by our Model
+            key = key.lower().strip()
+            if hasattr(default_conf, key):
+                conf_dict[key] = value
+
+    return FirewalldGlobalConfig(**conf_dict)

--- a/repos/system_upgrade/el8toel9/models/firewalldglobalconfig.py
+++ b/repos/system_upgrade/el8toel9/models/firewalldglobalconfig.py
@@ -1,0 +1,27 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class FirewalldGlobalConfig(Model):
+    """
+    The model contains firewalld global configuration. The configuration is
+    usually located at /etc/firewalld/firewalld.conf.
+    """
+    topic = SystemInfoTopic
+
+    # Defaults for RHEL-9.
+    #
+    defaultzone = fields.String(default='public')
+    cleanuponexit = fields.Boolean(default=True)
+    cleanupmodulesonexit = fields.Boolean(default=False)
+    lockdown = fields.Boolean(default=False)
+    ipv6_rpfilter = fields.Boolean(default=True)
+    individualcalls = fields.Boolean(default=False)
+    logdenied = fields.String(default='off')
+    firewallbackend = fields.String(default='nftables')
+    flushallonreload = fields.Boolean(default=True)
+    rfc3964_ipv4 = fields.Boolean(default=True)
+
+    # These have been removed in RHEL-9.
+    #
+    allowzonedrifting = fields.Boolean(default=False)


### PR DESCRIPTION
This config option does not exist in RHEL-9. So we must make sure it's
not being used.

Fixes: OAMG-4391