### PR TITLE
Run 8to9 regression tests on /rerun

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -146,25 +146,7 @@ jobs:
           arch: 'x86_64'
           copr: 'epel-7-x86_64'
           debug: ${{ secrets.ACTIONS_STEP_DEBUG }}
-
-      - name: Add comment with Testing Farm request/result
-        # This step adds a new comment to the pull request with a link to the test.
-
-        # TODO: This is a temporary workaround until a proper way to set a commit status is implemented.
-        if: ${{ steps.run_test_7to8.outputs.req_id != '' }}
-        id: comment_7to8
-        uses: actions/github-script@v4
-        with:
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Testing Farm [request](${{ secrets.TF_ENDPOINT }}/requests/${{ steps.run_test_7to8.outputs.req_id }})' +
-                    ' for 7to8 regression testing has been created. Once finished, results should be available' +
-                    ' [here](http://artifacts.osci.redhat.com/testing-farm/${{ steps.run_test_7to8.outputs.req_id }}/).' +
-                    '\n[Full pipeline log](http://artifacts.osci.redhat.com/testing-farm/${{ steps.run_test_7to8.outputs.req_id }}/pipeline.log).'
-            })
+          test_name: '7to8'
 
       - name: Schedule regression testing for 8to9
         id: run_test_8to9
@@ -182,22 +164,4 @@ jobs:
           arch: 'x86_64'
           copr: 'epel-8-x86_64'
           debug: ${{ secrets.ACTIONS_STEP_DEBUG }}
-
-      - name: Add comment with Testing Farm request/result
-        # This step adds a new comment to the pull request with a link to the test.
-
-        # TODO: This is a temporary workaround until a proper way to set a commit status is implemented.
-        id: comment_8to9
-        if: ${{ steps.run_test_8to9.outputs.req_id != '' }}
-        uses: actions/github-script@v4
-        with:
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Testing Farm [request](${{ secrets.TF_ENDPOINT }}/requests/${{ steps.run_test_8to9.outputs.req_id }})' +
-                    ' for 8to9 regression testing has been created. Once finished, results should be available' +
-                    ' [here](http://artifacts.osci.redhat.com/testing-farm/${{ steps.run_test_8to9.outputs.req_id }}/).' +
-                    '\n[Full pipeline log](http://artifacts.osci.redhat.com/testing-farm/${{ steps.run_test_8to9.outputs.req_id }}/pipeline.log).'
-            })
+          test_name: '8to9'

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -130,59 +130,22 @@ jobs:
               body: 'Copr build succeeded: ${{ steps.copr_build_leapp.outputs.copr_url }}'
             })
 
-      - name: Generate a tmt test request
-        id: gen_tmt_request
-        run: |
-          cat << EOF > request.json
-          {
-            "api_key": "${{ secrets.TF_API_KEY }}",
-            "test": {"fmf": {
-              "url": "https://gitlab.cee.redhat.com/oamg/tmt-plans",
-              "ref": "master",
-              "name": "^(?!.*c2r)(?!.*sap)"
-            }},
-            "environments": [{
-              "arch": "x86_64",
-              "os": {"compose": "${{ secrets.COMPOSE_RHEL79 }}"},
-              "artifacts": [{"type": "fedora-copr-build", "id": "${{ steps.copr_build.outputs.copr_id }}:epel-7-x86_64"}]
-            }]
-          }
-          EOF
-
-          if [ "${{ secrets.ACTIONS_STEP_DEBUG }}" = "true" ]; then
-              echo request.json
-              jq < request.json
-          fi
-
-      - name: Add information about dependent leapp artifact to the tft request
-        id: amend_tmt_request
-        if: ${{ steps.leapp_pr_regex_match.outputs.match != '' }}
-        run: |
-          jq '.environments[0].artifacts += [{"type": "fedora-copr-build", "id": "${{ steps.copr_build_leapp.outputs.copr_id }}:epel-7-x86_64"}]' < request.json > request_updated.json
-          mv request_updated.json request.json
-
-      - name: Send request to testing farm service
-        # This step schedules a tmt test. The test id is stored in `req_id` variable for a later use.
-
-        # All the discovered test plans matching the regex `tests.fmf.name` from the repository specified in
-        # `tests.fmf.url` are run.
-        #
-        # At this moment repo/sha that triggered the action is used, i.e. all tests plans specified in THIS repository
-        # are run.
-
-        id: sched_test
-        run: |
-          curl ${{ secrets.TF_ENDPOINT }}/requests \
-            --data @request.json \
-            --header "Content-Type: application/json" \
-            --output response.json
-
-          if [ "${{ secrets.ACTIONS_STEP_DEBUG }}" = "true" ]; then
-              echo response.json
-              jq < response.json
-          fi
-
-          echo "::set-output name=req_id::$(jq -r .id response.json)"
+      - name: Schedule a test run
+        id: run_test_7to8
+        env:
+          ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{},{}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
+        uses: fernflower/testing-farm-service-action@main
+        with:
+          # required
+          tft_server: ${{ secrets.TF_ENDPOINT }}
+          tft_token: ${{ secrets.TF_API_KEY }}
+          compose: ${{ secrets.COMPOSE_RHEL79 }}
+          artifacts: ${{ env.ARTIFACTS }}
+          # optional
+          tests_regex: "^(?!.*c2r)(?!.*sap)(?!.*8to9)"
+          arch: 'x86_64'
+          copr: 'epel-7-x86_64'
+          debug: ${{ secrets.ACTIONS_STEP_DEBUG }}
 
       - name: Add comment with Testing Farm request/result
         # This step adds a new comment to the pull request with a link to the test.
@@ -196,8 +159,8 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Testing Farm [request](${{ secrets.TF_ENDPOINT }}/requests/${{ steps.sched_test.outputs.req_id }})' +
+              body: 'Testing Farm [request](${{ secrets.TF_ENDPOINT }}/requests/${{ steps.run_test_7to8.outputs.req_id }})' +
                     ' for tmt test was created. Once finished, results should be available' +
-                    ' [here](http://artifacts.osci.redhat.com/testing-farm/${{ steps.sched_test.outputs.req_id }}/).' +
-                    '\n[Full pipeline log](http://artifacts.osci.redhat.com/testing-farm/${{ steps.sched_test.outputs.req_id }}/pipeline.log).'
+                    ' [here](http://artifacts.osci.redhat.com/testing-farm/${{ steps.run_test_7to8.outputs.req_id }}/).' +
+                    '\n[Full pipeline log](http://artifacts.osci.redhat.com/testing-farm/${{ steps.run_test_7to8.outputs.req_id }}/pipeline.log).'
             })

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -165,3 +165,4 @@ jobs:
           copr: 'epel-8-x86_64'
           debug: ${{ secrets.ACTIONS_STEP_DEBUG }}
           test_name: '8to9'
+          env_vars: 'TARGET_VERSION=9.0'

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -130,7 +130,7 @@ jobs:
               body: 'Copr build succeeded: ${{ steps.copr_build_leapp.outputs.copr_url }}'
             })
 
-      - name: Schedule a test run
+      - name: Schedule regression testing for 7to8
         id: run_test_7to8
         env:
           ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{},{}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
@@ -151,7 +151,8 @@ jobs:
         # This step adds a new comment to the pull request with a link to the test.
 
         # TODO: This is a temporary workaround until a proper way to set a commit status is implemented.
-        id: comment
+        if: ${{ steps.run_test_7to8.outputs.req_id != '' }}
+        id: comment_7to8
         uses: actions/github-script@v4
         with:
           script: |
@@ -160,7 +161,43 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: 'Testing Farm [request](${{ secrets.TF_ENDPOINT }}/requests/${{ steps.run_test_7to8.outputs.req_id }})' +
-                    ' for tmt test was created. Once finished, results should be available' +
+                    ' for 7to8 regression testing has been created. Once finished, results should be available' +
                     ' [here](http://artifacts.osci.redhat.com/testing-farm/${{ steps.run_test_7to8.outputs.req_id }}/).' +
                     '\n[Full pipeline log](http://artifacts.osci.redhat.com/testing-farm/${{ steps.run_test_7to8.outputs.req_id }}/pipeline.log).'
+            })
+
+      - name: Schedule regression testing for 8to9
+        id: run_test_8to9
+        env:
+          ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{},{}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
+        uses: fernflower/testing-farm-service-action@main
+        with:
+          # required
+          tft_server: ${{ secrets.TF_ENDPOINT }}
+          tft_token: ${{ secrets.TF_API_KEY }}
+          compose: ${{ secrets.COMPOSE_RHEL86 }}
+          artifacts: ${{ env.ARTIFACTS }}
+          # optional
+          tests_regex: "^(?!.*c2r)(?!.*sap)(?!.*7to8)"
+          arch: 'x86_64'
+          copr: 'epel-8-x86_64'
+          debug: ${{ secrets.ACTIONS_STEP_DEBUG }}
+
+      - name: Add comment with Testing Farm request/result
+        # This step adds a new comment to the pull request with a link to the test.
+
+        # TODO: This is a temporary workaround until a proper way to set a commit status is implemented.
+        id: comment_8to9
+        if: ${{ steps.run_test_8to9.outputs.req_id != '' }}
+        uses: actions/github-script@v4
+        with:
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Testing Farm [request](${{ secrets.TF_ENDPOINT }}/requests/${{ steps.run_test_8to9.outputs.req_id }})' +
+                    ' for 8to9 regression testing has been created. Once finished, results should be available' +
+                    ' [here](http://artifacts.osci.redhat.com/testing-farm/${{ steps.run_test_8to9.outputs.req_id }}/).' +
+                    '\n[Full pipeline log](http://artifacts.osci.redhat.com/testing-farm/${{ steps.run_test_8to9.outputs.req_id }}/pipeline.log).'
             })

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -134,7 +134,7 @@ jobs:
         id: run_test_7to8
         env:
           ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{},{}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
-        uses: fernflower/testing-farm-service-action@main
+        uses: oamg/testing-farm-service-action@main
         with:
           # required
           tft_server: ${{ secrets.TF_ENDPOINT }}
@@ -152,7 +152,7 @@ jobs:
         id: run_test_8to9
         env:
           ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{},{}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
-        uses: fernflower/testing-farm-service-action@main
+        uses: oamg/testing-farm-service-action@main
         with:
           # required
           tft_server: ${{ secrets.TF_ENDPOINT }}


### PR DESCRIPTION
With the need to add 8to9 regression tests along with 7to8 refactor of tmt-tests workflow needs to be done.