### PR TITLE
Require leapp-framework >= 2.1

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -94,7 +94,7 @@ Requires:       leapp-repository-dependencies = %{leapp_repo_deps}
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' instead of the real framework rpm version.
-Requires:       leapp-framework >= 2.0, leapp-framework < 3
+Requires:       leapp-framework >= 2.1, leapp-framework < 3
 
 # Since we provide sub-commands for the leapp utility, we expect the leapp
 # tool to be installed as well.


### PR DESCRIPTION
Changes in commands introduced in #753 requires up-to-date changes
in the leapp itself. Installing older builds of leapp makes the
current implementation malfunction. Update of requirements fixes
the problem.

Relates: #753
Requires: https://github.com/oamg/leapp/pull/746