### PR TITLE
Fix instructions in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,9 +42,9 @@ Attach (or provide link to) log files if applicable (optional - may contain conf
 
 **For your convenience you can pack all logs with this command:**
 
-`# tar -czf leapp-logs.tgz /var/log/leapp /var/lib/leapp/leapp.db`
+`# tar -czf leapp-logs.tar.gz /var/log/leapp /var/lib/leapp/leapp.db`
 
-Then you may attach only the `leapp-logs.tgz` file.
+Then you may attach only the `leapp-logs.tar.gz` file.
 
 ****
 


### PR DESCRIPTION
We told people to attach the leapp-logs.tgz file when they report the
bug, however github does not know ".tgz" suffix which is acronym
for ".tar.gz". Update the suffix so github is happy.