### PR TITLE
Bump leapp-framework-dependencies to 4

### DIFF
--- a/packaging/leapp-el7toel8-deps.spec
+++ b/packaging/leapp-el7toel8-deps.spec
@@ -10,7 +10,7 @@
 
 
 %define leapp_repo_deps  6
-%define leapp_framework_deps   3
+%define leapp_framework_deps 4
 
 # NOTE: the Version contains the %{rhel} macro just for the convenience to
 # have always upgrade path between newer and older deps packages. So for


### PR DESCRIPTION
Regarding the change in https://github.com/oamg/leapp/pull/747
The target system dependencies stays intact.