### PR TITLE
Packit: stop merging with master for PRs builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,6 +6,7 @@ specfile_path: packaging/leapp-repository.spec
 upstream_package_name: leapp-repository
 downstream_package_name: leapp-repository
 upstream_tag_template: 'v{version}'
+merge_pr_in_ci: false
 
 # This is just for the build from the CLI - all other builds for jobs use own
 # actions


### PR DESCRIPTION
When a PR build is created by PackIt it contains different hash
of the commit than the latest in the PR. This is caused by the
default behaviour, when PackIt merge locally the PR changes to the
master.

As we like this idea to test stuff how it works when applied to the
master, it has several problems:
  - sometimes a PR could have conflicts with master and the build
    will not be created in such a case; but for some simple testing
    it could be a little bit annoying for someone
  - it's not possible to install a build to a specific commit using
    the commit short-hash; sometimes it's usefull when you want to
    really try the build from specific commit and it's hard to find
    the right one in such a case

So let's set `merge_pr_in_ci` to `false` so the created build
is identical to the one in the PR.