### PR TITLE
Fix invalid format string in tmt-tests workflow

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Schedule regression testing for 7to8
         id: run_test_7to8
         env:
-          ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{},{}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
+          ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{0},{1}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
         uses: oamg/testing-farm-service-action@main
         with:
           # required
@@ -151,7 +151,7 @@ jobs:
       - name: Schedule regression testing for 8to9
         id: run_test_8to9
         env:
-          ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{},{}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
+          ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{0},{1}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
         uses: oamg/testing-farm-service-action@main
         with:
           # required


### PR DESCRIPTION
This should make multiple copr build tests to be launced again with
/rerun LEAPP_PR_NUMBER command.