### PR TITLE
Pass TARGET_RELEASE, not TARGET_VERSION

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -165,4 +165,4 @@ jobs:
           copr: 'epel-8-x86_64'
           debug: ${{ secrets.ACTIONS_STEP_DEBUG }}
           test_name: '8to9'
-          env_vars: 'TARGET_VERSION=9.0'
+          env_vars: 'TARGET_RELEASE=9.0'


### PR DESCRIPTION
In order to set target_release variable in ansible playbooks
that would eventually define compose_url we should pass
TARGET_RELEASE, not TARGET_VERSION.