### PR TITLE
Packaging: Added note into the spec about noarch

### DIFF
--- a/packaging/leapp-el7toel8-deps.spec
+++ b/packaging/leapp-el7toel8-deps.spec
@@ -23,6 +23,8 @@ Name:       leapp-el7toel8-deps
 Version:    5.0.%{rhel}
 Release:    1%{?dist}
 Summary:    Dependencies for *leapp* packages
+
+# NOTE: Our packages must be noarch. Do no drop this in any way.
 BuildArch:  noarch
 
 License:    ASL 2.0

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -49,6 +49,8 @@ License:        ASL 2.0
 URL:            https://oamg.github.io/leapp/
 Source0:        https://github.com/oamg/%{name}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        deps-pkgs.tar.gz
+
+# NOTE: Our packages must be noarch. Do no drop this in any way.
 BuildArch:      noarch
 
 %description


### PR DESCRIPTION
Our packages have to stay noarch in future for various reasons.
To reduce stress of some people, let's make it more explicit that
if someone see the change from noarch to arch specific packages,
the change must not be merged.