### PR TITLE
eficheckboot: fix dir hierarchy

### DIFF
--- a/repos/system_upgrade/common/actors/efibootorderfix/eficheckboot/actor.py
+++ b/repos/system_upgrade/common/actors/efibootorderfix/eficheckboot/actor.py
@@ -1,9 +1,9 @@
 import os
 
-from leapp.actors import Actor
 from leapp import reporting
-from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+from leapp.actors import Actor
 from leapp.models import FirmwareFacts
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
 class EfiCheckBoot(Actor):


### PR DESCRIPTION
The original dir hierarchy has been invalid regarding the official
doc as it provided actors inside actors:
```
   efibootorderfix
   ├── actor.py
   ├── finalization
   │   └── actor.py
   └── interim
       └── actor.py
```
The new dir hierarchy is:
```
    efibootorderfix
    ├── eficheckboot
    │   └── actor.py
    ├── finalization
    │   └── actor.py
    └── interim
        └── actor.py
```

+ order of imports fixed in the actor.