### PR TITLE
dnfdryrun: Consume BootContent to run the actor after upgrade initramfs

### DIFF
--- a/repos/system_upgrade/common/actors/dnfdryrun/actor.py
+++ b/repos/system_upgrade/common/actors/dnfdryrun/actor.py
@@ -1,6 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.common import dnfplugin
 from leapp.models import (
+    BootContent,
     DNFPluginTask,
     FilteredRpmTransactionTasks,
     RHUIInfo,
@@ -8,7 +9,7 @@ from leapp.models import (
     TargetUserSpaceInfo,
     TransactionDryRun,
     UsedTargetRepositories,
-    XFSPresence,
+    XFSPresence
 )
 from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
 
@@ -23,6 +24,7 @@ class DnfDryRun(Actor):
 
     name = 'dnf_dry_run'
     consumes = (
+        BootContent,
         DNFPluginTask,
         FilteredRpmTransactionTasks,
         RHUIInfo,


### PR DESCRIPTION
The actor is supposed to check the "free space" for the upgrade
transaction after the upgrade initramfs is generated and before the
bootloader is updated. However in some cases we could see the actor
is executed before the upgrade initramfs is generated, which is
problematic in case there is not enough free space on the disk.

Consume the BootContent msg in the actor so we are sure it's
executed always after the upgrade initramfs is generated.