### PR TITLE
actor: Add postgresqlcheck actor for el8toel9 upgrade

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/postgresqlcheck/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/postgresqlcheck/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.postgresqlcheck import report_installed_packages
+from leapp.models import InstalledRedHatSignedRPM, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class PostgresqlCheck(Actor):
+    """
+    Actor checking for presence of PostgreSQL installation.
+
+    Provides user with information related to upgrading systems
+    with PostgreSQL installed.
+    """
+    name = 'postgresql_check'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        report_installed_packages()

--- a/repos/system_upgrade/el8toel9/actors/postgresqlcheck/libraries/postgresqlcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/postgresqlcheck/libraries/postgresqlcheck.py
@@ -1,0 +1,56 @@
+from leapp import reporting
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM
+
+# Summary for postgresql-server report
+report_server_inst_summary = (
+    'PostgreSQL server component will be upgraded. Since RHEL-9 includes'
+    ' PostgreSQL server 13 by default, which is incompatible with 9.6, 10 and 12'
+    ' included in RHEL-8, it is necessary to proceed with additional steps'
+    ' for the complete upgrade of the PostgreSQL data.'
+)
+
+report_server_inst_hint = (
+    'Back up your data before proceeding with the upgrade'
+    ' and follow steps in the documentation section "Migrating to a RHEL 9 version of PostgreSQL"'
+    ' after the upgrade.'
+)
+
+# Link URL for postgresql-server report
+report_server_inst_link_url = 'https://access.redhat.com/articles/6654721'  # noqa: E501; pylint: disable=line-too-long
+
+
+def _report_server_installed():
+    """
+    Create report on postgresql-server package installation detection.
+
+    Should remind user about present PostgreSQL server package
+    installation, warn them about necessary additional steps, and
+    redirect them to online documentation for the upgrade process.
+    """
+    reporting.create_report([
+        reporting.Title('PostgreSQL (postgresql-server) has been detected on your system'),
+        reporting.Summary(report_server_inst_summary),
+        reporting.Severity(reporting.Severity.MEDIUM),
+        reporting.Tags([reporting.Tags.SERVICES]),
+        reporting.ExternalLink(title='Migrating to a RHEL 9 version of PostgreSQL',
+                               url=report_server_inst_link_url),
+        reporting.RelatedResource('package', 'postgresql-server'),
+        reporting.Remediation(hint=report_server_inst_hint),
+        ])
+
+
+def report_installed_packages(_context=api):
+    """
+    Create reports according to detected PostgreSQL packages.
+
+    Create the report if the postgresql-server rpm (RH signed) is installed.
+    Additionally, create another report if the postgresql-contrib rpm
+    is installed.
+    """
+    has_server = has_package(InstalledRedHatSignedRPM, 'postgresql-server', context=_context)
+
+    if has_server:
+        # postgresql-server
+        _report_server_installed()

--- a/repos/system_upgrade/el8toel9/actors/postgresqlcheck/tests/test_postgresqlcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/postgresqlcheck/tests/test_postgresqlcheck.py
@@ -1,0 +1,65 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor.postgresqlcheck import report_installed_packages
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM, RPM
+
+
+def _generate_rpm_with_name(name):
+    """
+    Generate new RPM model item with given name.
+
+    Parameters:
+        name (str): rpm name
+
+    Returns:
+        rpm  (RPM): new RPM object with name parameter set
+    """
+    return RPM(name=name,
+               version='0.1',
+               release='1.sm01',
+               epoch='1',
+               pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51',
+               packager='Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>',
+               arch='noarch')
+
+
+@pytest.mark.parametrize('has_server', [
+    (True),  # with server
+    (False),  # without server
+])
+def test_actor_execution(monkeypatch, has_server):
+    """
+    Parametrized helper function for test_actor_* functions.
+
+    First generate list of RPM models based on set arguments. Then, run
+    the actor feeded with our RPM list. Finally, assert Reports
+    according to set arguments.
+
+    Parameters:
+        has_server  (bool): postgresql-server installed
+    """
+
+    # Couple of random packages
+    rpms = [_generate_rpm_with_name('sed'),
+            _generate_rpm_with_name('htop')]
+
+    if has_server:
+        # Add postgresql-server
+        rpms += [_generate_rpm_with_name('postgresql-server')]
+
+    curr_actor_mocked = CurrentActorMocked(msgs=[InstalledRedHatSignedRPM(items=rpms)])
+    monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    # Executed actor feeded with out fake RPMs
+    report_installed_packages(_context=api)
+
+    if has_server:
+        # Assert for postgresql-server package installed
+        assert reporting.create_report.called == 1
+    else:
+        # Assert for no postgresql packages installed
+        assert not reporting.create_report.called


### PR DESCRIPTION
actor: Add postgresqlcheck actor for el8toel9 upgrade
Since RHEL 8 supports multiple Postgresql streams(9.6, 10, 12, and 13)
and RHEL 9 contains only Postgresql 13 the actor checks presence of
postgresql-server and provides a link to upgrade documentation.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2037850