### PR TITLE
modularity: Handle missing modulestream_maps

### DIFF
--- a/repos/system_upgrade/common/actors/peseventsscanner/tests/files/sample04.json
+++ b/repos/system_upgrade/common/actors/peseventsscanner/tests/files/sample04.json
@@ -43,6 +43,28 @@
       "in_packageset": { "set_id": 3, "package": [{ "name": "removed", "repository": "repo" }] },
       "out_packageset": null,
       "release": { "z_stream": null, "major_version": 8, "tag": null, "os_name": "RHEL", "minor_version": 0 }
-    }
+    },
+    {
+        "id": 3,
+        "action": 7,
+        "in_packageset": { 
+            "set_id": 3, 
+            "package": [{ 
+                "name": "modularized",
+                 "repository": "repo", 
+                "modulestreams": [null, { "name": "module", "stream": "stream_in" }] 
+            }]
+        },
+        "out_packageset": { 
+            "set_id": 3, 
+            "package": [{ 
+                "name": "demodularized",
+                "repository": "repo", 
+                "modulestreams": [null]
+            }]
+        },
+
+        "release": { "z_stream": null, "major_version": 8, "tag": null, "os_name": "RHEL", "minor_version": 0 }
+      }
   ]
 }

--- a/repos/system_upgrade/common/actors/peseventsscanner/tests/unit_test_peseventsscanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/tests/unit_test_peseventsscanner.py
@@ -144,7 +144,7 @@ def test_parse_pes_events_with_modulestreams(current_actor_context):
     """
     with open(os.path.join(CUR_DIR, 'files/sample04.json')) as f:
         events = parse_pes_events(f.read())
-    assert len(events) == 3
+    assert len(events) == 5
     Expected = namedtuple('Expected', 'action,in_pkgs,out_pkgs')
     expected = [
         Expected(action=Action.SPLIT, in_pkgs={Package('original', 'repo', ('module', 'stream_in'))}, out_pkgs={
@@ -153,6 +153,10 @@ def test_parse_pes_events_with_modulestreams(current_actor_context):
                  out_pkgs={Package('split01', 'repo', ('module', 'stream_out')),
                            Package('split02', 'repo', ('module', 'stream_out'))}),
         Expected(action=Action.REMOVED, in_pkgs={Package('removed', 'repo', None)}, out_pkgs=set()),
+        Expected(action=Action.RENAMED, in_pkgs={Package('modularized', 'repo', ('module', 'stream_in'))}, out_pkgs={
+                 Package('demodularized', 'repo', None)}),
+        Expected(action=Action.RENAMED, in_pkgs={Package('modularized', 'repo', None)}, out_pkgs={
+                 Package('demodularized', 'repo', None)}),
     ]
 
     for event in events:


### PR DESCRIPTION
In the case that there's no modulestream_maps in the pes event, handle
the situation for now as if it would be demodularized. There's no other
good solution than this, as we cannot guess what will be the actual
target in case there would be multiple output modulestreams.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>