### PR TITLE
Display the NFS mounts inhibiting upgrade

### DIFF
--- a/repos/system_upgrade/common/actors/checknfs/actor.py
+++ b/repos/system_upgrade/common/actors/checknfs/actor.py
@@ -37,7 +37,8 @@ class CheckNfs(Actor):
             for mount in storage.mount:
                 if _is_nfs(mount.tp):
                     nfs_found = True
-                    details += "- Currently mounted NFS shares\n"
+                    details += "- Currently mounted NFS share:\n"
+                    details += "%s %s %s %s\n" % (mount.name, mount.mount, mount.tp, mount.options)
                     break
 
             # Check systemd-mount


### PR DESCRIPTION
When a user is running the preupgrade step and it finds NFS mounts
it's helpful to the user to identify the mount.