### PR TITLE
Fix GRUB configuration with BLS on ppc64le

### DIFF
--- a/repos/system_upgrade/common/actors/systemfacts/actor.py
+++ b/repos/system_upgrade/common/actors/systemfacts/actor.py
@@ -1,8 +1,20 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import systemfacts
-from leapp.models import SysctlVariablesFacts, ActiveKernelModulesFacts, UsersFacts, GroupsFacts, RepositoriesFacts, \
-    SELinuxFacts, FirewallsFacts, FirmwareFacts
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.libraries.common.config import architecture
+from leapp.models import (
+    ActiveKernelModulesFacts,
+    DefaultGrubInfo,
+    FirewallsFacts,
+    FirmwareFacts,
+    GroupsFacts,
+    GrubCfgBios,
+    Report,
+    RepositoriesFacts,
+    SELinuxFacts,
+    SysctlVariablesFacts,
+    UsersFacts
+)
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
 class SystemFactsActor(Actor):
@@ -22,14 +34,19 @@ class SystemFactsActor(Actor):
 
     name = 'system_facts'
     consumes = ()
-    produces = (SysctlVariablesFacts,
-                ActiveKernelModulesFacts,
-                UsersFacts,
-                GroupsFacts,
-                RepositoriesFacts,
-                SELinuxFacts,
-                FirewallsFacts,
-                FirmwareFacts)
+    produces = (
+        SysctlVariablesFacts,
+        ActiveKernelModulesFacts,
+        UsersFacts,
+        GroupsFacts,
+        RepositoriesFacts,
+        SELinuxFacts,
+        FirewallsFacts,
+        FirmwareFacts,
+        DefaultGrubInfo,
+        GrubCfgBios,
+        Report
+    )
     tags = (IPUWorkflowTag, FactsPhaseTag,)
 
     def process(self):
@@ -41,3 +58,10 @@ class SystemFactsActor(Actor):
         self.produce(systemfacts.get_selinux_status())
         self.produce(systemfacts.get_firewalls_status())
         self.produce(systemfacts.get_firmware())
+
+        if not architecture.matches_architecture(architecture.ARCH_S390X):
+            self.produce(systemfacts.get_default_grub_conf())
+
+        bios_grubcfg_details = systemfacts.get_bios_grubcfg_details()
+        if bios_grubcfg_details:
+            self.produce(bios_grubcfg_details)

--- a/repos/system_upgrade/common/libraries/grub.py
+++ b/repos/system_upgrade/common/libraries/grub.py
@@ -1,7 +1,7 @@
 import os
 
-from leapp.libraries.stdlib import run, api, CalledProcessError
 from leapp.exceptions import StopActorExecution
+from leapp.libraries.stdlib import api, CalledProcessError, run
 
 
 def has_grub(blk_dev):
@@ -70,3 +70,14 @@ def get_grub_device():
     api.current_logger().info('GRUB is installed on {}'.format(grub_dev))
     # if has_grub(grub_dev):
     return grub_dev if has_grub(grub_dev) else None
+
+
+def is_blscfg_enabled_in_defaultgrub(default_grub_msg):
+    """
+    Check if GRUB_ENABLE_BLSCFG is true in /etc/default/grub file
+    """
+    grub_options_lst = default_grub_msg.default_grub_info
+    default_grub_options = {
+        option.name: option.value.strip('"') for option in grub_options_lst
+    }
+    return bool(default_grub_options.get('GRUB_ENABLE_BLSCFG', '') == 'true')

--- a/repos/system_upgrade/common/libraries/tests/test_grub.py
+++ b/repos/system_upgrade/common/libraries/tests/test_grub.py
@@ -4,8 +4,9 @@ import pytest
 
 from leapp.exceptions import StopActorExecution
 from leapp.libraries.common import grub
-from leapp.libraries.stdlib import CalledProcessError, api
 from leapp.libraries.common.testutils import logger_mocked
+from leapp.libraries.stdlib import api, CalledProcessError
+from leapp.models import DefaultGrub, DefaultGrubInfo
 
 BOOT_PARTITION = '/dev/vda1'
 BOOT_DEVICE = '/dev/vda'
@@ -102,3 +103,22 @@ def test_device_no_grub_library(monkeypatch):
     result = grub.get_grub_device()
     assert grub.run.called == 2
     assert not result
+
+
+@pytest.mark.parametrize('enabled', [True, False])
+def test_is_blscfg_library(monkeypatch, enabled):
+    bls_cfg_enabled = DefaultGrubInfo(
+        default_grub_info=[DefaultGrub(name='GRUB_ENABLE_BLSCFG', value='true')]
+    )
+
+    bls_cfg_not_enabled = DefaultGrubInfo(
+        default_grub_info=[DefaultGrub(name='GRUB_ENABLE_BLSCFG', value='false')]
+    )
+
+    bls_cfg = bls_cfg_enabled if enabled else bls_cfg_not_enabled
+
+    result = grub.is_blscfg_enabled_in_defaultgrub(bls_cfg)
+    if enabled:
+        assert result
+    else:
+        assert not result

--- a/repos/system_upgrade/common/models/defaultgrubinfo.py
+++ b/repos/system_upgrade/common/models/defaultgrubinfo.py
@@ -1,0 +1,25 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemFactsTopic
+
+
+class DefaultGrub(Model):
+    """
+    A model with '/etc/default/grub' option as key / value
+    """
+    topic = SystemFactsTopic
+
+    name = fields.String()
+    """ Option name, e.g. GRUB_TIMEOUT """
+    value = fields.String()
+    """ Option value, e.g. '5' in case of GRUB_TIMEOUT=5 """
+
+
+class DefaultGrubInfo(Model):
+    """
+    A message with '/etc/default/grub' content
+    """
+
+    topic = SystemFactsTopic
+
+    default_grub_info = fields.List(fields.Model(DefaultGrub))
+    """ List of '/etc/default/grub' options as key / value """

--- a/repos/system_upgrade/common/models/firmwarefacts.py
+++ b/repos/system_upgrade/common/models/firmwarefacts.py
@@ -1,4 +1,4 @@
-from leapp.models import Model, fields
+from leapp.models import fields, Model
 from leapp.topics import SystemFactsTopic
 
 
@@ -6,3 +6,6 @@ class FirmwareFacts(Model):
     topic = SystemFactsTopic
 
     firmware = fields.StringEnum(['bios', 'efi'])
+    """ System firmware interface (BIOS or EFI) """
+    ppc64le_opal = fields.Nullable(fields.Boolean())
+    """ Check OPAL presence to identify ppc64le bare metal systems """

--- a/repos/system_upgrade/common/models/grubcfgbios.py
+++ b/repos/system_upgrade/common/models/grubcfgbios.py
@@ -1,0 +1,12 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemFactsTopic
+
+
+class GrubCfgBios(Model):
+    """
+    A message providing info about BIOS (non-EFI) GRUB config
+    """
+    topic = SystemFactsTopic
+
+    insmod_bls = fields.Boolean()
+    """ Inform whether blscfg is loaded """

--- a/repos/system_upgrade/el8toel9/actors/checkblsgrubcfgonppc64/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/checkblsgrubcfgonppc64/actor.py
@@ -1,0 +1,29 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import blsgrubcfgonppc64
+from leapp.models import DefaultGrubInfo, FirmwareFacts, GrubCfgBios, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckBlsGrubOnPpc64(Actor):
+    """
+    Check whether GRUB config is BLS aware on RHEL 8 ppc64le systems
+
+    After a ppc64 system is upgraded from RHEL 8 to RHEL 9 and
+    GRUB config on RHEL 8 is not yet BLS aware, the system boots
+    into el8 kernel because the config is not successfuly migrated by
+    GRUB during the upgrade process.
+
+    IMPORTANT NOTE: The later fix which is based on the outcome of this
+    actor is applied only for virtualized ppc64le systems as we got
+    unexpected behavior on bare metal ppc64le systems which needs to be
+    investigated first.
+
+    """
+
+    name = 'check_bls_grub_onppc64'
+    consumes = (DefaultGrubInfo, GrubCfgBios, FirmwareFacts)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        blsgrubcfgonppc64.process()

--- a/repos/system_upgrade/el8toel9/actors/checkblsgrubcfgonppc64/libraries/blsgrubcfgonppc64.py
+++ b/repos/system_upgrade/el8toel9/actors/checkblsgrubcfgonppc64/libraries/blsgrubcfgonppc64.py
@@ -1,0 +1,54 @@
+from leapp import reporting
+from leapp.libraries.common import grub
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+from leapp.models import DefaultGrubInfo, FirmwareFacts, GrubCfgBios
+
+
+def process():
+    default_grub_msg = next(api.consume(DefaultGrubInfo), None)
+    grub_cfg = next(api.consume(GrubCfgBios), None)
+    ff = next(api.consume(FirmwareFacts), None)
+    if None in (default_grub_msg, grub_cfg):
+        api.current_logger().debug(
+            'Skipping execution. No DefaultGrubInfo and GrubCfgBios messages have '
+            'been produced'
+        )
+        return
+
+    if not architecture.matches_architecture(architecture.ARCH_PPC64LE):
+        return
+
+    if ff and ff.ppc64le_opal:
+        reporting.create_report([
+            reporting.Title(
+                'Leapp cannot continue with upgrade on "ppc64le" bare metal systems'
+            ),
+            reporting.Summary(
+                'Currently, there is a known issue that prevents Leapp from upgrading '
+                'ppc64le bare metal systems. You can file a bug in http://bugzilla.redhat.com/ '
+                'for leapp-repository component and include "[ppc64le bare metal upgrade]" in '
+                'the title to get the issue prioritized.'
+            ),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Flags(['inhibitor']),
+            reporting.Tags([reporting.Tags.BOOT]),
+        ])
+
+    if (
+        not grub_cfg.insmod_bls and grub.is_blscfg_enabled_in_defaultgrub(default_grub_msg)
+    ):
+        reporting.create_report([
+            reporting.Title(
+                'Leapp will execute "grub2-mkconfig" to fix BLS Grub configuration.'
+            ),
+            reporting.Summary(
+                'On "ppc64le" systems with BLS enabled, the GRUB configuration is not '
+                'properly converted after the upgrade and Leapp has to run "grub2-mkconfig" '
+                '-o /boot/grub2/grub.cfg command in order to fix an issue with booting into '
+                'the RHEL 8 kernel instead of RHEL 9.'
+
+            ),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.BOOT]),
+        ])

--- a/repos/system_upgrade/el8toel9/actors/checkblsgrubcfgonppc64/tests/test_checkblsgrubcfgonppc64.py
+++ b/repos/system_upgrade/el8toel9/actors/checkblsgrubcfgonppc64/tests/test_checkblsgrubcfgonppc64.py
@@ -1,0 +1,48 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import blsgrubcfgonppc64
+from leapp.libraries.common import testutils
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import DefaultGrub, DefaultGrubInfo, GrubCfgBios
+
+
+@pytest.mark.parametrize(
+    'is_bls,bls_cfg_enabled,is_ppc64', (
+        (True, True, True),
+        (True, True, False),
+        (True, False, True),
+        (False, True, False),
+        (False, False, False),
+    )
+)
+def test_check_grub_bls_cfg_ppc64(monkeypatch, is_bls, bls_cfg_enabled, is_ppc64):
+
+    grub_cfg_msg = GrubCfgBios(insmod_bls=is_bls)
+
+    bls_cfg_enabled = DefaultGrubInfo(
+        default_grub_info=[DefaultGrub(name='GRUB_ENABLE_BLSCFG', value='true')]
+    )
+
+    bls_cfg_not_enabled = DefaultGrubInfo(
+        default_grub_info=[DefaultGrub(name='GRUB_ENABLE_BLSCFG', value='false')]
+    )
+
+    bls_cfg = bls_cfg_enabled if bls_cfg_enabled else bls_cfg_not_enabled
+
+    arch = testutils.architecture.ARCH_PPC64LE if is_ppc64 else testutils.architecture.ARCH_X86_64
+
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[grub_cfg_msg, bls_cfg], arch=arch))
+    blsgrubcfgonppc64.process()
+
+    if (
+        not is_bls and
+        is_ppc64 and
+        bls_cfg_enabled
+    ):
+        assert reporting.create_report.called
+        assert reporting.create_report.report_fields['title'] == 'TBA'
+    else:
+        assert not reporting.create_report.called

--- a/repos/system_upgrade/el8toel9/actors/grub2mkconfigonppc64/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/grub2mkconfigonppc64/actor.py
@@ -1,0 +1,29 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import grub2mkconfigonppc64
+from leapp.models import DefaultGrubInfo, FirmwareFacts
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class Grub2MkconfigOnPpc64(Actor):
+    """
+    Regenerate Grub config after RHEL 8 to RHEL 9 rpm transaction
+
+    Actor runs 'grub2-mkconfig' to regenerate Grub config after RHEL 8 to RHEL 9
+    rpm transaction in case system is running on ppc64le, GRUB_ENABLE_BLSCFG=true
+    and '/boot/grub2/grub.cfg' config file does not yet work with BLS entries.
+    For the system to successfully boot into el9 kernel, it is essential that the
+    grub config file is abvle to work with the BLS entries.
+
+    IMPORTANT NOTE: The fix is applied only for virtualized ppc64le systems as we got
+    unexpected behavior on bare metal ppc64le systems which needs to be
+    investigated first.
+
+    """
+
+    name = 'grub2mkconfig_on_ppc64'
+    consumes = (DefaultGrubInfo, FirmwareFacts)
+    produces = ()
+    tags = (IPUWorkflowTag, ApplicationsPhaseTag)
+
+    def process(self):
+        grub2mkconfigonppc64.process()

--- a/repos/system_upgrade/el8toel9/actors/grub2mkconfigonppc64/libraries/grub2mkconfigonppc64.py
+++ b/repos/system_upgrade/el8toel9/actors/grub2mkconfigonppc64/libraries/grub2mkconfigonppc64.py
@@ -1,0 +1,36 @@
+from leapp.libraries.common import grub
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import DefaultGrubInfo, FirmwareFacts
+
+GRUB_CFG_PATH = '/boot/grub2/grub.cfg'
+
+
+def _is_grub_cfg_bls():
+    # We do not want to use info from the GrubCfgBios model as it may not be valid
+    # after the RPM upgrade transaction.
+
+    with open(GRUB_CFG_PATH, 'r') as fo:
+        grub_cfg = fo.read()
+    if 'insmod blscfg' in grub_cfg:
+        return True
+    return False
+
+
+def process():
+    if not architecture.matches_architecture(architecture.ARCH_PPC64LE):
+        return
+    default_grub_msg = next(api.consume(DefaultGrubInfo), None)
+    ff = next(api.consume(FirmwareFacts), None)
+    if ff and ff.ppc64le_opal:
+        return
+    if (
+        not _is_grub_cfg_bls() and
+        grub.is_blscfg_enabled_in_defaultgrub(default_grub_msg)
+    ):
+        try:
+            run(['grub2-mkconfig', '-o', GRUB_CFG_PATH])
+        except CalledProcessError as e:
+            api.current_logger().error(
+                'Command grub2-mkconfig -o {} failed: {}'.format(GRUB_CFG_PATH, e)
+            )

--- a/repos/system_upgrade/el8toel9/actors/grub2mkconfigonppc64/tests/test_grub2mkconfigonppc64.py
+++ b/repos/system_upgrade/el8toel9/actors/grub2mkconfigonppc64/tests/test_grub2mkconfigonppc64.py
@@ -1,0 +1,75 @@
+import os
+from io import StringIO
+
+import pytest
+
+from leapp.libraries.actor import grub2mkconfigonppc64
+from leapp.libraries.common import testutils
+from leapp.libraries.common.testutils import CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import DefaultGrub, DefaultGrubInfo, FirmwareFacts
+
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class MockedRun(object):
+    def __init__(self):
+        self.commands = []
+
+    def __call__(self, cmd, *args, **kwargs):
+        self.commands.append(cmd)
+        return {}
+
+
+@pytest.mark.parametrize('cmd_issued', [True, False])
+def test_run_grub2mkconfig(monkeypatch, cmd_issued):
+
+    grub2_cfg_bls_excerpt = (
+        'fi'
+        'insmod blscfg'
+        'blscfg'
+        '### END /etc/grub.d/10_linux ###'
+    )
+
+    grub2_cfg_non_bls_excerpt = (
+        '### BEGIN /etc/grub.d/10_linux ###'
+        'menuentry "Red Hat Enterprise Linux Server (3.10.0-1160.45.1.el7.x86_64) 7.9 (Maipo)"'
+    )
+
+    class _mock_open(object):
+        def __init__(self, path, mode):
+            input_ = grub2_cfg_non_bls_excerpt if cmd_issued else grub2_cfg_bls_excerpt
+            self._fp = StringIO(input_)
+
+        def __enter__(self):
+            return self._fp
+
+        def __exit__(self, *args, **kwargs):
+            return None
+
+    bls_cfg_enabled = DefaultGrubInfo(
+        default_grub_info=[DefaultGrub(name='GRUB_ENABLE_BLSCFG', value='true')]
+    )
+
+    bls_cfg_not_enabled = DefaultGrubInfo(
+        default_grub_info=[DefaultGrub(name='GRUB_ENABLE_BLSCFG', value='false')]
+    )
+
+    bls_cfg = bls_cfg_enabled if cmd_issued else bls_cfg_not_enabled
+
+    arch = testutils.architecture.ARCH_PPC64LE if cmd_issued else testutils.architecture.ARCH_X86_64
+
+    ppc64le_bare = FirmwareFacts(firmware='bios', ppc64le_opal=True)
+    ppc64le_virt = FirmwareFacts(firmware='bios', ppc64le_opal=False)
+
+    opal = ppc64le_virt if cmd_issued else ppc64le_bare
+
+    mocked_run = MockedRun()
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[bls_cfg, opal], arch=arch))
+    monkeypatch.setattr(grub2mkconfigonppc64, 'run', mocked_run)
+    monkeypatch.setattr(grub2mkconfigonppc64, 'open', _mock_open, False)
+    grub2mkconfigonppc64.process()
+    if cmd_issued:
+        assert mocked_run.commands == [['grub2-mkconfig', '-o', '/boot/grub2/grub.cfg']]
+    else:
+        assert not mocked_run.commands


### PR DESCRIPTION
On "ppc64le" systems with BLS enabled, the GRUB configuration is not
properly converted after the upgrade and Leapp has to run "grub2-mkconfig"
-o /boot/grub2/grub.cfg command in order to fix an issue with booting into
the RHEL 8 kernel instead of RHEL 9.