### PR TITLE
selinux: Exit cleanly in case of no custom modules

### DIFF
--- a/repos/system_upgrade/common/actors/selinux/selinuxapplycustom/actor.py
+++ b/repos/system_upgrade/common/actors/selinux/selinuxapplycustom/actor.py
@@ -52,6 +52,9 @@ class SELinuxApplyCustom(Actor):
             # check for presence of udica templates and make sure to install their latest versions
             selinuxapplycustom.install_udica_templates(semodules.templates)
 
+            if not semodules.modules:
+                continue
+
             command = ['semodule']
             for module in semodules.modules:
                 # Skip modules that are already installed. This prevents DSP modules installed with wrong

--- a/repos/system_upgrade/common/actors/selinux/selinuxapplycustom/libraries/selinuxapplycustom.py
+++ b/repos/system_upgrade/common/actors/selinux/selinuxapplycustom/libraries/selinuxapplycustom.py
@@ -36,6 +36,9 @@ def list_selinux_modules():
 
 # determine which (if any) udica templates where installed and install their new versions
 def install_udica_templates(templates):
+    if not templates:
+        return
+
     command = ['semodule']
     for module in templates:
         command.extend(


### PR DESCRIPTION
Make sure all actors exit cleanly in case there are no custom modules
present in the upgraded system.

Fixes:
  WARNING: Failed to remove some "udica" policy templates: At least one mode must be specified.
  usage:  semodule [option]... MODE...
  ...

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>