### PR TITLE
PESEventsScanner: Use pkg name to determine which in_pkgs of an merge event to mark as to_remove

### DIFF
--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/peseventsscanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/peseventsscanner.py
@@ -616,8 +616,8 @@ def filter_out_out_pkgs(event_in_pkgs, event_out_pkgs):
     to gdbm and gdbm-libs, we would incorrectly mandate removing gdbm without this filter. But for example in case of
     a split of Cython to python2-Cython and python3-Cython, we will correctly mandate removing Cython.
     """
-    out_pkgs_keys = {(p.name, p.modulestream) for p in event_out_pkgs}
-    return {p for p in event_in_pkgs if (p.name, p.modulestream) not in out_pkgs_keys}
+    out_pkgs_keys = {p.name for p in event_out_pkgs}
+    return {p for p in event_in_pkgs if p.name not in out_pkgs_keys}
 
 
 SKIPPED_PKGS_MSG = (


### PR DESCRIPTION
PESEventsScanner: Use pkg name to determine which in_pkgs of an merge event to mark as to_remove

PESEventsScanner relies on using both package name and its module stream to determine which 
input packages of the processed merge event should be marked as to_remove. However, this causes 
problems when one of the input packages of the merge event has the same name as the output
package, which means that the package will marked as to_install and to_remove at the same time. 
This patch fixes this behavior by relying only on the package name when determining that an input 
package is not in the output package set, and therefore, should be marked as to_remove.  