### PR TITLE
Provide LEAPP_IPU_IN_PROGRESS envar

### DIFF
--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -204,6 +204,12 @@ def prepare_configuration(args):
     os.environ['LEAPP_UPGRADE_PATH_TARGET_RELEASE'] = target_version
     os.environ['LEAPP_UPGRADE_PATH_FLAVOUR'] = flavor
 
+    current_version = command_utils.get_os_release_version_id('/etc/os-release')
+    os.environ['LEAPP_IPU_IN_PROGRESS'] = '{source}to{target}'.format(
+        source=command_utils.get_major_version(current_version),
+        target=command_utils.get_major_version(target_version)
+    )
+
     configuration = {
         'debug': os.getenv('LEAPP_DEBUG', '0'),
         'verbose': os.getenv('LEAPP_VERBOSE', '0'),


### PR DESCRIPTION
The environement variable contains string in format XtoY, where
*  X is major version of the current system
*  Y is major version of the target system

So contains:
*  `7to8` for IPU 7 -> 8,
*  `8to9` for IPU 8 -> 9

this envar is supposed to be used e.g. in RPM scriptlets in case
maintainers want to treat the upgrade correctly during the IPU
process between major releases of RHEL.

As a benefit, this allows people to handle situations when specific
action has to happen in the middle of the DNF transaction - as leapp
actors can do actions only before and after the transaction.