### PR TITLE
Bind the /run/lock dir into the container in the upgrade initramfs env

### DIFF
--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -29,7 +29,7 @@ export LEAPP3_BIN=$LEAPPHOME/leapp3
 
 export NEWROOT=${NEWROOT:-"/sysroot"}
 
-NSPAWN_OPTS="--capability=all --bind=/dev --bind=/dev/pts --bind=/proc --bind=/run/udev"
+NSPAWN_OPTS="--capability=all --bind=/dev --bind=/dev/pts --bind=/proc --bind=/run/udev --bind=/run/lock"
 [ -d /dev/mapper ] && NSPAWN_OPTS="$NSPAWN_OPTS --bind=/dev/mapper"
 if [ "$RHEL_OS_MAJOR_RELEASE" == "8" ]; then
     # IPU 7 -> 8


### PR DESCRIPTION
/var/lock is symlink to ../run/lock directory. However the symlink
is broken inside the container. We have to bind mount the /run/lock
into to container as some RPM scriptlets need it and crashes otherwise.
The problem is generic, so apply it for all upgrade paths.