### PR TITLE
actor: Add mariadbcheck actor for el8toel9 upgrade

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/mariadbcheck/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/mariadbcheck/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.mariadbcheck import report_installed_packages
+from leapp.models import InstalledRedHatSignedRPM, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class MariadbCheck(Actor):
+    """
+    Actor checking for presence of MariaDB installation.
+
+    Provides user with information related to upgrading systems
+    with MariaDB installed.
+    """
+    name = 'mariadb_check'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        report_installed_packages()

--- a/repos/system_upgrade/el8toel9/actors/mariadbcheck/libraries/mariadbcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/mariadbcheck/libraries/mariadbcheck.py
@@ -1,0 +1,53 @@
+from leapp import reporting
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM
+
+# Summary for mariadb-server report
+report_server_inst_summary = (
+    'MariaDB server component will be upgraded. Since RHEL-9 includes'
+    ' MariaDB server 10.5 by default, which is incompatible with 10.3'
+    ' included in RHEL-8, it is necessary to proceed with additional steps'
+    ' for the complete upgrade of the MariaDB data.'
+)
+
+report_server_inst_hint = (
+    'Back up your data before proceeding with the upgrade'
+    ' and follow steps in the documentation section "Migrating to a RHEL 9 version of MariaDB"'
+    ' after the upgrade.'
+)
+
+# Link URL for mariadb-server report
+report_server_inst_link_url = 'https://access.redhat.com/articles/6743671'
+
+
+def _report_server_installed():
+    """
+    Create report on mariadb-server package installation detection.
+
+    Should remind user about present MariaDB server package
+    installation, warn them about necessary additional steps, and
+    redirect them to online documentation for the upgrade process.
+    """
+    reporting.create_report([
+        reporting.Title('MariaDB (mariadb-server) has been detected on your system'),
+        reporting.Summary(report_server_inst_summary),
+        reporting.Severity(reporting.Severity.MEDIUM),
+        reporting.Tags([reporting.Tags.SERVICES]),
+        reporting.ExternalLink(title='Migrating to a RHEL 9 version of MariaDB',
+                               url=report_server_inst_link_url),
+        reporting.RelatedResource('package', 'mariadb-server'),
+        reporting.Remediation(hint=report_server_inst_hint),
+        ])
+
+
+def report_installed_packages(_context=api):
+    """
+    Create reports according to detected MariaDB packages.
+
+    Create the report if the mariadb-server rpm (RH signed) is installed.
+    """
+    has_server = has_package(InstalledRedHatSignedRPM, 'mariadb-server', context=_context)
+
+    if has_server:
+        _report_server_installed()

--- a/repos/system_upgrade/el8toel9/actors/mariadbcheck/tests/test_mariadbcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/mariadbcheck/tests/test_mariadbcheck.py
@@ -1,0 +1,65 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor.mariadbcheck import report_installed_packages
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM, RPM
+
+
+def _generate_rpm_with_name(name):
+    """
+    Generate new RPM model item with given name.
+
+    Parameters:
+        name (str): rpm name
+
+    Returns:
+        rpm  (RPM): new RPM object with name parameter set
+    """
+    return RPM(name=name,
+               version='0.1',
+               release='1.sm01',
+               epoch='1',
+               pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51',
+               packager='Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>',
+               arch='noarch')
+
+
+@pytest.mark.parametrize('has_server', [
+    (True),  # with server
+    (False),  # without server
+])
+def test_actor_execution(monkeypatch, has_server):
+    """
+    Parametrized helper function for test_actor_* functions.
+
+    First generate list of RPM models based on set arguments. Then, run
+    the actor feeded with our RPM list. Finally, assert Reports
+    according to set arguments.
+
+    Parameters:
+        has_server  (bool): mariadb-server installed
+    """
+
+    # Couple of random packages
+    rpms = [_generate_rpm_with_name('sed'),
+            _generate_rpm_with_name('htop')]
+
+    if has_server:
+        # Add mariadb-server
+        rpms += [_generate_rpm_with_name('mariadb-server')]
+
+    curr_actor_mocked = CurrentActorMocked(msgs=[InstalledRedHatSignedRPM(items=rpms)])
+    monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    # Executed actor feeded with fake RPMs
+    report_installed_packages(_context=api)
+
+    if has_server:
+        # Assert for mariadb-server package installed
+        assert reporting.create_report.called == 1
+    else:
+        # Assert for no mariadb packages installed
+        assert not reporting.create_report.called


### PR DESCRIPTION
actor: Add mariadbcheck actor for el8toel9 upgrade
Since RHEL 8 supports multiple Mariadb streams(10.3, 10.5)
and RHEL 9 contains only Mariadb 10.5 the actor checks presence of
mariadb-server and provides a link to upgrade documentation.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2037853