### PR TITLE
Add kpatch actor

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/kernel/checkkpatch/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/kernel/checkkpatch/actor.py
@@ -1,0 +1,29 @@
+from leapp.actors import Actor
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import CopyFile, InstalledRedHatSignedRPM, TargetUserSpacePreupgradeTasks
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+PLUGIN_PKGNAME = "kpatch-dnf"
+CONFIG_PATH = "/etc/dnf/plugins/kpatch.conf"
+
+
+class CheckKpatch(Actor):
+    """
+    Carry over kpatch-dnf and it's config into the container
+
+    Check is kpatch-dnf plugin is installed and if it is, install it and copy
+    over the config file so that the plugin can make a decision on whether any
+    kpatch-patch packages need to be installed during in-place upgrade.
+    """
+
+    name = 'check_kpatch'
+    consumes = (InstalledRedHatSignedRPM,)
+    produces = (TargetUserSpacePreupgradeTasks,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        if has_package(InstalledRedHatSignedRPM, PLUGIN_PKGNAME):
+            api.produce(TargetUserSpacePreupgradeTasks(
+                install_rpms=[PLUGIN_PKGNAME],
+                copy_files=[CopyFile(src=CONFIG_PATH)]))


### PR DESCRIPTION
Add an actor that makes sure kpatch-dnf plugin and its config is carried
over to the container so that it installs appropriate kpatch-patch
during in-place-upgrade if needed.