### PR TITLE
targetinitramfsgenerator: remove extra quotes causing dracut install failures

### DIFF
--- a/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/libraries/targetinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/libraries/targetinitramfsgenerator.py
@@ -1,12 +1,8 @@
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.stdlib import api, CalledProcessError, run
-from leapp.models import (
-    InitrdIncludes,  # deprecated
-    InstalledTargetKernelVersion,
-    TargetInitramfsTasks,
-)
+from leapp.models import InitrdIncludes  # deprecated
+from leapp.models import InstalledTargetKernelVersion, TargetInitramfsTasks
 from leapp.utils.deprecation import suppress_deprecation
-
 
 DRACUT_DIR = '/usr/lib/dracut/modules.d/'
 
@@ -75,9 +71,9 @@ def process():
         module_names = list({module.name for module in modules})
         cmd = ['dracut', '-f', '--kver', target_kernel.version]
         if files:
-            cmd += ['--install', '"{}"'.format(' '.join(files))]
+            cmd += ['--install', '{}'.format(' '.join(files))]
         if modules:
-            cmd += ['--add', '"{}"'.format(' '.join(module_names))]
+            cmd += ['--add', '{}'.format(' '.join(module_names))]
         run(cmd)
     except CalledProcessError as e:
         # just hypothetic check, it should not die


### PR DESCRIPTION
The presence of extra double quotes in the dracut --install and --add
parameters is causing the target initramfs generation to fail. This
patch removes the extra quotes.

## Steps to verify that the current command crashes
Place the problematic code to some of the actors executed early on (e.g. `SystemFactsActor`). This way, it is not necessary to wait until the target initramfs is being built. The code precisely mimics how the dracut command is prepared in the targetinitramfsgenerator.
```python3
        from leapp.libraries.stdlib import run
        files = ['/etc/os-release']
        dracut = ['dracut', '-f', '--install', '"{}"'.format(' '.join(files))]
        run(dracut)
```
Same for the `--add`:
```python3
        from leapp.libraries.stdlib import run
        files = ['dm']
        dracut = ['dracut', '-f', '--add', '"{}"'.format(' '.join(files))]
        run(dracut)
```