### PR TITLE
el8toel9: Add actor that checks upgradability of ifcfg files

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/checkifcfg/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/checkifcfg/actor.py
@@ -1,0 +1,24 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkifcfg_ifcfg as ifcfg
+from leapp.models import InstalledRPM, Report, RpmTransactionTasks
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class CheckIfcfg(Actor):
+    """
+    Ensures that ifcfg files are compatible with NetworkManager
+
+    Checks whether the ifcfg files would work with NetworkManager's ifcfg-rh
+    compatibility module -- they are of known type, well-formed and not
+    explicitly disabled with NM_CONTROLLED=no.
+
+    Makes sure relevant NetworkManager modules end up getting installed.
+    """
+
+    name = "check_ifcfg"
+    consumes = (InstalledRPM,)
+    produces = (Report, RpmTransactionTasks,)
+    tags = (IPUWorkflowTag, FactsPhaseTag,)
+
+    def process(self):
+        ifcfg.process()

--- a/repos/system_upgrade/el8toel9/actors/checkifcfg/libraries/checkifcfg_ifcfg.py
+++ b/repos/system_upgrade/el8toel9/actors/checkifcfg/libraries/checkifcfg_ifcfg.py
@@ -1,0 +1,151 @@
+import os
+
+from leapp import reporting
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRPM, RpmTransactionTasks
+
+FMT_LIST_SEPARATOR = '\n    - '
+
+
+def process():
+    SYSCONFIG_DIR = '/etc/sysconfig/network-scripts'
+    TRUE_VALUES = ['yes', 'true', '1']
+    TYPE_MAP = {
+        'ethernet':     'NetworkManager',
+        'ctc':          'NetworkManager',
+        'infiniband':   'NetworkManager',
+        'bond':         'NetworkManager',
+        'vlan':         'NetworkManager',
+        'bridge':       'NetworkManager',
+        'wireless':     'NetworkManager-wifi',
+        'team':         'NetworkManager-team',
+    }
+
+    bad_type_files = []
+    not_controlled_files = []
+    rpms_to_install = []
+
+    if not has_package(InstalledRPM, 'network-scripts'):
+        # If network-scripts package was not installed,
+        # we don't do anything.
+        return
+
+    for f in os.listdir(SYSCONFIG_DIR):
+        bad_type = False
+        got_type = None
+        nm_controlled = True
+
+        path = os.path.join(SYSCONFIG_DIR, f)
+
+        if not os.path.isfile(path):
+            continue
+
+        if f.startswith('rule-') or f.startswith('rule6-'):
+            if 'NetworkManager-dispatcher-routing-rules' not in rpms_to_install:
+                rpms_to_install.append('NetworkManager-dispatcher-routing-rules')
+            continue
+
+        if not f.startswith('ifcfg-'):
+            continue
+
+        if f == 'ifcfg-lo':
+            continue
+
+        for line in open(path).readlines():
+            try:
+                (key, value) = line.split('#')[0].strip().split('=')
+            except ValueError:
+                # We're not interested in lines that are not
+                # simple assignments. Play it safe.
+                continue
+
+            if key in ('TYPE', 'DEVICETYPE'):
+                if got_type is None:
+                    got_type = value.lower()
+                elif got_type != value.lower():
+                    bad_type = True
+
+            if key == 'BONDING_MASTER':
+                if got_type is None:
+                    got_type = 'bond'
+                elif got_type != 'bond':
+                    bad_type = True
+
+            if key == 'NM_CONTROLLED' and value.lower() not in TRUE_VALUES:
+                nm_controlled = False
+
+        if got_type in TYPE_MAP:
+            if TYPE_MAP[got_type] not in rpms_to_install:
+                rpms_to_install.append(TYPE_MAP[got_type])
+        else:
+            bad_type = True
+
+        # Don't bother reporting the file for NM_CONTROLLED=no
+        # if its type is not supportable with NetworkManager anyway
+        if bad_type is True:
+            bad_type_files.append(path)
+        elif nm_controlled is False:
+            not_controlled_files.append(path)
+
+    if bad_type_files:
+        title = 'Network configuration for unsupported device types detected'
+        summary = ('RHEL 9 does not support the legacy network-scripts'
+                   ' package that was deprecated in RHEL 8 in favor of'
+                   ' NetworkManager. Files for device types that are not'
+                   ' supported by NetworkManager are present in the system.'
+                   ' Files with the problematic configuration:{}').format(
+            ''.join(['{}{}'.format(FMT_LIST_SEPARATOR, bfile) for bfile in bad_type_files])
+        )
+        remediation = ('Consult the nm-settings-ifcfg-rh(5) manual for'
+                       ' valid types of ifcfg files. Remove configuration'
+                       ' files that can not be supported.')
+        reporting.create_report([
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Remediation(hint=remediation),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.NETWORK, reporting.Tags.SERVICES]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.RelatedResource('package', 'NetworkManager'),
+        ] + [
+            reporting.RelatedResource('file', fname)
+            for fname in bad_type_files
+        ])
+
+    if not_controlled_files:
+        title = 'Network configuration with disabled NetworkManager support detected'
+        summary = ('RHEL 9 does not support the legacy network-scripts'
+                   ' package that was deprecated in RHEL 8 in favor of'
+                   ' NetworkManager. Configuration present in the system'
+                   ' prohibit NetworkManager from loading it.'
+                   ' Files with the problematic configuration:{}').format(
+            ''.join(['{}{}'.format(FMT_LIST_SEPARATOR, bfile) for bfile in not_controlled_files])
+        )
+        remediation = ('Ensure the ifcfg files comply with format described in'
+                       ' nm-settings-ifcfg-rh(5) manual and remove the'
+                       ' NM_CONTROLLED key from them.')
+        reporting.create_report([
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Remediation(hint=remediation),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([reporting.Tags.NETWORK, reporting.Tags.SERVICES]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.RelatedResource('package', 'NetworkManager'),
+            reporting.ExternalLink(
+                title='nm-settings-ifcfg-rh - Description of ifcfg-rh settings plugin',
+                url='https://networkmanager.dev/docs/api/latest/nm-settings-ifcfg-rh.html',
+            ),
+        ] + [
+            reporting.RelatedResource('file', fname)
+            for fname in not_controlled_files
+        ])
+
+    if rpms_to_install:
+        if not has_package(InstalledRPM, 'NetworkManager'):
+            # If the user was not using NetworkManager previously,
+            # make sure NetworkManager is configured consistently with how
+            # network-scripts behaved.
+            rpms_to_install.append('NetworkManager-config-server')
+        api.produce(RpmTransactionTasks(to_install=rpms_to_install))

--- a/repos/system_upgrade/el8toel9/actors/checkifcfg/tests/unit_test_ifcfg.py
+++ b/repos/system_upgrade/el8toel9/actors/checkifcfg/tests/unit_test_ifcfg.py
@@ -1,0 +1,147 @@
+import mock
+import six
+
+from leapp import reporting
+from leapp.libraries.actor import checkifcfg_ifcfg as ifcfg
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRPM, RPM, RpmTransactionTasks
+
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+
+NETWORK_SCRIPTS_RPM = RPM(
+    name='network-scripts', version='10.00.17', release='1.el8', epoch='',
+    packager=RH_PACKAGER, arch='x86_64',
+    pgpsig='RSA/SHA256, Fri 04 Feb 2022 03:32:47 PM CET, Key ID 199e2f91fd431d51'
+)
+
+NETWORK_MANAGER_RPM = RPM(
+    name='NetworkManager', version='1.36.0', release='0.8.el8', epoch='1',
+    packager=RH_PACKAGER, arch='x86_64',
+    pgpsig='RSA/SHA256, Mon 14 Feb 2022 08:45:37 PM CET, Key ID 199e2f91fd431d51'
+)
+
+INITSCRIPTS_INSTALLED = CurrentActorMocked(
+    msgs=[InstalledRPM(items=[NETWORK_SCRIPTS_RPM])]
+)
+
+INITSCRIPTS_AND_NM_INSTALLED = CurrentActorMocked(
+    msgs=[InstalledRPM(items=[NETWORK_SCRIPTS_RPM, NETWORK_MANAGER_RPM])]
+)
+
+
+def test_ifcfg_none(monkeypatch):
+    """
+    No report and don't install anything if there are no ifcfg files.
+    """
+
+    monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_AND_NM_INSTALLED)
+    monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
+    monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('hello', 'world',))
+    monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    ifcfg.process()
+    assert not reporting.create_report.called
+    assert not api.produce.called
+
+
+def test_ifcfg_rule_file(monkeypatch):
+    """
+    Install NetworkManager-dispatcher-routing-rules package if there's a
+    file with ip rules.
+    """
+
+    monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_AND_NM_INSTALLED)
+    monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
+    monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('hello', 'world', 'rule-eth0',))
+    monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    ifcfg.process()
+    assert not reporting.create_report.called
+    assert api.produce.called
+    assert isinstance(api.produce.model_instances[0], RpmTransactionTasks)
+    assert api.produce.model_instances[0].to_install == ['NetworkManager-dispatcher-routing-rules']
+
+
+def test_ifcfg_good_type(monkeypatch):
+    """
+    No report if there's an ifcfg file that would work with NetworkManager.
+    Make sure NetworkManager itself is installed though.
+    """
+
+    mock_config = mock.mock_open(read_data="TYPE=Ethernet")
+    with mock.patch("builtins.open" if six.PY3 else "__builtin__.open", mock_config) as mock_ifcfg:
+        monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_AND_NM_INSTALLED)
+        monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
+        monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('hello', 'world', 'ifcfg-eth0', 'ifcfg-lo',))
+        monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
+        monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+        ifcfg.process()
+        mock_ifcfg.assert_called_once_with('/etc/sysconfig/network-scripts/ifcfg-eth0')
+        assert not reporting.create_report.called
+        assert api.produce.called
+        assert isinstance(api.produce.model_instances[0], RpmTransactionTasks)
+        assert api.produce.model_instances[0].to_install == ['NetworkManager']
+
+
+def test_ifcfg_not_controlled(monkeypatch):
+    """
+    Report if there's a NM_CONTROLLED=no file.
+    """
+
+    mock_config = mock.mock_open(read_data="TYPE=Ethernet\nNM_CONTROLLED=no")
+    with mock.patch("builtins.open" if six.PY3 else "__builtin__.open", mock_config) as mock_ifcfg:
+        monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_INSTALLED)
+        monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
+        monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('hello', 'world', 'ifcfg-eth0',))
+        monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
+        monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+        ifcfg.process()
+        mock_ifcfg.assert_called_once_with('/etc/sysconfig/network-scripts/ifcfg-eth0')
+        assert reporting.create_report.called
+        assert 'disabled NetworkManager' in reporting.create_report.report_fields['title']
+        assert api.produce.called
+
+
+def test_ifcfg_unknown_type(monkeypatch):
+    """
+    Report if there's configuration for a type we don't recognize.
+    """
+
+    mock_config = mock.mock_open(read_data="TYPE=AvianCarrier")
+    with mock.patch("builtins.open" if six.PY3 else "__builtin__.open", mock_config) as mock_ifcfg:
+        monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_AND_NM_INSTALLED)
+        monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
+        monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('hello', 'world', 'ifcfg-pigeon0',))
+        monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
+        monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+        ifcfg.process()
+        mock_ifcfg.assert_called_once_with('/etc/sysconfig/network-scripts/ifcfg-pigeon0')
+        assert reporting.create_report.called
+        assert 'unsupported device types' in reporting.create_report.report_fields['title']
+        assert not api.produce.called
+
+
+def test_ifcfg_install_subpackage(monkeypatch):
+    """
+    Install NetworkManager-team if there's a team connection and also
+    ensure NetworkManager-config-server is installed if NetworkManager
+    was not there.
+    """
+
+    mock_config = mock.mock_open(read_data="TYPE=Team")
+    with mock.patch("builtins.open" if six.PY3 else "__builtin__.open", mock_config) as mock_ifcfg:
+        monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_INSTALLED)
+        monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
+        monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('ifcfg-team0',))
+        monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
+        monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+        ifcfg.process()
+        mock_ifcfg.assert_called_once_with('/etc/sysconfig/network-scripts/ifcfg-team0')
+        assert not reporting.create_report.called
+        assert api.produce.called
+        assert isinstance(api.produce.model_instances[0], RpmTransactionTasks)
+        assert api.produce.model_instances[0].to_install == [
+            'NetworkManager-team',
+            'NetworkManager-config-server'
+        ]


### PR DESCRIPTION
RHEL 9 is not going to ship network-scripts. While NetworkManager
generally supports ifcfg files just fine, there are some corner cases
that are either unsupportable or explicitely configured not to work with
NetworkManager.

This adds an actor that checks for those cases and inhibits upgrade if
they are encountered.

https://bugzilla.redhat.com/show_bug.cgi?id=2052343