### PR TITLE
Fix detection of enabled yum plugins (debugloglevel = 2)

### DIFF
--- a/repos/system_upgrade/common/actors/yumconfigscanner/libraries/yumconfigscanner.py
+++ b/repos/system_upgrade/common/actors/yumconfigscanner/libraries/yumconfigscanner.py
@@ -63,8 +63,13 @@ def scan_enabled_yum_plugins():
     # /etc/yum/pluginconf.d/
 
     if get_source_major_version() == '7':
-        yum_cmd = ['yum']
+        # in case of yum, set debuglevel=2 to be sure the output is always
+        # same. The format of data is different for various debuglevels
+        yum_cmd = ['yum', '--setopt=debuglevel=2']
     else:
+        # the verbose mode in dnf always set particular debuglevel, so the
+        # output is not affected by the default debug level set on the
+        # system
         yum_cmd = ['dnf', '-v']  # On RHEL8 we need to supply an extra switch
 
     yum_output = run(yum_cmd, split=True, checked=False)  # The yum command will certainly fail (does not matter).

--- a/repos/system_upgrade/common/actors/yumconfigscanner/tests/test_yumconfigscanner.py
+++ b/repos/system_upgrade/common/actors/yumconfigscanner/tests/test_yumconfigscanner.py
@@ -24,7 +24,7 @@ def assert_plugins_identified_as_enabled(expected_plugins, identified_plugins):
 @pytest.mark.parametrize(
     ('source_major_version', 'yum_command'),
     [
-        ('7', ['yum']),
+        ('7', ['yum', '--setopt=debuglevel=2']),
         ('8', ['dnf', '-v']),
     ]
 )


### PR DESCRIPTION
If the yum configuration set the debugloglevel to a non default
values, the output can be different and the current parsing is not
working well. To set just minimal changes, let's set the debuglevel=2
always in the yumconfigscanner actor so we can use the current parser.