### PR TITLE
Fix scanning "/etc/default/grub" with empty line

### DIFF
--- a/repos/system_upgrade/common/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/common/actors/systemfacts/libraries/systemfacts.py
@@ -289,6 +289,8 @@ def _default_grub_info():
         ])
     else:
         for line in run(['cat', default_grb_fpath], split=True)['stdout']:
+            if not line.strip():
+                continue
             name, value = tuple(map(type(line).strip, line.split('=', 1)))
             yield DefaultGrub(
                 name=name,


### PR DESCRIPTION
E.g. in Azure RHEL 8 image, "/etc/default/grub" file containes
an empty line for some reason and Leapp in this case fails with
"ValueError: not enough values to unpack (expected 2, got 1)"