### PR TITLE
config: Fallback to /etc/leapp/repos.d if missing config option

### DIFF
--- a/commands/answer/__init__.py
+++ b/commands/answer/__init__.py
@@ -1,7 +1,7 @@
 import itertools
 import sys
 
-from leapp.config import get_config
+from leapp.cli.commands.config import get_config
 from leapp.exceptions import UsageError
 from leapp.messaging.answerstore import AnswerStore
 from leapp.utils.clicmd import command, command_opt

--- a/commands/config.py
+++ b/commands/config.py
@@ -1,0 +1,7 @@
+from leapp import config
+
+
+def get_config():
+    if not config._LEAPP_CONFIG:
+        config._CONFIG_DEFAULTS['repositories'] = {'repo_path': '/etc/leapp/repos.d'}
+    return config.get_config()

--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -3,8 +3,8 @@ import sys
 import uuid
 
 from leapp.cli.commands import command_utils
+from leapp.cli.commands.config import get_config
 from leapp.cli.commands.upgrade import breadcrumbs, util
-from leapp.config import get_config
 from leapp.exceptions import CommandError, LeappError
 from leapp.logger import configure_logger
 from leapp.utils.audit import Execution

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -3,8 +3,8 @@ import sys
 import uuid
 
 from leapp.cli.commands import command_utils
+from leapp.cli.commands.config import get_config
 from leapp.cli.commands.upgrade import breadcrumbs, util
-from leapp.config import get_config
 from leapp.exceptions import CommandError, LeappError
 from leapp.logger import configure_logger
 from leapp.utils.audit import Execution

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -7,7 +7,7 @@ import tarfile
 from datetime import datetime
 
 from leapp.cli.commands import command_utils
-from leapp.config import get_config
+from leapp.cli.commands.config import get_config
 from leapp.exceptions import CommandError
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.utils import audit


### PR DESCRIPTION
Previously if the repositories.repo_path configuration value was missing
from the leapp.conf, because someone deleted it, leapp fell back to to
the current working directory as root path which could have caused
unwanted side effects.
This patch will force /etc/leapp/repos.d to be the default path for
leapp answer/upgrade/preupgrade etc

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>