### PR TITLE
el8toel9: Add nis_check actor

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/nischeck/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/nischeck/actor.py
@@ -1,0 +1,19 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.nischeck import report_nis
+from leapp.models import InstalledRedHatSignedRPM, NISConfig, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class NISCheck(Actor):
+    """
+    Checks if any of NIS components is installed and configured
+    on the system and warns users about discontinuation.
+    """
+
+    name = 'nis_check'
+    consumes = (InstalledRedHatSignedRPM, NISConfig)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        report_nis()

--- a/repos/system_upgrade/el8toel9/actors/nischeck/libraries/nischeck.py
+++ b/repos/system_upgrade/el8toel9/actors/nischeck/libraries/nischeck.py
@@ -1,0 +1,72 @@
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM, NISConfig
+
+report_summary = (
+    'The NIS components (ypserv, ypbind, and yp-tools) are no longer available in RHEL-9.'
+    ' The technology behind those packages is based an outdated design patterns, which are'
+    ' no longer considered as secure. There is no direct alternative with fully compatible'
+    ' features.'
+)
+
+report_hint = (
+    'The alternatives are LDAP and for some use cases Kerberos or migrating to IPA.'
+)
+
+report_link_url = 'https://access.redhat.com/solutions/5991271'
+
+
+def report_nis():
+    """
+    Create the report if any of NIS packages (RH signed)
+    is installed and configured.
+
+    Should notify user about present NIS compnent package
+    installation, warn them about discontinuation, and
+    redirect them to online documentation for possible
+    alternatives.
+    """
+
+    installed_packages = []
+    configured_rpms = []
+
+    # Get necessary models created by another actors
+    nis_confs = api.consume(NISConfig)
+    nis_conf = next(nis_confs, None)
+    if not nis_conf:
+        raise StopActorExecutionError(
+            'Could not obtain NIS RPM information',
+            details={'details': 'Actor did not receive NISConfig message.'}
+        )
+
+    if next(nis_confs, None):
+        api.current_logger().warning('Unexpectedly received more than one NISConfig message.')
+
+    configured_rpms = nis_conf.nis_not_default_conf
+
+    installed_packages = [package for package in (
+        'ypserv', 'ypbind') if has_package(InstalledRedHatSignedRPM, package)]
+
+    # Final list of NIS packages (configured and installed)
+    rpms_configured_installed = [x for x in installed_packages if x in configured_rpms]
+
+    if not rpms_configured_installed:
+        return
+
+    # Create report
+    report_content = [
+        reporting.Title('NIS component has been detected on your system'),
+        reporting.Summary(report_summary),
+        reporting.Severity(reporting.Severity.MEDIUM),
+        reporting.Tags([reporting.Tags.SERVICES]),
+        reporting.ExternalLink(title='RHEL 9 (NIS) discontinuation',
+                               url=report_link_url),
+        reporting.Remediation(hint=report_hint),
+    ]
+
+    related_resources = [reporting.RelatedResource('package', pkg) for pkg in rpms_configured_installed]
+    report_content += related_resources
+
+    reporting.create_report(report_content)

--- a/repos/system_upgrade/el8toel9/actors/nischeck/tests/test_nischeck.py
+++ b/repos/system_upgrade/el8toel9/actors/nischeck/tests/test_nischeck.py
@@ -1,0 +1,71 @@
+import functools
+
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import nischeck
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRedHatSignedRPM, NISConfig, RPM
+
+_generate_rpm = functools.partial(RPM,
+                                  pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51',
+                                  packager='Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>',
+                                  arch='noarch')
+
+
+@pytest.mark.parametrize('pkgs_installed', [
+    ('ypserv',),
+    ('ypbind',),
+    ('ypserv-not-ypbind',),
+    ('ypbind', 'ypserv'),
+])
+@pytest.mark.parametrize('pkgs_configured', [
+    (),
+    ('ypbind',),
+    ('ypserv',),
+    ('ypbind', 'ypserv'),
+])
+def test_actor_nis(monkeypatch, pkgs_installed, pkgs_configured):
+    """
+    Parametrized helper function for test_actor_* functions.
+
+    First generate list of RPM models based on set arguments. Then, run
+    the actor feeded with our RPM list and mocked functions. Finally, assert
+    Reports according to set arguments.
+
+    Parameters:
+        pkgs_installed  (touple): installed pkgs
+        fill_conf_file  (bool): not default ypbind config file
+        fill_ypserv_dir  (bool): not default ypserv dir content
+    """
+
+    # Generate few standard packages
+    rpms = [_generate_rpm(name='rclone', version='2.3', release='3', epoch='1'),
+            _generate_rpm(name='gdb', version='2.0.1', release='1', epoch='2')]
+
+    # Generate packages from 'pkgs_installed'
+    for pkg_name in pkgs_installed:
+        rpms += [_generate_rpm(name=pkg_name, version='2.0', release='3', epoch='1')]
+
+    # Generate NIS facts
+    nis_facts = NISConfig(nis_not_default_conf=pkgs_configured)
+
+    curr_actor_mocked = CurrentActorMocked(msgs=[InstalledRedHatSignedRPM(items=rpms), nis_facts])
+    monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    # Executed actor feeded with out fake msgs
+    nischeck.report_nis()
+
+    # Iterate through installed packages
+    for pkg in pkgs_installed:
+        # Check if package is configured
+        if pkg in pkgs_configured:
+            # Don't waste time checking other conditions
+            # if one of pkgs is already found
+            assert reporting.create_report.called == 1
+            break
+    else:
+        # Assert for no NIS installed and configured packages
+        assert not reporting.create_report.called

--- a/repos/system_upgrade/el8toel9/actors/nisscanner/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/nisscanner/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.nisscan import NISScanLibrary
+from leapp.models import NISConfig
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class NISScanner(Actor):
+    """
+    Collect information about the NIS packages configuration.
+    """
+
+    name = 'nis_scanner'
+    consumes = ()
+    produces = (NISConfig,)
+    tags = (FactsPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        NISScanLibrary().process()

--- a/repos/system_upgrade/el8toel9/actors/nisscanner/libraries/nisscan.py
+++ b/repos/system_upgrade/el8toel9/actors/nisscanner/libraries/nisscan.py
@@ -1,0 +1,58 @@
+import os
+
+from leapp.libraries.stdlib import api
+from leapp.models import NISConfig
+
+PACKAGES_NAMES = ('ypserv', 'ypbind')
+YPBIND_CONF_FILE = '/etc/yp.conf'
+YPSERV_DIR_PATH = '/var/yp'
+YPSERV_DEFAULT_FILES = ('binding', 'Makefile', 'nicknames')
+
+
+class NISScanLibrary:
+    """
+    Helper library for NISScan actor.
+    """
+
+    def client_has_non_default_configuration(self):
+        """
+        Check for any significant ypbind configuration lines in .conf file.
+        """
+        if not os.path.isfile(YPBIND_CONF_FILE):
+            return False
+
+        # Filter whitespaces and empty lines
+        with open(YPBIND_CONF_FILE) as f:
+            lines = [line.strip() for line in f.readlines() if line.strip()]
+
+        for line in lines:
+            # Cheks for any valid configuration entry
+            if not line.startswith('#'):
+                return True
+        return False
+
+    def server_has_non_default_configuration(self):
+        """
+        Check for any additional (not default) files in ypserv DIR.
+        """
+        if not os.path.isdir(YPSERV_DIR_PATH):
+            return False
+
+        return any(f not in YPSERV_DEFAULT_FILES for f in os.listdir(YPSERV_DIR_PATH))
+
+    def process(self):
+        """
+        Check NIS pkgs configuration for the following options:
+
+        - yp.conf custom configuration
+        - /var/yp not default entry
+        """
+        pkgs = []
+
+        if self.server_has_non_default_configuration():
+            pkgs.append('ypserv')
+
+        if self.client_has_non_default_configuration():
+            pkgs.append('ypbind')
+
+        api.produce(NISConfig(nis_not_default_conf=pkgs))

--- a/repos/system_upgrade/el8toel9/actors/nisscanner/tests/test_nisscan.py
+++ b/repos/system_upgrade/el8toel9/actors/nisscanner/tests/test_nisscan.py
@@ -1,0 +1,82 @@
+import mock
+import pytest
+import six
+
+from leapp.libraries.actor import nisscan
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import NISConfig
+
+# Examples of /etc/yp.conf configuration file (default and configured)
+YPBIND_DEFAULT_CONF = """# /etc/yp.conf - ypbind configuration file
+# Valid entries are
+#
+# domain NISDOMAIN server HOSTNAME
+#	Use server HOSTNAME for the domain NISDOMAIN"""
+
+YPBIND_CONFIGURED_CONF = """# /etc/yp.conf - ypbind configuration file
+domain whoisredhat.redhat server prod-db
+
+domain whatisredhat.redhat server prod-db"""
+
+
+@pytest.mark.parametrize('pkgs_installed', [
+    ('ypserv',),
+    ('ypbind',),
+    ('ypserv-not-ypbind',),
+    ('ypbind', 'ypserv'),
+])
+@pytest.mark.parametrize("fill_conf_file", [True, False])
+@pytest.mark.parametrize("fill_ypserv_dir", [True, False])
+def test_actor_nisscan(monkeypatch, pkgs_installed, fill_conf_file, fill_ypserv_dir):
+    """
+    Parametrized helper function for test_actor_* functions.
+
+    Run the actor feeded with our mocked functions and assert
+    produced messages according to set arguments.
+
+    Parameters:
+        pkgs_installed  (touple): installed pkgs
+        fill_conf_file  (bool): not default ypbind config file
+        fill_ypserv_dir  (bool): not default ypserv dir content
+    """
+
+    # Store final list of configured NIS packages
+    configured_pkgs = []
+
+    # Fill ypbind config
+    yp_conf_content = YPBIND_CONFIGURED_CONF if fill_conf_file else YPBIND_DEFAULT_CONF
+
+    # Fill ypserv dir files
+    yp_dir_content = (nisscan.YPSERV_DEFAULT_FILES + ('example.com',) if fill_ypserv_dir
+                      else nisscan.YPSERV_DEFAULT_FILES)
+
+    # Mock 'isfile' & 'isdir' based on installed pkgs
+    mocked_isfile = 'ypbind' in pkgs_installed
+    mocked_isdir = 'ypserv' in pkgs_installed
+
+    mock_config = mock.mock_open(read_data=yp_conf_content)
+    with mock.patch("builtins.open" if six.PY3 else "__builtin__.open", mock_config):
+        curr_actor_mocked = CurrentActorMocked()
+        monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
+        monkeypatch.setattr(api, "produce", produce_mocked())
+        monkeypatch.setattr(nisscan.os, 'listdir', lambda dummy: yp_dir_content)
+        monkeypatch.setattr(nisscan.os.path, 'isfile', lambda dummy: mocked_isfile)
+        monkeypatch.setattr(nisscan.os.path, 'isdir', lambda dummy: mocked_isdir)
+
+        # Executed actor feeded with mocked functions
+        nisscan.NISScanLibrary().process()
+
+    # Filter NIS pkgs
+    filtered_installed_pkgs = [x for x in pkgs_installed if x in nisscan.PACKAGES_NAMES]
+
+    # Create correct list of pkgs for assert check
+    for pkg in filtered_installed_pkgs:
+        if (pkg == 'ypserv' and fill_ypserv_dir) or (pkg == 'ypbind' and fill_conf_file):
+            configured_pkgs.append(pkg)
+
+    # Sort NISConfig objects
+    nisconf_template = set(NISConfig(nis_not_default_conf=configured_pkgs).nis_not_default_conf)
+    nisconf_result = set(api.produce.model_instances[0].nis_not_default_conf)
+
+    assert nisconf_template == nisconf_result

--- a/repos/system_upgrade/el8toel9/models/nis.py
+++ b/repos/system_upgrade/el8toel9/models/nis.py
@@ -1,0 +1,16 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class NISConfig(Model):
+    """
+    The model contains NIS packages configuration status.
+    """
+    topic = SystemInfoTopic
+
+    nis_not_default_conf = fields.List(fields.String(), default=[])
+    """
+    List of names of NIS packages with modified default configuration.
+
+    e.g. ["ypbind", "ypserv"]
+    """


### PR DESCRIPTION
NIS components (ypserv, ypbind, yp-tools) will no longer be available in RHEL-9.
Check and notify user about possible solutions when any of the NIS packages is installed and configured.

- It check if any packages (ypbind, ypserver) is installed
- if above statement is true, it check for any not default configuration (depends on detected packages)
- if above statement is true, report is created with installed NIS packages

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2060066