### PR TITLE
OpenSSH PermitRootLogin check: avoid false reports

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/opensshconfigscanner/libraries/readopensshconfig.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshconfigscanner/libraries/readopensshconfig.py
@@ -1,8 +1,7 @@
 import errno
 
+from leapp.libraries.stdlib import api, run
 from leapp.models import OpenSshConfig, OpenSshPermitRootLogin
-from leapp.libraries.stdlib import run, api
-
 
 CONFIG = '/etc/ssh/sshd_config'
 DEPRECATED_DIRECTIVES = ['showpatchlevel']

--- a/repos/system_upgrade/el7toel8/actors/opensshconfigscanner/tests/test_readopensshconfig_opensshconfigscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshconfigscanner/tests/test_readopensshconfig_opensshconfigscanner.py
@@ -1,6 +1,5 @@
+from leapp.libraries.actor.readopensshconfig import line_empty, parse_config, parse_config_modification, produce_config
 from leapp.models import OpenSshConfig, OpenSshPermitRootLogin
-from leapp.libraries.actor.readopensshconfig import parse_config, \
-    produce_config, line_empty, parse_config_modification
 
 
 def test_line_empty():

--- a/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
@@ -42,9 +42,10 @@ class OpenSshPermitRootLoginCheck(Actor):
             reporting.RelatedResource('package', 'openssh-server'),
             reporting.RelatedResource('file', '/etc/ssh/sshd_config')
         ]
-        if not config.permit_root_login:
-            # TODO find out whether the file was modified and will be
-            # replaced by the update. If so, this message is bogus
+        # When the configuration does not contain the PermitRootLogin directive and
+        # the configuration file was locally modified, it will not get updated by
+        # RPM and the user might be locked away from the server. Warn the user here.
+        if not config.permit_root_login and config.modified:
             create_report([
                 reporting.Title('Possible problems with remote login using root account'),
                 reporting.Summary(

--- a/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/opensshpermitrootlogincheck/actor.py
@@ -1,12 +1,11 @@
+from leapp import reporting
 from leapp.actors import Actor
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor.opensshpermitrootlogincheck import semantics_changes
-from leapp.models import Report, OpenSshConfig
-from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 from leapp.libraries.stdlib import api
+from leapp.models import OpenSshConfig, Report
 from leapp.reporting import create_report
-from leapp import reporting
-
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 COMMON_REPORT_TAGS = [
     reporting.Tags.AUTHENTICATION,

--- a/repos/system_upgrade/el7toel8/models/opensshconfig.py
+++ b/repos/system_upgrade/el7toel8/models/opensshconfig.py
@@ -1,4 +1,4 @@
-from leapp.models import Model, fields
+from leapp.models import fields, Model
 from leapp.topics import SystemInfoTopic
 
 


### PR DESCRIPTION
I thought this was implemented as all the bits were available. But it
turned out that this check was missing and was marked only with TODO for
all these years ...