### PR TITLE
scancpu: fullmatch is not available in Py2.7

### DIFF
--- a/repos/system_upgrade/common/actors/scancpu/libraries/scancpu.py
+++ b/repos/system_upgrade/common/actors/scancpu/libraries/scancpu.py
@@ -48,7 +48,7 @@ def _is_detected_s390x(lscpu, entry):
 def _is_detected_ppc64le(lscpu, entry):
     try:
         _, _, machine_type, _ = entry.device_id.split(':', 4)
-        match = PPC64LE_MODEL.fullmatch(lscpu.get('Model'))
+        match = PPC64LE_MODEL.match(lscpu.get('Model'))
         if not match:
             return False
         family = match.group('family')


### PR DESCRIPTION
Switching to repattern.match because fullmatch is not available in
Python2.7

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>