### PR TITLE
Openssh sftp

### DIFF
--- a/repos/system_upgrade/common/actors/opensshconfigscanner/actor.py
+++ b/repos/system_upgrade/common/actors/opensshconfigscanner/actor.py
@@ -15,6 +15,7 @@ class OpenSshConfigScanner(Actor):
      * Protocol
      * Ciphers
      * MACs
+     * Subsystem sftp
 
     """
 

--- a/repos/system_upgrade/common/actors/opensshconfigscanner/libraries/readopensshconfig.py
+++ b/repos/system_upgrade/common/actors/opensshconfigscanner/libraries/readopensshconfig.py
@@ -61,6 +61,12 @@ def parse_config(config):
             if not ret.macs:
                 ret.macs = value
 
+        elif el[0].lower() == 'subsystem':
+            # Record only first occurence, which is effective
+            if el[1].lower() == 'sftp' and len(el) > 2 and not ret.subsystem_sftp:
+                # here we need to record all remaining items as command and arguments
+                ret.subsystem_sftp = ' '.join(el[2:])
+
         elif el[0].lower() in DEPRECATED_DIRECTIVES:
             # Filter out duplicit occurences of the same deprecated directive
             if el[0].lower() not in ret.deprecated_directives:

--- a/repos/system_upgrade/common/actors/opensshconfigscanner/tests/test_readopensshconfig_opensshconfigscanner.py
+++ b/repos/system_upgrade/common/actors/opensshconfigscanner/tests/test_readopensshconfig_opensshconfigscanner.py
@@ -24,6 +24,8 @@ def test_parse_config():
         "hostkey /etc/ssh/ssh_host_ed25519_key",
         "ciphers aes128-ctr",
         "macs hmac-md5",
+        "subsystem sftp internal-sftp",
+        "subsystem other internal-other",  # this is ignored
     ]
 
     output = parse_config(config)
@@ -34,6 +36,7 @@ def test_parse_config():
     assert output.protocol == "2"
     assert output.ciphers == "aes128-ctr"
     assert output.macs == "hmac-md5"
+    assert output.subsystem_sftp == "internal-sftp"
 
 
 def test_parse_config_case():
@@ -41,6 +44,7 @@ def test_parse_config_case():
         "PermitRootLogin prohibit-password",
         "UsePrivilegeSeparation yes",
         "Protocol 1",
+        "SubSystem sftp sftp-server",
     ]
 
     output = parse_config(config)
@@ -49,6 +53,7 @@ def test_parse_config_case():
     assert output.permit_root_login[0].value == "prohibit-password"
     assert output.use_privilege_separation == "yes"
     assert output.protocol == "1"
+    assert output.subsystem_sftp == "sftp-server"
 
 
 def test_parse_config_multiple():
@@ -58,6 +63,8 @@ def test_parse_config_multiple():
         "PermitRootLogin yes",
         "Ciphers aes128-cbc",
         "Ciphers aes256-cbc",
+        "subsystem sftp internal-sftp",
+        "subsystem sftp internal-sftp2",
     ]
 
     output = parse_config(config)
@@ -69,6 +76,7 @@ def test_parse_config_multiple():
     assert output.use_privilege_separation is None
     assert output.protocol is None
     assert output.ciphers == 'aes128-cbc'
+    assert output.subsystem_sftp == 'internal-sftp'
 
 
 def test_parse_config_commented():
@@ -76,6 +84,7 @@ def test_parse_config_commented():
         "#PermitRootLogin no",
         "#UsePrivilegeSeparation no",
         "#Protocol 12",
+        "#SubSystem sftp internal-sftp",
     ]
 
     output = parse_config(config)
@@ -83,6 +92,7 @@ def test_parse_config_commented():
     assert not output.permit_root_login
     assert output.use_privilege_separation is None
     assert output.protocol is None
+    assert output.subsystem_sftp is None
 
 
 def test_parse_config_missing_argument():
@@ -90,6 +100,8 @@ def test_parse_config_missing_argument():
         "PermitRootLogin",
         "UsePrivilegeSeparation",
         "Protocol"
+        "SubSystem"
+        "SubSystem sftp"
     ]
 
     output = parse_config(config)
@@ -97,6 +109,7 @@ def test_parse_config_missing_argument():
     assert not output.permit_root_login
     assert output.use_privilege_separation is None
     assert output.protocol is None
+    assert output.subsystem_sftp is None
 
 
 def test_parse_config_match():
@@ -174,6 +187,7 @@ def test_produce_config():
         use_privilege_separation="yes",
         protocol="1",
         deprecated_directives=[],
+        subsystem_sftp="internal-sftp",
     )
 
     produce_config(fake_producer, config)
@@ -183,6 +197,7 @@ def test_produce_config():
     assert cfg.permit_root_login[0].value == "no"
     assert cfg.use_privilege_separation == "yes"
     assert cfg.protocol == '1'
+    assert cfg.subsystem_sftp == 'internal-sftp'
 
 
 def test_actor_execution(current_actor_context):

--- a/repos/system_upgrade/common/models/opensshconfig.py
+++ b/repos/system_upgrade/common/models/opensshconfig.py
@@ -34,7 +34,10 @@ class OpenSshConfig(Model):
     """ Value of the Ciphers directive, if present. Ciphers separated by comma. """
     macs = fields.Nullable(fields.String())
     """ Value of the MACs directive, if present. """
-    modified = fields.Boolean(default=False)
-    """ True if the configuration file was modified. """
     deprecated_directives = fields.List(fields.String())
     """ Configuration directives that were deprecated in the new version of openssh. """
+    subsystem_sftp = fields.Nullable(fields.String())
+    """ The "Subsystem sftp" configuration option, if present """
+
+    modified = fields.Boolean(default=False)
+    """ True if the configuration file was modified. """

--- a/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import opensshsubsystemsftp
+from leapp.models import InstalledRedHatSignedRPM, OpenSshConfig
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class OpenSshSubsystemSftp(Actor):
+    """
+    The RHEL9 changes the SCP to use SFTP protocol internally. The both RHEL8 and RHEL9
+    enable SFTP server by default, but if the user disabled the SFTP for some reason,
+    it might make sense to warn that some previously working SCP operations could stop
+    working.
+    """
+
+    name = 'open_ssh_subsystem_sftp'
+    consumes = (OpenSshConfig, InstalledRedHatSignedRPM,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        opensshsubsystemsftp.process(self.consume(OpenSshConfig))

--- a/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/libraries/opensshsubsystemsftp.py
+++ b/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/libraries/opensshsubsystemsftp.py
@@ -1,0 +1,47 @@
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+
+
+def process(openssh_messages):
+    config = next(openssh_messages, None)
+    if list(openssh_messages):
+        api.current_logger().warning('Unexpectedly received more than one OpenSshConfig message.')
+    if not config:
+        raise StopActorExecutionError(
+            'Could not check openssh configuration', details={'details': 'No OpenSshConfig facts found.'}
+        )
+
+    # not modified configuration will get updated by RPM automatically
+    if not config.modified:
+        return
+
+    if not config.subsystem_sftp:
+        resources = [
+            reporting.RelatedResource('package', 'openssh-server'),
+            reporting.RelatedResource('file', '/etc/ssh/sshd_config'),
+            reporting.ExternalLink(
+                title="SCP support in RHEL",
+                url="https://access.redhat.com/articles/5284081",
+            ),
+            # TODO provide a link to documentation or blog post
+        ]
+        reporting.create_report([
+            reporting.Title('OpenSSH configured without SFTP subsystem'),
+            reporting.Summary(
+                'The RHEL9 is changing the default SCP behaviour to use SFTP internally '
+                'so not having SFTP server enabled can prevent interoperability and break existing '
+                'scripts on other systems updated to RHEL9 to copy files to or from this machine.'
+            ),
+            reporting.Remediation(
+                hint='Add the following line to the /etc/ssh/sshd_config to enable SFTP server: '
+                     'Subsystem sftp /usr/libexec/openssh/sftp-server'
+            ),
+            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Tags([
+                    reporting.Tags.AUTHENTICATION,
+                    reporting.Tags.SECURITY,
+                    reporting.Tags.NETWORK,
+                    reporting.Tags.SERVICES
+            ]),
+        ] + resources)

--- a/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/tests/test_opensshsubsystemsftp.py
+++ b/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/tests/test_opensshsubsystemsftp.py
@@ -1,0 +1,33 @@
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import opensshsubsystemsftp
+from leapp.models import OpenSshConfig, Report
+
+
+def test_no_config(current_actor_context):
+    with pytest.raises(StopActorExecutionError):
+        opensshsubsystemsftp.process(iter([]))
+
+
+@pytest.mark.parametrize('modified,subsystem,expected_report', [
+    (False, None, False),  # should not happen
+    (False, '/usr/libexec/openssh/sftp-server', False),  # Defaults
+    (True, None, True),
+    (True, 'internal-sftp', False),
+    (True, '/usr/libexec/openssh/sftp-server', False)
+])
+def test_subsystem(current_actor_context, modified, subsystem, expected_report):
+    conf = OpenSshConfig(
+        modified=modified,
+        permit_root_login=[],
+        deprecated_directives=[]
+    )
+    if subsystem is not None:
+        conf.subsystem_sftp = subsystem
+    current_actor_context.feed(conf)
+    current_actor_context.run()
+    if expected_report:
+        assert current_actor_context.consume(Report)
+    else:
+        assert not current_actor_context.consume(Report)


### PR DESCRIPTION
The first commit overlaps with a first commit from  #860.

Regarding our changes in RHEL9, changing from SCP to SFTP. The default configuration of sshd allows sftp server so the transition should be quite painless. But on upgraded systems, where the sftp subsystem was disabled in sshd config, it might cause existing scripts using scp to start failing. Our proposal is to warn user if there is a chance to hit this.