### PR TITLE
Switch to semicolon build separator in tmt-tests

### DIFF
--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Schedule regression testing for 7to8
         id: run_test_7to8
         env:
-          ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{0},{1}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
+          ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{0};{1}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
         uses: sclorg/testing-farm-as-github-action@v1.2.9
         with:
           # required
@@ -166,7 +166,7 @@ jobs:
       - name: Schedule regression testing for 8to9
         id: run_test_8to9
         env:
-          ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{0},{1}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
+          ARTIFACTS: ${{ steps.leapp_pr_regex_match.outputs.match != '' && format('{0};{1}', steps.copr_build_leapp.outputs.copr_id, steps.copr_build.outputs.copr_id) || steps.copr_build.outputs.copr_id }}
         uses: sclorg/testing-farm-as-github-action@v1.2.9
         with:
           # required


### PR DESCRIPTION
Official github action separates test artifacts string by ; only,
so in order to test multiple artifacts this has to land.