### PR TITLE
pcidevicesscanner: Also match deprecation data against kernel modules

### DIFF
--- a/repos/system_upgrade/common/actors/pcidevicesscanner/libraries/pcidevicesscanner.py
+++ b/repos/system_upgrade/common/actors/pcidevicesscanner/libraries/pcidevicesscanner.py
@@ -1,7 +1,13 @@
 import re
 
 from leapp.libraries.stdlib import api, run
-from leapp.models import DetectedDeviceOrDriver, DeviceDriverDeprecationData, PCIDevice, PCIDevices
+from leapp.models import (
+    ActiveKernelModulesFacts,
+    DetectedDeviceOrDriver,
+    DeviceDriverDeprecationData,
+    PCIDevice,
+    PCIDevices
+)
 
 # Regex to capture Vendor, Device and SVendor and SDevice values
 PCI_ID_REG = re.compile(r"(?<=Vendor:\t|Device:\t)\w+")
@@ -82,6 +88,26 @@ def produce_detected_devices(devices):
     ])
 
 
+def produce_detected_drivers(devices):
+    active_modules = {
+        module.file_name
+        for message in api.consume(ActiveKernelModulesFacts) for module in message.kernel_modules
+    }
+
+    # Create a lookup by driver_name and filter out the kernel that are active
+    entry_lookup = {
+        entry.driver_name: entry
+        for message in api.consume(DeviceDriverDeprecationData) for entry in message.entries
+        if entry.driver_name and entry.driver_name not in active_modules
+    }
+
+    drivers = {device.driver for device in devices if device.driver in entry_lookup}
+    api.produce(*[
+        DetectedDeviceOrDriver(**entry_lookup[driver].dump())
+        for driver in drivers
+    ])
+
+
 def produce_pci_devices(producer, devices):
     """ Produce a Leapp message with all PCI devices """
     producer(PCIDevices(devices=devices))
@@ -93,4 +119,5 @@ def scan_pci_devices(producer):
     pci_numeric = run(['lspci', '-vmmkn'], checked=False)['stdout']
     devices = parse_pci_devices(pci_textual, pci_numeric)
     produce_detected_devices(devices)
+    produce_detected_drivers(devices)
     produce_pci_devices(producer, devices)


### PR DESCRIPTION
Previously when the deprecation data got introduced the kernel drivers
reported to be used by lspci have not been checked.
This patch fixes this regression.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>