### PR TITLE
call Satellite installer with --disable-system-checks if possible

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/actor.py
@@ -32,6 +32,8 @@ class SatelliteUpgradeFacts(Actor):
         if not has_foreman:
             return
 
+        has_katello_installer = has_package(InstalledRPM, 'foreman-installer-katello')
+
         local_postgresql = has_package(InstalledRPM, 'rh-postgresql12-postgresql-server')
         postgresql_contrib = has_package(InstalledRPM, 'rh-postgresql12-postgresql-contrib')
         postgresql_evr = has_package(InstalledRPM, 'rh-postgresql12-postgresql-evr')
@@ -114,6 +116,7 @@ class SatelliteUpgradeFacts(Actor):
 
         self.produce(SatelliteFacts(
             has_foreman=has_foreman,
+            has_katello_installer=has_katello_installer,
             postgresql=SatellitePostgresqlFacts(
                 local_postgresql=local_postgresql,
                 old_var_lib_pgsql_data=old_pgsql_data,

--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/tests/unit_test_satellite_upgrade_facts.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/tests/unit_test_satellite_upgrade_facts.py
@@ -13,6 +13,7 @@ def fake_package(pkg_name):
 
 FOREMAN_RPM = fake_package('foreman')
 FOREMAN_PROXY_RPM = fake_package('foreman-proxy')
+KATELLO_INSTALLER_RPM = fake_package('foreman-installer-katello')
 KATELLO_RPM = fake_package('katello')
 POSTGRESQL_RPM = fake_package('rh-postgresql12-postgresql-server')
 
@@ -36,6 +37,20 @@ def test_satellite_capsule_present(current_actor_context):
     current_actor_context.run()
     message = current_actor_context.consume(SatelliteFacts)[0]
     assert message.has_foreman
+
+
+def test_no_katello_installer_present(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[FOREMAN_RPM]))
+    current_actor_context.run()
+    message = current_actor_context.consume(SatelliteFacts)[0]
+    assert not message.has_katello_installer
+
+
+def test_katello_installer_present(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[FOREMAN_RPM, KATELLO_INSTALLER_RPM]))
+    current_actor_context.run()
+    message = current_actor_context.consume(SatelliteFacts)[0]
+    assert message.has_katello_installer
 
 
 def test_enables_ruby_module(current_actor_context):

--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrader/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrader/actor.py
@@ -19,9 +19,13 @@ class SatelliteUpgrader(Actor):
         if not facts or not facts.has_foreman:
             return
 
+        installer_cmd = ['foreman-installer']
+        if facts.has_katello_installer:
+            installer_cmd.append('--disable-system-checks')
+
         api.current_actor().show_message('Running the installer. This can take a while.')
         try:
-            run(['foreman-installer'])
+            run(installer_cmd)
         except OSError as e:
             api.current_logger().error('Failed to run `foreman-installer`: {}'.format(str(e)))
         except CalledProcessError:

--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrader/tests/unit_test_satellite_upgrader.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrader/tests/unit_test_satellite_upgrader.py
@@ -21,4 +21,15 @@ def test_run_installer(monkeypatch, current_actor_context):
     current_actor_context.run()
     assert mocked_run.commands
     assert len(mocked_run.commands) == 1
+    assert mocked_run.commands[0] == ['foreman-installer', '--disable-system-checks']
+
+
+def test_run_installer_without_katello(monkeypatch, current_actor_context):
+    mocked_run = MockedRun()
+    monkeypatch.setattr('leapp.libraries.stdlib.run', mocked_run)
+    current_actor_context.feed(SatelliteFacts(has_foreman=True, has_katello_installer=False,
+                                              postgresql=SatellitePostgresqlFacts()))
+    current_actor_context.run()
+    assert mocked_run.commands
+    assert len(mocked_run.commands) == 1
     assert mocked_run.commands[0] == ['foreman-installer']

--- a/repos/system_upgrade/el7toel8/models/satellite.py
+++ b/repos/system_upgrade/el7toel8/models/satellite.py
@@ -22,5 +22,7 @@ class SatelliteFacts(Model):
 
     has_foreman = fields.Boolean(default=False)
     """Whether or not foreman is installed on this system"""
+    has_katello_installer = fields.Boolean(default=True)
+    """Whether or not the installer supports Katello additions"""
     postgresql = fields.Model(SatellitePostgresqlFacts)
     """ Foreman related PostgreSQL facts """


### PR DESCRIPTION
The installer has a set of checks to verify whether the current system
is suitable for running Satellite. The administrator of the system can
choose to ignore those checks with `--disable-system-checks`.

As the installer invocation inside LEAPP is non-interactive, we should
err on the side of not running checks, so that the upgrade doesn't abort
in the case where the administrator has chosen to ignore the warnings.

This is in line with other non-interactive invocations of the installer
that other tools (like foreman-maintain) do.

The "if katello installer" logic is needed, as the checks and the cli
parameter is only present in Katello installations, not plain Foreman.