### PR TITLE
pciscanner: Fix 2 issues in regards to pci address handling

### DIFF
--- a/repos/system_upgrade/common/actors/pcidevicesscanner/libraries/pcidevicesscanner.py
+++ b/repos/system_upgrade/common/actors/pcidevicesscanner/libraries/pcidevicesscanner.py
@@ -78,7 +78,7 @@ def parse_pci_devices(pci_textual, pci_numeric):
 def produce_detected_devices(devices):
     prefix_re = re.compile('0x')
     entry_lookup = {
-        prefix_re.sub(' ', entry.device_id): entry
+        prefix_re.sub('', entry.device_id): entry
         for message in api.consume(DeviceDriverDeprecationData) for entry in message.entries
     }
     api.produce(*[
@@ -98,7 +98,7 @@ def produce_detected_drivers(devices):
     entry_lookup = {
         entry.driver_name: entry
         for message in api.consume(DeviceDriverDeprecationData) for entry in message.entries
-        if entry.driver_name and entry.driver_name not in active_modules
+        if not entry.device_id and entry.driver_name and entry.driver_name not in active_modules
     }
 
     drivers = {device.driver for device in devices if device.driver in entry_lookup}


### PR DESCRIPTION
In a previous patch, the introduction of the new handling of deprecation
data, 2 problems slipped through.

1. The regex replacement for pci ids errornous adds an empty space
   instead of empty string
2. Drivers should be matched on lspci output against the driver
   deprecation data only if the pci_id is empty

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>