### PR TITLE
CheckNFS actor should respect nfsd filesystem

### DIFF
--- a/repos/system_upgrade/common/actors/checknfs/actor.py
+++ b/repos/system_upgrade/common/actors/checknfs/actor.py
@@ -1,7 +1,7 @@
+from leapp import reporting
 from leapp.actors import Actor
 from leapp.models import StorageInfo
-from leapp.reporting import Report, create_report
-from leapp import reporting
+from leapp.reporting import create_report, Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
@@ -22,24 +22,27 @@ class CheckNfs(Actor):
                   "We have found NFS usage at the following locations:\n"
         nfs_found = False
 
+        def _is_nfs(a_type):
+            return a_type.startswith('nfs') and a_type != 'nfsd'
+
         for storage in self.consume(StorageInfo):
             # Check fstab
             for fstab in storage.fstab:
-                if fstab.fs_vfstype.startswith("nfs"):
+                if _is_nfs(fstab.fs_vfstype):
                     nfs_found = True
                     details += "- One or more NFS entries in /etc/fstab\n"
                     break
 
             # Check mount
             for mount in storage.mount:
-                if mount.tp.startswith("nfs"):
+                if _is_nfs(mount.tp):
                     nfs_found = True
                     details += "- Currently mounted NFS shares\n"
                     break
 
             # Check systemd-mount
             for systemdmount in storage.systemdmount:
-                if systemdmount.fs_type.startswith("nfs"):
+                if _is_nfs(systemdmount.fs_type):
                     nfs_found = True
                     details += "- One or more configured NFS mounts in systemd-mount\n"
                     break

--- a/repos/system_upgrade/common/actors/checknfs/tests/test_checknfs.py
+++ b/repos/system_upgrade/common/actors/checknfs/tests/test_checknfs.py
@@ -1,8 +1,8 @@
 import pytest
 
-from leapp.snactor.fixture import current_actor_context
-from leapp.models import StorageInfo, SystemdMountEntry, FstabEntry, MountEntry
+from leapp.models import FstabEntry, MountEntry, StorageInfo, SystemdMountEntry
 from leapp.reporting import Report
+from leapp.snactor.fixture import current_actor_context
 
 
 @pytest.mark.parametrize('nfs_fstype', ('nfs', 'nfs4'))
@@ -46,6 +46,13 @@ def test_actor_without_fstab_entry(current_actor_context):
                                       fs_mntops="defaults,x-systemd.device-timeout=0",
                                       fs_freq="1", fs_passno="2")]
     current_actor_context.feed(StorageInfo(fstab=without_fstab_entry))
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+
+
+def test_actor_with_nfsd(current_actor_context):
+    with_nfsd = [MountEntry(name="nfsd", mount="/proc/fs/nfsd", tp="nfsd", options="rw,relatime")]
+    current_actor_context.feed(StorageInfo(mount=with_nfsd))
     current_actor_context.run()
     assert not current_actor_context.consume(Report)
 


### PR DESCRIPTION
Check filesystem type for full match with 'nfs'
otherwise false positive fires like in 'nfsd' may
occur.

OAMG-6355