### PR TITLE
Remove temporary leapp directory in /root

### DIFF
--- a/repos/system_upgrade/common/actors/createresumeservice/actor.py
+++ b/repos/system_upgrade/common/actors/createresumeservice/actor.py
@@ -1,11 +1,12 @@
-import shutil
 import os
+import shutil
 
-from leapp.exceptions import StopActorExecutionError
-from leapp.actors import Actor
-from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
-from leapp.reporting import Report, create_report
 from leapp import reporting
+from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp.reporting import create_report, Report
+from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
 
 
 class CreateSystemdResumeService(Actor):
@@ -35,6 +36,12 @@ class CreateSystemdResumeService(Actor):
             os.mkdir(os.path.join(systemd_dir, 'default.target.wants'))
         except OSError:
             pass
+
+        if os.path.exists(symlink_path):
+            api.current_logger().debug(
+                'Symlink {} already exists (from previous upgrade?). Removing... '.format(symlink_path)
+            )
+            os.unlink(symlink_path)
 
         try:
             os.symlink(service_path, symlink_path)

--- a/repos/system_upgrade/common/actors/preparepythonworkround/libraries/workaround.py
+++ b/repos/system_upgrade/common/actors/preparepythonworkround/libraries/workaround.py
@@ -1,7 +1,9 @@
 import os
+import shutil
 import sys
 
 from leapp.libraries.common.utils import makedirs
+from leapp.libraries.stdlib import api
 
 LEAPP_HOME = '/root/tmp_leapp_py3'
 
@@ -18,10 +20,15 @@ def _get_orig_leapp_path():
 
 def apply_python3_workaround():
     py3_leapp = os.path.join(LEAPP_HOME, 'leapp3')
+    if os.path.exists(LEAPP_HOME):
+        try:
+            shutil.rmtree(LEAPP_HOME)
+        except OSError as e:
+            api.current_logger().error('Could not remove {} directory: {}'.format(LEAPP_HOME, str(e)))
+
     makedirs(LEAPP_HOME)
     leapp_lib_symlink_path = os.path.join(LEAPP_HOME, 'leapp')
-    if not os.path.exists(leapp_lib_symlink_path):
-        os.symlink(_get_orig_leapp_path(), leapp_lib_symlink_path)
+    os.symlink(_get_orig_leapp_path(), leapp_lib_symlink_path)
     with open(py3_leapp, 'w') as f:
         f_content = [
             '#!/usr/bin/python3',


### PR DESCRIPTION
Leaving the directory behind will cause issues during upgrades to
another major version. E.g in case of RHEL 7 > RHEL 8 > RHEL 9
upgrades.