### PR TITLE
BZ#2087144 - do not enable Ansible repository when upgrading Satellite

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/actor.py
@@ -129,8 +129,7 @@ class SatelliteUpgradeFacts(Actor):
             modules_to_enable=modules_to_enable
             )
         )
-        repositories_to_enable = ['ansible-2.9-for-rhel-8-x86_64-rpms',
-                                  'satellite-maintenance-6.11-for-rhel-8-x86_64-rpms']
+        repositories_to_enable = ['satellite-maintenance-6.11-for-rhel-8-x86_64-rpms']
         if has_package(InstalledRPM, 'foreman'):
             repositories_to_enable.append('satellite-6.11-for-rhel-8-x86_64-rpms')
         else:

--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/tests/unit_test_satellite_upgrade_facts.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/tests/unit_test_satellite_upgrade_facts.py
@@ -103,7 +103,6 @@ def test_enables_right_repositories_on_satellite(current_actor_context):
 
     rpmmessage = current_actor_context.consume(RepositoriesSetupTasks)[0]
 
-    assert 'ansible-2.9-for-rhel-8-x86_64-rpms' in rpmmessage.to_enable
     assert 'satellite-maintenance-6.11-for-rhel-8-x86_64-rpms' in rpmmessage.to_enable
     assert 'satellite-6.11-for-rhel-8-x86_64-rpms' in rpmmessage.to_enable
     assert 'satellite-capsule-6.11-for-rhel-8-x86_64-rpms' not in rpmmessage.to_enable
@@ -115,7 +114,6 @@ def test_enables_right_repositories_on_capsule(current_actor_context):
 
     rpmmessage = current_actor_context.consume(RepositoriesSetupTasks)[0]
 
-    assert 'ansible-2.9-for-rhel-8-x86_64-rpms' in rpmmessage.to_enable
     assert 'satellite-maintenance-6.11-for-rhel-8-x86_64-rpms' in rpmmessage.to_enable
     assert 'satellite-6.11-for-rhel-8-x86_64-rpms' not in rpmmessage.to_enable
     assert 'satellite-capsule-6.11-for-rhel-8-x86_64-rpms' in rpmmessage.to_enable


### PR DESCRIPTION
Having it enabled, confuses the upgrade as there is now also
ansible-core in RHEL 8.6 and we need to upgrade to that instead of
legacy Ansible from the dedicated repository.