### PR TITLE
Migrate OpenSSL configuration to el9

### DIFF
--- a/repos/system_upgrade/common/actors/opensshconfigscanner/tests/test_readopensshconfig_opensshconfigscanner.py
+++ b/repos/system_upgrade/common/actors/opensshconfigscanner/tests/test_readopensshconfig_opensshconfigscanner.py
@@ -1,4 +1,4 @@
-from leapp.libraries.actor.readopensshconfig import line_empty, parse_config, parse_config_modification, produce_config
+from leapp.libraries.actor.readopensshconfig import line_empty, parse_config, produce_config
 from leapp.models import OpenSshConfig, OpenSshPermitRootLogin
 
 
@@ -147,33 +147,6 @@ def test_parse_config_empty():
     assert not output.permit_root_login
     assert output.use_privilege_separation is None
     assert output.protocol is None
-
-
-def test_parse_config_modification():
-    # This one was modified
-    data = [
-        "S.5....T.  c /etc/ssh/sshd_config",
-    ]
-    assert parse_config_modification(data)
-
-    # This one was just touched (timestamp does not match)
-    data = [
-        ".......T.  c /etc/ssh/sshd_config",
-    ]
-    assert not parse_config_modification(data)
-
-    # This one was not modified (not listed at all)
-    data = [
-        ".......T.  c /etc/sysconfig/sshd",
-    ]
-    assert not parse_config_modification(data)
-
-    # Parse multiple lines
-    data = [
-        "S.5....T.  c /etc/sysconfig/sshd",
-        "S.5....T.  c /etc/ssh/sshd_config",
-    ]
-    assert parse_config_modification(data)
 
 
 def test_produce_config():

--- a/repos/system_upgrade/common/libraries/rpms.py
+++ b/repos/system_upgrade/common/libraries/rpms.py
@@ -54,3 +54,52 @@ def has_package(model, package_name, arch=None, context=stdlib.api):
     keys = ('name',) if not arch else ('name', 'arch')
     rpm_lookup = create_lookup(model, field='items', keys=keys, context=context)
     return (package_name, arch) in rpm_lookup if arch else (package_name,) in rpm_lookup
+
+
+def _read_rpm_modifications(config):
+    """
+    Ask RPM database whether the configuration file was modified.
+
+    :param config: a config file to check
+    """
+    try:
+        return stdlib.run(['rpm', '-Vf', config], split=True, checked=False)['stdout']
+    except OSError as err:
+        error = 'Failed to check the modification status of the file {}: {}'.format(config, str(err))
+        stdlib.api.current_logger().error(error)
+        return []
+
+
+def _parse_config_modification(data, config):
+    """
+    Handle the output of rpm verify command to figure out if configuration file was modified.
+
+    :param data: output of the rpm verify
+    :param config: a config file to check
+    """
+
+    # First assume it is not modified -- empty data says it is not modified
+    modified = False
+    for line in data:
+        parts = line.split(' ')
+        # The last part of the line is the actual file we care for
+        if parts[-1] == config:
+            # First part contains information, if the size and digest differ
+            if '5' in parts[0] or 'S' in parts[0]:
+                modified = True
+        # Ignore any other files lurking here
+
+    return modified
+
+
+def check_file_modification(config):
+    """
+    Check if the given configuration file tracked by RPM was modified
+
+    This is useful when figuring out if the file will be replaced by the rpm on the upgrade
+    or we need to take care of the upgrade manually.
+
+    :param config: The configuration file to check
+    """
+    output = _read_rpm_modifications(config)
+    return _parse_config_modification(output, config)

--- a/repos/system_upgrade/common/libraries/tests/test_rpms.py
+++ b/repos/system_upgrade/common/libraries/tests/test_rpms.py
@@ -1,0 +1,32 @@
+from leapp.libraries.common.rpms import _parse_config_modification
+
+
+def test_parse_config_modification():
+    # Empty means no modification
+    data = []
+    assert not _parse_config_modification(data, "/etc/ssh/sshd_config")
+
+    # This one was modified
+    data = [
+        "S.5....T.  c /etc/ssh/sshd_config",
+    ]
+    assert _parse_config_modification(data, "/etc/ssh/sshd_config")
+
+    # This one was just touched (timestamp does not match)
+    data = [
+        ".......T.  c /etc/ssh/sshd_config",
+    ]
+    assert not _parse_config_modification(data, "/etc/ssh/sshd_config")
+
+    # This one was not modified (not listed at all)
+    data = [
+        ".......T.  c /etc/sysconfig/sshd",
+    ]
+    assert not _parse_config_modification(data, "/etc/ssh/sshd_config")
+
+    # Parse multiple lines
+    data = [
+        "S.5....T.  c /etc/sysconfig/sshd",
+        "S.5....T.  c /etc/ssh/sshd_config",
+    ]
+    assert _parse_config_modification(data, "/etc/ssh/sshd_config")

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/actor.py
@@ -71,7 +71,11 @@ class OpenSslConfigCheck(Actor):
         #
         # + [provider_sect]
         # + default = default_sect
+        # + ##legacy = legacy_sect
         # +
         # + [default_sect]
         # + activate = 1
+        # +
+        # + ##[legacy_sect]
+        # + ##activate = 1
         check_default_modules(config)

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/actor.py
@@ -1,0 +1,77 @@
+from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor.opensslconfigcheck import (
+    check_crypto_policies,
+    check_default_modules,
+    check_duplicate_extensions,
+    check_min_max_protocol
+)
+from leapp.libraries.stdlib import api
+from leapp.models import OpenSslConfig, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class OpenSslConfigCheck(Actor):
+    """
+    The OpenSSL configuration changed between RHEL8 and RHEL9 significantly with the rebase to
+    OpenSSL 3.0. There are several things to check:
+
+     * If the file was not modified by user, the RPM will take care of the upgrade
+     * The file was modified and for some reason the link to the system-wide crypto
+       policies is missing -- this is not recommended so we should warn users about that
+     * The new OpenSSL 3.0 is using providers so we need to add them to the configuration
+       file to make sure they behave the same way as when the original configuration file
+       is used, especially for FIPS mode.
+    """
+
+    name = 'open_ssl_config_check'
+    consumes = (OpenSslConfig,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag,)
+
+    def process(self):
+        openssl_messages = self.consume(OpenSslConfig)
+        config = next(openssl_messages, None)
+        if list(openssl_messages):
+            api.current_logger().warning('Unexpectedly received more than one OpenSslConfig message.')
+        if not config:
+            raise StopActorExecutionError(
+                'Could not check openssl configuration', details={'details': 'No OpenSslConfig facts found.'}
+            )
+
+        # If the configuration file was not modified, the rpm update will bring the new
+        # changes by itself
+        if not config.modified:
+            return
+
+        # Missing crypto policies is not recommended
+        check_crypto_policies(config)
+
+        # MinProtocol and MaxProtocol in [tls_system_default] changed their meaning
+        check_min_max_protocol(config)
+
+        # If the configuration file contains several X509 extensions with the same name,
+        # only the last one will be used.
+        check_duplicate_extensions(config)
+
+        # Check and report what we are going to rewrite.
+        #
+        # Change the initialization:
+        #
+        # - openssl_conf = default_modules
+        # + openssl_conf = openssl_init
+        #
+        # Rename the default block and link the providers block:
+        #
+        # - [default_modules]
+        # + [openssl_init]
+        # + providers = provider_sect
+        #
+        # Add the providers block:
+        #
+        # + [provider_sect]
+        # + default = default_sect
+        # +
+        # + [default_sect]
+        # + activate = 1
+        check_default_modules(config)

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/libraries/opensslconfigcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/libraries/opensslconfigcheck.py
@@ -1,0 +1,350 @@
+from leapp import reporting
+from leapp.libraries.stdlib import api
+
+
+def _normalize_key(key):
+    """
+    Strip the part of the key before the first dot
+    """
+    s = key.split(".", 1)
+    if len(s) == 2:
+        return s[1]
+    return key
+
+
+def _key_equal(pair, key):
+    """
+    Check the keys are equal in OpenSSL configuration semantics
+
+    The OpenSSL semantics ignores everything before the first dot to allow specifying
+    something like following, where the first line would be otherwise normally ignored
+
+        TLS.MaxProtocol = TLSv1.3
+        DTLS.MaxProtocol = DTLSv1.2
+    """
+    if pair.key == key:
+        return True
+    return _normalize_key(pair.key) == key
+
+
+def _find_pair(block, key):
+    """
+    Find key-value pair in the given configuration block
+
+    In the given configuration block (OpenSslConfigBlock) find a key-value with a given key.
+    If multiple values match, only the last one is returned.
+    """
+    res = None
+    for pair in block.pairs:
+        if _key_equal(pair, key):
+            res = pair
+
+    return res
+
+
+def _openssl_find_block(config, name):
+    """
+    In the given configuration file (OpenSslConfig) find a block with a given name
+    """
+    for block in config.blocks:
+        if block.name == name:
+            return block
+
+    return None
+
+
+def _openssl_reachable_block(config, start_name, end_name, limit=10):
+    """
+    Check if the end_name is reachable from the start_name in given config
+
+    This searches path between one block name and some other block name in a chain
+    like (the names in square braces are block names, the other keys pointing to another
+    block in the chain)
+    [default_modules] -> ssl_conf -> [ssl_module] -> system_default -> [crypto_policy]
+    using simple recursion. The end block name is not checked for presence so it can
+    be just value.
+    """
+    if limit <= 0:
+        api.current_logger().debug("Recursion limit reached while searching for {}."
+                                   .format(end_name))
+        return False
+
+    if start_name == end_name:
+        return True
+
+    start = _openssl_find_block(config, start_name)
+    if not start:
+        api.current_logger().debug("Starting block {} not found in current configuration"
+                                   .format(start_name))
+        return False
+
+    for pair in start.pairs:
+        if pair.value == end_name:
+            return True
+        block = _openssl_find_block(config, pair.value)
+        if block and _openssl_reachable_block(config, block.name, end_name, limit - 1):
+            return True
+
+    return False
+
+
+def _openssl_reachable_block_root(config, end_name, limit=10):
+    """
+    Check if the given block is reachable from the root block given in the config.
+    """
+    return _openssl_reachable_block(config, config.openssl_conf, end_name, limit)
+
+
+def _openssl_reachable_key(config, key, value=None):
+    """
+    Check if the key=value pair is reachable from the root block.
+
+    If no value is specified, any value assigned to the given key is matched.
+    """
+    for block in config.blocks:
+        for pair in block.pairs:
+            if _key_equal(pair, key) and (value is None or pair.value == value):
+                api.current_logger().debug("The key {} found in block {}"
+                                           .format(key, block.name))
+                if _openssl_reachable_block_root(config, block.name):
+                    api.current_logger().debug("The block {} is reachable from the start key {}"
+                                               .format(block.name, config.openssl_conf))
+                    return True
+
+    api.current_logger().debug("The key {} not found".format(key))
+    return False
+
+
+# pylint: disable=too-many-return-statements -- could not simplify more
+def _openssl_reachable_path(config, path, value=None):
+    """
+    Check if the given path is reachable in OpenSSL configuration
+
+    The path is list where to search for a value. It is a list of keys starting
+    with a section of a known name followed by key to search for in that section
+    and then another section, which is assigned to that key.
+
+    If no value is specified, any value assigned to the given key is matched.
+    """
+    path_iterator = iter(path)
+    block_name = next(path_iterator)
+    if not _openssl_reachable_block_root(config, block_name):
+        api.current_logger().debug("The block {} not reachable from the start key {}"
+                                   .format(block_name, config.openssl_conf))
+        return False
+
+    while block_name and block_name != value:
+        # Find in the block by name
+        block = _openssl_find_block(config, block_name)
+        if not block:
+            api.current_logger().debug("Block {} not found in current configuration"
+                                       .format(block_name))
+            return False
+
+        try:
+            key = next(path_iterator)
+        except StopIteration:
+            api.current_logger().debug("Missing key in the path")
+            return False
+
+        # Find the pair in block
+        pair = _find_pair(block, key)
+        if not pair:
+            api.current_logger().debug("Key {} not found in block {}".format(key, block_name))
+            return False
+
+        try:
+            block_name = next(path_iterator)
+        except StopIteration:
+            # if there are no other parts in the path and the value is the one we look for, stop
+            if pair.value == value or value is None:
+                api.current_logger().debug("Found reachable value {}".format(pair.value))
+                return True
+
+        # otherwise make sure it is the expected one
+        if pair.value != block_name:
+            return False
+
+    api.current_logger().debug("Value {} not reachable in current configuration".format(value))
+    return False
+
+
+def _find_duplicates(config, block_name):
+    """
+    Finds duplicate keys in given block name
+    """
+    block = _openssl_find_block(config, block_name)
+    if not block:
+        api.current_logger().debug("Did not find a block {} when searching for duplicates"
+                                   .format(block_name))
+        return []
+
+    duplicates = []
+    # not most effective
+    for p in block.pairs:
+        for p2 in block.pairs:
+            key = _normalize_key(p.key)
+            if p != p2 and key == _normalize_key(p2.key) and key not in duplicates:
+                duplicates.append(key)
+
+    return duplicates
+
+
+def _openssl_duplicate_keys_in(config, key):
+    """
+    Search for duplicate keys in block named "key"
+
+    Used for searching for duplicate extensions. The given key can be defined in different
+    blocks and references a block where we search for duplicate keys with the openssl specific
+    name handling (ignoring content before the dot).
+    """
+    duplicates = []
+
+    # first find all the keys in all the blocks with the given name
+    for block in config.blocks:
+        for pair in block.pairs:
+            if _key_equal(pair, key):
+                duplicates += _find_duplicates(config, pair.value)
+
+    return duplicates
+
+
+resources = [
+    reporting.RelatedResource('package', 'openssl'),
+    reporting.RelatedResource('file', '/etc/pki/tls/openssl.cnf')
+]
+
+
+def check_crypto_policies(config):
+    """
+    Check the presence of the crypto policies include
+
+    The default openssl.cnf provides include of dynamic crypto policies to keep
+    applications using OpenSSL in sync with the rest of the OS. Not having this
+    directive in the configuration file is not recommended.
+    """
+    if not _openssl_reachable_path(config,
+                                   path=("default_modules", "ssl_conf", "ssl_module",
+                                         "system_default", "crypto_policy", ".include"),
+                                   value="/etc/crypto-policies/back-ends/opensslcnf.config"):
+        reporting.create_report([
+            reporting.Title('The OpenSSL configuration is missing the crypto policies integration'),
+            reporting.Summary(
+                'The OpenSSL configuration file `/etc/pki/tls/openssl.cnf` does not contain the '
+                'directive to include the system-wide crypto policies. This is not recommended '
+                'by Red Hat and can lead to decreasing overall system security and inconsistent '
+                'behavior between applications. If you need to adjust the crypto policies to your '
+                'needs, it is recommended to use custom crypto policies.'
+            ),
+            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Tags([
+                    reporting.Tags.AUTHENTICATION,
+                    reporting.Tags.SECURITY,
+                    reporting.Tags.NETWORK,
+                    reporting.Tags.SERVICES
+            ]),
+            reporting.RelatedResource('package', 'crypto-policies'),
+        ] + resources)
+
+
+def check_min_max_protocol(config):
+    """
+    Check for the MinProtocol and MaxProtocol options
+
+    These options changed their meaning in openssl.cnf so better warn the user
+    """
+    if _openssl_reachable_key(config, "MinProtocol") or _openssl_reachable_key(config, "MaxProtocol"):
+        reporting.create_report([
+            reporting.Title('The meaning of MinProtocol and MaxProtocol in openssl.cnf changed'),
+            reporting.Summary(
+                'The OpenSSL configuration file `/etc/pki/tls/openssl.cnf` contain the '
+                'directive MinProtocol or MaxProtocol, which was previously applied to both '
+                'TLS and DTLS versions. This is no longer case and if you want to limit both '
+                'protocols, you need to add another option, for example for '
+                '`MinProtocol TLSv1.2` add the following line `DTLS.MinProtocol = DTLSv1.2`.'
+            ),
+            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Tags([
+                    reporting.Tags.SECURITY,
+                    reporting.Tags.NETWORK,
+                    reporting.Tags.SERVICES
+            ]),
+        ] + resources)
+
+
+def check_duplicate_extensions(config):
+    dup = _openssl_duplicate_keys_in(config, "x509_extensions")
+    if dup:
+        reporting.create_report([
+            reporting.Title('There are duplicate x509 extensions defined in openssl.cnf'),
+            reporting.Summary(
+                'The OpenSSL configuration file `/etc/pki/tls/openssl.cnf` contains the '
+                'following duplicate X509 extensions: {}. With OpenSSL 3.0 only the last defined '
+                'will get used. Please, review the configuration file and remove duplicate '
+                'extensions to silence this warning.'.format(', '.join(dup))
+            ),
+            reporting.Severity(reporting.Severity.LOW),
+            reporting.Tags([
+                    reporting.Tags.SECURITY,
+                    reporting.Tags.NETWORK,
+                    reporting.Tags.SERVICES
+            ]),
+        ] + resources)
+
+
+def check_default_modules(config):
+    if config.openssl_conf != "default_modules" or not _openssl_find_block(config, "default_modules"):
+        reporting.create_report([
+            reporting.Title('Non-standard configuration of openssl.cnf'),
+            reporting.Summary(
+                'The OpenSSL configuration file `/etc/pki/tls/openssl.cnf` does not contain '
+                'expected initialization so it can not be updated to support OpenSSL 3.0 '
+                'with the new providers.'
+            ),
+            reporting.Remediation(
+                'The openssl.cnf file needs to contain the following initialization: '
+                '`openssl_conf = default_modules` and corresponding `[ default_modules] '
+                'block. The `openssl_conf` now contains {} or the `[ default_modules ]` '
+                'block is missing. '.format(config.openssl_conf)
+            ),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Tags([
+                    reporting.Tags.SECURITY,
+                    reporting.Tags.NETWORK,
+                    reporting.Tags.SERVICES
+            ]),
+        ] + resources)
+    else:
+        reporting.create_report([
+            reporting.Title('The OpenSSL configuration will be updated to support OpenSSL 3.0'),
+            reporting.Summary(
+                'The OpenSSL configuration file `/etc/pki/tls/openssl.cnf` will be updated '
+                'to support OpenSSL 3.0 with the new providers. The following changes are '
+                'going to be applied:\n'
+                ' * Change the initialization:\n'
+                '\n'
+                ' - openssl_conf = default_modules\n'
+                ' + openssl_conf = openssl_init\n'
+                '\n'
+                ' * Rename the default block and link the providers block:\n'
+                '\n'
+                ' - [default_modules]\n'
+                ' + [openssl_init]\n'
+                ' + providers = provider_sect\n'
+                '\n'
+                ' * Add the providers block:\n'
+                '\n'
+                ' + [provider_sect]\n'
+                ' + default = default_sect\n'
+                ' + \n'
+                ' + [default_sect]\n'
+                ' + activate = 1\n'
+            ),
+            reporting.Severity(reporting.Severity.INFO),
+            reporting.Tags([
+                    reporting.Tags.SECURITY,
+                    reporting.Tags.NETWORK,
+                    reporting.Tags.SERVICES
+            ]),
+        ] + resources)

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/libraries/opensslconfigcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/libraries/opensslconfigcheck.py
@@ -337,9 +337,13 @@ def check_default_modules(config):
                 '\n'
                 ' + [provider_sect]\n'
                 ' + default = default_sect\n'
+                ' + ##legacy = legacy_sect\n'
                 ' + \n'
                 ' + [default_sect]\n'
                 ' + activate = 1\n'
+                ' + \n'
+                ' + ##[legacy_sect]\n'
+                ' + ##activate = 1\n'
             ),
             reporting.Severity(reporting.Severity.INFO),
             reporting.Tags([

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/tests/component_test_opensslconfigcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/tests/component_test_opensslconfigcheck.py
@@ -1,0 +1,189 @@
+from leapp.models import OpenSslConfig, OpenSslConfigBlock, OpenSslConfigPair, Report
+
+
+def test_actor_execution_empty(current_actor_context):
+    current_actor_context.feed(
+        OpenSslConfig(
+            blocks=[],
+            # modified=False, # default
+        )
+    )
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+
+
+def test_actor_execution_empty_modified(current_actor_context):
+    current_actor_context.feed(
+        OpenSslConfig(
+            blocks=[],
+            modified=True,
+        )
+    )
+    current_actor_context.run()
+    r = current_actor_context.consume(Report)
+    assert r
+    assert 'missing the crypto policies integration' in r[0].report['title']
+
+
+def test_actor_execution_default_modified(current_actor_context):
+    current_actor_context.feed(
+        OpenSslConfig(
+            openssl_conf='default_modules',
+            blocks=[
+                OpenSslConfigBlock(
+                    name="default_modules",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key="ssl_conf",
+                            value="ssl_module"
+                        )
+                    ]
+                ),
+                OpenSslConfigBlock(
+                    name="ssl_module",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key="system_default",
+                            value="crypto_policy"
+                        )
+                    ]
+                ),
+                OpenSslConfigBlock(
+                    name="crypto_policy",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key=".include",
+                            value="/etc/crypto-policies/back-ends/opensslcnf.config"
+                        )
+                    ]
+                ),
+            ],
+            modified=True,
+        )
+    )
+    current_actor_context.run()
+    r = current_actor_context.consume(Report)
+    assert r
+    assert 'The OpenSSL configuration will be updated to support OpenSSL 3.0' in r[0].report['title']
+
+
+def test_actor_execution_minprotocol_modified(current_actor_context):
+    current_actor_context.feed(
+        OpenSslConfig(
+            openssl_conf='default_modules',
+            blocks=[
+                OpenSslConfigBlock(
+                    name="default_modules",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key="ssl_conf",
+                            value="ssl_module"
+                        )
+                    ]
+                ),
+                OpenSslConfigBlock(
+                    name="ssl_module",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key="system_default",
+                            value="crypto_policy"
+                        )
+                    ]
+                ),
+                OpenSslConfigBlock(
+                    name="crypto_policy",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key=".include",
+                            value="/etc/crypto-policies/back-ends/opensslcnf.config"
+                        )
+                    ]
+                ),
+                OpenSslConfigBlock(
+                    name="crypto_policy",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key="TLS.MinProtocol",
+                            value="TLSv1.2"
+                        ),
+                    ]
+                )
+            ],
+            modified=True,
+        )
+    )
+    current_actor_context.run()
+    r = current_actor_context.consume(Report)
+    assert r
+    assert 'MinProtocol and MaxProtocol' in r[0].report['title']
+    assert 'The OpenSSL configuration will be updated to support OpenSSL 3.0' in r[1].report['title']
+
+
+def test_actor_execution_duplicate_extensions_modified(current_actor_context):
+    current_actor_context.feed(
+        OpenSslConfig(
+            openssl_conf='default_modules',
+            blocks=[
+                OpenSslConfigBlock(
+                    name="default_modules",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key="ssl_conf",
+                            value="ssl_module"
+                        )
+                    ]
+                ),
+                OpenSslConfigBlock(
+                    name="ssl_module",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key="system_default",
+                            value="crypto_policy"
+                        )
+                    ]
+                ),
+                OpenSslConfigBlock(
+                    name="crypto_policy",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key=".include",
+                            value="/etc/crypto-policies/back-ends/opensslcnf.config"
+                        )
+                    ]
+                ),
+                OpenSslConfigBlock(
+                    name="req",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key="x509_extensions",
+                            value="v3_ca",
+                        ),
+                    ]
+                ),
+                OpenSslConfigBlock(
+                    name="v3_ca",
+                    pairs=[
+                        OpenSslConfigPair(
+                            key="keyUsage",
+                            value="cRLSign, keyCertSign",
+                        ),
+                        OpenSslConfigPair(
+                            key="keyUsage",
+                            value="cRLSign",
+                        ),  # yay, duplicate
+                        OpenSslConfigPair(
+                            key="keyUsage",
+                            value="keyCertSign",
+                        ),  # yay, duplicate
+                    ]
+                ),
+            ],
+            modified=True,
+        )
+    )
+    current_actor_context.run()
+    r = current_actor_context.consume(Report)
+    assert r
+    assert 'duplicate x509 extensions' in r[0].report['title']
+    assert 'keyUsage' in r[0].report['summary']
+    assert 'The OpenSSL configuration will be updated to support OpenSSL 3.0' in r[1].report['title']

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/tests/test_reachable.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/tests/test_reachable.py
@@ -1,0 +1,308 @@
+from leapp.libraries.actor.opensslconfigcheck import (
+    _find_duplicates,
+    _find_pair,
+    _key_equal,
+    _normalize_key,
+    _openssl_duplicate_keys_in,
+    _openssl_find_block,
+    _openssl_reachable_block,
+    _openssl_reachable_block_root,
+    _openssl_reachable_key,
+    _openssl_reachable_path
+)
+from leapp.models import OpenSslConfig, OpenSslConfigBlock, OpenSslConfigPair
+
+
+def _setup_config():
+    return OpenSslConfig(
+        openssl_conf="default_modules",
+        blocks=[
+            OpenSslConfigBlock(
+                name="default_modules",
+                pairs=[
+                    OpenSslConfigPair(
+                        key="ssl_conf",
+                        value="ssl_module",
+                    )
+                ]
+            ),
+            OpenSslConfigBlock(
+                name="ssl_module",
+                pairs=[
+                    OpenSslConfigPair(
+                        key="system_default",
+                        value="crypto_policy",
+                    )
+                ]
+            ),
+            OpenSslConfigBlock(
+                name="crypto_policy",
+                pairs=[
+                    OpenSslConfigPair(
+                        key=".include",
+                        value="/etc/crypto-policies/back-ends/opensslcnf.config",
+                    )
+                ]
+            ),
+            OpenSslConfigBlock(
+                name="tsa",
+                pairs=[
+                    OpenSslConfigPair(
+                        key="1.default_tsa",
+                        value="tsa_config1",
+                    ),
+                    OpenSslConfigPair(
+                        key="2.default_tsa",
+                        value="tsa_config2",
+                    )
+                ]
+            ),
+            OpenSslConfigBlock(
+                name="ca",
+                pairs=[
+                    OpenSslConfigPair(
+                        key="default_ca",
+                        value="CA_default",
+                    ),
+                ]
+            ),
+            OpenSslConfigBlock(
+                name="CA_default",
+                pairs=[
+                    OpenSslConfigPair(
+                        key="x509_extensions",
+                        value="usr_cert",
+                    ),
+                ]
+            ),
+            OpenSslConfigBlock(
+                name="usr_cert",
+                pairs=[
+                    OpenSslConfigPair(
+                        key="subjectKeyIdentifier",
+                        value="hash",
+                    ),
+                    OpenSslConfigPair(
+                        key="basicConstraints",
+                        value="critical,CA:true",
+                    ),
+                    OpenSslConfigPair(
+                        key="keyUsage",
+                        value="nonRepudiation, digitalSignature, keyEncipherment",
+                    ),
+                    OpenSslConfigPair(
+                        key="subjectAltName",
+                        value="email:copy",
+                    ),
+                    OpenSslConfigPair(
+                        key="subjectAltName",
+                        value="email:move",
+                    ),  # yay, duplicate
+                ]
+            ),
+            OpenSslConfigBlock(
+                name="req",
+                pairs=[
+                    OpenSslConfigPair(
+                        key="default_bits",
+                        value="2048",
+                    ),
+                    OpenSslConfigPair(
+                        key="default_md",
+                        value="sha256",
+                    ),
+                    OpenSslConfigPair(
+                        key="x509_extensions",
+                        value="v3_ca",
+                    ),
+                ]
+            ),
+            OpenSslConfigBlock(
+                name="v3_ca",
+                pairs=[
+                    OpenSslConfigPair(
+                        key="subjectKeyIdentifier",
+                        value="hash",
+                    ),
+                    OpenSslConfigPair(
+                        key="basicConstraints",
+                        value="critical,CA:true",
+                    ),
+                    OpenSslConfigPair(
+                        key="keyUsage",
+                        value="cRLSign, keyCertSign",
+                    ),
+                    OpenSslConfigPair(
+                        key="keyUsage",
+                        value="cRLSign",
+                    ),  # yay, duplicate
+                    OpenSslConfigPair(
+                        key="keyUsage",
+                        value="keyCertSign",
+                    ),  # yay, duplicate
+                ]
+            ),
+        ]
+    )
+
+
+def test_normalize_key():
+    assert _normalize_key("default_tsa") == "default_tsa"
+
+    # TODO this is questionable, but probably ok
+    assert _normalize_key(".include") == "include"
+
+    assert _normalize_key("DTLS.MaxProtocol") == "MaxProtocol"
+
+    assert _normalize_key("DTLS.TLS.MaxProtocol") == "TLS.MaxProtocol"
+
+
+def test_key_equal():
+    pair = OpenSslConfigPair(key="default_tsa", value="tsa_config1")
+    assert _key_equal(pair, "default_tsa")
+
+    pair = OpenSslConfigPair(key="default_tsa", value="tsa_config1")
+    assert not _key_equal(pair, "tsa")
+
+    pair = OpenSslConfigPair(key=".include", value="/some/path")
+    assert _key_equal(pair, ".include")
+
+    # TODO this is questionable, but probably ok
+    pair = OpenSslConfigPair(key=".include", value="/some/path")
+    assert _key_equal(pair, "include")
+
+    pair = OpenSslConfigPair(key="DTLS.MaxProtocol", value="DTLSv1.2")
+    assert _key_equal(pair, "MaxProtocol")
+
+    pair = OpenSslConfigPair(key="DTLS.TLS.MaxProtocol", value="DTLSv1.2")
+    assert not _key_equal(pair, "MaxProtocol")
+
+
+def test_find():
+    config = _setup_config()
+
+    result = _openssl_find_block(config, 'default_modules')
+    assert result.name == 'default_modules'
+    pair = _find_pair(result, 'ssl_conf')
+    assert pair.key == 'ssl_conf'
+    assert pair.value == 'ssl_module'
+
+    result = _openssl_find_block(config, 'ssl_module')
+    assert result.name == 'ssl_module'
+    pair = _find_pair(result, 'system_default')
+    assert pair.key == 'system_default'
+    assert pair.value == 'crypto_policy'
+
+    result = _openssl_find_block(config, 'crypto_policy')
+    assert result.name == 'crypto_policy'
+    pair = _find_pair(result, '.include')
+    assert pair.key == '.include'
+    assert pair.value == '/etc/crypto-policies/back-ends/opensslcnf.config'
+
+    assert _find_pair(result, 'nonexisting') is None
+
+    assert _openssl_find_block(config, 'nonexisting') is None
+
+    # duplicates
+    b = _openssl_find_block(config, "tsa")
+    assert b
+    p = _find_pair(b, "default_tsa")
+    assert p.key == "2.default_tsa"
+    assert p.value == "tsa_config2"
+
+
+def test_reachable_block():
+    config = _setup_config()
+
+    assert _openssl_reachable_block_root(config, "default_modules")
+
+    assert _openssl_reachable_block_root(config, "ssl_module")
+
+    assert _openssl_reachable_block_root(config, "crypto_policy")
+
+    assert not _openssl_reachable_block_root(config, "crypto_policy", 1)
+
+    assert not _openssl_reachable_block_root(config, "tsa")
+
+    # searching from arbitrary block
+    assert _openssl_reachable_block(config, "tsa", "tsa_config1")
+
+    # non-existent start key
+    assert not _openssl_reachable_block(config, "ecdsa", "crypto_policy")
+
+
+def test_reachable_path():
+    config = _setup_config()
+
+    assert _openssl_reachable_path(config,
+                                   ("default_modules", "ssl_conf", "ssl_module", "system_default",
+                                    "crypto_policy", ".include"),
+                                   "/etc/crypto-policies/back-ends/opensslcnf.config")
+
+    assert _openssl_reachable_path(config,
+                                   ("ssl_module", "system_default"),
+                                   "crypto_policy")
+
+    # missing key in the path
+    assert not _openssl_reachable_path(config,
+                                       ("ssl_module", "system_default", "crypto_policy"),
+                                       "crypto_policy")
+
+    # non continuous path/wrong value in path
+    assert not _openssl_reachable_path(config,
+                                       ("ssl_module", "tsa"),
+                                       "tsa_config1")
+
+    # wrong value
+    assert not _openssl_reachable_path(config,
+                                       ("ssl_module", "system_default"),
+                                       ".include")
+
+    # not reachable from the root
+    assert not _openssl_reachable_path(config,
+                                       ("tsa", "default_tsa"),
+                                       "tsa_config1")
+
+    # any value
+    assert _openssl_reachable_path(config, ("ssl_module", "system_default"))
+    assert not _openssl_reachable_path(config, ("ssl_module", "tsa"))
+
+
+def test_reachable_key():
+    config = _setup_config()
+
+    assert _openssl_reachable_key(config, "system_default")
+    assert _openssl_reachable_key(config, "system_default", "crypto_policy")
+    assert not _openssl_reachable_key(config, "tsa")
+    assert not _openssl_reachable_key(config, "default_tsa", "tsa_config2")
+
+
+def test_find_duplicates():
+    config = _setup_config()
+
+    d = _find_duplicates(config, "non-existent")
+    assert len(d) == 0
+
+    d = _find_duplicates(config, "default_modules")
+    assert len(d) == 0
+
+    d = _find_duplicates(config, "tsa")
+    assert len(d) == 1
+    assert d[0] == 'default_tsa'
+
+    d = _find_duplicates(config, "v3_ca")
+    assert len(d) == 1
+    assert d[0] == 'keyUsage'
+
+    d = _find_duplicates(config, "usr_cert")
+    assert len(d) == 1
+    assert d[0] == 'subjectAltName'
+
+
+def test_duplicate_keys_in():
+    config = _setup_config()
+
+    d = _openssl_duplicate_keys_in(config, "x509_extensions")
+    assert len(d) == 2
+    assert 'keyUsage' in d
+    assert 'subjectAltName' in d

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigscanner/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigscanner/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import readconf
+from leapp.models import OpenSslConfig
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class OpenSslConfigScanner(Actor):
+    """
+    Read an OpenSSL configuration file for further analysis.
+    """
+
+    name = 'open_ssl_config_scanner'
+    consumes = ()
+    produces = (OpenSslConfig,)
+    tags = (FactsPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        readconf.scan_config(self.produce)

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigscanner/libraries/readconf.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigscanner/libraries/readconf.py
@@ -1,0 +1,97 @@
+import errno
+
+from leapp.libraries.common.rpms import check_file_modification
+from leapp.libraries.stdlib import api
+from leapp.models import OpenSslConfig, OpenSslConfigBlock, OpenSslConfigPair
+
+CONFIG = '/etc/pki/tls/openssl.cnf'
+
+
+def strip_whitespace_and_comments(line):
+    """
+    Returns everything before the first hash sign after stripping leading and trailing whitespace
+    """
+    parts = line.split("#", 1)
+    return parts[0].strip()
+
+
+def parse_config(config):
+    """
+    Parse openssl.cnf configuration
+    """
+    ret = OpenSslConfig(blocks=[])
+
+    block = None
+    for line in config:
+        line = strip_whitespace_and_comments(line)
+        if not line:
+            continue
+
+        # match the block header
+        if line[0] == "[" and line[-1] == "]":
+            name = line[1:-1].strip()
+            block = OpenSslConfigBlock(name=name, pairs=[])
+            ret.blocks.append(block)
+            continue
+
+        # the rest values are key-value pairs separated with equal sign
+        el = line.split('=', 1)
+        if len(el) < 2:
+            # The special options .include and .pragma can appear without the equal sign
+            if el[0].startswith('.include '):
+                key = ".include"
+                value = el[0][8:].strip()
+            # elif el.startswith('.pragma '):
+                # we do not care about this option now
+            else:
+                continue
+        else:
+            key = el[0].strip()
+            value = el[1].strip()
+
+        if block:
+            pair = OpenSslConfigPair(key=key, value=value)
+            block.pairs.append(pair)
+            continue
+
+        if key == 'openssl_conf':
+            ret.openssl_conf = value
+
+    return ret
+
+
+def produce_config(producer, config):
+    """
+    Produce a Leapp message with all interesting openssl configuration options.
+    """
+
+    producer(config)
+
+
+def read_config():
+    """
+    Read the actual configuration file.
+    """
+    try:
+        with open(CONFIG, 'r') as fd:
+            return fd.readlines()
+    except IOError as err:
+        if err.errno != errno.ENOENT:
+            error = 'Failed to read config: {}'.format(str(err))
+            api.current_logger().error(error)
+        return []
+
+
+def scan_config(producer):
+    """
+    Parse openssl.cnf file to create OpenSslConfig message.
+    """
+
+    # direct access to configuration file
+    output = read_config()
+    config = parse_config(output)
+
+    # find out whether the file was modified from the one shipped in rpm
+    config.modified = check_file_modification(CONFIG)
+
+    produce_config(producer, config)

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigscanner/tests/test_opensslconfigscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigscanner/tests/test_opensslconfigscanner.py
@@ -1,0 +1,146 @@
+import pytest
+
+from leapp.libraries.actor.readconf import parse_config, produce_config, strip_whitespace_and_comments
+from leapp.models import OpenSslConfig, OpenSslConfigBlock, OpenSslConfigPair
+
+testdata = (
+    ('key = value', 'key = value'),  # normal formatting
+    ('  key = value    ', 'key = value'),  # trailing and leading whitespace
+    ('  key   =   value    ', 'key   =   value'),  # whitespace in between is kept
+    ('[ section ]', '[ section ]'),  # normal section formatting
+    ('    [ section ]    ', '[ section ]'),  # trailing and leading whitespace
+    ('[    section    ]', '[    section    ]'),  # whitespace in braces is kept
+    ('# comment', ''),  # only comment
+    ('    # comment   ', ''),  # only comment with whitespace
+    ('key = value# comment', 'key = value'),  # key value with comment
+    ('key = value     # comment', 'key = value'),  # key value with comment and more whitespace
+    ('[ section ]# comment', '[ section ]'),  # the section with comment
+    ('[ section ]     # comment', '[ section ]'),  # the section with comment and more whitespace
+)
+
+
+@pytest.mark.parametrize('line,expected_result', testdata)
+def test_strip_whitespace_and_comments(line, expected_result):
+    result = strip_whitespace_and_comments(line)
+    assert result == expected_result
+
+
+def test_parse_config():
+    config = [
+        "# comment from file",
+        "",  # empty line
+        "   ",  # whitespace line
+        "HOME                    = .",  # ignored before the start of block
+        "openssl_conf = default_modules",  # the start key
+        "# key = value in comment",  # ignored
+        "HOME                    = .",  # ignored again
+        "[ default_modules ]",  # first block
+        "ssl_conf = ssl_module",
+        "[ ssl_module ]",
+        "system_default = crypto_policy",
+        "[ crypto_policy ]",
+        "# key = value in comment",  # ignored
+        ".include = /etc/crypto-policies/back-ends/opensslcnf.config",
+    ]
+
+    output = parse_config(config)
+    assert isinstance(output, OpenSslConfig)
+    assert output.openssl_conf == "default_modules"
+    assert len(output.blocks) == 3
+    assert output.blocks[0].name == "default_modules"
+    assert len(output.blocks[0].pairs) == 1
+    assert output.blocks[0].pairs[0].key == "ssl_conf"
+    assert output.blocks[0].pairs[0].value == "ssl_module"
+    assert output.blocks[1].name == "ssl_module"
+    assert len(output.blocks[1].pairs) == 1
+    assert output.blocks[1].pairs[0].key == "system_default"
+    assert output.blocks[1].pairs[0].value == "crypto_policy"
+    assert output.blocks[2].name == "crypto_policy"
+    assert len(output.blocks[2].pairs) == 1
+    assert output.blocks[2].pairs[0].key == ".include"
+    assert output.blocks[2].pairs[0].value == "/etc/crypto-policies/back-ends/opensslcnf.config"
+
+
+def test_parse_config_empty():
+    output = parse_config([])
+    assert isinstance(output, OpenSslConfig)
+    assert not output.openssl_conf
+    assert len(output.blocks) == 0
+
+
+def test_parse_config_bare_include():
+    config = [
+        "[ crypto_policy ]",
+        ".include    /etc/crypto-policies/back-ends/opensslcnf.config",
+    ]
+    output = parse_config(config)
+    assert isinstance(output, OpenSslConfig)
+    assert not output.openssl_conf
+    assert len(output.blocks) == 1
+    assert output.blocks[0].name == "crypto_policy"
+    assert len(output.blocks[0].pairs) == 1
+    assert output.blocks[0].pairs[0].key == ".include"
+    assert output.blocks[0].pairs[0].value == "/etc/crypto-policies/back-ends/opensslcnf.config"
+
+
+def test_produce_config():
+    output = []
+
+    def fake_producer(*args):
+        output.extend(args)
+
+    config = OpenSslConfig(
+        openssl_conf="default_modules",
+        blocks=[
+            OpenSslConfigBlock(
+                name="default_modules",
+                pairs=[
+                    OpenSslConfigPair(
+                        key="ssl_conf",
+                        value="ssl_module"
+                    )
+                ]
+            ),
+            OpenSslConfigBlock(
+                name="ssl_module",
+                pairs=[
+                    OpenSslConfigPair(
+                        key="system_default",
+                        value="crypto_policy"
+                    )
+                ]
+            ),
+            OpenSslConfigBlock(
+                name="crypto_policy",
+                pairs=[
+                    OpenSslConfigPair(
+                        key=".include",
+                        value="/etc/crypto-policies/back-ends/opensslcnf.config"
+                    )
+                ]
+            )
+        ]
+    )
+
+    produce_config(fake_producer, config)
+    assert len(output) == 1
+    cfg = output[0]
+    assert cfg.openssl_conf == "default_modules"
+    assert len(cfg.blocks) == 3
+    assert cfg.blocks[0].name == "default_modules"
+    assert len(cfg.blocks[0].pairs) == 1
+    assert cfg.blocks[0].pairs[0].key == "ssl_conf"
+    assert cfg.blocks[0].pairs[0].value == "ssl_module"
+    assert cfg.blocks[1].name == "ssl_module"
+    assert len(cfg.blocks[1].pairs) == 1
+    assert cfg.blocks[1].pairs[0].key == "system_default"
+    assert cfg.blocks[1].pairs[0].value == "crypto_policy"
+    assert cfg.blocks[2].name == "crypto_policy"
+    assert len(cfg.blocks[2].pairs) == 1
+    assert cfg.blocks[2].pairs[0].key == ".include"
+    assert cfg.blocks[2].pairs[0].value == "/etc/crypto-policies/back-ends/opensslcnf.config"
+
+
+def test_actor_execution(current_actor_context):
+    current_actor_context.run()
+    assert current_actor_context.consume(OpenSslConfig)

--- a/repos/system_upgrade/el8toel9/actors/opensslproviders/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslproviders/actor.py
@@ -1,0 +1,37 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import add_provider
+from leapp.models import OpenSslConfig
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class OpenSslProviders(Actor):
+    """
+    Modify the openssl.cnf file to support new providers in OpenSSL 3.0
+
+    Change the initialization:
+
+    - openssl_conf = default_modules
+    + openssl_conf = openssl_init
+
+    Rename the default block and link the providers block:
+
+    - [default_modules]
+    + [openssl_init]
+    + providers = provider_sect
+
+    Add the providers block:
+
+    + [provider_sect]
+    + default = default_sect
+    +
+    + [default_sect]
+    + activate = 1
+    """
+
+    name = 'open_ssl_providers'
+    consumes = (OpenSslConfig,)
+    produces = ()
+    tags = (IPUWorkflowTag, ApplicationsPhaseTag,)
+
+    def process(self):
+        add_provider.process(self.consume(OpenSslConfig))

--- a/repos/system_upgrade/el8toel9/actors/opensslproviders/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslproviders/actor.py
@@ -23,9 +23,13 @@ class OpenSslProviders(Actor):
 
     + [provider_sect]
     + default = default_sect
+    + ##legacy = legacy_sect
     +
     + [default_sect]
     + activate = 1
+    +
+    + ##[legacy_sect]
+    + ##activate = 1
     """
 
     name = 'open_ssl_providers'

--- a/repos/system_upgrade/el8toel9/actors/opensslproviders/libraries/add_provider.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslproviders/libraries/add_provider.py
@@ -12,9 +12,13 @@ LEAPP_COMMENT = '# Modified by leapp during upgrade to RHEL 9\n'
 APPEND_STRING = (
     '[provider_sect]\n'
     'default = default_sect\n'
+    '##legacy = legacy_sect\n'
     '\n'
     '[default_sect]\n'
     'activate = 1\n'
+    '\n'
+    '##[legacy_sect]\n'
+    '##activate = 1\n'
 )
 
 

--- a/repos/system_upgrade/el8toel9/actors/opensslproviders/libraries/add_provider.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslproviders/libraries/add_provider.py
@@ -1,0 +1,133 @@
+import re
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+
+# The openssl configuration file
+# TODO copied from opensslconfigscanner/libraries/readconf.py
+CONFIG = '/etc/pki/tls/openssl.cnf'
+
+LEAPP_COMMENT = '# Modified by leapp during upgrade to RHEL 9\n'
+APPEND_STRING = (
+    '[provider_sect]\n'
+    'default = default_sect\n'
+    '\n'
+    '[default_sect]\n'
+    'activate = 1\n'
+)
+
+
+def _add_lines(lines, add):
+    """
+    Add lines to the list of lines. Breaking possible newlines onto separate items
+    """
+    for l in add.split("\n"):
+        lines.append("{}\n".format(l))
+    return lines
+
+
+class NotFoundException(Exception):
+    pass
+
+
+def _replace(lines, search, replace, comment=None, backup=False, fail_on_error=True):
+    """
+    Replace pattern with new value with optional backup
+
+    Replace the lines (ignoring leading and trailing whitespace) matching `search` regex
+    in the given file (as `lines` collected using readlines()) with the `replace` line optional
+    comment is added on line preceding the change.
+    """
+    res = []
+    found = False
+    for line in lines:
+        if re.search(search, line.strip()):
+            if comment:
+                res.append(comment)
+            if backup:
+                res.append("# {}".format(line))
+            res = _add_lines(res, replace)
+            found = True
+        else:
+            res.append(line)
+    if not found and fail_on_error:
+        raise NotFoundException("The pattern {} not found.".format(search))
+    return res
+
+
+def _append(lines, add, comment=None):
+    """
+    Append a line to the existing list with optional comment
+    """
+    if comment:
+        lines.append(comment)
+    return _add_lines(lines, add)
+
+
+def _modify_file(f, fail_on_error=True):
+    """
+    Modify the openssl configuration file to accomodate el8toel9 changes
+    """
+    lines = f.readlines()
+    lines = _replace(lines, r"openssl_conf\s*=\s*default_modules",
+                     "openssl_conf = openssl_init",
+                     LEAPP_COMMENT, True, fail_on_error)
+    lines = _replace(lines, r"\[\s*default_modules\s*\]",
+                     "[openssl_init]\n"
+                     "providers = provider_sect",
+                     LEAPP_COMMENT, True, fail_on_error)
+    lines = _append(lines, APPEND_STRING, LEAPP_COMMENT)
+    f.seek(0)
+    f.write(''.join(lines))
+
+
+def process(openssl_messages):
+    """
+    Process the changes needed to update configuration file
+
+    Steps:
+     * read the file
+     * replace the required chunks
+     * write the file
+    """
+    config = next(openssl_messages, None)
+    if list(openssl_messages):
+        api.current_logger().warning('Unexpectedly received more than one OpenSslConfig message.')
+    if not config:
+        raise StopActorExecutionError(
+            'Could not check openssl configuration', details={'details': 'No OpenSslConfig facts found.'}
+        )
+
+    # If the configuration file was not modified, the rpm update will bring the new
+    # changes by itself -- do not change the file now.
+    if not config.modified:
+        return
+
+    # otherwise modify the file as announced in actors/opensslconfigcheck/actor.py
+    api.current_logger().debug('Modifying the {}.'.format(CONFIG))
+    try:
+        with open(CONFIG, 'r+') as f:
+            _modify_file(f)
+    except (OSError, IOError, NotFoundException) as error:
+        api.current_logger().error('Failed to modify the file {}: {} '.format(CONFIG, error))
+        reporting.create_report([
+            reporting.Title('Could not modify {}: {}'.format(CONFIG, error)),
+            reporting.Summary(
+                'The original version was kept in place.'
+                'The OpenSSL should keep working as expected in most of the cases, but you '
+                'might encounter some issues if you need to use custom providers. Consider '
+                'updating the configuration manually. For reference, see the openssl.cnf.rpmnew'
+            ),
+            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Tags([
+                    reporting.Tags.SECURITY,
+                    reporting.Tags.NETWORK,
+                    reporting.Tags.SERVICES
+            ]),
+            reporting.Groups([
+                reporting.Groups.POST
+            ]),
+            reporting.RelatedResource('package', 'openssl'),
+            reporting.RelatedResource('file', '/etc/pki/tls/openssl.cnf')
+        ])

--- a/repos/system_upgrade/el8toel9/actors/opensslproviders/tests/test_add_provider.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslproviders/tests/test_add_provider.py
@@ -1,0 +1,111 @@
+import pytest
+
+from leapp.libraries.actor.add_provider import (
+    _add_lines,
+    _append,
+    _modify_file,
+    _replace,
+    APPEND_STRING,
+    LEAPP_COMMENT,
+    NotFoundException
+)
+
+testdata = (
+    ([], 'one', ['one\n']),
+    (['first'], 'one', ['first', 'one\n']),
+    (['first'], 'one\ntwo', ['first', 'one\n', 'two\n']),
+)
+
+
+@pytest.mark.parametrize('lines,add,expected', testdata)
+def test_add_lines(lines, add, expected):
+    r = _add_lines(lines, add)
+    assert r == expected
+
+
+testdata = (
+    ([], "search", "replace", None, False, None),
+    ([], "search", "replace", "comment", False, None),
+    ([], r"\s*", "replace", None, False, None),
+    ([], r"\s*", "replace", "comment", False, None),
+    (["text"], "text", "replace", None, False, ["replace\n"]),
+    (["text"], "text", "replace", "comment", False, ["comment", "replace\n"]),
+    (["text"], "text", "replace", "comment", True, ["comment", "# text", "replace\n"]),
+    (["text    "], "text", "replace", "comment", True, ["comment", "# text    ", "replace\n"]),
+    (["    text"], "text", "replace", "comment", True, ["comment", "#     text", "replace\n"]),
+    (["text    text"], r"text\s*text", "replace", "comment", True, ["comment", "# text    text", "replace\n"]),
+    (["first", "text", "last"], "text", "replace", "comment", True,
+     ["first", "comment", "# text", "replace\n", "last"]),
+)
+
+
+@pytest.mark.parametrize('lines,search,replace,comment,backup,expected', testdata)
+def test_replace(lines, search, replace, comment, backup, expected):
+    try:
+        r = _replace(lines, search, replace, comment, backup)
+        if expected:
+            assert r == expected
+        else:
+            assert False
+    except NotFoundException:
+        assert not expected
+
+
+testdata = (
+    ([], 'one', 'comment', ['comment', 'one\n']),
+    (['first'], 'one', 'comment', ['first', 'comment', 'one\n']),
+    (['first'], 'one\ntwo', 'comment', ['first', 'comment', 'one\n', 'two\n']),
+)
+
+
+@pytest.mark.parametrize('lines,add,comment,expected', testdata)
+def test_append(lines, add, comment, expected):
+    r = _append(lines, add, comment)
+    assert r == expected
+
+
+class MockFile(object):
+    def __init__(self, content=None):
+        self.content = content
+        self.error = False
+
+    def readlines(self):
+        return self.content.splitlines(True)
+
+    def seek(self, n):
+        self.content = ''
+
+    def write(self, content):
+        self.content = content
+
+
+testdata = (
+    ('', ''),
+    ('openssl_conf=default_modules\n',
+     '{}# openssl_conf=default_modules\nopenssl_conf = openssl_init\n'.format(LEAPP_COMMENT)),
+    ('openssl_conf = default_modules\n',
+     '{}# openssl_conf = default_modules\nopenssl_conf = openssl_init\n'.format(LEAPP_COMMENT)),
+    ('openssl_conf  =  default_modules\n',
+     '{}# openssl_conf  =  default_modules\nopenssl_conf = openssl_init\n'.format(LEAPP_COMMENT)),
+    ('  openssl_conf = default_modules  \n',
+     '{}#   openssl_conf = default_modules  \nopenssl_conf = openssl_init\n'.format(LEAPP_COMMENT)),
+    ('[default_modules]\n',
+     '{}# [default_modules]\n[openssl_init]\nproviders = provider_sect\n'.format(LEAPP_COMMENT)),
+    ('[  default_modules  ]\n',
+     '{}# [  default_modules  ]\n[openssl_init]\nproviders = provider_sect\n'.format(LEAPP_COMMENT)),
+    ('  [ default_modules ] \n',
+     '{}#   [ default_modules ] \n[openssl_init]\nproviders = provider_sect\n'.format(LEAPP_COMMENT)),
+    ('openssl_conf=default_modules\n[default_modules]\n',
+     '{c}# openssl_conf=default_modules\nopenssl_conf = openssl_init\n'
+     '{c}# [default_modules]\n[openssl_init]\nproviders = provider_sect\n'.format(c=LEAPP_COMMENT)),
+)
+
+
+@pytest.mark.parametrize('file_content,expected', testdata)
+def test_modify_file(file_content, expected):
+    f = MockFile(file_content)
+
+    # Test separate replaces and do not fail if pattern is not found
+    _modify_file(f, False)
+
+    assert f.content == "{}{}{}\n".format(expected, LEAPP_COMMENT, APPEND_STRING)

--- a/repos/system_upgrade/el8toel9/models/opensslconfig.py
+++ b/repos/system_upgrade/el8toel9/models/opensslconfig.py
@@ -1,0 +1,72 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class OpenSslConfigPair(Model):
+    """
+    Key-value pair in the OpenSSL config block
+
+    [ name ]
+    key = value
+    key2 = value2
+    ...
+
+    This model is not expected to be used as a message (produced/consumed by actors).
+    See the OpenSslConfig.
+    """
+    topic = SystemInfoTopic
+
+    key = fields.String()
+    """ The key is usually fixed name for specific purpose """
+    value = fields.String()
+    """ The value, can be a reference to another block """
+
+
+class OpenSslConfigBlock(Model):
+    """
+    Every block in the openssl.cnf in the following format:
+
+    [ name ]
+    key = value
+    key2 = value2
+    ...
+
+    This model is not expected to be used as a message (produced/consumed by actors).
+    See the OpenSslConfig.
+    """
+    topic = SystemInfoTopic
+
+    name = fields.String()
+    """ The block name """
+    pairs = fields.List(fields.Model(OpenSslConfigPair))
+    """ The key-value pairs """
+
+
+class OpenSslConfig(Model):
+    """
+    openssl.cnf
+
+    This mode contains interesting parts of the RHEL8 OpenSSL configuration file
+    that will be later used to decide if it needs to be updated to keep working
+    in RHEL9.
+    """
+    topic = SystemInfoTopic
+
+    openssl_conf = fields.Nullable(fields.String())
+    """
+    The value of openssl_conf field
+
+    It is used to load default TLS policy in RHEL8, but controls loading of all
+    providers in RHEL9 so it needs to be adjusted for upgrade. This is listed
+    befor any block.
+    """
+
+    blocks = fields.List(fields.Model(OpenSslConfigBlock))
+    """
+    The list of blocks in the openssl.cnf
+
+    We are mostly interested in the ones referenced by the openssl_conf value above.
+    """
+
+    modified = fields.Boolean(default=False)
+    """ True if the configuration file was modified. """


### PR DESCRIPTION
The `openssl.cnf` have several changes in RHEL 9 mostly related to the new version OpenSSL 3.0 and providers support. This PR provides actors that scan the existing `openssl.cnf` file for possible incompatibilities that are reported to the user and tries to update it to the format that is shipped by the new OpenSSL in case the simple update using rpm can not be done.

What is checked:
 * presence of crypto policies include file to make sure system is in sane state
 * check for duplicate X.509 extensions
 * the default modules are present
 * If MinProtocol or MaxProtocol options are present -- they have different meaning in OpenSSL 3.0 as they affect only TLS or DTLS