### PR TITLE
Fix set of supported OS versions for IPU 8 -> 9

### DIFF
--- a/repos/system_upgrade/common/libraries/config/version.py
+++ b/repos/system_upgrade/common/libraries/config/version.py
@@ -14,7 +14,7 @@ OP_MAP = {
 _SUPPORTED_VERSIONS = {
     # Note: 'rhel-alt' is detected when on 'rhel' with kernel 4.x
     '7': {'rhel': ['7.9'], 'rhel-alt': ['7.6'], 'rhel-saphana': ['7.9']},
-    '8': {'rhel': ['8.5', '8.6']},
+    '8': {'rhel': ['8.6', '8.7'], 'rhel-saphana': ['8.6']},
 }
 
 


### PR DESCRIPTION
Previously we have updated the upgrade_paths.json file to create
a mapping 8.7 -> 9.0. However, we have not enabled 8.7 for in-place
upgrades. Also, RHEL for SAP HANA has not been enabled for
IPU 8 -> 9.

Enable 8.7 for rhel and 8.6 for saphana for IPU 8 -> 9 via
SUPPORT_VERSIONS in the leapp.libraries.common.config.version
library.

Also drop 8.5 from the list of supported versions. 8.6 is still kept for RHEL for the testing purposes.