### PR TITLE
Add "Wants" for root and related filesystem targets

### DIFF
--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/90sys-upgrade/upgrade.target
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/90sys-upgrade/upgrade.target
@@ -2,6 +2,7 @@
 Description=System Upgrade
 Documentation=man:upgrade.target(7)
 # ##sysinit.target sockets.target initrd-root-fs.target initrd-root-device.target initrd-fs.target
+Wants=initrd-root-fs.target initrd-root-device.target initrd-fs.target initrd-usr-fs.target
 Requires=basic.target sysroot.mount
 After=basic.target sysroot.mount
 AllowIsolate=yes


### PR DESCRIPTION
During booting into our initramdisk, there happens a race condition
where we do not have root fs mounted yet, however dracut mount module
requires it and fails. This fixes the situation.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2092005