### PR TITLE
storage: check for /var mounted with the noexec option

### DIFF
--- a/repos/system_upgrade/common/actors/checkmountoptions/actor.py
+++ b/repos/system_upgrade/common/actors/checkmountoptions/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.checkmountoptions import check_mount_options
+from leapp.models import StorageInfo
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckMountOptions(Actor):
+    """
+    Check for mount options preventing the upgrade.
+
+    Checks performed:
+        - /var is mounted with the noexec option
+    """
+    name = "check_mount_options"
+    consumes = (StorageInfo,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        check_mount_options()

--- a/repos/system_upgrade/common/actors/checkmountoptions/libraries/checkmountoptions.py
+++ b/repos/system_upgrade/common/actors/checkmountoptions/libraries/checkmountoptions.py
@@ -1,0 +1,75 @@
+from leapp import reporting
+from leapp.libraries.stdlib import api
+from leapp.models import StorageInfo
+
+
+def inhibit_upgrade_due_var_with_noexec(mountpoint, found_in_fstab=False):
+    summary = (
+        'Leapp detected that the {0} mountpoint is mounted with the "noexec" option, '
+        'which prevents binaries necessary for the upgrade from being executed. '
+        'The upgrade process cannot continue with {0} mounted using the "noexec" option.'
+    )
+
+    if found_in_fstab:
+        hint = (
+            'Temporarily remove the "noexec" option from {0} entry in /etc/fstab until the system is upgraded, '
+            'and remount the partition without the "noexec" option.'
+        )
+        related_resource = [reporting.RelatedResource('file', '/etc/fstab')]
+    else:
+        hint = (
+            'Remount {0} without the noexec option and make sure the change is persistent'
+            'during the entire in-place upgrade process.'
+        )
+        related_resource = []
+
+    reporting.create_report([
+        reporting.Title(
+            'Detected partitions mounted with the "noexec" option, preventing a successful in-place upgrade.'
+        ),
+        reporting.Summary(summary.format(mountpoint)),
+        reporting.Remediation(hint=hint.format(mountpoint)),
+        reporting.RelatedResource('file', '/etc/fstab'),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Tags([reporting.Tags.FILESYSTEM]),
+        reporting.Flags([reporting.Flags.INHIBITOR]),
+    ] + related_resource)
+
+
+def find_mount_entry_with_mountpoint(mount_entries, mountpoint):
+    for mount_entry in mount_entries:
+        if mount_entry.mount == mountpoint:
+            return mount_entry
+    return None
+
+
+def find_fstab_entry_with_mountpoint(fstab_entries, mountpoint):
+    for fstab_entry in fstab_entries:
+        if fstab_entry.fs_file == mountpoint:
+            return fstab_entry
+    return None
+
+
+def check_noexec_on_var(storage_info):
+    """Check for /var or /var/lib being mounted with noexec mount option."""
+
+    # Order of checking is important as mount options on /var/lib override those on /var
+    mountpoints_to_check = ('/var/lib/leapp', '/var/lib', '/var')
+    for mountpoint in mountpoints_to_check:
+        fstab_entry = find_fstab_entry_with_mountpoint(storage_info.fstab, mountpoint)
+        if fstab_entry and 'noexec' in fstab_entry.fs_mntops.split(','):
+            inhibit_upgrade_due_var_with_noexec(fstab_entry.fs_file, found_in_fstab=True)
+            return  # Do not check further as present mounts would likely reflect fstab
+
+    # Make sure present mountpoints don't contain noexec as well - user might have fixed noexec in fstab
+    # but did not remount the partition, or, less likely, mounted the partition without creating a fstab entry
+    for mountpoint in mountpoints_to_check:
+        mount_entry = find_mount_entry_with_mountpoint(storage_info.mount, mountpoint)
+        if mount_entry and 'noexec' in mount_entry.options.split(','):
+            inhibit_upgrade_due_var_with_noexec(mount_entry.mount, found_in_fstab=False)
+            return
+
+
+def check_mount_options():
+    for storage_info in api.consume(StorageInfo):
+        check_noexec_on_var(storage_info)

--- a/repos/system_upgrade/common/actors/checkmountoptions/tests/test_checkmountoptions.py
+++ b/repos/system_upgrade/common/actors/checkmountoptions/tests/test_checkmountoptions.py
@@ -1,0 +1,61 @@
+from collections import namedtuple
+from functools import partial
+
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor.checkmountoptions import check_mount_options
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import FstabEntry, MountEntry, StorageInfo
+
+
+@pytest.mark.parametrize(
+    ('fstab_entries', 'mounts', 'should_inhibit'),
+    [
+        (
+            (('/var', 'default'), ),
+            (('/var', 'default'), ),
+            False
+        ),
+        (
+            (('/var', 'default'), ('/var/lib', 'default'), ),
+            (('/var', 'default'), ('/var/lib', 'default'), ),
+            False
+        ),
+        (
+            (('/var', 'default'), ('/var/lib/leapp', 'noexec')),
+            (('/var', 'default'), ('/var/lib/leapp', 'noexec')),
+            True
+        ),
+        (
+            (('/var', 'defaults'), ('/var/lib', 'noexec')),
+            (('/var', 'noexec'), ('/var/lib', 'noexec')),
+            True
+        ),
+        (
+            (('/var', 'noexec'), ('/var/lib', 'defaults')),
+            (('/var', 'noexec'), ('/var/lib', 'noexec')),
+            True
+        ),
+    ]
+)
+def test_var_mounted_with_noexec_is_detected(monkeypatch, fstab_entries, mounts, should_inhibit):
+    mounts = [
+        MountEntry(name='/dev/sdaX', tp='ext4', mount=mountpoint, options=options) for mountpoint, options in mounts
+    ]
+
+    fstab_entries = [
+        FstabEntry(fs_spec='', fs_file=mountpoint, fs_vfstype='',
+                   fs_mntops=opts, fs_freq='0', fs_passno='0') for mountpoint, opts in fstab_entries
+    ]
+
+    storage_info = StorageInfo(mount=mounts, fstab=fstab_entries)
+
+    created_reports = create_report_mocked()
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[storage_info]))
+    monkeypatch.setattr(reporting, 'create_report', created_reports)
+
+    check_mount_options()
+
+    assert bool(created_reports.called) == should_inhibit


### PR DESCRIPTION
When /var is mounted with noexec option leapp fails as it cannot execute
binaries from containers. This patch adds a generic actor checking for
mounting options, currently only checking for /var being mounted with
noexec.

JIRA ref: OAMG-3248
BZ: 1836179