### PR TITLE
Detect kernel-core|kernel-rt-core on RHEL 8+

### DIFF
--- a/repos/system_upgrade/common/actors/kernel/checkinstalledkernels/libraries/checkinstalledkernels.py
+++ b/repos/system_upgrade/common/actors/kernel/checkinstalledkernels/libraries/checkinstalledkernels.py
@@ -87,12 +87,23 @@ def get_newest_evr(pkgs):
     return newest_evr
 
 
-def process():
-    kernel_name = 'kernel'
+def _get_kernel_rpm_name():
+    base_name = 'kernel'
     if version.is_rhel_realtime():
         api.current_logger().info('The Real Time kernel boot detected.')
-        kernel_name = 'kernel-rt'
+        base_name = 'kernel-rt'
 
+    if version.get_source_major_version() == '7':
+        return base_name
+
+    # Since RHEL 8, the kernel|kernel-rt rpm is just a metapackage that even
+    # does not have to be installed on the system.
+    # The kernel-core|kernel-rt-core rpm is the one we care about instead.
+    return '{}-core'.format(base_name)
+
+
+def process():
+    kernel_name = _get_kernel_rpm_name()
     pkgs = get_pkgs(kernel_name)
     if not pkgs:
         # Hypothatical, user is not allowed to install any kernel that is not signed by RH

--- a/repos/system_upgrade/common/actors/kernel/checkinstalledkernels/tests/unit_test_checkinstalledkernels.py
+++ b/repos/system_upgrade/common/actors/kernel/checkinstalledkernels/tests/unit_test_checkinstalledkernels.py
@@ -5,7 +5,7 @@ from leapp.libraries.actor import checkinstalledkernels
 from leapp.libraries.common.config import architecture
 from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, logger_mocked
 from leapp.libraries.stdlib import api
-from leapp.models import RPM, InstalledRedHatSignedRPM
+from leapp.models import InstalledRedHatSignedRPM, RPM
 
 RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
 
@@ -206,3 +206,14 @@ def test_newest_kernel_realtime(monkeypatch, expect_report, msgs, curr_kernel):
         assert reporting.create_report.report_fields['title'] == 'Newest installed kernel not in use'
     else:
         assert not reporting.create_report.called
+
+
+@pytest.mark.parametrize('current_actor_mocked,expected_name', [
+    (CurrentActorMocked(kernel='3.10.0-957.43.1.el7.x86_64', src_ver='7.9'), 'kernel'),
+    (CurrentActorMocked(kernel='3.10.0-789.35.2.rt56.1133.el7.x86_64', src_ver='7.9'), 'kernel-rt'),
+    (CurrentActorMocked(kernel='4.14.0-115.29.1.el7.x86_64', src_ver='8.6'), 'kernel-core'),
+    (CurrentActorMocked(kernel='4.14.0-789.35.2.rt56.1133.el8.x86_64', src_ver='8.6'), 'kernel-rt-core'),
+])
+def test_kernel_name(monkeypatch, current_actor_mocked, expected_name):
+    monkeypatch.setattr(api, 'current_actor', current_actor_mocked)
+    assert expected_name == checkinstalledkernels._get_kernel_rpm_name()


### PR DESCRIPTION
Since RHEL 8, the kernel|kernel-rt rpm is just a metapackage that even
does not have to be installed on the system.
The kernel-core|kernel-rt-core rpm is the one we care about instead.