### PR TITLE
InterimPreparationPhase: change the error policy to FailImmediately

### DIFF
--- a/repos/system_upgrade/common/workflows/inplace_upgrade.py
+++ b/repos/system_upgrade/common/workflows/inplace_upgrade.py
@@ -116,7 +116,7 @@ class IPUWorkflow(Workflow):
 
         name = 'InterimPreparation'
         filter = TagFilter(tags.InterimPreparationPhaseTag)
-        policies = Policies(Policies.Errors.FailPhase,
+        policies = Policies(Policies.Errors.FailImmediately,
                             Policies.Retry.Phase)
         flags = Flags(request_restart_after_phase=True)
 


### PR DESCRIPTION
Currently, the InterimPreparationPhase has its error policy set to
FailPhase, meaning that other actors are allowed to run even when an
actor fails with an error. This policy makes it possible to add a boot
entry when dnf dry run fails, as the AddUpgradeBootEntry actor does not
checks for whether the DNFDryRun really produced a message (it only
declares a dependency on its output). A possible solution would be to
handle not receiving the required message in AddUpgradeBootEntry,
however, due to the linear nature of the dependency of actors executed
during the InterimPreparationPhase, it is better to handle the
situations where such message-retrieval-checking logic is missing
globally by setting the error policy on the phase - implemented in this
patch.