### PR TITLE
Enable 8to9 ipu on azure vanilla

### DIFF
--- a/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
+++ b/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
@@ -55,7 +55,8 @@ class RedHatSignedRpmScanner(Actor):
             return pkg.name.startswith('katello-ca-consumer')
 
         upg_path = rhui.get_upg_path()
-        whitelisted_cloud_flavours = ('azure', 'azure-sap', 'google', 'google-sap')
+        # AWS RHUI packages do not have to be whitelisted because they are signed by RedHat
+        whitelisted_cloud_flavours = ('azure', 'azure-eus', 'azure-sap', 'google', 'google-sap')
         whitelisted_cloud_pkgs = {
             rhui.RHUI_CLOUD_MAP[upg_path].get(flavour, {}).get('src_pkg') for flavour in whitelisted_cloud_flavours
         }

--- a/repos/system_upgrade/common/actors/rpmscanner/libraries/rpmscanner.py
+++ b/repos/system_upgrade/common/actors/rpmscanner/libraries/rpmscanner.py
@@ -1,8 +1,9 @@
 import warnings
 
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.stdlib import api
+from leapp.libraries.common import module as module_lib
 from leapp.libraries.common import rpms
+from leapp.libraries.stdlib import api
 from leapp.models import InstalledRPM, RPM
 
 no_yum = False
@@ -79,33 +80,11 @@ def get_package_repository_data():
     raise StopActorExecutionError(message=no_yum_warning_msg)
 
 
-def get_modules():
-    """
-    Return info about all module streams as a list of libdnf.module.ModulePackage objects.
-    """
-    if no_dnf:
-        return []
-
-    base = dnf.Base()
-    base.init_plugins()
-    base.read_all_repos()
-    # e.g. the amazon-id plugin requires loaded repositories
-    # for the proper configuration.
-    base.configure_plugins()
-    base.fill_sack()
-
-    module_base = dnf.module.module_base.ModuleBase(base)
-    # this method is absent on RHEL 7, in which case there are no modules anyway
-    if 'get_modules' not in dir(module_base):
-        return []
-    return module_base.get_modules('*')[0]
-
-
 def map_modular_rpms_to_modules():
     """
     Map modular packages to the module streams they come from.
     """
-    modules = get_modules()
+    modules = module_lib.get_modules()
     # empty on RHEL 7 because of no modules
     if not modules:
         return {}

--- a/repos/system_upgrade/common/actors/rpmscanner/tests/test_rpmscanner.py
+++ b/repos/system_upgrade/common/actors/rpmscanner/tests/test_rpmscanner.py
@@ -101,7 +101,8 @@ MODULES = [
 
 
 @pytest.mark.skipif(no_yum and no_dnf, reason='yum/dnf is unavailable')
-def test_actor_execution(current_actor_context):
+def test_actor_execution(monkeypatch, current_actor_context):
+    monkeypatch.setattr(rpmscanner.module_lib, 'get_modules', lambda: [])
     current_actor_context.run()
     assert current_actor_context.consume(InstalledRPM)
     assert current_actor_context.consume(InstalledRPM)[0].items

--- a/repos/system_upgrade/common/actors/rpmscanner/tests/test_rpmscanner.py
+++ b/repos/system_upgrade/common/actors/rpmscanner/tests/test_rpmscanner.py
@@ -2,11 +2,12 @@ import sys
 
 import pytest
 
-from leapp.models import InstalledRPM, RPM
-from leapp.snactor.fixture import current_actor_context
 from leapp.libraries.actor import rpmscanner
+from leapp.libraries.common import module as module_lib
 from leapp.libraries.common import rpms, testutils
 from leapp.libraries.stdlib import api
+from leapp.models import InstalledRPM, RPM
+from leapp.snactor.fixture import current_actor_context
 
 no_yum = False
 try:
@@ -107,13 +108,13 @@ def test_actor_execution(current_actor_context):
 
 
 def test_map_modular_rpms_to_modules_empty(monkeypatch):
-    monkeypatch.setattr(rpmscanner, 'get_modules', lambda: [])
+    monkeypatch.setattr(module_lib, 'get_modules', lambda: [])
     mapping = rpmscanner.map_modular_rpms_to_modules()
     assert not mapping
 
 
 def test_map_modular_rpms_to_modules(monkeypatch):
-    monkeypatch.setattr(rpmscanner, 'get_modules', lambda: MODULES)
+    monkeypatch.setattr(module_lib, 'get_modules', lambda: MODULES)
     mapping = rpmscanner.map_modular_rpms_to_modules()
     assert mapping[
         ('afterburn', '0', '4.2.0', '1.module_f31+6825+8330d585', 'x86_64')
@@ -151,7 +152,7 @@ PACKAGE_REPOS = {
 
 
 def test_process(monkeypatch):
-    monkeypatch.setattr(rpmscanner, 'get_modules', lambda: MODULES)
+    monkeypatch.setattr(module_lib, 'get_modules', lambda: MODULES)
     monkeypatch.setattr(rpmscanner, 'get_package_repository_data', lambda: PACKAGE_REPOS)
     monkeypatch.setattr(rpms, 'get_installed_rpms', lambda: INSTALLED_RPMS)
     monkeypatch.setattr(api, 'produce', testutils.produce_mocked())

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -133,12 +133,29 @@ RHUI_CLOUD_MAP = {
                 ('leapp-aws-sap-e4s.repo', YUM_REPOS_PATH)
             ],
         },
-        # not yet enabled
         'azure': {
             'src_pkg': 'rhui-azure-rhel8',
             'target_pkg': 'rhui-azure-rhel9',
             'agent_pkg': 'WALinuxAgent',
             'leapp_pkg': 'leapp-rhui-azure',
+            'leapp_pkg_repo': 'leapp-azure.repo',
+            'files_map': [
+                ('content.crt', RHUI_PKI_PRODUCT_DIR),
+                ('key.pem', RHUI_PKI_PRIVATE_DIR),
+                ('leapp-azure.repo', YUM_REPOS_PATH)
+            ],
+        },
+        # FIXME(mhecko): This entry is identical to the azure one, since we have no EUS content yet, therefore, it
+        # #              serves only the purpose of containing the name of rhui client package to correctly detect
+        # #              cloud provider. Trying to work around this entry by specifying --channel, will result in
+        # #              failures - there is no repomapping for EUS content, and the name of target pkg differs on EUS.
+        # #              If the EUS image is available sooner than the 'azure-eus' entry gets modified, the user can
+        # #              still upgrade to non-EUS, and switch the newly upgraded system to EUS manually.
+        'azure-eus': {
+            'src_pkg': 'rhui-azure-rhel8-eus',
+            'target_pkg': 'rhui-azure-rhel9',
+            'agent_pkg': 'WALinuxAgent',
+            'leapp_pkg': 'leapp-rhui-azure-eus',
             'leapp_pkg_repo': 'leapp-azure.repo',
             'files_map': [
                 ('content.crt', RHUI_PKI_PRODUCT_DIR),


### PR DESCRIPTION
Implements necessary changes to enable 8to9 upgrade on base RHEL8 running on Azure.