### PR TITLE
Update LsblkEntry (StorageInfo) and fix the vdo scanner

### DIFF
--- a/repos/system_upgrade/common/actors/inhibitwhenluks/tests/test_inhibitwhenluks.py
+++ b/repos/system_upgrade/common/actors/inhibitwhenluks/tests/test_inhibitwhenluks.py
@@ -5,9 +5,8 @@ from leapp.utils.report import is_inhibitor
 
 
 def test_actor_with_luks(current_actor_context):
-    with_luks = [LsblkEntry(name='luks-132', maj_min='253:0', rm='0',
-                            size='10G', ro='0', tp='crypt', mountpoint=''
-                            )]
+    with_luks = [LsblkEntry(name='luks-132', kname='kname1', maj_min='253:0', rm='0',
+                            size='10G', bsize=10*(1 << 39), ro='0', tp='crypt', mountpoint='')]
 
     current_actor_context.feed(StorageInfo(lsblk=with_luks))
     current_actor_context.run()
@@ -17,9 +16,8 @@ def test_actor_with_luks(current_actor_context):
 
 
 def test_actor_with_luks_ceph_only(current_actor_context):
-    with_luks = [LsblkEntry(name='luks-132', maj_min='253:0', rm='0',
-                            size='10G', ro='0', tp='crypt', mountpoint=''
-                            )]
+    with_luks = [LsblkEntry(name='luks-132', kname='kname1', maj_min='253:0', rm='0',
+                            size='10G', bsize=10*(1 << 39), ro='0', tp='crypt', mountpoint='')]
     ceph_volume = ['luks-132']
     current_actor_context.feed(StorageInfo(lsblk=with_luks))
     current_actor_context.feed(CephInfo(encrypted_volumes=ceph_volume))
@@ -28,9 +26,8 @@ def test_actor_with_luks_ceph_only(current_actor_context):
 
 
 def test_actor_without_luks(current_actor_context):
-    without_luks = [LsblkEntry(name='sda1', maj_min='8:0', rm='0',
-                               size='10G', ro='0', tp='part', mountpoint='/boot'
-                               )]
+    without_luks = [LsblkEntry(name='sda1', kname='sda1', maj_min='8:0', rm='0',
+                               size='10G', bsize=10*(1 << 39), ro='0', tp='part', mountpoint='/boot')]
 
     current_actor_context.feed(StorageInfo(lsblk=without_luks))
     current_actor_context.run()

--- a/repos/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py
+++ b/repos/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py
@@ -169,14 +169,19 @@ def _get_lsblk_info():
     cmd = ['lsblk', '-pbnr', '--output', 'NAME,MAJ:MIN,RM,SIZE,RO,TYPE,MOUNTPOINT']
     for entry in _get_cmd_output(cmd, ' ', 7):
         dev_path, maj_min, rm, bsize, ro, tp, mountpoint = entry
-        name, kname, size = next(_get_cmd_output(['lsblk', '-nr', '--output', 'NAME,KNAME,SIZE', dev_path], ' ', 3))
+        lsblk_cmd = ['lsblk', '-nr', '--output', 'NAME,KNAME,SIZE', dev_path]
+        lsblk_info_for_devpath = next(_get_cmd_output(lsblk_cmd, ' ', 3), None)
+        if not lsblk_info_for_devpath:
+            return
+
+        name, kname, size = lsblk_info_for_devpath
         yield LsblkEntry(
             name=name,
             kname=kname,
             maj_min=maj_min,
             rm=rm,
             size=size,
-            bsize=bsize,
+            bsize=int(bsize),
             ro=ro,
             tp=tp,
             mountpoint=mountpoint)

--- a/repos/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py
+++ b/repos/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py
@@ -166,13 +166,17 @@ def _get_mount_info(path):
 @aslist
 def _get_lsblk_info():
     """ Collect storage info from lsblk command """
-    for entry in _get_cmd_output(['lsblk', '-r', '--noheadings'], ' ', 7):
-        name, maj_min, rm, size, ro, tp, mountpoint = entry
+    cmd = ['lsblk', '-pbnr', '--output', 'NAME,MAJ:MIN,RM,SIZE,RO,TYPE,MOUNTPOINT']
+    for entry in _get_cmd_output(cmd, ' ', 7):
+        dev_path, maj_min, rm, bsize, ro, tp, mountpoint = entry
+        name, kname, size = next(_get_cmd_output(['lsblk', '-nr', '--output', 'NAME,KNAME,SIZE', dev_path], ' ', 3))
         yield LsblkEntry(
             name=name,
+            kname=kname,
             maj_min=maj_min,
             rm=rm,
             size=size,
+            bsize=bsize,
             ro=ro,
             tp=tp,
             mountpoint=mountpoint)

--- a/repos/system_upgrade/common/models/storageinfo.py
+++ b/repos/system_upgrade/common/models/storageinfo.py
@@ -1,4 +1,4 @@
-from leapp.models import Model, fields
+from leapp.models import fields, Model
 from leapp.topics import SystemInfoTopic
 
 

--- a/repos/system_upgrade/common/models/storageinfo.py
+++ b/repos/system_upgrade/common/models/storageinfo.py
@@ -35,9 +35,11 @@ class LsblkEntry(Model):
     topic = SystemInfoTopic
 
     name = fields.String()
+    kname = fields.String()
     maj_min = fields.String()
     rm = fields.String()
     size = fields.String()
+    bsize = fields.Integer()
     ro = fields.String()
     tp = fields.String()
     mountpoint = fields.String()

--- a/repos/system_upgrade/el8toel9/actors/vdoconversionscanner/libraries/vdoconversionscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/vdoconversionscanner/libraries/vdoconversionscanner.py
@@ -1,6 +1,10 @@
+import os
+
 from leapp import models
-from leapp.libraries import stdlib
 from leapp.libraries.common import rpms
+from leapp.libraries.stdlib import api, run
+
+MIN_DISK_SIZE = 2 ** 22  # 4 MiB
 
 
 def _check_vdo_lvm_managed(device):
@@ -9,7 +13,7 @@ def _check_vdo_lvm_managed(device):
     as a post-conversion vdo device (at the level of vdo) is managed by lvm.
     """
     command = ['blkid', '--match-token', 'TYPE=LVM2_member', device]
-    result = stdlib.run(command, checked=False)
+    result = run(command, checked=False)
     exit_code = result['exit_code']
     #     0: Is LVM managed
     #     2: Is not LVM manaaged
@@ -23,7 +27,7 @@ def _check_vdo_pre_conversion(device):
     pre-conversion vdo device or a post-conversion vdo device.
     """
     command = ['/usr/libexec/vdoprepareforlvm', '--check', device]
-    result = stdlib.run(command, checked=False)
+    result = run(command, checked=False)
     exit_code = result['exit_code']
     #   255: Not a vdo device
     #     0: A post-conversion vdo device
@@ -50,7 +54,9 @@ def get_info(storage_info):
         vdo_package_installed = _vdo_package_installed()
 
         for lsblk in storage_info.lsblk:
-            if lsblk.tp not in ('disk', 'part'):
+            # NOTE: partitions < MIN_DISK_SIZE cannot be handled by vdo and
+            # the check results in unexpected outputs
+            if lsblk.tp not in ('disk', 'part') or lsblk.bsize < MIN_DISK_SIZE:
                 continue
 
             if not vdo_package_installed:
@@ -58,15 +64,41 @@ def get_info(storage_info):
                     models.VdoConversionUndeterminedDevice(name=lsblk.name))
                 continue
 
-            device = '/dev/{0}'.format(lsblk.name)
+            # refer to kernel name
+            device = '/dev/{0}'.format(lsblk.kname)
+            if not os.path.exists(device):
+                # NOTE: Corner case. It's hypothetical situation which could possibly
+                # happen but we do not know under what circumstances and we do not
+                # have time now for investigation. Let's see if someone report it
+                # to us so we will have a data :)
+                # For now, stay on the safe side and inhibit the upgrade if this
+                # happens.
+                failure = (
+                    'cannot check device {0} (kernel name: {1}): file {2} does not exist'
+                    .format(lsblk.name, lsblk.kname, device)
+                )
+                api.current_logger().warning(failure)
+                undetermined_conversion_devices.append(
+                    models.VdoConversionUndeterminedDevice(
+                        name=lsblk.name,
+                        check_failed=True,
+                        failure=failure
+                    )
+                )
+                continue
             result = _check_vdo_pre_conversion(device)
             if result not in (255, 0, 1):
-                failure = ('unexpected error from \'vdoprepareforlvm\' for {0}; '
-                           'result = {1}'.format(lsblk.name, result))
+                failure = (
+                    'unexpected error from \'vdoprepareforlvm\' for {0}; result = {1}'
+                    .format(lsblk.name, result)
+                )
                 undetermined_conversion_devices.append(
-                    models.VdoConversionUndeterminedDevice(name=lsblk.name,
-                                                           check_failed=True,
-                                                           failure=failure))
+                    models.VdoConversionUndeterminedDevice(
+                        name=lsblk.name,
+                        check_failed=True,
+                        failure=failure
+                    )
+                )
                 continue
 
             if result == 255:

--- a/repos/system_upgrade/el8toel9/actors/vdoconversionscanner/tests/unit_test_vdoconversionscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/vdoconversionscanner/tests/unit_test_vdoconversionscanner.py
@@ -3,7 +3,6 @@ import os
 import random
 
 from leapp import models, reporting
-from leapp.libraries import stdlib
 from leapp.libraries.actor import vdoconversionscanner
 from leapp.libraries.common.testutils import create_report_mocked
 
@@ -16,19 +15,22 @@ def aslist(f):
     return inner
 
 
-def _lsblk_entry(prefix, number, types):
+def _lsblk_entry(prefix, number, types, size='128G', bsize=2 ** 37):
+    lsblk_entry_name = '{0}{1}'.format(prefix, number)
     return models.LsblkEntry(
-        name='{0}{1}'.format(prefix, number),
+        name=lsblk_entry_name,
+        kname=lsblk_entry_name,
         maj_min='253:{0}'.format(number),
         rm='0',
-        size='100G',
+        size=size,
+        bsize=bsize,
         ro='0',
         tp=types[random.randint(0, len(types) - 1)],
         mountpoint='')
 
 
 @aslist
-def _lsblk_entries(pre=0, post=0, complete=0, undetermined=0):
+def _lsblk_entries(pre=0, post=0, complete=0, undetermined=0, small=0, missing=0):
 
     begin = pre
     for x in range(begin):
@@ -45,10 +47,20 @@ def _lsblk_entries(pre=0, post=0, complete=0, undetermined=0):
 
     for x in range(begin, begin + undetermined):
         yield _lsblk_entry('vdo_undetermined_', x, ['disk', 'part'])
+    begin += undetermined
+
+    for x in range(begin, begin + small):
+        # this one will not be undetermined. We want to test this one is actually really
+        # skipped, so we do not find it in the list
+        yield _lsblk_entry('vdo_undetermined_small_skipped', x, ['disk', 'part'], size='2K', bsize=2 ** 11)
+    begin += small
+
+    for x in range(begin, begin + missing):
+        yield _lsblk_entry('vdo_undetermined_missing_', x, ['disk', 'part'])
 
 
-def _storage_info(pre=0, post=0, complete=0, undetermined=0):
-    return models.StorageInfo(lsblk=_lsblk_entries(pre, post, complete, undetermined))
+def _storage_info(pre=0, post=0, complete=0, undetermined=0, small=0, missing=0):
+    return models.StorageInfo(lsblk=_lsblk_entries(pre, post, complete, undetermined, small, missing))
 
 
 def _check_vdo_lvm_managed(device):
@@ -72,8 +84,9 @@ def test_check_vdo_pre_conversion(monkeypatch):
     monkeypatch.setattr(vdoconversionscanner, '_lvm_package_installed', lambda: True)
     monkeypatch.setattr(vdoconversionscanner, '_vdo_package_installed', lambda: True)
     monkeypatch.setattr(vdoconversionscanner, '_check_vdo_lvm_managed', _check_vdo_lvm_managed)
+    monkeypatch.setattr(os.path, 'exists', lambda dummy_file: True)
 
-    monkeypatch.setattr(stdlib, 'run', lambda _, checked: {'exit_code': 0})
+    monkeypatch.setattr(vdoconversionscanner, 'run', lambda _, checked: {'exit_code': 0})
     info = vdoconversionscanner.get_info(_storage_info(pre=1))
     assert isinstance(info, models.VdoConversionInfo)
     assert isinstance(info.pre_conversion, list) and (not info.pre_conversion)
@@ -81,21 +94,21 @@ def test_check_vdo_pre_conversion(monkeypatch):
     assert not info.post_conversion[0].complete
     assert isinstance(info.undetermined_conversion, list) and (not info.undetermined_conversion)
 
-    monkeypatch.setattr(stdlib, 'run', lambda _, checked: {'exit_code': 1})
+    monkeypatch.setattr(vdoconversionscanner, 'run', lambda _, checked: {'exit_code': 1})
     info = vdoconversionscanner.get_info(_storage_info(pre=1))
     assert isinstance(info, models.VdoConversionInfo)
     assert isinstance(info.pre_conversion, list) and (len(info.pre_conversion) == 1)
     assert isinstance(info.post_conversion, list) and (not info.post_conversion)
     assert isinstance(info.undetermined_conversion, list) and (not info.undetermined_conversion)
 
-    monkeypatch.setattr(stdlib, 'run', lambda _, checked: {'exit_code': 255})
+    monkeypatch.setattr(vdoconversionscanner, 'run', lambda _, checked: {'exit_code': 255})
     info = vdoconversionscanner.get_info(_storage_info(pre=1))
     assert isinstance(info, models.VdoConversionInfo)
     assert isinstance(info.pre_conversion, list) and (not info.pre_conversion)
     assert isinstance(info.post_conversion, list) and (not info.post_conversion)
     assert isinstance(info.undetermined_conversion, list) and (not info.undetermined_conversion)
 
-    monkeypatch.setattr(stdlib, 'run', lambda _, checked: {'exit_code': -1})
+    monkeypatch.setattr(vdoconversionscanner, 'run', lambda _, checked: {'exit_code': -1})
     info = vdoconversionscanner.get_info(_storage_info(pre=1))
     assert isinstance(info, models.VdoConversionInfo)
     assert isinstance(info.pre_conversion, list) and (not info.pre_conversion)
@@ -104,12 +117,13 @@ def test_check_vdo_pre_conversion(monkeypatch):
 
 
 def test_check_vdo_lvm_managed(monkeypatch):
+    monkeypatch.setattr(os.path, 'exists', lambda dummy_file: True)
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     monkeypatch.setattr(vdoconversionscanner, '_lvm_package_installed', lambda: True)
     monkeypatch.setattr(vdoconversionscanner, '_vdo_package_installed', lambda: True)
     monkeypatch.setattr(vdoconversionscanner, '_check_vdo_pre_conversion', _check_vdo_pre_conversion)
 
-    monkeypatch.setattr(stdlib, 'run', lambda _, checked: {'exit_code': 0})
+    monkeypatch.setattr(vdoconversionscanner, 'run', lambda _, checked: {'exit_code': 0})
     info = vdoconversionscanner.get_info(_storage_info(post=1))
     assert isinstance(info, models.VdoConversionInfo)
     assert isinstance(info.pre_conversion, list) and (not info.pre_conversion)
@@ -118,7 +132,7 @@ def test_check_vdo_lvm_managed(monkeypatch):
     assert not info.post_conversion[0].failure
     assert isinstance(info.undetermined_conversion, list) and (not info.undetermined_conversion)
 
-    monkeypatch.setattr(stdlib, 'run', lambda _, checked: {'exit_code': 2})
+    monkeypatch.setattr(vdoconversionscanner, 'run', lambda _, checked: {'exit_code': 2})
     info = vdoconversionscanner.get_info(_storage_info(post=1))
     assert isinstance(info, models.VdoConversionInfo)
     assert isinstance(info.pre_conversion, list) and (not info.pre_conversion)
@@ -127,7 +141,7 @@ def test_check_vdo_lvm_managed(monkeypatch):
     assert not info.post_conversion[0].failure
     assert isinstance(info.undetermined_conversion, list) and (not info.undetermined_conversion)
 
-    monkeypatch.setattr(stdlib, 'run', lambda _, checked: {'exit_code': -1})
+    monkeypatch.setattr(vdoconversionscanner, 'run', lambda _, checked: {'exit_code': -1})
     info = vdoconversionscanner.get_info(_storage_info(post=1))
     assert isinstance(info, models.VdoConversionInfo)
     assert isinstance(info.pre_conversion, list) and (not info.pre_conversion)
@@ -173,6 +187,7 @@ def test_no_vdo_devices(monkeypatch):
 
 
 def test_vdo_devices(monkeypatch):
+    monkeypatch.setattr(os.path, 'exists', lambda dummy_file: True)
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     monkeypatch.setattr(vdoconversionscanner, '_lvm_package_installed', lambda: True)
     monkeypatch.setattr(vdoconversionscanner, '_vdo_package_installed', lambda: True)
@@ -211,5 +226,56 @@ def test_vdo_package_not_installed(monkeypatch):
     assert isinstance(info, models.VdoConversionInfo)
     assert isinstance(info.pre_conversion, list) and (not info.pre_conversion)
     assert isinstance(info.post_conversion, list) and (not info.post_conversion)
-    assert (isinstance(info.undetermined_conversion, list) and
-            (len(info.undetermined_conversion) == (pre + post + undetermined)))
+    assert isinstance(info.undetermined_conversion, list)
+    assert len(info.undetermined_conversion) == (pre + post + undetermined)
+
+
+def test_missing_devices(monkeypatch):
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(vdoconversionscanner, '_lvm_package_installed', lambda: True)
+    monkeypatch.setattr(vdoconversionscanner, '_vdo_package_installed', lambda: True)
+    monkeypatch.setattr(vdoconversionscanner, '_check_vdo_pre_conversion', _check_vdo_pre_conversion)
+    monkeypatch.setattr(vdoconversionscanner, '_check_vdo_lvm_managed', _check_vdo_lvm_managed)
+    monkeypatch.setattr(os.path, 'exists', lambda fname: '_missing_' not in fname)
+
+    complete = 1
+    undetermined = 2
+    missing = 1
+
+    info = vdoconversionscanner.get_info(_storage_info(
+        complete=complete, undetermined=undetermined, missing=missing
+    ))
+
+    assert isinstance(info, models.VdoConversionInfo)
+    assert isinstance(info.pre_conversion, list) and (not info.pre_conversion)
+    assert isinstance(info.post_conversion, list) and (len(info.post_conversion) == complete)
+    assert isinstance(info.undetermined_conversion, list)
+    assert len([x for x in info.post_conversion if x.complete]) == complete
+    assert len(info.undetermined_conversion) == (undetermined + missing)
+    missing_detected = False
+    for item in info.undetermined_conversion:
+        if 'does not exist' in item.failure and '_missing_' in item.name:
+            missing_detected = True
+    assert missing_detected
+
+
+def test_small_partition_skip(monkeypatch):
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(vdoconversionscanner, '_lvm_package_installed', lambda: True)
+    monkeypatch.setattr(vdoconversionscanner, '_vdo_package_installed', lambda: True)
+    monkeypatch.setattr(vdoconversionscanner, '_check_vdo_pre_conversion', _check_vdo_pre_conversion)
+    monkeypatch.setattr(vdoconversionscanner, '_check_vdo_lvm_managed', _check_vdo_lvm_managed)
+    monkeypatch.setattr(os.path, 'exists', lambda fname: '_missing_' not in fname)
+
+    undetermined = 2
+    small = 2
+
+    info = vdoconversionscanner.get_info(_storage_info(undetermined=undetermined, small=small))
+
+    assert isinstance(info, models.VdoConversionInfo)
+    assert isinstance(info.pre_conversion, list) and (not info.pre_conversion)
+    assert isinstance(info.post_conversion, list) and (not info.post_conversion)
+    assert isinstance(info.undetermined_conversion, list)
+    assert len(info.undetermined_conversion) == undetermined
+    for item in info.undetermined_conversion:
+        assert 'small' not in item.name


### PR DESCRIPTION
The /usr/libexec/vdopreparelvm binary fails when try to check
devices/partitions smaller than 4 MiB as VDO does not count
with any use-case with such small partitions. To cover this,
skip all such small devices when checking for the converted
VDO devices. (rhbz#2090830)

Also it could happen on some systems that check fails when the
NAME and KERNEL NAME of a device is different as the actor
checked devices just on `/dev/{NAME}` path. This should be mostly
ok when checking `/dev/{KNAME}` instead. However after discussion
with @jshimkus-rh and @bmarzins we know there could be cases when
even this is not true. In such cases, report the valid error msg
so it's more clear what actually happened.
(rhbz#206159)

To simplify the solution mentioned above, the `LsblkEntry` model
has been extended to cover kernel name (`kname`) and size in
bytes (`bsize`) as well. Includes changes in the `storagescanner`
actor.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2090830
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2096159

-----------
## TODO
- [x] update unit-tests
- [x] testing (pretesting done, excluding report of the missing media that I do not have idea how to reproduce as it's corner case; covered at least by unit-tests)
