### PR TITLE
Fix for RHEL 8.6 to 9 upgrades on AWS

### DIFF
--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -105,7 +105,7 @@ RHUI_CLOUD_MAP = {
     },
     '8to9': {
         'aws': {
-            'src_pkg': 'rh-amazon-rhui-client-ha',
+            'src_pkg': 'rh-amazon-rhui-client',
             'target_pkg': 'rh-amazon-rhui-client',
             'leapp_pkg': 'leapp-rhui-aws',
             'leapp_pkg_repo': 'leapp-aws.repo',
@@ -130,7 +130,6 @@ RHUI_CLOUD_MAP = {
                 ('content-rhel9-sap.crt', RHUI_PKI_PRODUCT_DIR),
                 ('content-rhel9-sap.key', RHUI_PKI_DIR),
                 ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
-                (AWS_DNF_PLUGIN_NAME, DNF_PLUGIN_PATH_PY2),
                 ('leapp-aws-sap-e4s.repo', YUM_REPOS_PATH)
             ],
         },


### PR DESCRIPTION
This change is a fix for RHEL 8.6 to 9 leapp upgrades on AWS. The src client package for AWS should be rh-amazon-rhui-client as rh-amazon-rhui-client-ha is the RHUI client package for the RHEL with HA add-on image.

I also tested the change and confirmed it resolves the issue.

Bugzilla: [rhbz#2106904](https://bugzilla.redhat.com/show_bug.cgi?id=2106904)