### PR TITLE
Check if /var/lib/leapp is mounted in a persistent fashion

### DIFF
--- a/repos/system_upgrade/common/actors/checkpersistentmounts/actor.py
+++ b/repos/system_upgrade/common/actors/checkpersistentmounts/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.checkpersistentmounts import check_persistent_mounts
+from leapp.models import StorageInfo
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckPersistentMounts(Actor):
+    """
+    Check if mounts required to be persistent are mounted in persistent fashion.
+
+    Checks performed:
+        - if /var/lib/leapp is mounted it has an entry in /etc/fstab
+    """
+    name = "check_persistent_mounts"
+    consumes = (StorageInfo,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        check_persistent_mounts()

--- a/repos/system_upgrade/common/actors/checkpersistentmounts/libraries/checkpersistentmounts.py
+++ b/repos/system_upgrade/common/actors/checkpersistentmounts/libraries/checkpersistentmounts.py
@@ -1,0 +1,43 @@
+from leapp import reporting
+from leapp.libraries.stdlib import api
+from leapp.models import StorageInfo
+
+
+def inhibit_upgrade_due_non_persistent_mount(mountpoint):
+    summary = (
+        'Leapp detected that the {0} mountpoint is mounted, with no corresponding entry in /etc/fstab. '
+        'The upgrade process cannot continue with {0} mounted in non-persistent fashion, '
+        'as Leapp needs this mount to be available after a reboot.'
+    )
+
+    hint = (
+        'Add {0} mount entry to /etc/fstab'
+    )
+
+    reporting.create_report([
+        reporting.Title(
+            'Detected partitions mounted in a non-persistent fashion, preventing a successful in-place upgrade.'
+        ),
+        reporting.Summary(summary.format(mountpoint)),
+        reporting.Remediation(hint=hint.format(mountpoint)),
+        reporting.RelatedResource('file', '/etc/fstab'),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Tags([reporting.Tags.FILESYSTEM]),
+        reporting.Flags([reporting.Flags.INHIBITOR]),
+    ])
+
+
+def check_mount_is_persistent(storage_info, mountpoint):
+    """Check if mountpoint is mounted in persistent fashion"""
+
+    mount_entry_exists = any(me.mount == mountpoint for me in storage_info.mount)
+    fstab_entry_exists = any(fe.fs_file == mountpoint for fe in storage_info.fstab)
+
+    if mount_entry_exists and not fstab_entry_exists:
+        inhibit_upgrade_due_non_persistent_mount(mountpoint)
+
+
+def check_persistent_mounts():
+    storage_info = next(api.consume(StorageInfo), None)
+    if storage_info:
+        check_mount_is_persistent(storage_info, '/var/lib/leapp')

--- a/repos/system_upgrade/common/actors/checkpersistentmounts/tests/test_checkpersistentmounts.py
+++ b/repos/system_upgrade/common/actors/checkpersistentmounts/tests/test_checkpersistentmounts.py
@@ -1,0 +1,40 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor.checkpersistentmounts import check_persistent_mounts
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import FstabEntry, MountEntry, StorageInfo
+
+MOUNT_ENTRY = MountEntry(name='/dev/sdaX', tp='ext4', mount='/var/lib/leapp', options='defaults')
+
+FSTAB_ENTRY = FstabEntry(fs_spec='', fs_file='/var/lib/leapp', fs_vfstype='',
+                         fs_mntops='defaults', fs_freq='0', fs_passno='0')
+
+
+@pytest.mark.parametrize(
+    ('storage_info', 'should_inhibit'),
+    [
+        (
+            StorageInfo(mount=[MOUNT_ENTRY], fstab=[]),
+            True
+        ),
+        (
+            StorageInfo(mount=[], fstab=[FSTAB_ENTRY]),
+            False
+        ),
+        (
+            StorageInfo(mount=[MOUNT_ENTRY], fstab=[FSTAB_ENTRY]),
+            False
+        ),
+    ]
+)
+def test_var_lib_leapp_non_persistent_is_detected(monkeypatch, storage_info, should_inhibit):
+
+    created_reports = create_report_mocked()
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[storage_info]))
+    monkeypatch.setattr(reporting, 'create_report', created_reports)
+
+    check_persistent_mounts()
+
+    assert bool(created_reports.called) == should_inhibit


### PR DESCRIPTION
A new `check_persistent_mounts` actor checks if `/var/lib/leapp` is mounted
and in that case checks if there is an `/etc/fstab` entry with this
mountpoint. If there isn't, the upgrade is inhibited. This ensures
`/var/lib/leapp/` will be available after a reboot for leapp toaccess the
upgrade environment. access the upgrade environment.

Jira ref: OAMG-7070

Tested on RHEL7 by mounting `/var/lib/leapp' to a directory using bind mount. Example report:

```
Risk Factor: high (inhibitor)
Title: Detected partitions mounted in a non-persistent fashion, preventing a successful in-place upgrade.
Summary: Leapp detected that the /var/lib/leapp mountpoint is mounted, with no corresponding entry in /etc/fstab. The upgrade process cannot continue with /var/lib/leapp mounted in non-persistent fashion, as Leapp needs this mount to be available after a reboot.
Remediation: [hint] Add /var/lib/leapp mount entry to /etc/fstab
```