### PR TITLE
sssd: Fix sssd startup problem due to cache files

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/sssd_handle_cache_files/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/sssd_handle_cache_files/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.sssd_cache_files import remove_sssd_cache_files
+from leapp.models import SSSDConfig
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class SSSDHandleCacheFiles(Actor):
+    """
+    If an SSSD configuration has been detected, special handling for SSSD cache files will be scheduled.
+
+    After the upgrade from EL7 to EL8, SSSD isn't able to start anymore because the cache files have a newer
+    format in RHEL7.9 than in RHEL8. This is a workaround for this issue.
+    """
+
+    name = 'sssd_handle_cache_files'
+    consumes = (SSSDConfig,)
+    produces = ()
+    tags = (IPUWorkflowTag, ApplicationsPhaseTag)
+
+    def process(self):
+        remove_sssd_cache_files(
+            next(self.consume(SSSDConfig), None)
+        )

--- a/repos/system_upgrade/el7toel8/actors/sssd_handle_cache_files/libraries/sssd_cache_files.py
+++ b/repos/system_upgrade/el7toel8/actors/sssd_handle_cache_files/libraries/sssd_cache_files.py
@@ -1,0 +1,19 @@
+import glob
+import os
+
+from leapp.libraries.stdlib import api
+
+
+def remove_sssd_cache_files(config):
+    """
+    Remove all SSSD cache files.
+    """
+    if not config:
+        return
+
+    for cache_file in glob.glob('/var/lib/sss/db/*.ldb'):
+        try:
+            api.current_logger().info('Pruning SSSD cache file {}'.format(cache_file))
+            os.remove(cache_file)
+        except OSError:
+            api.current_logger().warning('Failed to remove cache file: %s', cache_file)

--- a/repos/system_upgrade/el7toel8/actors/sssd_handle_cache_files/tests/unit_test_sssd_handle_cache_files.py
+++ b/repos/system_upgrade/el7toel8/actors/sssd_handle_cache_files/tests/unit_test_sssd_handle_cache_files.py
@@ -1,0 +1,23 @@
+import os
+
+from leapp.libraries.actor import sssd_cache_files
+
+
+def glob_sssd_files(path_spec):
+    if path_spec.endswith('*.ldb'):
+        path_spec = path_spec[:-5]
+        return list([os.path.join(path_spec, 'removed_file1.ldb'), os.path.join(path_spec, 'removed_file2.ldb')])
+    return []
+
+
+def test_remove_sssd_cache_files(monkeypatch):
+    monkeypatch.setattr(
+        sssd_cache_files.glob,
+        'glob',
+        glob_sssd_files)
+    removed = []
+    monkeypatch.setattr(sssd_cache_files.os, 'remove', removed.append)
+    sssd_cache_files.remove_sssd_cache_files(None)
+    assert not removed
+    sssd_cache_files.remove_sssd_cache_files(True)
+    assert removed == ['/var/lib/sss/db/removed_file1.ldb', '/var/lib/sss/db/removed_file2.ldb']


### PR DESCRIPTION
In RHEL8 sssd uses a lower version for the sssd cache file format than
in RHEL7.9 which causes the SSSD service to fail on startup after the
upgrade.

This patch solves this problem by adding a workaround to remove the sssd
cache files during the upgrade.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2109309
Jira ref.: OAMG-7246