### PR TITLE
Add Makefile targets for running tests in containers

### DIFF
--- a/utils/container-tests/Containerfile.f34
+++ b/utils/container-tests/Containerfile.f34
@@ -1,0 +1,18 @@
+FROM fedora:34
+
+VOLUME /repo
+
+RUN dnf update -y && \
+    dnf install -y findutils make rsync
+
+ENV PYTHON_VENV python3.9
+
+RUN cp -a /repo /repocopy
+
+WORKDIR /repocopy
+
+RUN rm -rf tut*
+
+RUN make clean && make install-deps-fedora
+
+WORKDIR /

--- a/utils/container-tests/Containerfile.rhel7
+++ b/utils/container-tests/Containerfile.rhel7
@@ -1,0 +1,24 @@
+FROM registry.access.redhat.com/ubi7/ubi:7.9
+
+VOLUME /repo
+
+RUN yum update -y && \
+    yum install -y python-virtualenv python-setuptools make git rsync
+
+# see ./Containerfile.ubi7 for explanation
+RUN yum -y install python27-python-pip && \
+    scl enable python27 -- pip install -U --target /usr/lib/python2.7/site-packages/ pip==20.3.0 && \
+    python -m pip install --ignore-installed pip==20.3.4 ipaddress virtualenv
+
+ENV PYTHON_VENV python2.7
+
+RUN cp -a /repo /repocopy
+
+WORKDIR /repocopy
+
+RUN rm -rf tut*
+
+RUN make clean && make install-deps
+
+WORKDIR /
+

--- a/utils/container-tests/Containerfile.rhel8
+++ b/utils/container-tests/Containerfile.rhel8
@@ -1,0 +1,18 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+VOLUME /repo
+
+RUN dnf update -y && \
+    dnf install -y python3-virtualenv python3-setuptools python3-pip make git rsync
+
+ENV PYTHON_VENV python3.6
+
+RUN cp -a /repo /repocopy
+
+WORKDIR /repocopy
+
+RUN rm -rf tut*
+
+RUN make clean && make install-deps-fedora
+
+WORKDIR /


### PR DESCRIPTION
Running tests in containers brings multiple benefits:
 - avoids conflicts between multiple repositories (unsafe namespaces)
 - allows running test on host where tests are broken (e.g. Fedora 35)
 - avoids polluting the host with dependencies, the only dependency is `podman`

To run tests in container run `make test_container`.
To run justs test without linitinh run `make test_container_no_lint`.
By default `rhel8` container is used. To change the container set the
`TEST_CONTAINER` environment variable. For example
`TEST_CONTAINER="rhel7" make test_container`.

There are also targets for running tests in all available containers,
`test_container_all` and `test_container_no_lint`.

Since tests are already being run in parallel, the `test_container_all` and
`test_container_all_no_lint` targets don't run containers in parallel as
this would bring no benefit.

Available containers are `f34`, `rhel7` and `rhel8`.

On first run container image with dependencies installed is built. This
acts as a cache to avoid installing dependencies on every run.
Subsequent runs reuse the image. To delete these images (to force a
rebuild for example) run `make clean_containers`.

Cointainer images are built from Containerfiles in
`utils/container-tests/`. Existing `Containerfile.ubi*` container files
couldn't be reused, because extra dependencies are needed e.g. `rsync`
and because of having `ENTRYPOINT` set, which is undesirable as
container setup is needed before running the tests.

On some Python versions two IPUs are tested, because for example both
el7toeel8 and el8toel9 IPUs must work on python3.6 as this is the
version on RHEL8.

Tests are run in a copy of the repository, host is not modified. For
copying `rsync` is used to easily keep repo on the host in sync with the
copy in the container and exclude system specific files we don't want to
sync such as virtualenv. Since rsync is called only from inside the
containers it is not required to be installed on the host system.

Jira ref: OAMG-6965