### PR TITLE
Enable 8to9 ipu on aws sap

### DIFF
--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -118,17 +118,16 @@ RHUI_CLOUD_MAP = {
                 ('leapp-aws.repo', YUM_REPOS_PATH)
             ],
         },
-        # not yet enabled
         'aws-sap-e4s': {
-            'src_pkg': 'rh-amazon-rhui-client-sap-bundle',
+            'src_pkg': 'rh-amazon-rhui-client-sap-bundle-e4s',
             'target_pkg': 'rh-amazon-rhui-client-sap-bundle-e4s',
             'leapp_pkg': 'leapp-rhui-aws-sap-e4s',
             'leapp_pkg_repo': 'leapp-aws-sap-e4s.repo',
             'files_map': [
                 ('rhui-client-config-server-9-sap-bundle.crt', RHUI_PKI_PRODUCT_DIR),
                 ('rhui-client-config-server-9-sap-bundle.key', RHUI_PKI_DIR),
-                ('content-rhel9-sap.crt', RHUI_PKI_PRODUCT_DIR),
-                ('content-rhel9-sap.key', RHUI_PKI_DIR),
+                ('content-rhel9-sap-bundle-e4s.crt', RHUI_PKI_PRODUCT_DIR),
+                ('content-rhel9-sap-bundle-e4s.key', RHUI_PKI_DIR),
                 ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
                 ('leapp-aws-sap-e4s.repo', YUM_REPOS_PATH)
             ],


### PR DESCRIPTION
This PR adds 8to9 upgrade path for SAP systems running on AWS. At the moment, the PR is sort of a Frankenstein's monster composed of commits cherry-picket from other PRs, therefore, it should be merged after #919 and #918 are merged.

Jira-ref: OAMG-7171