### PR TITLE
selinux: Improve importing customizations

### DIFF
--- a/repos/system_upgrade/common/actors/selinux/selinuxapplycustom/actor.py
+++ b/repos/system_upgrade/common/actors/selinux/selinuxapplycustom/actor.py
@@ -101,6 +101,8 @@ class SELinuxApplyCustom(Actor):
                 )
                 # Retry, but install each module separately
                 for module in semodules.modules:
+                    if module.name in installed_modules:
+                        continue
                     cil_filename = os.path.join(
                         WORKING_DIRECTORY, '{}.cil'.format(module.name)
                     )
@@ -126,32 +128,20 @@ class SELinuxApplyCustom(Actor):
                     '\n'.join(custom.commands)
                 )
             )
-            semanage_filename = os.path.join(WORKING_DIRECTORY, 'semanage')
-            # save SELinux customizations to disk
-            try:
-                with open(semanage_filename, 'w') as s_file:
-                    s_file.write('\n'.join(custom.commands))
-            except OSError as e:
-                self.log.warning(
-                    'Error writing SELinux customizations to disk: {}'.format(e)
-                )
-                failed_custom.extend(custom.commands)
             # import customizations
             try:
-                run(['semanage', 'import', '-f', semanage_filename])
+                run(['semanage', 'import'], stdin='\n'.join(custom.commands))
             except CalledProcessError as e:
                 self.log.warning(
-                    'Failed to import SELinux customizations: {}'.format(e.stderr)
+                    'Error importing SELinux customizations in a single transaction:'
+                    '{}\nRetrying -- now each command will be applied separately.'.format(e.stderr)
                 )
-                failed_custom.extend(custom.commands)
-                continue
-            # clean-up
-            try:
-                os.remove(semanage_filename)
-            except OSError as e:
-                self.log.warning(
-                    'Failed to remove temporary file {}: {}'.format(semanage_filename, e)
-                )
+                for cmd in custom.commands:
+                    try:
+                        run(['semanage', 'import'], stdin='{}\n'.format(cmd))
+                    except CalledProcessError as e:
+                        self.log.warning('Error applying "semanage {}": {}'.format(cmd, e.stderr))
+                        failed_custom.append(cmd)
                 continue
 
         # clean-up

--- a/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/libraries/selinuxcontentscanner.py
+++ b/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/libraries/selinuxcontentscanner.py
@@ -227,6 +227,10 @@ def get_selinux_customizations():
         # can be reapplied after the upgrade
         semanage = run(["semanage", "export"], split=True)
         for line in semanage.get("stdout", []):
+            # Skip "deleteall" commands to avoid removing customizations
+            # done by package scripts during upgrade
+            if " -D" in line:
+                continue
             for setype in removed_types:
                 if setype in line:
                     semanage_removed.append(line)

--- a/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/tests/unit_test_selinuxcontentscanner.py
+++ b/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/tests/unit_test_selinuxcontentscanner.py
@@ -68,7 +68,8 @@ def test_get_selinux_customizations(monkeypatch):
 
     (semanage_valid, semanage_removed) = selinuxcontentscanner.get_selinux_customizations()
 
-    assert len(semanage_valid) == 11
-    assert semanage_valid[0] == "boolean -D"
-    assert semanage_valid[10] == "fcontext -a -f a -t httpd_sys_content_t '/web(/.*)?'"
+    assert len(semanage_valid) == 3
+    assert semanage_valid[0] == "boolean -m -1 cron_can_relabel"
+    assert semanage_valid[1] == "port -a -t http_port_t -p udp 81"
+    assert semanage_valid[2] == "fcontext -a -f a -t httpd_sys_content_t '/web(/.*)?'"
     assert semanage_removed == ["fcontext -a -f a -t cgdcbxd_exec_t '/ganesha(/.*)?'"]


### PR DESCRIPTION
Re-applying customizations in a single transaction may fail in case a
package already applied it during upgrade. Fall back to applying
customizations one by one.

Stop using a file for "semanage import", since "stdin" is much cleaner.

Do not import "delete all" commands to avoid removing customizations
done by package scripts during upgrade.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2111074

Signed-off-by: Vit Mojzis <vmojzis@redhat.com>