### PR TITLE
RHUI: Add 7to8 upgrade path for SAP Apps on Azure

### DIFF
--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -66,6 +66,20 @@ RHUI_CLOUD_MAP = {
                 ('leapp-azure.repo', YUM_REPOS_PATH)
             ],
         },
+        'azure-sap-apps': {
+            'src_pkg': 'rhui-azure-rhel7-base-sap-apps',
+            'target_pkg': 'rhui-azure-rhel8-sapapps',
+            'agent_pkg': 'WALinuxAgent',
+            'leapp_pkg': 'leapp-rhui-azure-sap',
+            'leapp_pkg_repo': 'leapp-azure-sap-apps.repo',
+            'files_map': [
+                ('content-rhel8-eus.crt', RHUI_PKI_PRODUCT_DIR),
+                ('content-rhel8-sapapps.crt', RHUI_PKI_PRODUCT_DIR),
+                ('key-rhel8-eus.pem', RHUI_PKI_DIR),
+                ('key-rhel8-sapapps.pem', RHUI_PKI_DIR),
+                ('leapp-azure-sap-apps.repo', YUM_REPOS_PATH),
+            ],
+        },
         'azure-sap': {
             'src_pkg': 'rhui-azure-rhel7-base-sap-ha',
             'target_pkg': 'rhui-azure-rhel8-sap-ha',


### PR DESCRIPTION
At the moment Leapp supports upgrades of SAP HA RHEL7 systems on Azure, however, we have found that there is another variant of SAP RHEL7 systems which will require a special care in order for Leapp to be able to upgrade it correctly. This patch adds a support for 7to8 upgrade of SAP Apps systems on Azure.