### PR TITLE
Inhibit Satellite migrations if PG data is a mount

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrade_check/libraries/satellite_upgrade_check.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrade_check/libraries/satellite_upgrade_check.py
@@ -28,7 +28,10 @@ def satellite_upgrade_check(facts):
             summary = "Your PostgreSQL data will be automatically migrated."
         else:
             scl_psql_path = '/var/opt/rh/rh-postgresql12/lib/pgsql/data/'
-            if facts.postgresql.space_required > facts.postgresql.space_available:
+            if facts.dedicated_partition:
+                flags = [reporting.Flags.INHIBITOR]
+                severity = reporting.Severity.HIGH
+            elif facts.postgresql.space_required > facts.postgresql.space_available:
                 storage_message = """You currently don't have enough free storage to move the data.
                 Automatic moving cannot be performed."""
                 flags = [reporting.Flags.INHIBITOR]

--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/actor.py
@@ -74,6 +74,7 @@ class SatelliteUpgradeFacts(Actor):
         bytes_required = None
         bytes_available = None
         old_pgsql_data = False
+        dedicated_partition = False
 
         if local_postgresql:
             """
@@ -100,6 +101,7 @@ class SatelliteUpgradeFacts(Actor):
                     break
 
             if scl_psql_stat.st_dev != nonscl_psql_stat.st_dev:
+                dedicated_partition = os.path.ismount(POSTGRESQL_SCL_DATA_PATH)
                 on_same_partition = False
                 # get the current disk usage of the PostgreSQL data
                 scl_du_call = run(['du', '--block-size=1', '--summarize', POSTGRESQL_SCL_DATA_PATH])
@@ -124,6 +126,7 @@ class SatelliteUpgradeFacts(Actor):
             postgresql=SatellitePostgresqlFacts(
                 local_postgresql=local_postgresql,
                 old_var_lib_pgsql_data=old_pgsql_data,
+                dedicated_partition=dedicated_partition,
                 same_partition=on_same_partition,
                 space_required=bytes_required,
                 space_available=bytes_available,


### PR DESCRIPTION
shutil.move fails if the source directory is a mountpoint. The short term solution is to inhibit the migration so the user doesn't end up in a broken state. Long term we may want to introduce a bind mount or otherwise.

https://bugzilla.redhat.com/show_bug.cgi?id=2111835

This is a draft PR to start the conversation.