### PR TITLE
Add Makefile target for building RPMs locally in containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,12 @@ eggs/
 .eggs/
 lib/
 lib64/
+packaging/BUILD/
+packaging/BUILDROOT/
 packaging/SRPMS/
+packaging/RPMS/
 packaging/sources/
+packaging/tmp/
 parts/
 sdist/
 tut/

--- a/utils/container-builds/Containerfile.centos7
+++ b/utils/container-builds/Containerfile.centos7
@@ -1,0 +1,10 @@
+FROM centos:7
+
+VOLUME /repo
+
+RUN yum update -y && \
+    yum install -y rpm-build python-devel make git
+
+WORKDIR /repo
+ENV DIST_VERSION 7
+ENTRYPOINT make _build_local

--- a/utils/container-builds/Containerfile.ubi8
+++ b/utils/container-builds/Containerfile.ubi8
@@ -1,0 +1,10 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+VOLUME /repo
+
+RUN dnf update -y && \
+    dnf install -y python3-devel rpm-build make git
+
+WORKDIR /repo
+ENV DIST_VERSION 8
+ENTRYPOINT make _build_local


### PR DESCRIPTION
Builds are done in containers where dependencies can be met, for example
`python-devel` (python2) on el7, which might not be available on host
machine.

For el7 builds CentOS 7 container is used, because `rpm-build` package
is not available on ubi7.

To build RPMs in a container use `make build_container`. The
`BUILD_CONTAINER` variable must be set to either `el7` or `el8`.

Also added `.gitignore` entries for subfolders in `packaging/` as
packages and intermediate build files shouldn`t be in the repo.