### PR TITLE
Make flake8 happy with E275

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/checkbind/libraries/iscmodel.py
+++ b/repos/system_upgrade/el7toel8/actors/checkbind/libraries/iscmodel.py
@@ -18,7 +18,7 @@ def add_statement(statement, state):
 def find_dnssec_lookaside(statement, state):
     try:
         arg = statement.var(1)
-        if not(arg.type() == arg.TYPE_BARE and arg.value() == 'no'):
+        if not (arg.type() == arg.TYPE_BARE and arg.value() == 'no'):
             # auto or yes statement
             # dnssec-lookaside "." trust-anchor "dlv.isc.org";
             add_statement(statement, state)


### PR DESCRIPTION
One space after keywords is a decent rule, let's not violate
it.