### PR TITLE
Add possibility to use docker to run tests and build in containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,6 @@ _build_local: source
 	@mv packaging/$(PKGNAME).spec.bak packaging/$(PKGNAME).spec
 
 build_container:
-	@[ "$(_CONTAINER_TOOL)" == "docker" -a "$$UID" -ne 0 ] && { echo "Container tool 'docker' must be run as root!"; exit 1; }; \
 	echo "--- Build RPM ${PKGNAME}-${VERSION}-${RELEASE}.el$(DIST_VERSION).rpm in container ---"; \
 	case "$(BUILD_CONTAINER)" in \
 		el7) \
@@ -381,7 +380,6 @@ _test_container_ipu:
 # because e.g. RHEL7 to RHEL8 IPU must work on python2.7 and python3.6
 # and RHEL8 to RHEL9 IPU must work on python3.6 and python3.9.
 test_container:
-	@[ "$(_CONTAINER_TOOL)" == "docker" -a "$$UID" -ne 0 ] && { echo "The 'docker' container tool must be run as root!"; exit 1; }; \
 	case $(_TEST_CONTAINER) in \
 	f34) \
 		export CONT_FILE="utils/container-tests/Containerfile.f34"; \
@@ -441,7 +439,6 @@ test_container_all_no_lint:
 
 # clean all testing and building containers and their images
 clean_containers:
-	@[ "$(_CONTAINER_TOOL)" == "docker" -a "$$UID" -ne 0 ] && { echo "Container tool 'docker' must be run as root!"; exit 1; }; \
 	for i in "leapp-repo-tests-f34" "leapp-repo-tests-rhel7" "leapp-repo-tests-rhel8" \
 	"leapp-repo-build-el7" "leapp-repo-build-el8"; do \
 		$(_CONTAINER_TOOL) kill "$$i-cont" || :; \

--- a/utils/container-tests/Containerfile.f34
+++ b/utils/container-tests/Containerfile.f34
@@ -7,7 +7,7 @@ RUN dnf update -y && \
 
 ENV PYTHON_VENV python3.9
 
-RUN cp -a /repo /repocopy
+COPY . /repocopy
 
 WORKDIR /repocopy
 

--- a/utils/container-tests/Containerfile.rhel7
+++ b/utils/container-tests/Containerfile.rhel7
@@ -12,7 +12,7 @@ RUN yum -y install python27-python-pip && \
 
 ENV PYTHON_VENV python2.7
 
-RUN cp -a /repo /repocopy
+COPY . /repocopy
 
 WORKDIR /repocopy
 

--- a/utils/container-tests/Containerfile.rhel8
+++ b/utils/container-tests/Containerfile.rhel8
@@ -7,7 +7,7 @@ RUN dnf update -y && \
 
 ENV PYTHON_VENV python3.6
 
-RUN cp -a /repo /repocopy
+COPY . /repocopy
 
 WORKDIR /repocopy
 


### PR DESCRIPTION
On some systems podman is unavailable. Also, some people prefer docker
over podman. Add possibility to use docker to run tests and build
packages.

Set the `CONTAINER_TOOL` environment variable to change the container
tool used for running tests and building packages, for example:
`CONTAINER_TOOL="docker" make test_container`.

Unless you are running the Docker daemon in rootless mode, you will have
to run as root. In such case files created in `packaging/` using `make
build_container` will be owned by root. To change the ownership back to
your user, you can for example run `chown -R $USER packaging/`.

Several podman commands and options such as `container exists` are
unavailable in docker, therefore a more ugly but compatible alternative
is used.

It is also impossible to mount a volume during `docker build`. The
Containerfile `COPY` directive works around that.

Jira ref: OAMG-7286