### PR TITLE
Stop debug kernelopt from getting to target

### DIFF
--- a/repos/system_upgrade/common/actors/addupgradebootentry/actor.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/actor.py
@@ -1,9 +1,9 @@
 import os
 
 from leapp.actors import Actor
-from leapp.libraries.actor.addupgradebootentry import add_boot_entry, fix_grub_config_error
-from leapp.models import BootContent, GrubConfigError, FirmwareFacts, TransactionDryRun
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor.addupgradebootentry import add_boot_entry, fix_grub_config_error
+from leapp.models import BootContent, FirmwareFacts, GrubConfigError, TargetKernelCmdlineArgTasks, TransactionDryRun
 from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
 
 
@@ -16,7 +16,7 @@ class AddUpgradeBootEntry(Actor):
 
     name = 'add_upgrade_boot_entry'
     consumes = (BootContent, GrubConfigError, FirmwareFacts, TransactionDryRun)
-    produces = ()
+    produces = (TargetKernelCmdlineArgTasks,)
     tags = (IPUWorkflowTag, InterimPreparationPhaseTag)
 
     def process(self):

--- a/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
@@ -5,10 +5,10 @@ import pytest
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import addupgradebootentry
-from leapp.libraries.common.config.architecture import ARCH_X86_64, ARCH_S390X
-from leapp.libraries.common.testutils import CurrentActorMocked
+from leapp.libraries.common.config.architecture import ARCH_S390X, ARCH_X86_64
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
 from leapp.libraries.stdlib import api
-from leapp.models import BootContent
+from leapp.models import BootContent, KernelCmdlineArg, TargetKernelCmdlineArgTasks
 
 CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -65,6 +65,7 @@ def test_add_boot_entry(monkeypatch, run_args, arch):
         return '/abc', '/def'
 
     monkeypatch.setattr(addupgradebootentry, 'get_boot_file_paths', get_boot_file_paths_mocked)
+    monkeypatch.setattr(api, 'produce', produce_mocked())
     monkeypatch.setenv('LEAPP_DEBUG', '1')
     monkeypatch.setattr(addupgradebootentry, 'run', run_mocked())
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch))
@@ -74,9 +75,33 @@ def test_add_boot_entry(monkeypatch, run_args, arch):
     assert len(addupgradebootentry.run.args) == run_args.args_len
     assert addupgradebootentry.run.args[0] == run_args.args_remove
     assert addupgradebootentry.run.args[1] == run_args.args_add
+    assert api.produce.model_instances == [
+        TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='debug')])
+    ]
 
     if run_args.args_zipl:
         assert addupgradebootentry.run.args[2] == run_args.args_zipl
+
+
+@pytest.mark.parametrize('is_leapp_invoked_with_debug', [True, False])
+def test_debug_kernelopt_removal_task_production(monkeypatch, is_leapp_invoked_with_debug):
+    def get_boot_file_paths_mocked():
+        return '/abc', '/def'
+
+    monkeypatch.setattr(addupgradebootentry, 'get_boot_file_paths', get_boot_file_paths_mocked)
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setenv('LEAPP_DEBUG', '1' if is_leapp_invoked_with_debug else '0')
+    monkeypatch.setattr(addupgradebootentry, 'run', run_mocked())
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+
+    addupgradebootentry.add_boot_entry()
+
+    expected_produced_messages = []
+    if is_leapp_invoked_with_debug:
+        expected_produced_messages = [TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='debug')])]
+
+    assert api.produce.model_instances == expected_produced_messages
 
 
 def test_add_boot_entry_configs(monkeypatch):
@@ -86,7 +111,8 @@ def test_add_boot_entry_configs(monkeypatch):
     monkeypatch.setattr(addupgradebootentry, 'get_boot_file_paths', get_boot_file_paths_mocked)
     monkeypatch.setenv('LEAPP_DEBUG', '1')
     monkeypatch.setattr(addupgradebootentry, 'run', run_mocked())
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(ARCH_X86_64))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', produce_mocked())
 
     addupgradebootentry.add_boot_entry(CONFIGS)
 
@@ -95,6 +121,9 @@ def test_add_boot_entry_configs(monkeypatch):
     assert addupgradebootentry.run.args[1] == run_args_remove + ['-c', CONFIGS[1]]
     assert addupgradebootentry.run.args[2] == run_args_add + ['-c', CONFIGS[0]]
     assert addupgradebootentry.run.args[3] == run_args_add + ['-c', CONFIGS[1]]
+    assert api.produce.model_instances == [
+        TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='debug')])
+    ]
 
 
 def test_get_boot_file_paths(monkeypatch):

--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/actor.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/actor.py
@@ -1,10 +1,10 @@
 import os
 
 from leapp.actors import Actor
-from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg, FirmwareFacts
-from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import kernelcmdlineconfig
+from leapp.models import FirmwareFacts, InstalledTargetKernelVersion, KernelCmdlineArg, TargetKernelCmdlineArgTasks
+from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
 
 
 class KernelCmdlineConfig(Actor):
@@ -13,7 +13,7 @@ class KernelCmdlineConfig(Actor):
     """
 
     name = 'kernelcmdlineconfig'
-    consumes = (KernelCmdlineArg, InstalledTargetKernelVersion, FirmwareFacts)
+    consumes = (KernelCmdlineArg, InstalledTargetKernelVersion, FirmwareFacts, TargetKernelCmdlineArgTasks)
     produces = ()
     tags = (FinalizationPhaseTag, IPUWorkflowTag)
 

--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/actor.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/actor.py
@@ -29,4 +29,4 @@ class KernelCmdlineConfig(Actor):
 
         if ff.firmware == 'bios' and os.path.ismount('/boot/efi'):
             configs = ['/boot/grub2/grub.cfg', '/boot/efi/EFI/redhat/grub.cfg']
-        kernelcmdlineconfig.process(configs)
+        kernelcmdlineconfig.modify_kernel_args_in_boot_configs(configs)

--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/actor.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/actor.py
@@ -29,4 +29,4 @@ class KernelCmdlineConfig(Actor):
 
         if ff.firmware == 'bios' and os.path.ismount('/boot/efi'):
             configs = ['/boot/grub2/grub.cfg', '/boot/efi/EFI/redhat/grub.cfg']
-        kernelcmdlineconfig.modify_kernel_args_in_boot_configs(configs)
+        kernelcmdlineconfig.modify_kernel_args_in_boot_cfg(configs)

--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
@@ -2,7 +2,7 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries import stdlib
 from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
-from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg
+from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg, TargetKernelCmdlineArgTasks
 
 
 def run_grubby_cmd(cmd):
@@ -20,29 +20,47 @@ def run_grubby_cmd(cmd):
             details={"details": str(e)})
 
 
-def append_kernel_args_in_boot_cfg(configs_to_modify_explicitly=None):
+def format_kernelarg_msgs_for_grubby_cmd(kernelarg_msgs):
+    kernelarg_msgs = sorted(kernelarg_msgs, key=lambda arg: arg.key)
+    kernel_args = []
+    for arg in kernelarg_msgs:
+        if arg.value:
+            kernel_args.append('{0}={1}'.format(arg.key, arg.value))
+        else:
+            kernel_args.append('{0}'.format(arg.key))
+    return ' '.join(kernel_args)
+
+
+def modify_kernel_args_in_boot_cfg(configs_to_modify_explicitly=None):
     kernel_version = next(api.consume(InstalledTargetKernelVersion), None)
     if not kernel_version:
         return
 
-    kernelarg_msgs = sorted(api.consume(KernelCmdlineArg), key=lambda arg: arg.key)
-    if not kernelarg_msgs:
-        return  # No kernel args modification was requested
+    # Collect desired kernelopt modifications
+    kernelargs_msgs_to_add = list(api.consume(KernelCmdlineArg))
+    kernelargs_msgs_to_remove = []
+    for target_kernel_arg_task in api.consume(TargetKernelCmdlineArgTasks):
+        kernelargs_msgs_to_add.extend(target_kernel_arg_task.to_add)
+        kernelargs_msgs_to_remove.extend(target_kernel_arg_task.to_remove)
 
-    # Format the received args so they can be joined and passed to grubby --args=
-    kernel_args_to_append = []
-    for arg in kernelarg_msgs:
-        if arg.value:
-            kernel_args_to_append.append('{0}={1}'.format(arg.key, arg.value))
-        else:
-            kernel_args_to_append.append('{0}'.format(arg.key))
+    if not kernelargs_msgs_to_add and not kernelargs_msgs_to_remove:
+        return  # There is no work to do
 
-    grubby_append_args_cmd = ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(kernel_version.version),
-                              '--args={}'.format(' '.join(kernel_args_to_append))]
+    grubby_modify_kernelargs_cmd = ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(kernel_version.version)]
+
+    if kernelargs_msgs_to_add:
+        grubby_modify_kernelargs_cmd += [
+            '--args', '{}'.format(format_kernelarg_msgs_for_grubby_cmd(kernelargs_msgs_to_add))
+        ]
+
+    if kernelargs_msgs_to_remove:
+        grubby_modify_kernelargs_cmd += [
+            '--remove-args', '{}'.format(format_kernelarg_msgs_for_grubby_cmd(kernelargs_msgs_to_remove))
+        ]
 
     if configs_to_modify_explicitly:
         for config_to_modify in configs_to_modify_explicitly:
-            cmd = grubby_append_args_cmd + ['-c', config_to_modify]
+            cmd = grubby_modify_kernelargs_cmd + ['-c', config_to_modify]
             run_grubby_cmd(cmd)
     else:
-        run_grubby_cmd(grubby_append_args_cmd)
+        run_grubby_cmd(grubby_modify_kernelargs_cmd)

--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
@@ -5,28 +5,44 @@ from leapp.libraries.stdlib import api
 from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg
 
 
-def process(configs=None):
-    kernel_version = next(api.consume(InstalledTargetKernelVersion), None)
-    if kernel_version:
-        while True:
-            config = []
-            if configs:
-                config = ['-c', configs.pop(0)]
-            for arg in api.consume(KernelCmdlineArg):
-                cmd = ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(kernel_version.version),
-                       '--args={}={}'.format(arg.key, arg.value)]
-                cmd += config
-                try:
-                    stdlib.run(cmd)
-                    if architecture.matches_architecture(architecture.ARCH_S390X):
-                        # on s390x we need to call zipl explicitly because of issue in grubby,
-                        # otherwise the entry is not updated in the ZIPL bootloader
-                        # See https://bugzilla.redhat.com/show_bug.cgi?id=1764306
-                        stdlib.run(['/usr/sbin/zipl'])
+def run_grubby_cmd(cmd):
+    try:
+        stdlib.run(cmd)
+        if architecture.matches_architecture(architecture.ARCH_S390X):
+            # On s390x we need to call zipl explicitly because of issue in grubby,
+            # otherwise the entry is not updated in the ZIPL bootloader
+            # See https://bugzilla.redhat.com/show_bug.cgi?id=1764306
+            stdlib.run(['/usr/sbin/zipl'])
 
-                except (OSError, stdlib.CalledProcessError) as e:
-                    raise StopActorExecutionError(
-                        "Failed to append extra arguments to kernel command line.",
-                        details={"details": str(e)})
-            if not configs:
-                break
+    except (OSError, stdlib.CalledProcessError) as e:
+        raise StopActorExecutionError(
+            "Failed to append extra arguments to kernel command line.",
+            details={"details": str(e)})
+
+
+def append_kernel_args_in_boot_cfg(configs_to_modify_explicitly=None):
+    kernel_version = next(api.consume(InstalledTargetKernelVersion), None)
+    if not kernel_version:
+        return
+
+    kernelarg_msgs = sorted(api.consume(KernelCmdlineArg), key=lambda arg: arg.key)
+    if not kernelarg_msgs:
+        return  # No kernel args modification was requested
+
+    # Format the received args so they can be joined and passed to grubby --args=
+    kernel_args_to_append = []
+    for arg in kernelarg_msgs:
+        if arg.value:
+            kernel_args_to_append.append('{0}={1}'.format(arg.key, arg.value))
+        else:
+            kernel_args_to_append.append('{0}'.format(arg.key))
+
+    grubby_append_args_cmd = ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(kernel_version.version),
+                              '--args={}'.format(' '.join(kernel_args_to_append))]
+
+    if configs_to_modify_explicitly:
+        for config_to_modify in configs_to_modify_explicitly:
+            cmd = grubby_append_args_cmd + ['-c', config_to_modify]
+            run_grubby_cmd(cmd)
+    else:
+        run_grubby_cmd(grubby_append_args_cmd)

--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
@@ -1,11 +1,13 @@
 from collections import namedtuple
 
+import pytest
+
 from leapp.libraries import stdlib
 from leapp.libraries.actor import kernelcmdlineconfig
 from leapp.libraries.common.config import architecture
 from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.stdlib import api
-from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg
+from leapp.models import InstalledTargetKernelVersion, KernelCmdlineArg, TargetKernelCmdlineArgTasks
 
 KERNEL_VERSION = '1.2.3-4.x86_64.el8'
 
@@ -19,64 +21,89 @@ class MockedRun(object):
         return {}
 
 
-def mocked_consume(*models):
-    if InstalledTargetKernelVersion in models:
-        return iter((InstalledTargetKernelVersion(version=KERNEL_VERSION),))
-    return iter((
-        KernelCmdlineArg(key='some_key1', value='some_value1'),
-        KernelCmdlineArg(key='some_key2', value='some_value2')
-    ))
+@pytest.mark.parametrize(
+    ('msgs', 'expected_grubby_kernelopt_args'),
+    [
+        (
+            [KernelCmdlineArg(key='key1', value='value1'), KernelCmdlineArg(key='key2', value='value2')],
+            ['--args', 'key1=value1 key2=value2']
+        ),
+        (
+            [TargetKernelCmdlineArgTasks(to_add=[KernelCmdlineArg(key='key1', value='value1'),
+                                                 KernelCmdlineArg(key='key2')])],
+            ['--args', 'key1=value1 key2']
+        ),
+        (
+            [TargetKernelCmdlineArgTasks(to_add=[KernelCmdlineArg(key='key1', value='value1')]),
+             KernelCmdlineArg(key='key2', value='value2')],
+            ['--args', 'key1=value1 key2=value2']
+        ),
+        (
+            [TargetKernelCmdlineArgTasks(to_add=[KernelCmdlineArg(key='key1', value='value1')],
+                                         to_remove=[KernelCmdlineArg(key='key3')]),
+             KernelCmdlineArg(key='key2', value='value2')],
+            ['--args', 'key1=value1 key2=value2', '--remove-args', 'key3']
+        ),
+        (
+            [TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='key3'), KernelCmdlineArg(key='key4')])],
+            ['--remove-args', 'key3 key4']
+        ),
+    ]
+)
+def test_kernelcmdline_config_valid_msgs(monkeypatch, msgs, expected_grubby_kernelopt_args):
+    grubby_base_cmd = ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(KERNEL_VERSION)]
+    expected_grubby_cmd = grubby_base_cmd + expected_grubby_kernelopt_args
 
-
-def mocked_consume_no_args(*models):
-    if InstalledTargetKernelVersion in models:
-        return iter((InstalledTargetKernelVersion(version=KERNEL_VERSION),))
-    return iter(())
-
-
-def mocked_consume_no_version(*models):
-    if InstalledTargetKernelVersion in models:
-        return iter(())
-    assert False and 'this should not be called'  # pylint: disable=condition-evals-to-constant
-    return iter(())
-
-
-def test_kernelcmdline_config_intel(monkeypatch):
     mocked_run = MockedRun()
     monkeypatch.setattr(stdlib, 'run', mocked_run)
-    monkeypatch.setattr(api, 'consume', mocked_consume)
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
-    kernelcmdlineconfig.append_kernel_args_in_boot_cfg()
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64,
+                        msgs=[InstalledTargetKernelVersion(version=KERNEL_VERSION)] + msgs))
+    kernelcmdlineconfig.modify_kernel_args_in_boot_cfg()
     assert mocked_run.commands and len(mocked_run.commands) == 1
-    assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
-        KERNEL_VERSION), '--args=some_key1=some_value1 some_key2=some_value2'] == mocked_run.commands.pop()
+    assert expected_grubby_cmd == mocked_run.commands.pop()
 
-
-def test_kernelcmdline_config_ibmz(monkeypatch):
     mocked_run = MockedRun()
     monkeypatch.setattr(stdlib, 'run', mocked_run)
-    monkeypatch.setattr(api, 'consume', mocked_consume)
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
-    kernelcmdlineconfig.append_kernel_args_in_boot_cfg()
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X,
+                        msgs=[InstalledTargetKernelVersion(version=KERNEL_VERSION)] + msgs))
+    kernelcmdlineconfig.modify_kernel_args_in_boot_cfg()
     assert mocked_run.commands and len(mocked_run.commands) == 2
-    assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
-        KERNEL_VERSION), '--args=some_key1=some_value1 some_key2=some_value2'] == mocked_run.commands.pop(0)
+    assert expected_grubby_cmd == mocked_run.commands.pop(0)
     assert ['/usr/sbin/zipl'] == mocked_run.commands.pop(0)
+
+
+def test_kernelcmdline_explicit_configs(monkeypatch):
+    mocked_run = MockedRun()
+    monkeypatch.setattr(stdlib, 'run', mocked_run)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64,
+                        msgs=[InstalledTargetKernelVersion(version=KERNEL_VERSION),
+                              TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='key1', value='value1')])]))
+
+    configs = ['/boot/grub2/grub.cfg', '/boot/efi/EFI/redhat/grub.cfg']
+    kernelcmdlineconfig.modify_kernel_args_in_boot_cfg(configs_to_modify_explicitly=configs)
+
+    grubby_cmd_without_config = ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(KERNEL_VERSION),
+                                 '--remove-args', 'key1=value1']
+    expected_cmds = [
+        grubby_cmd_without_config + ['-c', '/boot/grub2/grub.cfg'],
+        grubby_cmd_without_config + ['-c', '/boot/efi/EFI/redhat/grub.cfg']
+    ]
+
+    assert mocked_run.commands == expected_cmds
 
 
 def test_kernelcmdline_config_no_args(monkeypatch):
     mocked_run = MockedRun()
     monkeypatch.setattr(stdlib, 'run', mocked_run)
-    monkeypatch.setattr(api, 'consume', mocked_consume_no_args)
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
-    kernelcmdlineconfig.append_kernel_args_in_boot_cfg()
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X,
+                        msgs=[InstalledTargetKernelVersion(version=KERNEL_VERSION)]))
+    kernelcmdlineconfig.modify_kernel_args_in_boot_cfg()
     assert not mocked_run.commands
 
 
 def test_kernelcmdline_config_no_version(monkeypatch):
     mocked_run = MockedRun()
     monkeypatch.setattr(stdlib, 'run', mocked_run)
-    monkeypatch.setattr(api, 'consume', mocked_consume_no_version)
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
-    kernelcmdlineconfig.append_kernel_args_in_boot_cfg()
+    kernelcmdlineconfig.modify_kernel_args_in_boot_cfg()
     assert not mocked_run.commands

--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/tests/test_kernelcmdlineconfig.py
@@ -46,12 +46,10 @@ def test_kernelcmdline_config_intel(monkeypatch):
     monkeypatch.setattr(stdlib, 'run', mocked_run)
     monkeypatch.setattr(api, 'consume', mocked_consume)
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_X86_64))
-    kernelcmdlineconfig.process()
-    assert mocked_run.commands and len(mocked_run.commands) == 2
+    kernelcmdlineconfig.append_kernel_args_in_boot_cfg()
+    assert mocked_run.commands and len(mocked_run.commands) == 1
     assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
-        KERNEL_VERSION), '--args=some_key2=some_value2'] == mocked_run.commands.pop()
-    assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
-        KERNEL_VERSION), '--args=some_key1=some_value1'] == mocked_run.commands.pop()
+        KERNEL_VERSION), '--args=some_key1=some_value1 some_key2=some_value2'] == mocked_run.commands.pop()
 
 
 def test_kernelcmdline_config_ibmz(monkeypatch):
@@ -59,13 +57,10 @@ def test_kernelcmdline_config_ibmz(monkeypatch):
     monkeypatch.setattr(stdlib, 'run', mocked_run)
     monkeypatch.setattr(api, 'consume', mocked_consume)
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
-    kernelcmdlineconfig.process()
-    assert mocked_run.commands and len(mocked_run.commands) == 4
+    kernelcmdlineconfig.append_kernel_args_in_boot_cfg()
+    assert mocked_run.commands and len(mocked_run.commands) == 2
     assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
-        KERNEL_VERSION), '--args=some_key1=some_value1'] == mocked_run.commands.pop(0)
-    assert ['/usr/sbin/zipl'] == mocked_run.commands.pop(0)
-    assert ['grubby', '--update-kernel=/boot/vmlinuz-{}'.format(
-        KERNEL_VERSION), '--args=some_key2=some_value2'] == mocked_run.commands.pop(0)
+        KERNEL_VERSION), '--args=some_key1=some_value1 some_key2=some_value2'] == mocked_run.commands.pop(0)
     assert ['/usr/sbin/zipl'] == mocked_run.commands.pop(0)
 
 
@@ -74,7 +69,7 @@ def test_kernelcmdline_config_no_args(monkeypatch):
     monkeypatch.setattr(stdlib, 'run', mocked_run)
     monkeypatch.setattr(api, 'consume', mocked_consume_no_args)
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
-    kernelcmdlineconfig.process()
+    kernelcmdlineconfig.append_kernel_args_in_boot_cfg()
     assert not mocked_run.commands
 
 
@@ -83,5 +78,5 @@ def test_kernelcmdline_config_no_version(monkeypatch):
     monkeypatch.setattr(stdlib, 'run', mocked_run)
     monkeypatch.setattr(api, 'consume', mocked_consume_no_version)
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(architecture.ARCH_S390X))
-    kernelcmdlineconfig.process()
+    kernelcmdlineconfig.append_kernel_args_in_boot_cfg()
     assert not mocked_run.commands

--- a/repos/system_upgrade/common/models/kernelcmdlineargs.py
+++ b/repos/system_upgrade/common/models/kernelcmdlineargs.py
@@ -1,4 +1,4 @@
-from leapp.models import Model, fields
+from leapp.models import fields, Model
 from leapp.topics import SystemInfoTopic
 
 
@@ -12,6 +12,16 @@ class KernelCmdlineArg(Model):
 
     key = fields.String()
     value = fields.Nullable(fields.String())
+
+
+class TargetKernelCmdlineArgTasks(Model):
+    """
+    Desired modifications of the target kernel args
+    """
+    topic = SystemInfoTopic
+
+    to_add = fields.List(fields.Model(KernelCmdlineArg), default=[])
+    to_remove = fields.List(fields.Model(KernelCmdlineArg), default=[])
 
 
 class KernelCmdline(Model):


### PR DESCRIPTION
This patch:
- cleans up the `kernelcmdlineconfig` actor
- adds a new model `TargetKernelCmdlineArgTasks` to allow clear specification of what args to add/remove to the target boot entry
- extends `kernelcmdlineconfig` to be able to also remove modules

Jira ref: OAMG-6918