### PR TITLE
Detect missing new line in /etc/default/grub and fix it

### DIFF
--- a/repos/system_upgrade/common/actors/addupgradebootentry/actor.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/actor.py
@@ -20,9 +20,9 @@ class AddUpgradeBootEntry(Actor):
     tags = (IPUWorkflowTag, InterimPreparationPhaseTag)
 
     def process(self):
-        grub_config_error_detected = next(self.consume(GrubConfigError), GrubConfigError()).error_detected
-        if grub_config_error_detected:
-            fix_grub_config_error('/etc/default/grub')
+        for grub_config_error in self.consume(GrubConfigError):
+            if grub_config_error.error_detected:
+                fix_grub_config_error('/etc/default/grub', grub_config_error.error_type)
 
         configs = None
         ff = next(self.consume(FirmwareFacts), None)

--- a/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
@@ -91,17 +91,20 @@ def write_to_file(filename, content):
         f.write(content)
 
 
-def fix_grub_config_error(conf_file):
+def fix_grub_config_error(conf_file, error_type):
     with open(conf_file, 'r') as f:
         config = f.read()
 
-    # move misplaced '"' to the end
-    pattern = r'GRUB_CMDLINE_LINUX=.+?(?=GRUB|\Z)'
-    original_value = re.search(pattern, config, re.DOTALL).group()
-    parsed_value = original_value.split('"')
-    new_value = '{KEY}"{VALUE}"{END}'.format(KEY=parsed_value[0], VALUE=''.join(parsed_value[1:]).rstrip(),
-                                             END=original_value[-1])
+    if error_type == 'GRUB_CMDLINE_LINUX syntax':
+        # move misplaced '"' to the end
+        pattern = r'GRUB_CMDLINE_LINUX=.+?(?=GRUB|\Z)'
+        original_value = re.search(pattern, config, re.DOTALL).group()
+        parsed_value = original_value.split('"')
+        new_value = '{KEY}"{VALUE}"{END}'.format(KEY=parsed_value[0], VALUE=''.join(parsed_value[1:]).rstrip(),
+                                                 END=original_value[-1])
 
-    config = config.replace(original_value, new_value)
+        config = config.replace(original_value, new_value)
+        write_to_file(conf_file, config)
 
-    write_to_file(conf_file, config)
+    elif error_type == 'missing newline':
+        write_to_file(conf_file, config + '\n')

--- a/repos/system_upgrade/common/actors/addupgradebootentry/tests/files/grub_test_newline.fixed
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/tests/files/grub_test_newline.fixed
@@ -1,0 +1,7 @@
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL_OUTPUT="console"
+GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+GRUB_DISABLE_RECOVERY="true"

--- a/repos/system_upgrade/common/actors/addupgradebootentry/tests/files/grub_test_newline.wrong
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/tests/files/grub_test_newline.wrong
@@ -1,0 +1,7 @@
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL_OUTPUT="console"
+GRUB_CMDLINE_LINUX="console=tty0 crashkernel=auto console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+GRUB_DISABLE_RECOVERY="true"

--- a/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
@@ -147,9 +147,17 @@ def test_get_boot_file_paths(monkeypatch):
         addupgradebootentry.get_boot_file_paths()
 
 
-def test_fix_grub_config_error(monkeypatch):
+@pytest.mark.parametrize(
+    ('error_type', 'test_file_name'),
+    [
+        ('GRUB_CMDLINE_LINUX syntax', 'grub_test'),
+        ('missing newline', 'grub_test_newline')
+    ]
+)
+def test_fix_grub_config_error(monkeypatch, error_type, test_file_name):
     monkeypatch.setattr(addupgradebootentry, 'write_to_file', write_to_file_mocked())
-    addupgradebootentry.fix_grub_config_error(os.path.join(CUR_DIR, 'files/grub_test.wrong'))
+    addupgradebootentry.fix_grub_config_error(os.path.join(CUR_DIR, 'files/{}.wrong'.format(test_file_name)),
+                                              error_type)
 
-    with open(os.path.join(CUR_DIR, 'files/grub_test.fixed')) as f:
+    with open(os.path.join(CUR_DIR, 'files/{}.fixed'.format(test_file_name))) as f:
         assert addupgradebootentry.write_to_file.content == f.read()

--- a/repos/system_upgrade/common/actors/detectmissingnewlineingrubcfg/actor.py
+++ b/repos/system_upgrade/common/actors/detectmissingnewlineingrubcfg/actor.py
@@ -1,0 +1,35 @@
+from leapp import reporting
+from leapp.actors import Actor
+from leapp.libraries.actor.detectmissingnewlineingrubcfg import is_grub_config_missing_final_newline
+from leapp.models import GrubConfigError
+from leapp.reporting import create_report, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class DetectMissingNewlineInGrubCfg(Actor):
+    """
+    Check the grub configuration for a missing newline at its end.
+    """
+
+    name = 'detect_missing_newline_in_grub_cfg'
+    consumes = ()
+    produces = (Report, GrubConfigError)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        config = '/etc/default/grub'
+        if is_grub_config_missing_final_newline(config):
+            create_report([
+                reporting.Title('Detected a missing newline at the end of grub configuration file.'),
+                reporting.Summary(
+                    'The missing newline in /etc/default/grub causes booting issues when appending '
+                    'new entries to this file during the upgrade. Leapp will automatically fix this '
+                    'problem by appending the missing newline to the grub configuration file.'
+                ),
+                reporting.Severity(reporting.Severity.LOW),
+                reporting.Tags([reporting.Tags.BOOT]),
+                reporting.RelatedResource('file', config)
+            ])
+
+            config_error = GrubConfigError(error_detected=True, error_type='missing newline')
+            self.produce(config_error)

--- a/repos/system_upgrade/common/actors/detectmissingnewlineingrubcfg/libraries/detectmissingnewlineingrubcfg.py
+++ b/repos/system_upgrade/common/actors/detectmissingnewlineingrubcfg/libraries/detectmissingnewlineingrubcfg.py
@@ -1,0 +1,13 @@
+import os
+
+
+def _get_config_contents(config_path):
+    if os.path.isfile(config_path):
+        with open(config_path, 'r') as config:
+            return config.read()
+    return ''
+
+
+def is_grub_config_missing_final_newline(conf_file):
+    config_contents = _get_config_contents(conf_file)
+    return config_contents != '' and config_contents[-1] != '\n'

--- a/repos/system_upgrade/common/actors/detectmissingnewlineingrubcfg/tests/test_detectmissingnewlineingrubcfg.py
+++ b/repos/system_upgrade/common/actors/detectmissingnewlineingrubcfg/tests/test_detectmissingnewlineingrubcfg.py
@@ -1,0 +1,23 @@
+import pytest
+
+from leapp.libraries.actor import detectmissingnewlineingrubcfg
+
+
+@pytest.mark.parametrize(
+    ('config_contents', 'error_detected'),
+    [
+        ('GRUB_DEFAULT=saved\nGRUB_DISABLE_SUBMENU=true\n', False),
+        ('GRUB_DEFAULT=saved\nGRUB_DISABLE_SUBMENU=true', True)
+    ]
+)
+def test_is_grub_config_missing_final_newline(monkeypatch, config_contents, error_detected):
+
+    config_path = '/etc/default/grub'
+
+    def mocked_get_config_contents(path):
+        assert path == config_path
+        return config_contents
+
+    monkeypatch.setattr(detectmissingnewlineingrubcfg, '_get_config_contents', mocked_get_config_contents)
+
+    assert detectmissingnewlineingrubcfg.is_grub_config_missing_final_newline(config_path) == error_detected

--- a/repos/system_upgrade/common/models/grubconfigerror.py
+++ b/repos/system_upgrade/common/models/grubconfigerror.py
@@ -1,4 +1,4 @@
-from leapp.models import Model, fields
+from leapp.models import fields, Model
 from leapp.topics import SystemFactsTopic
 
 
@@ -6,3 +6,4 @@ class GrubConfigError(Model):
     topic = SystemFactsTopic
 
     error_detected = fields.Boolean(default=False)
+    error_type = fields.StringEnum(['GRUB_CMDLINE_LINUX syntax', 'missing newline'])

--- a/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/detectgrubconfigerror/actor.py
@@ -1,9 +1,9 @@
+from leapp import reporting
 from leapp.actors import Actor
 from leapp.libraries.actor.scanner import detect_config_error
 from leapp.libraries.common.config import architecture
 from leapp.models import GrubConfigError
-from leapp.reporting import Report, create_report
-from leapp import reporting
+from leapp.reporting import create_report, Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
@@ -23,8 +23,7 @@ class DetectGrubConfigError(Actor):
             # because ZIPL is used there
             return
         config = '/etc/default/grub'
-        error_detected = detect_config_error(config)
-        if error_detected:
+        if detect_config_error(config):
             create_report([
                 reporting.Title('Syntax error detected in grub configuration'),
                 reporting.Summary(
@@ -37,4 +36,6 @@ class DetectGrubConfigError(Actor):
                 reporting.RelatedResource('file', config)
             ])
 
-        self.produce(GrubConfigError(error_detected=error_detected))
+            config_error = GrubConfigError(error_detected=True,
+                                           error_type='GRUB_CMDLINE_LINUX syntax')
+            self.produce(config_error)


### PR DESCRIPTION
The missing new line at the end of ``/etc/default/grub`` causes the IPU to fail on
reboot. Detecting and fixing this problem before the upgrade is just a temporary
solution and it will be addressed in grub2 package instead, later on.

JIRA ref: OAMG-4535