### PR TITLE
Packaging: Provide leapp-command(<cmd>) for each leapp sub-cmd

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -110,6 +110,14 @@ Provides:       leapp-repository = %{version}-%{release}
 # to install "leapp-upgrade" in the official docs.
 Provides:       leapp-upgrade = %{version}-%{release}
 
+# Provide leapp-commands so the framework could refer to them when customers
+# do not have installed particular leapp-repositories
+Provides:       leapp-command(answer)
+Provides:       leapp-command(preupgrade)
+Provides:       leapp-command(upgrade)
+Provides:       leapp-command(rerun)
+Provides:       leapp-command(list-runs)
+
 
 %description -n %{lpr_name}
 Leapp repositories for the in-place upgrade to the next major version


### PR DESCRIPTION
The CLI for the leapp utility is provided nowadays by leapp-repository
packages. However, some people are used to install just `leapp` instead
of specific repository as we suggest (e.g. `leapp-upgrade`).

To handle the situation we decided to provide a proper error msg
to users suggesting what they should do. Inspired by DNF (hi guys \o)
we decided to set virtual provides in leapp-repository packages:
    leapp-command(CMD)
per each leapp CMD provided by particular package, so users can be
suggested to install missing packages e.g. by:
     dnf install 'leapp-command(upgrade)'
when they want to run `leapp upgrade`. Same for all other commands.

See the following PR in leapp handling this problem:
*    https://github.com/oamg/leapp/pull/785