### PR TITLE
Dont propragate enforcing=0 kernel arg to target system

### DIFF
--- a/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
@@ -41,6 +41,10 @@ def add_boot_entry(configs=None):
             # NOTE(mhecko): This will also unconditionally remove debug kernelopt if the source system used it.
             api.produce(TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='debug')]))
 
+        # NOTE(mmatuska): This will remove the option even if the source system had it set.
+        # However enforcing=0 shouldn't be set persistently anyway.
+        api.produce(TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='enforcing', value='0')]))
+
     except CalledProcessError as e:
         raise StopActorExecutionError(
            'Cannot configure bootloader.',

--- a/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
@@ -76,7 +76,8 @@ def test_add_boot_entry(monkeypatch, run_args, arch):
     assert addupgradebootentry.run.args[0] == run_args.args_remove
     assert addupgradebootentry.run.args[1] == run_args.args_add
     assert api.produce.model_instances == [
-        TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='debug')])
+        TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='debug')]),
+        TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='enforcing', value='0')])
     ]
 
     if run_args.args_zipl:
@@ -101,6 +102,10 @@ def test_debug_kernelopt_removal_task_production(monkeypatch, is_leapp_invoked_w
     if is_leapp_invoked_with_debug:
         expected_produced_messages = [TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='debug')])]
 
+    expected_produced_messages.append(
+        TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='enforcing', value='0')])
+    )
+
     assert api.produce.model_instances == expected_produced_messages
 
 
@@ -122,7 +127,8 @@ def test_add_boot_entry_configs(monkeypatch):
     assert addupgradebootentry.run.args[2] == run_args_add + ['-c', CONFIGS[0]]
     assert addupgradebootentry.run.args[3] == run_args_add + ['-c', CONFIGS[1]]
     assert api.produce.model_instances == [
-        TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='debug')])
+        TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='debug')]),
+        TargetKernelCmdlineArgTasks(to_remove=[KernelCmdlineArg(key='enforcing', value='0')])
     ]
 
 


### PR DESCRIPTION
The upgrade initramdisk has `enforcing=0` kernel arg set to disable
SELinux. After the upgrade these options are used for the target
kernel cmdline. However we don't want `enforcing=0` set on the target system.

Jira ref: OAMG-7452