### PR TITLE
Packaging: Update leapp-repository deps for RHEL 8+

### DIFF
--- a/packaging/leapp-el7toel8-deps.spec
+++ b/packaging/leapp-el7toel8-deps.spec
@@ -9,7 +9,7 @@
 %endif
 
 
-%define leapp_repo_deps  6
+%define leapp_repo_deps  7
 %define leapp_framework_deps 5
 
 # NOTE: the Version contains the %{rhel} macro just for the convenience to
@@ -55,6 +55,14 @@ Requires:   policycoreutils-python-utils
 # The package is first installed inside the target userspace container
 # Than we ensure the rpm will be present after the upgrade transaction.
 Requires:   dnf-command(config-manager)
+
+# It should not happen that dracut is not present on the target system,
+# but as dracut is removable on RHEL 8+, let's rather require it to be really
+# sure
+Requires:   dracut
+
+# just to be sure that /etc/modprobe.d is present
+Requires:   kmod
 
 %description -n %{lrdname}
 %{summary}

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -2,7 +2,7 @@
 %global repositorydir %{leapp_datadir}/repositories
 %global custom_repositorydir %{leapp_datadir}/custom-repositories
 
-%define leapp_repo_deps  6
+%define leapp_repo_deps  7
 
 %if 0%{?rhel} == 7
     %define leapp_python_sitelib %{python2_sitelib}
@@ -161,6 +161,13 @@ Requires:   python3-requests
 Requires:   python3-six
 # required by SELinux actors
 Requires:   policycoreutils-python-utils
+# required by systemfacts, and several other actors
+Requires:   procps-ng
+Requires:   kmod
+# since RHEL 8+ dracut does not have to be present on the system all the time
+# and missing dracut could be killing situation for us :)
+Requires:   dracut
+
 %endif
 ##################################################
 # end requirement


### PR DESCRIPTION
Since RHEL 8, several rpms do not have to be present on the system
anymore but they are mandatory for the IPU. Add requirement for
the following RPMs:
  kmod
  dracut
  propc-ng

Bump leapp-repository-dependencies to 7

Related tasks:
*    OAMG-7085:  https://bugzilla.redhat.com/show_bug.cgi?id=2100108
*    OAMG-7086:  https://bugzilla.redhat.com/show_bug.cgi?id=2100110