### PR TITLE
# Release 0.17.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -41,7 +41,7 @@ py2_byte_compile "%1" "%2"}
 # RHEL 8+ packages to be consistent with other leapp projects in future.
 
 Name:           leapp-repository
-Version:        0.16.0
+Version:        0.17.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Packaging
- Provide and require leapp-repository-dependencies 7 (#952)
- Provide `leapp-command(<CMD>)` for each CLI command provided by leapp-repository (#947)
- Require dracut, kmod, procps-ng on RHEL 8+ (#952)
- Require leapp-framework >= 3.1 (#905, #927)

## Upgrade handling
### Fixes
-  Do not create the upgrade bootloader entry when the dnf dry-run actor fails  (#912)
- Do not inhibit in-place upgrades in case LUKS volumes are Ceph OSDs (#735)
- Fix & improve application of custom selinux rules to be less error prone and do not override changes done by RPM scriptlets (#925)
- Fix detection of deprecated devices (and drivers) regarding the PCI address (#881)
- Fix detection of deprecated kernel modules (#874)
- Fix the false positive NFS storage detection on NFS servers (#888)
- Fix the issues on systems with the LANGUAGE environment variable (#887)
- Fix the root directory scan to deal with non-utf8 filenames (#927)
- Skip comment lines when parsing the GRUB configuration file (#883)
- Stop propagating the “debug” and ”enforcing=0” kernel cmdline options into the target kernel cmdline options (#938, #950)
- [IPU 7 -> 8] Fix the upgrade of the Satellite server (#875, #878, #879 #890, #899, #916, 934)
- [IPU 7 -> 8] Fix SSSD: Prune old cache files (the format of data is incompatible) (#922)
- [IPU 8 -> 9] Enable the CRB repository for the upgrade only if enabled on the source system (#942)
- [IPU 8 -> 9] Drop obsoleted actor blocking upgrade on z16 (#892)
- [IPU 8 -> 9] Fix cloud provider detection on AWS (#920)
- [IPU 8 -> 9] Fix detention of the latest kernel on RHEL 8+ systems (#909)
- [IPU 8 -> 9] Fix issues caused by leapp artifacts from previous in-place upgrades (#889)
- [IPU 8 -> 9] Fix issues with false positive switch to emergency console during the upgrade (#906)
- [IPU 8 -> 9] Fix swap page size on aarch64 (#937, #948)
- [IPU 8 -> 9] Fix the VDO scanner to skip partitions unrelated to VDO and adjust error messages (#919)

### Enhancements
- Add 8.7 & 9.1 Beta & GA product certificates (#891)
- Detect /var/lib/leapp being mounted in a non-persistent fashion (#921)
- Detect /var/lib/leapp mounted with the noexec option (#908)
- Improve the report msg when NFS partitions are discovered providing info about concrete mountpoints (#806)
- Inform about necessary migrations related to bacula-director (#896)
- [IPU 7 -> 8] The default upgrade path for RHEL SAP is 7.9 -> 8.6 (#939)
- [IPU 7 -> 8] Detect and fix missing newline at the end of /etc/default/grub (#945)
- [IPU 7 -> 8] Handle upgrades of SAP Apps systems on Azure (#926)
- [IPU 7 -> 8] Handle upgrades on RHUI Google Cloud (#897, #946)
- [IPU 8 -> 9] Support upgrade path RHEL 8.7 -> 9.0 and RHEL SAP 8.6 -> 9.0 (#903, #894)
- [IPU 8 -> 9] Add actors covering removal of NIS components on RHEL 9 (#851)
- [IPU 8 -> 9] Add checks for obsolete .NET versions (#867)
- [IPU 8 -> 9] Allow specifying the report schema v1.2.0 (#872)
- [IPU 8 -> 9] Check and handle upgrades with custom crypto policies (#898)
- [IPU 8 -> 9] Check and migrate OpenSSH configuration (#864, #860)
- [IPU 8 -> 9] Check and migrate multipath configuration the upgrade (#886)
- [IPU 8 -> 9] Check minimum memory requirements (#935)
- [IPU 8 -> 9] Enable Base and SAP In-place upgrades on Azure (#943)
- [IPU 8 -> 9] Enable in-place upgrades in Azure RHEL 8 base images using RHUI (#918)
- [IPU 8 -> 9] Handle upgrades of SAP systems on AWS (#924)
- [IPU 8 -> 9] Inhibit upgrade when NVIDIA driver is detected (#880)
- [IPU 8 -> 9] Migrate blocklisted CAs (#882)
- [IPU 8 -> 9] Migrate the OpenSSL configuration (#900)
- [IPU 8 -> 9] Report changes around SCP and SFTP (#863, #893)

## Additional changes interesting for devels
- Extend LsblkEntry model in StorageInfo by kernel name and size of partition in bytes (#919)
- Mass refactoring: Fix imports in actors and libraries to follow project guidelines (#932)
- Mass refactoring: Replace use of deprecated `reporting.(Tags|Flags)` by `reporting.Groups` (#932)
- PESEventScanner actor has been fully refactored  (#856, #941)
- Use library function is_inhibitor to check for failures (#905)

Signed-off-by: Petr Stodulka <pstodulk@redhat.com>