### PR TITLE
Disable isort check for deprecated imports

### DIFF
--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/actor.py
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/actor.py
@@ -1,13 +1,14 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import modscan
-from leapp.models import (
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+from leapp.utils.deprecation import suppress_deprecation
+
+from leapp.models import (  # isort:skip
     RequiredUpgradeInitramPackages,  # deprecated
     UpgradeDracutModule,  # deprecated
     TargetUserSpaceUpgradeTasks,
     UpgradeInitramfsTasks
 )
-from leapp.tags import FactsPhaseTag, IPUWorkflowTag
-from leapp.utils.deprecation import suppress_deprecation
 
 
 @suppress_deprecation(RequiredUpgradeInitramPackages, UpgradeDracutModule)

--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/libraries/modscan.py
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/libraries/modscan.py
@@ -3,14 +3,15 @@ import re
 
 from leapp.libraries.common.config import architecture, version
 from leapp.libraries.stdlib import api
-from leapp.models import (
+from leapp.utils.deprecation import suppress_deprecation
+
+from leapp.models import (  # isort:skip
     RequiredUpgradeInitramPackages,  # deprecated
     UpgradeDracutModule,  # deprecated
     DracutModule,
     TargetUserSpaceUpgradeTasks,
     UpgradeInitramfsTasks
 )
-from leapp.utils.deprecation import suppress_deprecation
 
 _REQUIRED_PACKAGES = [
     'binutils',

--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/tests/test_modscan_commonleappdracutmodules.py
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/tests/test_modscan_commonleappdracutmodules.py
@@ -8,13 +8,14 @@ from leapp.libraries.actor import modscan
 from leapp.libraries.common.config import architecture
 from leapp.libraries.common.testutils import CurrentActorMocked
 from leapp.libraries.stdlib import api
-from leapp.models import (
+from leapp.utils.deprecation import suppress_deprecation
+
+from leapp.models import (  # isort:skip
     RequiredUpgradeInitramPackages,  # deprecated
     UpgradeDracutModule,  # deprecated
     TargetUserSpaceUpgradeTasks,
     UpgradeInitramfsTasks
 )
-from leapp.utils.deprecation import suppress_deprecation
 
 
 def _files_get_folder_path(name):

--- a/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/tests/test_targetinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/tests/test_targetinitramfsgenerator.py
@@ -4,13 +4,14 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import targetinitramfsgenerator
 from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
 from leapp.libraries.stdlib import api, CalledProcessError
-from leapp.models import (
+from leapp.utils.deprecation import suppress_deprecation
+
+from leapp.models import (  # isort:skip
     InitrdIncludes,  # deprecated
     DracutModule,
     InstalledTargetKernelVersion,
     TargetInitramfsTasks
 )
-from leapp.utils.deprecation import suppress_deprecation
 
 FILES = ['/file1', '/file2', '/dir/ect/ory/file3', '/file4', '/file5']
 MODULES = [

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/tests/unit_test_upgradeinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/tests/unit_test_upgradeinitramfsgenerator.py
@@ -7,7 +7,9 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import upgradeinitramfsgenerator
 from leapp.libraries.common.config import architecture
 from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked, produce_mocked
-from leapp.models import (
+from leapp.utils.deprecation import suppress_deprecation
+
+from leapp.models import (  # isort:skip
     RequiredUpgradeInitramPackages,  # deprecated
     UpgradeDracutModule,  # deprecated
     BootContent,
@@ -16,7 +18,6 @@ from leapp.models import (
     TargetUserSpaceUpgradeTasks,
     UpgradeInitramfsTasks,
 )
-from leapp.utils.deprecation import suppress_deprecation
 
 CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 PKGS = ['pkg{}'.format(c) for c in 'ABCDEFGHIJ']


### PR DESCRIPTION
isort works fine most of the time, but the way it handles
multiline imports with inline comments is not acceptable
to everyone in the team.
So before we implement a solution it was decided to leave
those imports just as the have been for ages, do let's mute
isort import check.