### PR TITLE
CheckVDO: Ask user only faiulres and undetermined devices

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/checkvdo/libraries/checkvdo.py
+++ b/repos/system_upgrade/el8toel9/actors/checkvdo/libraries/checkvdo.py
@@ -1,10 +1,35 @@
 from leapp import reporting
 from leapp.libraries.stdlib import api
 
-_report_title = reporting.Title('VDO devices migration to LVM management')
+
+def _report_skip_check():
+    if not api.current_actor().get_vdo_answer():
+        return
+
+    summary = ('User has asserted all VDO devices on the system have been '
+               'successfully converted to LVM management or no VDO '
+               'devices are present.')
+    reporting.create_report([
+        reporting.Title('Skipping the VDO check of block devices'),
+        reporting.Summary(summary),
+        reporting.Severity(reporting.Severity.INFO),
+        reporting.Groups([reporting.Groups.SERVICES, reporting.Groups.DRIVERS]),
+    ])
 
 
-def _create_unexpected_resuilt_report(devices):
+def _process_failed_check_devices(conversion_info):
+    # Post-conversion VDOs that were not successfully checked for having
+    # completed the migration to LVM management.
+    # Return True if failed checks detected
+    devices = [x for x in conversion_info.post_conversion if (not x.complete) and x.check_failed]
+    devices += [x for x in conversion_info.undetermined_conversion if x.check_failed]
+    if not devices:
+        return False
+
+    if api.current_actor().get_vdo_answer():
+        # User asserted all possible VDO should be already converted - skip
+        return True
+
     names = [x.name for x in devices]
     multiple = len(names) > 1
     summary = ['Unexpected result checking device{0}'.format('s' if multiple else '')]
@@ -16,13 +41,14 @@ def _create_unexpected_resuilt_report(devices):
                            'and re-run the upgrade.'))
 
     reporting.create_report([
-        _report_title,
+        reporting.Title('Checking VDO conversion to LVM management of block devices failed'),
         reporting.Summary(summary),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Groups([reporting.Groups.SERVICES, reporting.Groups.DRIVERS]),
         reporting.Remediation(hint=remedy_hint),
         reporting.Groups([reporting.Groups.INHIBITOR])
     ])
+    return True
 
 
 def _process_post_conversion_vdos(vdos):
@@ -32,23 +58,28 @@ def _process_post_conversion_vdos(vdos):
     if post_conversion:
         devices = [x.name for x in post_conversion]
         multiple = len(devices) > 1
-        summary = ''.join(('VDO device{0} \'{1}\' '.format('s' if multiple else '',
-                                                           ', '.join(devices)),
-                           'did not complete migration to LVM management. ',
-                           'The named device{0} '.format('s' if multiple else ''),
-                           '{0} successfully converted at the '.format('were' if multiple else 'was'),
-                           'device format level; however, the expected LVM management '
-                           'portion of the conversion did not take place. This '
-                           'indicates that an exceptional condition (for example, a '
-                           'system crash) likely occurred during the conversion '
-                           'process. The LVM portion of the conversion must be '
-                           'performed in order for upgrade to proceed.'))
+        summary = (
+            'VDO device{s_suffix} \'{devices_str}\' '
+            'did not complete migration to LVM management. '
+            'The named device{s_suffix} {was_were} successfully converted '
+            'at the device format level; however, the expected LVM management '
+            'portion of the conversion did not take place. This indicates '
+            'that an exceptional condition (for example, a system crash) '
+            'likely occurred during the conversion process. The LVM portion '
+            'of the conversion must be performed in order for upgrade '
+            'to proceed.'
+            .format(
+                s_suffix='s' if multiple else '',
+                devices_str=', '.join(devices),
+                was_were='were' if multiple else 'was',
+            )
+        )
 
         remedy_hint = ('Consult the VDO to LVM conversion process '
                        'documentation for how to complete the conversion.')
 
         reporting.create_report([
-            _report_title,
+            reporting.Title('Detected VDO devices that have not finished the conversion to LVM management.'),
             reporting.Summary(summary),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.SERVICES, reporting.Groups.DRIVERS]),
@@ -56,33 +87,32 @@ def _process_post_conversion_vdos(vdos):
             reporting.Groups([reporting.Groups.INHIBITOR])
         ])
 
-    # Post-conversion VDOs that were not successfully checked for having
-    # completed the migration to LVM management.
-    post_conversion = [x for x in vdos if (not x.complete) and x.check_failed]
-    if post_conversion:
-        _create_unexpected_resuilt_report(post_conversion)
-
 
 def _process_pre_conversion_vdos(vdos):
     # Pre-conversion VDOs generate an inhibiting report.
     if vdos:
         devices = [x.name for x in vdos]
         multiple = len(devices) > 1
-        summary = ''.join(('VDO device{0} \'{1}\' require{2} '.format('s' if multiple else '',
-                                                                      ', '.join(devices),
-                                                                      '' if multiple else 's'),
-                           'migration to LVM management.'
-                           'After performing the upgrade VDO devices can only be '
-                           'managed via LVM. Any VDO device not currently managed '
-                           'by LVM must be converted to LVM management before '
-                           'upgrading. The data on any VDO device not converted to '
-                           'LVM management will be inaccessible after upgrading.'))
+        summary = (
+            'VDO device{s_suffix} \'{devices_str}\' require{s_suffix_verb} '
+            'migration to LVM management.'
+            'After performing the upgrade VDO devices can only be '
+            'managed via LVM. Any VDO device not currently managed '
+            'by LVM must be converted to LVM management before '
+            'upgrading. The data on any VDO device not converted to '
+            'LVM management will be inaccessible after upgrading.'
+            .format(
+                s_suffix='s' if multiple else '',
+                s_suffix_verb='' if multiple else 's',
+                devices_str=', '.join(devices),
+            )
+        )
 
         remedy_hint = ('Consult the VDO to LVM conversion process '
                        'documentation for how to perform the conversion.')
 
         reporting.create_report([
-            _report_title,
+            reporting.Title('Detected VDO devices not managed by LVM'),
             reporting.Summary(summary),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.SERVICES, reporting.Groups.DRIVERS]),
@@ -104,43 +134,40 @@ def _process_undetermined_conversion_devices(devices):
     # A device can only end up as undetermined either via a check that failed
     # or if it was not checked.  If the info for the device indicates that it
     # did not have a check failure that means it was not checked.
-
-    checked = [x for x in devices if x.check_failed]
-    if checked:
-        _create_unexpected_resuilt_report(checked)
+    # Return True if failed checks detected
 
     unchecked = [x for x in devices if not x.check_failed]
-    if unchecked:
-        no_vdo_devices = api.current_actor().get_no_vdo_devices_response()
-        if no_vdo_devices:
-            summary = ('User has asserted there are no VDO devices on the '
-                       'system in need of conversion to LVM management.')
+    if not unchecked:
+        return False
 
-            reporting.create_report([
-                _report_title,
-                reporting.Summary(summary),
-                reporting.Severity(reporting.Severity.INFO),
-                reporting.Groups([reporting.Groups.SERVICES, reporting.Groups.DRIVERS]),
-                reporting.Groups([])
-            ])
-        elif no_vdo_devices is False:
-            summary = ('User has opted to inhibit upgrade in regard to '
-                       'potential VDO devices requiring conversion to LVM '
-                       'management.')
-            remedy_hint = ('Install the \'vdo\' package and re-run upgrade to '
-                           'check for VDO devices requiring conversion.')
+    if api.current_actor().get_vdo_answer():
+        # User asserted no VDO devices are present
+        return True
 
-            reporting.create_report([
-                _report_title,
-                reporting.Summary(summary),
-                reporting.Severity(reporting.Severity.HIGH),
-                reporting.Groups([reporting.Groups.SERVICES, reporting.Groups.DRIVERS]),
-                reporting.Remediation(hint=remedy_hint),
-                reporting.Groups([reporting.Groups.INHIBITOR])
-            ])
+    summary = (
+        'The check of block devices could not be performed as the \'vdo\' '
+        'package is not installed. All VDO devices must be converted to '
+        'LVM management prior to the upgrade to prevent the loss of data.')
+    remedy_hint = ('Install the \'vdo\' package and re-run upgrade to '
+                   'check for VDO devices requiring conversion or confirm '
+                   'that all VDO devices, if any, are managed by LVM.')
+
+    reporting.create_report([
+        reporting.Title('Cannot perform the VDO check of block devices'),
+        reporting.Summary(summary),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.SERVICES, reporting.Groups.DRIVERS]),
+        reporting.Remediation(hint=remedy_hint),
+        reporting.Groups([reporting.Groups.INHIBITOR])
+    ])
+    return True
 
 
 def check_vdo(conversion_info):
     _process_pre_conversion_vdos(conversion_info.pre_conversion)
     _process_post_conversion_vdos(conversion_info.post_conversion)
-    _process_undetermined_conversion_devices(conversion_info.undetermined_conversion)
+
+    detected_under_dev = _process_undetermined_conversion_devices(conversion_info.undetermined_conversion)
+    detected_failed_check = _process_failed_check_devices(conversion_info)
+    if detected_under_dev or detected_failed_check:
+        _report_skip_check()

--- a/repos/system_upgrade/el8toel9/actors/checkvdo/tests/unit_test_checkvdo.py
+++ b/repos/system_upgrade/el8toel9/actors/checkvdo/tests/unit_test_checkvdo.py
@@ -13,14 +13,16 @@ from leapp.models import (
 from leapp.utils.report import is_inhibitor
 
 
-class MockedActorNoVdoDevices(CurrentActorMocked):
-    def get_no_vdo_devices_response(self):
-        return True
-
-
-class MockedActorSomeVdoDevices(CurrentActorMocked):
-    def get_no_vdo_devices_response(self):
+# Mock actor base for CheckVdo tests.
+class MockedActorCheckVdo(CurrentActorMocked):
+    def get_vdo_answer(self):
         return False
+
+
+# Mock actor for all_vdo_converted dialog response.
+class MockedActorAllVdoConvertedTrue(MockedActorCheckVdo):
+    def get_vdo_answer(self):
+        return True
 
 
 def aslist(f):
@@ -66,6 +68,7 @@ def _undetermined_conversion_vdos(count=0, failing=False, start_char='a'):
 
 # No VDOs tests.
 def test_no_vdos(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(),
@@ -76,6 +79,7 @@ def test_no_vdos(monkeypatch):
 
 # Concurrent pre- and post-conversion tests.
 def test_both_conversion_vdo_incomplete(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     post_count = 7
     checkvdo.check_vdo(
@@ -89,6 +93,7 @@ def test_both_conversion_vdo_incomplete(monkeypatch):
 
 # Post-conversion tests.
 def test_post_conversion_multiple_vdo_incomplete(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(7, 5),
@@ -100,6 +105,7 @@ def test_post_conversion_multiple_vdo_incomplete(monkeypatch):
 
 
 def test_post_conversion_multiple_vdo_complete(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(7, 7),
@@ -109,6 +115,7 @@ def test_post_conversion_multiple_vdo_complete(monkeypatch):
 
 
 def test_post_conversion_single_vdo_incomplete(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(1),
@@ -121,6 +128,7 @@ def test_post_conversion_single_vdo_incomplete(monkeypatch):
 
 
 def test_post_conversion_single_check_failing(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(2, complete=1, failing=1),
@@ -135,6 +143,7 @@ def test_post_conversion_single_check_failing(monkeypatch):
 
 
 def test_post_conversion_multiple_check_failing(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(7, complete=4, failing=3),
@@ -147,6 +156,7 @@ def test_post_conversion_multiple_check_failing(monkeypatch):
 
 
 def test_post_conversion_incomplete_and_check_failing(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(2, failing=1),
@@ -158,6 +168,7 @@ def test_post_conversion_incomplete_and_check_failing(monkeypatch):
 
 # Pre-conversion tests.
 def test_pre_conversion_multiple_vdo_incomplete(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(),
@@ -169,6 +180,7 @@ def test_pre_conversion_multiple_vdo_incomplete(monkeypatch):
 
 
 def test_pre_conversion_single_vdo_incomplete(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(),
@@ -182,6 +194,7 @@ def test_pre_conversion_single_vdo_incomplete(monkeypatch):
 
 # Undetermined tests.
 def test_undetermined_single_check_failing(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(),
@@ -196,6 +209,7 @@ def test_undetermined_single_check_failing(monkeypatch):
 
 
 def test_undetermined_multiple_check_failing(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(),
@@ -207,21 +221,8 @@ def test_undetermined_multiple_check_failing(monkeypatch):
             'Unexpected result checking devices')
 
 
-def test_undetermined_multiple_no_check_no_vdos(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', MockedActorNoVdoDevices())
-    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-    checkvdo.check_vdo(
-        VdoConversionInfo(post_conversion=_post_conversion_vdos(),
-                          pre_conversion=_pre_conversion_vdos(),
-                          undetermined_conversion=_undetermined_conversion_vdos(3)))
-    assert reporting.create_report.called == 1
-    assert not is_inhibitor(reporting.create_report.report_fields)
-    assert reporting.create_report.report_fields['summary'].startswith(
-            'User has asserted there are no VDO devices')
-
-
-def test_undetermined_multiple_no_check_some_vdos(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', MockedActorSomeVdoDevices())
+def test_undetermined_multiple_no_check(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorCheckVdo())
     monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
     checkvdo.check_vdo(
         VdoConversionInfo(post_conversion=_post_conversion_vdos(),
@@ -230,4 +231,19 @@ def test_undetermined_multiple_no_check_some_vdos(monkeypatch):
     assert reporting.create_report.called == 1
     assert is_inhibitor(reporting.create_report.report_fields)
     assert reporting.create_report.report_fields['summary'].startswith(
-            'User has opted to inhibit upgrade')
+            'The check of block devices could not be performed as the \'vdo\' '
+            'package is not installed.')
+
+
+# all_vdo_converted test.
+def test_all_vdo_converted_true(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', MockedActorAllVdoConvertedTrue())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    checkvdo.check_vdo(
+        VdoConversionInfo(post_conversion=_post_conversion_vdos(),
+                          pre_conversion=_pre_conversion_vdos(),
+                          undetermined_conversion=_undetermined_conversion_vdos(3)))
+    assert reporting.create_report.called == 1
+    assert not is_inhibitor(reporting.create_report.report_fields)
+    assert reporting.create_report.report_fields['summary'].startswith(
+            'User has asserted all VDO devices on the system have been successfully converted')


### PR DESCRIPTION
The previous solution made possible to skip the VDO check answering
the user question (confirming no vdo devices are present) if the
vdo package is not installed (as the scan of the system could not
be performed). However as part of the bug 2096159 it was discovered
that some systems have very dynamic storage which could dissapear
in the very moment the check by the vdo tool is performed which lead
to the reported inhibitor. We have discovered that this could be real
blocker of the upgrade on such systems as it's pretty simple to hit
at least 1 of N devices to raise such an issue. (*)

To make the upgrade possible on such systems, the dialog has been
updated to be able to skip any problematic VDO checks:
 - undetermined block devices
 - failures during the vdo scan of a block device

In such a case, user must confirm that no VDO device non-managed
by LVM is present. The dialog is asking now for the `confirm` key
from user instead of `all_vdo_converted`. If any non-LVM managed VDO
devices are discovered, the upgrade is inhibited despite the answer
(this is supposed to happen only when user's answer is not right so
we are ok about that behaviour).

Also reports are updated, as previously it could happen that several
reports with the same title appear during one run of leapp, but each
of them has a different meaning. Set individual titles to all
reports. Also summaries or reports have been updated.

(*) This also includes situations when discovered list of devices
is not complete as some block devices could be loaded after the
initial scan of block devices (StorageInfo msg) is created. Which
means that such devices will not be checked at all as they will not
be known to other actors. We consider this ok as when a system with
dynamic storage is present, usually many block devices are
redundant. So usually user will have to answer the dialog anyway due
to other "unstable" block devices.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2096159
Jira: OAMG-7025