### PR TITLE
migratentp: Don't raise StopActorExecutionError

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/migratentp.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/migratentp.py
@@ -2,11 +2,8 @@ import base64
 import io
 import tarfile
 
-from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.stdlib import CalledProcessError, run
-
-COMMON_REPORT_TAGS = [reporting.Groups.SERVICES, reporting.Groups.TIME_MANAGEMENT]
+from leapp.libraries.stdlib import api, CalledProcessError, run
 
 
 def extract_tgz64(s):
@@ -82,21 +79,7 @@ def migrate_ntp(migrate_services, config_tgz64):
 
     ignored_lines = ntp2chrony('/', ntp_conf, step_tickers)
 
-    config_resources = [reporting.RelatedResource('file', mc) for mc in migrate_configs + [ntp_conf]]
-    package_resources = [reporting.RelatedResource('package', p) for p in ['ntpd', 'chrony']]
-
-    if not ignored_lines:
-        reporting.create_report([
-            reporting.Title('{} configuration migrated to chrony'.format(' and '.join(migrate_configs))),
-            reporting.Summary('ntp2chrony executed successfully'),
-            reporting.Severity(reporting.Severity.INFO),
-            reporting.Groups(COMMON_REPORT_TAGS)
-        ] + config_resources + package_resources)
-
-    else:
-        reporting.create_report([
-            reporting.Title('{} configuration partially migrated to chrony'.format(' and '.join(migrate_configs))),
-            reporting.Summary('Some lines in /etc/ntp.conf were ignored in migration (check /etc/chrony.conf)'),
-            reporting.Severity(reporting.Severity.MEDIUM),
-            reporting.Groups(COMMON_REPORT_TAGS)
-        ] + config_resources + package_resources)
+    api.current_logger().info('Configuration files migrated to chrony: {}'.format(' '.join(migrate_configs)))
+    if ignored_lines:
+        api.current_logger().warning('Some lines in /etc/ntp.conf were ignored in migration'
+                                     ' (check /etc/chrony.conf)')

--- a/repos/system_upgrade/el7toel8/actors/migratentp/libraries/migratentp.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/libraries/migratentp.py
@@ -33,7 +33,7 @@ def ntp2chrony(root, ntp_conf, step_tickers):
         ntp_configuration = ntp2chrony.NtpConfiguration(root, ntp_conf, step_tickers)
         ntp_configuration.write_chrony_configuration('/etc/chrony.conf', '/etc/chrony.keys',
                                                      False, True)
-    except Exception as e:
+    except OSError as e:
         raise StopActorExecutionError('ntp2chrony failed: {}'.format(e))
 
     # Return ignored lines from ntp.conf, except 'disable monitor' from

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/unit_test_migratentp.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/unit_test_migratentp.py
@@ -55,7 +55,6 @@ def test_migration(monkeypatch):
                 (['ntp-wait'], ['chrony-wait'], 0),
                 (['ntpd', 'ntpdate', 'ntp-wait'], ['chronyd', 'chronyd', 'chrony-wait'], 1),
             ]:
-        monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
         monkeypatch.setattr(migratentp, 'extract_tgz64', extract_tgz64_mocked())
         monkeypatch.setattr(migratentp, 'enable_service', enable_service_mocked())
         monkeypatch.setattr(migratentp, 'write_file', write_file_mocked())
@@ -64,14 +63,6 @@ def test_migration(monkeypatch):
         migratentp.migrate_ntp(ntp_services, 'abcdef')
 
         if ntp_services:
-            assert reporting.create_report.called == 1
-            if ignored_lines > 0:
-                assert 'configuration partially migrated to chrony' in \
-                        reporting.create_report.report_fields['title']
-            else:
-                assert 'configuration migrated to chrony' in \
-                        reporting.create_report.report_fields['title']
-
             assert migratentp.extract_tgz64.called == 1
             assert migratentp.extract_tgz64.s == 'abcdef'
             assert migratentp.enable_service.called == len(chrony_services)
@@ -86,7 +77,6 @@ def test_migration(monkeypatch):
                     '/etc/ntp.conf' if 'ntpd' in ntp_services else '/etc/ntp.conf.nosources',
                     '/etc/ntp/step-tickers' if 'ntpdate' in ntp_services else '')
         else:
-            assert reporting.create_report.called == 0
             assert migratentp.extract_tgz64.called == 0
             assert migratentp.enable_service.called == 0
             assert migratentp.write_file.called == 0

--- a/repos/system_upgrade/el7toel8/actors/migratentp/tests/unit_test_migratentp.py
+++ b/repos/system_upgrade/el7toel8/actors/migratentp/tests/unit_test_migratentp.py
@@ -44,7 +44,7 @@ class ntp2chrony_mocked(object):
     def __call__(self, *args):
         self.called += 1
         self.args = args
-        return self.ignored_lines * ['a line']
+        return True, self.ignored_lines * ['a line']
 
 
 def test_migration(monkeypatch):


### PR DESCRIPTION
When a service cannot be enabled (e.g. due to masking) or when ntp2chrony fails, log an error message and create a report instead of failing the migration.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2089514