### PR TITLE
Add mapping based on the installed content

### DIFF
--- a/repos/system_upgrade/common/actors/setuptargetrepos/actor.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/actor.py
@@ -2,6 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor import setuptargetrepos
 from leapp.models import (
     CustomTargetRepository,
+    InstalledRPM,
     RepositoriesBlacklisted,
     RepositoriesFacts,
     RepositoriesMapping,
@@ -25,6 +26,7 @@ class SetupTargetRepos(Actor):
 
     name = 'setuptargetrepos'
     consumes = (CustomTargetRepository,
+                InstalledRPM,
                 RepositoriesSetupTasks,
                 RepositoriesMapping,
                 RepositoriesFacts,


### PR DESCRIPTION
Repositories covered by repositories mapping, that are used by installed RPM packages, are used to evaluate expected target repositories on top of evaluating the target repositories from enabled repositories. This covers repositories which might be disabled when upgrading, but should be used to upgrade installed packages during the upgrade.

Jira ref.: OAMG-7304