### PR TITLE
Rework network configuration handling

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -2,7 +2,7 @@
 %global repositorydir %{leapp_datadir}/repositories
 %global custom_repositorydir %{leapp_datadir}/custom-repositories
 
-%define leapp_repo_deps  8
+%define leapp_repo_deps  9
 
 %if 0%{?rhel} == 7
     %define leapp_python_sitelib %{python2_sitelib}
@@ -175,6 +175,11 @@ Requires:   kmod
 # since RHEL 8+ dracut does not have to be present on the system all the time
 # and missing dracut could be killing situation for us :)
 Requires:   dracut
+
+# Required to scan NetworkManagerConnection (e.g. to recognize secrets)
+# NM is requested to be used on RHEL 8+ systems
+Requires:   NetworkManager-libnm
+Requires:   python3-gobject-base
 
 %endif
 ##################################################

--- a/packaging/other_specs/leapp-el7toel8-deps.spec
+++ b/packaging/other_specs/leapp-el7toel8-deps.spec
@@ -9,7 +9,7 @@
 %endif
 
 
-%define leapp_repo_deps  8
+%define leapp_repo_deps  9
 %define leapp_framework_deps 5
 
 # NOTE: the Version contains the %{rhel} macro just for the convenience to
@@ -67,6 +67,7 @@ Requires:   cpio
 
 # just to be sure that /etc/modprobe.d is present
 Requires:   kmod
+
 
 %description -n %{lrdname}
 %{summary}

--- a/repos/system_upgrade/el8toel9/actors/checkifcfg/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/checkifcfg/actor.py
@@ -1,7 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import checkifcfg_ifcfg as ifcfg
-from leapp.models import InstalledRPM, Report, RpmTransactionTasks
-from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+from leapp.models import IfCfg, InstalledRPM, Report, RpmTransactionTasks
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
 class CheckIfcfg(Actor):
@@ -16,9 +16,9 @@ class CheckIfcfg(Actor):
     """
 
     name = "check_ifcfg"
-    consumes = (InstalledRPM,)
+    consumes = (IfCfg, InstalledRPM,)
     produces = (Report, RpmTransactionTasks,)
-    tags = (IPUWorkflowTag, FactsPhaseTag,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag,)
 
     def process(self):
         ifcfg.process()

--- a/repos/system_upgrade/el8toel9/actors/checkifcfg/tests/unit_test_ifcfg.py
+++ b/repos/system_upgrade/el8toel9/actors/checkifcfg/tests/unit_test_ifcfg.py
@@ -1,147 +1,144 @@
-import mock
-import six
+from leapp.models import IfCfg, IfCfgProperty, InstalledRPM, RPM, RpmTransactionTasks
+from leapp.reporting import Report
+from leapp.utils.report import is_inhibitor
 
-from leapp import reporting
-from leapp.libraries.actor import checkifcfg_ifcfg as ifcfg
-from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, produce_mocked
-from leapp.libraries.stdlib import api
-from leapp.models import InstalledRPM, RPM, RpmTransactionTasks
-
-RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+RH_PACKAGER = "Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>"
 
 NETWORK_SCRIPTS_RPM = RPM(
-    name='network-scripts', version='10.00.17', release='1.el8', epoch='',
-    packager=RH_PACKAGER, arch='x86_64',
-    pgpsig='RSA/SHA256, Fri 04 Feb 2022 03:32:47 PM CET, Key ID 199e2f91fd431d51'
+    name="network-scripts",
+    version="10.00.17",
+    release="1.el8",
+    epoch="",
+    packager=RH_PACKAGER,
+    arch="x86_64",
+    pgpsig="RSA/SHA256, Fri 04 Feb 2022 03:32:47 PM CET, Key ID 199e2f91fd431d51",
 )
 
 NETWORK_MANAGER_RPM = RPM(
-    name='NetworkManager', version='1.36.0', release='0.8.el8', epoch='1',
-    packager=RH_PACKAGER, arch='x86_64',
-    pgpsig='RSA/SHA256, Mon 14 Feb 2022 08:45:37 PM CET, Key ID 199e2f91fd431d51'
+    name="NetworkManager",
+    version="1.36.0",
+    release="0.8.el8",
+    epoch="1",
+    packager=RH_PACKAGER,
+    arch="x86_64",
+    pgpsig="RSA/SHA256, Mon 14 Feb 2022 08:45:37 PM CET, Key ID 199e2f91fd431d51",
 )
 
-INITSCRIPTS_INSTALLED = CurrentActorMocked(
-    msgs=[InstalledRPM(items=[NETWORK_SCRIPTS_RPM])]
-)
+INITSCRIPTS_INSTALLED = InstalledRPM(items=[
+    NETWORK_SCRIPTS_RPM
+])
+INITSCRIPTS_AND_NM_INSTALLED = InstalledRPM(items=[
+    NETWORK_SCRIPTS_RPM,
+    NETWORK_MANAGER_RPM
+])
 
-INITSCRIPTS_AND_NM_INSTALLED = CurrentActorMocked(
-    msgs=[InstalledRPM(items=[NETWORK_SCRIPTS_RPM, NETWORK_MANAGER_RPM])]
-)
 
-
-def test_ifcfg_none(monkeypatch):
+def test_ifcfg_none(current_actor_context):
     """
     No report and don't install anything if there are no ifcfg files.
     """
 
-    monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_AND_NM_INSTALLED)
-    monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
-    monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('hello', 'world',))
-    monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
-    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-    ifcfg.process()
-    assert not reporting.create_report.called
-    assert not api.produce.called
+    current_actor_context.feed(INITSCRIPTS_AND_NM_INSTALLED)
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+    assert not current_actor_context.consume(RpmTransactionTasks)
 
 
-def test_ifcfg_rule_file(monkeypatch):
+def test_ifcfg_rule_file(current_actor_context):
     """
     Install NetworkManager-dispatcher-routing-rules package if there's a
     file with ip rules.
     """
 
-    monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_AND_NM_INSTALLED)
-    monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
-    monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('hello', 'world', 'rule-eth0',))
-    monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
-    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-    ifcfg.process()
-    assert not reporting.create_report.called
-    assert api.produce.called
-    assert isinstance(api.produce.model_instances[0], RpmTransactionTasks)
-    assert api.produce.model_instances[0].to_install == ['NetworkManager-dispatcher-routing-rules']
+    current_actor_context.feed(IfCfg(
+        filename="/NM/ifcfg-eth0",
+        properties=(IfCfgProperty(name="TYPE", value="Ethernet"),),
+        rules=("foo bar baz",),
+    ))
+    current_actor_context.feed(INITSCRIPTS_AND_NM_INSTALLED)
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+    assert len(current_actor_context.consume(RpmTransactionTasks)) == 1
+    rpm_transaction = current_actor_context.consume(RpmTransactionTasks)[0]
+    assert rpm_transaction.to_install == ["NetworkManager-dispatcher-routing-rules"]
 
 
-def test_ifcfg_good_type(monkeypatch):
+def test_ifcfg_good_type(current_actor_context):
     """
     No report if there's an ifcfg file that would work with NetworkManager.
     Make sure NetworkManager itself is installed though.
     """
 
-    mock_config = mock.mock_open(read_data="TYPE=Ethernet")
-    with mock.patch("builtins.open" if six.PY3 else "__builtin__.open", mock_config) as mock_ifcfg:
-        monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_AND_NM_INSTALLED)
-        monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
-        monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('hello', 'world', 'ifcfg-eth0', 'ifcfg-lo',))
-        monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
-        monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-        ifcfg.process()
-        mock_ifcfg.assert_called_once_with('/etc/sysconfig/network-scripts/ifcfg-eth0')
-        assert not reporting.create_report.called
-        assert api.produce.called
-        assert isinstance(api.produce.model_instances[0], RpmTransactionTasks)
-        assert api.produce.model_instances[0].to_install == ['NetworkManager']
+    current_actor_context.feed(IfCfg(
+        filename="/NM/ifcfg-lo",
+        properties=()
+    ))
+    current_actor_context.feed(IfCfg(
+        filename="/NM/ifcfg-eth0",
+        properties=(IfCfgProperty(name="TYPE", value="Ethernet"),)
+    ))
+    current_actor_context.feed(INITSCRIPTS_AND_NM_INSTALLED)
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+    assert len(current_actor_context.consume(RpmTransactionTasks)) == 1
+    rpm_transaction = current_actor_context.consume(RpmTransactionTasks)[0]
+    assert rpm_transaction.to_install == ["NetworkManager"]
 
 
-def test_ifcfg_not_controlled(monkeypatch):
+def test_ifcfg_not_controlled(current_actor_context):
     """
     Report if there's a NM_CONTROLLED=no file.
     """
 
-    mock_config = mock.mock_open(read_data="TYPE=Ethernet\nNM_CONTROLLED=no")
-    with mock.patch("builtins.open" if six.PY3 else "__builtin__.open", mock_config) as mock_ifcfg:
-        monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_INSTALLED)
-        monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
-        monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('hello', 'world', 'ifcfg-eth0',))
-        monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
-        monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-        ifcfg.process()
-        mock_ifcfg.assert_called_once_with('/etc/sysconfig/network-scripts/ifcfg-eth0')
-        assert reporting.create_report.called
-        assert 'disabled NetworkManager' in reporting.create_report.report_fields['title']
-        assert api.produce.called
+    current_actor_context.feed(IfCfg(
+        filename="/NM/ifcfg-eth0",
+        properties=(
+            IfCfgProperty(name="TYPE", value="Ethernet"),
+            IfCfgProperty(name="NM_CONTROLLED", value="no"),
+        )
+    ))
+    current_actor_context.feed(INITSCRIPTS_INSTALLED)
+    current_actor_context.run()
+    assert len(current_actor_context.consume(Report)) == 1
+    report_fields = current_actor_context.consume(Report)[0].report
+    assert is_inhibitor(report_fields)
+    assert "disabled NetworkManager" in report_fields['title']
 
 
-def test_ifcfg_unknown_type(monkeypatch):
+def test_ifcfg_unknown_type(current_actor_context):
     """
     Report if there's configuration for a type we don't recognize.
     """
 
-    mock_config = mock.mock_open(read_data="TYPE=AvianCarrier")
-    with mock.patch("builtins.open" if six.PY3 else "__builtin__.open", mock_config) as mock_ifcfg:
-        monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_AND_NM_INSTALLED)
-        monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
-        monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('hello', 'world', 'ifcfg-pigeon0',))
-        monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
-        monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-        ifcfg.process()
-        mock_ifcfg.assert_called_once_with('/etc/sysconfig/network-scripts/ifcfg-pigeon0')
-        assert reporting.create_report.called
-        assert 'unsupported device types' in reporting.create_report.report_fields['title']
-        assert not api.produce.called
+    current_actor_context.feed(IfCfg(
+        filename="/NM/ifcfg-pigeon0",
+        properties=(IfCfgProperty(name="TYPE", value="AvianCarrier"),)
+    ))
+    current_actor_context.feed(INITSCRIPTS_AND_NM_INSTALLED)
+    current_actor_context.run()
+    assert len(current_actor_context.consume(Report)) == 1
+    report_fields = current_actor_context.consume(Report)[0].report
+    assert is_inhibitor(report_fields)
+    assert "unsupported device types" in report_fields['title']
 
 
-def test_ifcfg_install_subpackage(monkeypatch):
+def test_ifcfg_install_subpackage(current_actor_context):
     """
     Install NetworkManager-team if there's a team connection and also
     ensure NetworkManager-config-server is installed if NetworkManager
     was not there.
     """
 
-    mock_config = mock.mock_open(read_data="TYPE=Team")
-    with mock.patch("builtins.open" if six.PY3 else "__builtin__.open", mock_config) as mock_ifcfg:
-        monkeypatch.setattr(ifcfg.api, 'current_actor', INITSCRIPTS_INSTALLED)
-        monkeypatch.setattr(ifcfg.api, "produce", produce_mocked())
-        monkeypatch.setattr(ifcfg.os, 'listdir', lambda dummy: ('ifcfg-team0',))
-        monkeypatch.setattr(ifcfg.os.path, 'isfile', lambda dummy: True)
-        monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-        ifcfg.process()
-        mock_ifcfg.assert_called_once_with('/etc/sysconfig/network-scripts/ifcfg-team0')
-        assert not reporting.create_report.called
-        assert api.produce.called
-        assert isinstance(api.produce.model_instances[0], RpmTransactionTasks)
-        assert api.produce.model_instances[0].to_install == [
-            'NetworkManager-team',
-            'NetworkManager-config-server'
-        ]
+    current_actor_context.feed(IfCfg(
+        filename="/NM/ifcfg-team0",
+        properties=(IfCfgProperty(name="TYPE", value="Team"),)
+    ))
+    current_actor_context.feed(INITSCRIPTS_INSTALLED)
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+    assert len(current_actor_context.consume(RpmTransactionTasks)) == 1
+    rpm_transaction = current_actor_context.consume(RpmTransactionTasks)[0]
+    assert rpm_transaction.to_install == [
+        "NetworkManager-team",
+        "NetworkManager-config-server",
+    ]

--- a/repos/system_upgrade/el8toel9/actors/ifcfgscanner/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/ifcfgscanner/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import ifcfgscanner
+from leapp.models import IfCfg
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class IfCfgScanner(Actor):
+    """
+    Scan ifcfg files with legacy network configuration
+    """
+
+    name = "ifcfg_scanner"
+    consumes = ()
+    produces = (IfCfg,)
+    tags = (IPUWorkflowTag, FactsPhaseTag,)
+
+    def process(self):
+        ifcfgscanner.process()

--- a/repos/system_upgrade/el8toel9/actors/ifcfgscanner/libraries/ifcfgscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/ifcfgscanner/libraries/ifcfgscanner.py
@@ -1,0 +1,67 @@
+import errno
+from os import listdir, path
+
+from leapp.libraries.stdlib import api
+from leapp.models import IfCfg, IfCfgProperty
+
+SYSCONFIG_DIR = "/etc/sysconfig/network-scripts"
+
+
+def aux_file(prefix, filename):
+    directory = path.dirname(filename)
+    keys_base = path.basename(filename).replace("ifcfg-", prefix)
+    return path.join(directory, keys_base)
+
+
+def process_ifcfg(filename, secrets=False):
+    if not path.exists(filename):
+        return None
+
+    properties = []
+    for line in open(filename).readlines():
+        try:
+            (name, value) = line.split("#")[0].strip().split("=")
+            if secrets:
+                value = None
+        except ValueError:
+            # We're not interested in lines that are not
+            # simple assignments. Play it safe.
+            continue
+
+        properties.append(IfCfgProperty(name=name, value=value))
+    return properties
+
+
+def process_plain(filename):
+    if not path.exists(filename):
+        return None
+    return open(filename).readlines()
+
+
+def process_file(filename):
+    api.produce(IfCfg(
+        filename=filename,
+        properties=process_ifcfg(filename),
+        secrets=process_ifcfg(aux_file("keys-", filename), secrets=True),
+        rules=process_plain(aux_file("rule-", filename)),
+        rules6=process_plain(aux_file("rule6-", filename)),
+        routes=process_plain(aux_file("route-", filename)),
+        routes6=process_plain(aux_file("route6-", filename)),
+    ))
+
+
+def process_dir(directory):
+    try:
+        keyfiles = listdir(directory)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            return
+        raise
+
+    for f in keyfiles:
+        if f.startswith("ifcfg-"):
+            process_file(path.join(directory, f))
+
+
+def process():
+    process_dir(SYSCONFIG_DIR)

--- a/repos/system_upgrade/el8toel9/actors/ifcfgscanner/libraries/ifcfgscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/ifcfgscanner/libraries/ifcfgscanner.py
@@ -28,6 +28,12 @@ def process_ifcfg(filename, secrets=False):
             # simple assignments. Play it safe.
             continue
 
+        # Deal with simple quoting. We don't expand anything, nor do
+        # multiline strings or anything of that sort.
+        if value is not None and len(value) > 1 and value[0] == value[-1]:
+            if value.startswith('"') or value.startswith("'"):
+                value = value[1:-1]
+
         properties.append(IfCfgProperty(name=name, value=value))
     return properties
 

--- a/repos/system_upgrade/el8toel9/actors/ifcfgscanner/tests/unit_test_ifcfgscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/ifcfgscanner/tests/unit_test_ifcfgscanner.py
@@ -55,8 +55,8 @@ def test_ifcfg1(monkeypatch):
         TYPE=Wireless  # Some comment
         # Another comment
         ESSID=wep1
-        NAME=wep1
-        MODE=Managed
+        NAME="wep1"
+        MODE='Managed'   # comment
         WEP_KEY_FLAGS=ask
         SECURITYMODE=open
         DEFAULTKEY=1
@@ -81,6 +81,10 @@ def test_ifcfg1(monkeypatch):
         assert ifcfg.properties[0].value == "Wireless"
         assert ifcfg.properties[1].name == "ESSID"
         assert ifcfg.properties[1].value == "wep1"
+        assert ifcfg.properties[2].name == "NAME"
+        assert ifcfg.properties[2].value == "wep1"
+        assert ifcfg.properties[3].name == "MODE"
+        assert ifcfg.properties[3].value == "Managed"
 
 
 def test_ifcfg2(monkeypatch):

--- a/repos/system_upgrade/el8toel9/actors/ifcfgscanner/tests/unit_test_ifcfgscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/ifcfgscanner/tests/unit_test_ifcfgscanner.py
@@ -1,0 +1,123 @@
+import errno
+import textwrap
+from os.path import basename
+
+import mock
+import six
+
+from leapp.libraries.actor import ifcfgscanner
+from leapp.libraries.common.testutils import make_OSError, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import IfCfg
+
+_builtins_open = "builtins.open" if six.PY3 else "__builtin__.open"
+
+
+def _listdir_ifcfg(path):
+    if path == ifcfgscanner.SYSCONFIG_DIR:
+        return ["ifcfg-net0"]
+    raise make_OSError(errno.ENOENT)
+
+
+def _listdir_ifcfg2(path):
+    if path == ifcfgscanner.SYSCONFIG_DIR:
+        return ["ifcfg-net0", "ifcfg-net1"]
+    raise make_OSError(errno.ENOENT)
+
+
+def _exists_ifcfg(filename):
+    return basename(filename).startswith("ifcfg-")
+
+
+def _exists_keys(filename):
+    if _exists_ifcfg(filename):
+        return True
+    return basename(filename).startswith("keys-")
+
+
+def test_no_conf(monkeypatch):
+    """
+    No report if there are no ifcfg files.
+    """
+
+    monkeypatch.setattr(ifcfgscanner, "listdir", lambda _: ())
+    monkeypatch.setattr(api, "produce", produce_mocked())
+    ifcfgscanner.process()
+    assert not api.produce.called
+
+
+def test_ifcfg1(monkeypatch):
+    """
+    Parse a single ifcfg file.
+    """
+
+    ifcfg_file = textwrap.dedent("""
+        TYPE=Wireless  # Some comment
+        # Another comment
+        ESSID=wep1
+        NAME=wep1
+        MODE=Managed
+        WEP_KEY_FLAGS=ask
+        SECURITYMODE=open
+        DEFAULTKEY=1
+        KEY_TYPE=key
+    """)
+
+    mock_config = mock.mock_open(read_data=ifcfg_file)
+    with mock.patch(_builtins_open, mock_config):
+        monkeypatch.setattr(ifcfgscanner, "listdir", _listdir_ifcfg)
+        monkeypatch.setattr(ifcfgscanner.path, "exists", _exists_ifcfg)
+        monkeypatch.setattr(api, "produce", produce_mocked())
+        ifcfgscanner.process()
+
+        assert api.produce.called == 1
+        assert len(api.produce.model_instances) == 1
+        ifcfg = api.produce.model_instances[0]
+        assert isinstance(ifcfg, IfCfg)
+        assert ifcfg.filename == "/etc/sysconfig/network-scripts/ifcfg-net0"
+        assert ifcfg.secrets is None
+        assert len(ifcfg.properties) == 8
+        assert ifcfg.properties[0].name == "TYPE"
+        assert ifcfg.properties[0].value == "Wireless"
+        assert ifcfg.properties[1].name == "ESSID"
+        assert ifcfg.properties[1].value == "wep1"
+
+
+def test_ifcfg2(monkeypatch):
+    """
+    Parse two ifcfg files.
+    """
+
+    mock_config = mock.mock_open(read_data="TYPE=Ethernet")
+    with mock.patch(_builtins_open, mock_config):
+        monkeypatch.setattr(ifcfgscanner, "listdir", _listdir_ifcfg2)
+        monkeypatch.setattr(ifcfgscanner.path, "exists", _exists_ifcfg)
+        monkeypatch.setattr(api, "produce", produce_mocked())
+        ifcfgscanner.process()
+
+        assert api.produce.called == 2
+        assert len(api.produce.model_instances) == 2
+        ifcfg = api.produce.model_instances[0]
+        assert isinstance(ifcfg, IfCfg)
+
+
+def test_ifcfg_key(monkeypatch):
+    """
+    Report ifcfg secrets from keys- file.
+    """
+
+    mock_config = mock.mock_open(read_data="KEY_PASSPHRASE1=Hell0")
+    with mock.patch(_builtins_open, mock_config):
+        monkeypatch.setattr(ifcfgscanner, "listdir", _listdir_ifcfg)
+        monkeypatch.setattr(ifcfgscanner.path, "exists", _exists_keys)
+        monkeypatch.setattr(api, "produce", produce_mocked())
+        ifcfgscanner.process()
+
+        assert api.produce.called == 1
+        assert len(api.produce.model_instances) == 1
+        ifcfg = api.produce.model_instances[0]
+        assert isinstance(ifcfg, IfCfg)
+        assert ifcfg.filename == "/etc/sysconfig/network-scripts/ifcfg-net0"
+        assert len(ifcfg.secrets) == 1
+        assert ifcfg.secrets[0].name == "KEY_PASSPHRASE1"
+        assert ifcfg.secrets[0].value is None

--- a/repos/system_upgrade/el8toel9/actors/networkdeprecations/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/networkdeprecations/actor.py
@@ -1,7 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import networkdeprecations
-from leapp.models import Report
-from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+from leapp.models import IfCfg, NetworkManagerConnection, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
 class CheckNetworkDeprecations(Actor):
@@ -16,8 +16,9 @@ class CheckNetworkDeprecations(Actor):
     """
 
     name = "network_deprecations"
+    consumes = (IfCfg, NetworkManagerConnection,)
     produces = (Report,)
-    tags = (IPUWorkflowTag, FactsPhaseTag,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag,)
 
     def process(self):
         networkdeprecations.process()

--- a/repos/system_upgrade/el8toel9/actors/networkdeprecations/tests/unit_test_networkdeprecations.py
+++ b/repos/system_upgrade/el8toel9/actors/networkdeprecations/tests/unit_test_networkdeprecations.py
@@ -1,148 +1,124 @@
-import errno
-import textwrap
-
-import mock
-import six
-
-from leapp import reporting
-from leapp.libraries.actor import networkdeprecations
-from leapp.libraries.common.testutils import create_report_mocked, make_OSError
-
-
-def _listdir_nm_conn(path):
-    if path == networkdeprecations.NM_CONN_DIR:
-        return ['connection']
-    raise make_OSError(errno.ENOENT)
+from leapp.models import (
+    IfCfg,
+    IfCfgProperty,
+    NetworkManagerConnection,
+    NetworkManagerConnectionProperty,
+    NetworkManagerConnectionSetting
+)
+from leapp.reporting import Report
+from leapp.utils.report import is_inhibitor
 
 
-def _listdir_ifcfg(path):
-    if path == networkdeprecations.SYSCONFIG_DIR:
-        return ['ifcfg-wireless']
-    raise make_OSError(errno.ENOENT)
-
-
-def _listdir_keys(path):
-    if path == networkdeprecations.SYSCONFIG_DIR:
-        return ['keys-wireless']
-    raise make_OSError(errno.ENOENT)
-
-
-def test_no_conf(monkeypatch):
+def test_no_conf(current_actor_context):
     """
     No report if there are no networks.
     """
 
-    monkeypatch.setattr(networkdeprecations.os, 'listdir', lambda _: ())
-    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-    networkdeprecations.process()
-    assert not reporting.create_report.called
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
 
 
-def test_no_wireless(monkeypatch):
+def test_no_wireless(current_actor_context):
     """
     No report if there's a keyfile, but it's not for a wireless connection.
     """
 
-    mock_config = mock.mock_open(read_data='[connection]')
-    with mock.patch('builtins.open' if six.PY3 else '__builtin__.open', mock_config):
-        monkeypatch.setattr(networkdeprecations.os, 'listdir', _listdir_nm_conn)
-        monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-        networkdeprecations.process()
-        assert not reporting.create_report.called
+    not_wifi_nm_conn = NetworkManagerConnection(filename='/NM/wlan0.nmconn', settings=(
+        NetworkManagerConnectionSetting(name='connection'),
+    ))
+
+    current_actor_context.feed(not_wifi_nm_conn)
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
 
 
-def test_keyfile_static_wep(monkeypatch):
+def test_keyfile_static_wep(current_actor_context):
     """
     Report if there's a static WEP keyfile.
     """
 
-    STATIC_WEP_CONN = textwrap.dedent("""
-        [wifi-security]
-        auth-alg=open
-        key-mgmt=none
-        wep-key-type=1
-        wep-key0=abcde
-    """)
+    static_wep_nm_conn = NetworkManagerConnection(filename='/NM/wlan0.nmconn', settings=(
+        NetworkManagerConnectionSetting(name='wifi-security', properties=(
+            NetworkManagerConnectionProperty(name='auth-alg', value='open'),
+            NetworkManagerConnectionProperty(name='key-mgmt', value='none'),
+            NetworkManagerConnectionProperty(name='wep-key-type', value='1'),
+        )),
+    ))
 
-    mock_config = mock.mock_open(read_data=STATIC_WEP_CONN)
-    with mock.patch('builtins.open' if six.PY3 else '__builtin__.open', mock_config):
-        monkeypatch.setattr(networkdeprecations.os, 'listdir', _listdir_nm_conn)
-        monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-        networkdeprecations.process()
-        assert reporting.create_report.called
+    current_actor_context.feed(static_wep_nm_conn)
+    current_actor_context.run()
+    report_fields = current_actor_context.consume(Report)[0].report
+    assert is_inhibitor(report_fields)
 
 
-def test_keyfile_dynamic_wep(monkeypatch):
+def test_keyfile_dynamic_wep(current_actor_context):
     """
     Report if there's a dynamic WEP keyfile.
     """
 
-    DYNAMIC_WEP_CONN = textwrap.dedent("""
-        [wifi-security]
-        key-mgmt=ieee8021x
-    """)
+    dynamic_wep_conn = NetworkManagerConnection(filename='/NM/wlan0.nmconn', settings=(
+        NetworkManagerConnectionSetting(name='wifi-security', properties=(
+            NetworkManagerConnectionProperty(name='key-mgmt', value='ieee8021x'),
+        )),
+    ))
 
-    mock_config = mock.mock_open(read_data=DYNAMIC_WEP_CONN)
-    with mock.patch('builtins.open' if six.PY3 else '__builtin__.open', mock_config):
-        monkeypatch.setattr(networkdeprecations.os, 'listdir', _listdir_nm_conn)
-        monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-        networkdeprecations.process()
-        assert reporting.create_report.called
+    current_actor_context.feed(dynamic_wep_conn)
+    current_actor_context.run()
+    report_fields = current_actor_context.consume(Report)[0].report
+    assert is_inhibitor(report_fields)
 
 
-def test_ifcfg_static_wep_ask(monkeypatch):
+def test_ifcfg_static_wep_ask(current_actor_context):
     """
     Report if there's a static WEP sysconfig without stored key.
     """
 
-    STATIC_WEP_ASK_KEY_SYSCONFIG = textwrap.dedent("""
-        TYPE=Wireless
-        ESSID=wep1
-        NAME=wep1
-        MODE=Managed
-        WEP_KEY_FLAGS=ask
-        SECURITYMODE=open
-        DEFAULTKEY=1
-        KEY_TYPE=key
-    """)
+    static_wep_ask_key_ifcfg = IfCfg(filename='/NM/ifcfg-wlan0', properties=(
+        IfCfgProperty(name='TYPE', value='Wireless'),
+        IfCfgProperty(name='ESSID', value='wep1'),
+        IfCfgProperty(name='NAME', value='wep1'),
+        IfCfgProperty(name='MODE', value='Managed'),
+        IfCfgProperty(name='WEP_KEY_FLAGS', value='ask'),
+        IfCfgProperty(name='SECURITYMODE', value='open'),
+        IfCfgProperty(name='DEFAULTKEY', value='1'),
+        IfCfgProperty(name='KEY_TYPE', value='key'),
+    ))
 
-    mock_config = mock.mock_open(read_data=STATIC_WEP_ASK_KEY_SYSCONFIG)
-    with mock.patch('builtins.open' if six.PY3 else '__builtin__.open', mock_config):
-        monkeypatch.setattr(networkdeprecations.os, 'listdir', _listdir_ifcfg)
-        monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-        networkdeprecations.process()
-        assert reporting.create_report.called
+    current_actor_context.feed(static_wep_ask_key_ifcfg)
+    current_actor_context.run()
+    report_fields = current_actor_context.consume(Report)[0].report
+    assert is_inhibitor(report_fields)
 
 
-def test_ifcfg_static_wep(monkeypatch):
+def test_ifcfg_static_wep(current_actor_context):
     """
     Report if there's a static WEP sysconfig with a stored passphrase.
     """
 
-    mock_config = mock.mock_open(read_data='KEY_PASSPHRASE1=Hell0')
-    with mock.patch('builtins.open' if six.PY3 else '__builtin__.open', mock_config):
-        monkeypatch.setattr(networkdeprecations.os, 'listdir', _listdir_keys)
-        monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-        networkdeprecations.process()
-        assert reporting.create_report.called
+    static_wep_ifcfg = IfCfg(filename='/NM/ifcfg-wlan0', secrets=(
+        IfCfgProperty(name='KEY_PASSPHRASE1', value=None),
+    ))
+
+    current_actor_context.feed(static_wep_ifcfg)
+    current_actor_context.run()
+    report_fields = current_actor_context.consume(Report)[0].report
+    assert is_inhibitor(report_fields)
 
 
-def test_ifcfg_dynamic_wep(monkeypatch):
+def test_ifcfg_dynamic_wep(current_actor_context):
     """
     Report if there's a dynamic WEP sysconfig.
     """
 
-    DYNAMIC_WEP_SYSCONFIG = textwrap.dedent("""
-        ESSID=dynwep1
-        MODE=Managed
-        KEY_MGMT=IEEE8021X  # Dynamic WEP!
-        TYPE=Wireless
-        NAME=dynwep1
-    """)
+    dynamic_wep_ifcfg = IfCfg(filename='/NM/ifcfg-wlan0', properties=(
+        IfCfgProperty(name='ESSID', value='dynwep1'),
+        IfCfgProperty(name='MODE', value='Managed'),
+        IfCfgProperty(name='KEY_MGMT', value='IEEE8021X'),
+        IfCfgProperty(name='TYPE', value='Wireless'),
+        IfCfgProperty(name='NAME', value='dynwep1'),
+    ))
 
-    mock_config = mock.mock_open(read_data=DYNAMIC_WEP_SYSCONFIG)
-    with mock.patch('builtins.open' if six.PY3 else '__builtin__.open', mock_config):
-        monkeypatch.setattr(networkdeprecations.os, 'listdir', _listdir_ifcfg)
-        monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
-        networkdeprecations.process()
-        assert reporting.create_report.called
+    current_actor_context.feed(dynamic_wep_ifcfg)
+    current_actor_context.run()
+    report_fields = current_actor_context.consume(Report)[0].report
+    assert is_inhibitor(report_fields)

--- a/repos/system_upgrade/el8toel9/actors/networkmanagerconnectionscanner/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/networkmanagerconnectionscanner/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import networkmanagerconnectionscanner
+from leapp.models import NetworkManagerConnection
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class NetworkManagerConnectionScanner(Actor):
+    """
+    Scan NetworkManager connection keyfiles
+    """
+
+    name = "network_manager_connection_scanner"
+    consumes = ()
+    produces = (NetworkManagerConnection,)
+    tags = (IPUWorkflowTag, FactsPhaseTag,)
+
+    def process(self):
+        networkmanagerconnectionscanner.process()

--- a/repos/system_upgrade/el8toel9/actors/networkmanagerconnectionscanner/libraries/networkmanagerconnectionscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/networkmanagerconnectionscanner/libraries/networkmanagerconnectionscanner.py
@@ -1,0 +1,65 @@
+import errno
+import os
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import utils
+from leapp.libraries.stdlib import api
+from leapp.models import NetworkManagerConnection, NetworkManagerConnectionProperty, NetworkManagerConnectionSetting
+
+libnm_available = False
+err_details = None
+try:
+    import gi
+    try:
+        gi.require_version("NM", "1.0")
+        from gi.repository import GLib, NM
+        libnm_available = True
+    except ValueError:
+        err_details = 'NetworkManager-libnm package is not available'
+except ImportError:
+    err_details = 'python3-gobject-base package is not available'
+
+NM_CONN_DIR = "/etc/NetworkManager/system-connections"
+
+
+def process_file(filename):
+    # We're running this through libnm in order to clear the secrets.
+    # We don't know what keys are secret, but libnm does.
+    keyfile = GLib.KeyFile()
+    keyfile.load_from_file(filename, GLib.KeyFileFlags.NONE)
+    con = NM.keyfile_read(keyfile, NM_CONN_DIR, NM.KeyfileHandlerFlags.NONE)
+    con.clear_secrets()
+    keyfile = NM.keyfile_write(con, NM.KeyfileHandlerFlags.NONE)
+    cp = utils.parse_config(keyfile.to_data()[0])
+
+    settings = []
+    for setting_name in cp.sections():
+        properties = []
+        for name, value in cp.items(setting_name, raw=True):
+            properties.append(NetworkManagerConnectionProperty(name=name, value=value))
+        settings.append(
+            NetworkManagerConnectionSetting(name=setting_name, properties=properties)
+        )
+    api.produce(NetworkManagerConnection(filename=filename, settings=settings))
+
+
+def process_dir(directory):
+    try:
+        keyfiles = os.listdir(directory)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            return
+        raise
+
+    for f in keyfiles:
+        process_file(os.path.join(NM_CONN_DIR, f))
+
+
+def process():
+    if libnm_available:
+        process_dir(NM_CONN_DIR)
+    else:
+        raise StopActorExecutionError(
+            message='Failed to read NetworkManager connections',
+            details=err_details
+            )

--- a/repos/system_upgrade/el8toel9/actors/networkmanagerconnectionscanner/tests/unit_test_networkmanagerconnectionscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/networkmanagerconnectionscanner/tests/unit_test_networkmanagerconnectionscanner.py
@@ -1,0 +1,105 @@
+import errno
+import textwrap
+
+import pytest
+import six
+
+from leapp.libraries.actor import networkmanagerconnectionscanner as nmconnscanner
+from leapp.libraries.common.testutils import make_OSError, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import NetworkManagerConnection
+
+_builtins_open = "builtins.open" if six.PY3 else "__builtin__.open"
+
+
+def _listdir_nm_conn(path):
+    if path == nmconnscanner.NM_CONN_DIR:
+        return ["conn1.nmconnection"]
+    raise make_OSError(errno.ENOENT)
+
+
+def _listdir_nm_conn2(path):
+    if path == nmconnscanner.NM_CONN_DIR:
+        return ["conn1.nmconnection", "conn2.nmconnection"]
+    raise make_OSError(errno.ENOENT)
+
+
+def _load_from_file(keyfile, filename, flags):
+    if filename.endswith(".nmconnection"):
+        return keyfile.load_from_data(textwrap.dedent("""
+            [connection]
+            type=wifi
+            id=conn1
+            uuid=a1bc695d-c548-40e8-9c7f-205a6587135d
+
+            [wifi]
+            mode=infrastructure
+            ssid=wifi
+
+            [wifi-security]
+            auth-alg=open
+            key-mgmt=none
+            wep-key-type=1
+            wep-key0=abcde
+        """), nmconnscanner.GLib.MAXSIZE, flags)
+    raise make_OSError(errno.ENOENT)
+
+
+@pytest.mark.skipif(not nmconnscanner.libnm_available, reason="NetworkManager g-ir not installed")
+def test_no_conf(monkeypatch):
+    """
+    No report if there are no keyfiles
+    """
+
+    monkeypatch.setattr(nmconnscanner.os, "listdir", lambda _: ())
+    monkeypatch.setattr(api, "produce", produce_mocked())
+    nmconnscanner.process()
+    assert not api.produce.called
+
+
+@pytest.mark.skipif(not nmconnscanner.libnm_available, reason="NetworkManager g-ir not installed")
+def test_nm_conn(monkeypatch):
+    """
+    Check a basic keyfile
+    """
+
+    monkeypatch.setattr(nmconnscanner.os, "listdir", _listdir_nm_conn)
+    monkeypatch.setattr(api, "produce", produce_mocked())
+    monkeypatch.setattr(nmconnscanner.GLib.KeyFile, "load_from_file", _load_from_file)
+    nmconnscanner.process()
+
+    assert api.produce.called == 1
+    assert len(api.produce.model_instances) == 1
+    nm_conn = api.produce.model_instances[0]
+    assert isinstance(nm_conn, NetworkManagerConnection)
+    assert nm_conn.filename == "/etc/NetworkManager/system-connections/conn1.nmconnection"
+    assert len(nm_conn.settings) == 3
+    assert nm_conn.settings[0].name == "connection"
+    assert len(nm_conn.settings[0].properties) == 4
+    assert nm_conn.settings[0].properties[0].name == "id"
+    assert nm_conn.settings[0].properties[0].value == "conn1"
+    assert nm_conn.settings[2].name == "wifi-security"
+
+    # It's important that wek-key0 is gone
+    assert len(nm_conn.settings[2].properties) == 3
+    assert nm_conn.settings[2].properties[0].name == "auth-alg"
+    assert nm_conn.settings[2].properties[0].value == "open"
+    assert nm_conn.settings[2].properties[1].name != "wep-key0"
+    assert nm_conn.settings[2].properties[2].name != "wep-key0"
+
+
+@pytest.mark.skipif(not nmconnscanner.libnm_available, reason="NetworkManager g-ir not installed")
+def test_nm_conn2(monkeypatch):
+    """
+    Check a pair of keyfiles
+    """
+
+    monkeypatch.setattr(nmconnscanner.os, "listdir", _listdir_nm_conn2)
+    monkeypatch.setattr(api, "produce", produce_mocked())
+    monkeypatch.setattr(nmconnscanner.GLib.KeyFile, "load_from_file", _load_from_file)
+    nmconnscanner.process()
+
+    assert api.produce.called == 2
+    assert len(api.produce.model_instances) == 2
+    assert api.produce.model_instances[0].filename.endswith("/conn1.nmconnection")
+    assert api.produce.model_instances[1].filename.endswith("/conn2.nmconnection")

--- a/repos/system_upgrade/el8toel9/models/ifcfg.py
+++ b/repos/system_upgrade/el8toel9/models/ifcfg.py
@@ -1,0 +1,42 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class IfCfgProperty(Model):
+    """
+    Key-value pair for ifcfg properties.
+
+    This model is not expected to be used as a message (produced/consumed by actors).
+    It is used from within the IfCfg model.
+    """
+    topic = SystemInfoTopic
+
+    name = fields.String()
+    """ Name of a property """
+    value = fields.Nullable(fields.String())
+    """ Value of a property """
+
+
+class IfCfg(Model):
+    """
+    IfCfg file describing legacy network configuration
+
+    Produced for every ifcfg file loaded from key-value ("sysconfig")
+    format described in nm-settings-ifcfg-rh(5) manual.
+    """
+    topic = SystemInfoTopic
+
+    filename = fields.String()
+    """ Path to file this model was populated from """
+    properties = fields.List(fields.Model(IfCfgProperty), default=[])
+    """ The list of name-value pairs from ifcfg file """
+    secrets = fields.Nullable(fields.List(fields.Model(IfCfgProperty)))
+    """ The list of name-value pairs from keys file """
+    rules = fields.Nullable(fields.List(fields.String()))
+    """ The list of traffic rules for IPv4 """
+    rules6 = fields.Nullable(fields.List(fields.String()))
+    """ The list of traffic rules for IPv6 """
+    routes = fields.Nullable(fields.List(fields.String()))
+    """ The list of routes for IPv4 """
+    routes6 = fields.Nullable(fields.List(fields.String()))
+    """ The list of routes for IPv6 """

--- a/repos/system_upgrade/el8toel9/models/networkmanagerconnection.py
+++ b/repos/system_upgrade/el8toel9/models/networkmanagerconnection.py
@@ -1,0 +1,47 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class NetworkManagerConnectionProperty(Model):
+    """
+    Name-value pair for NetworkManager properties.
+
+    This model is not expected to be used as a message (produced/consumed by actors).
+    It is used within NetworkManagerConnectionSetting of a NetworkManagerConnection.
+    """
+    topic = SystemInfoTopic
+
+    name = fields.String()
+    """ Name of a property """
+    value = fields.String()
+    """ Value of a property """
+
+
+class NetworkManagerConnectionSetting(Model):
+    """
+    NetworkManager setting, composed of a name and a list of name-value pairs.
+
+    This model is not expected to be used as a message (produced/consumed by actors).
+    It is used within NetworkManagerConnection.
+    """
+    topic = SystemInfoTopic
+
+    name = fields.String()
+    """ The NetworkManager setting name """
+    properties = fields.List(fields.Model(NetworkManagerConnectionProperty), default=[])
+    """ The name-value pair for every setting property """
+
+
+class NetworkManagerConnection(Model):
+    """
+    NetworkManager native keyfile connection
+
+    Produced for every connection profile loaded from INI-stile files
+    described in nm-settings-keyfile(5) manual.
+    """
+    topic = SystemInfoTopic
+
+    settings = fields.List(fields.Model(NetworkManagerConnectionSetting), default=[])
+    """ List of NetworkManager settings """
+    filename = fields.String()
+    """ Path to file this model was populated from """

--- a/utils/container-tests/Containerfile.f34
+++ b/utils/container-tests/Containerfile.f34
@@ -3,7 +3,7 @@ FROM fedora:34
 VOLUME /repo
 
 RUN dnf update -y && \
-    dnf install -y findutils make rsync
+    dnf install -y findutils make rsync python3-gobject-base NetworkManager-libnm
 
 ENV PYTHON_VENV python3.9
 


### PR DESCRIPTION
This splits off the ifcfg & NetworkManager profile reading parts from CheckIfCfg and CheckNetworkDeprecations into separate scanners; allowing the ifcfg code to be shared.

There's a bugfix [1] at the end, depending on the IfCfg parsing consolidation.

[1] Make IfCfgScanner accept simple quoted values <https://bugzilla.redhat.com/show_bug.cgi?id=2111691>