### PR TITLE
firewalldcheckallowzonedrifting: Fix the remediation cmd

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/firewalldcheckallowzonedrifting/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/firewalldcheckallowzonedrifting/actor.py
@@ -46,6 +46,6 @@ class FirewalldCheckAllowZoneDrifting(Actor):
                 title='Changes in firewalld related to Zone Drifting'),
             reporting.Remediation(
                 hint='Set AllowZoneDrifting=no in /etc/firewalld/firewalld.conf',
-                commands=[['sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" '
+                commands=[['sed', '-i', 's/^AllowZoneDrifting=.*/AllowZoneDrifting=no/',
                            '/etc/firewalld/firewalld.conf']]),
         ])


### PR DESCRIPTION
The remediation cmd was incorrect as the cmd is written as string instead of list, the fix:
  ['cmd param param'] -> ['cmd', 'paramm', 'param']

JIRA: OAMG-7694