### PR TITLE
Enable device_cio_free.service systemd service on s390x

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/enableddeviceciofreeservices390/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/enableddeviceciofreeservices390/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import enabledeviceciofreeservice
+from leapp.models import SystemdServicesTasks
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class EnableDeviceCioFreeService(Actor):
+    """
+    Enables device_cio_free.service systemd service on s390x
+
+    After an upgrade this service ends up disabled even though it's vendor preset is set to enabled.
+    The service is used to enable devices which are not explicitly enabled on the kernel command line.
+    """
+
+    name = 'enable_device_cio_free_service'
+    consumes = ()
+    produces = (SystemdServicesTasks,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        enabledeviceciofreeservice.process()

--- a/repos/system_upgrade/el7toel8/actors/enableddeviceciofreeservices390/libraries/enabledeviceciofreeservice.py
+++ b/repos/system_upgrade/el7toel8/actors/enableddeviceciofreeservices390/libraries/enabledeviceciofreeservice.py
@@ -1,0 +1,8 @@
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+from leapp.models import SystemdServicesTasks
+
+
+def process():
+    if architecture.matches_architecture(architecture.ARCH_S390X):
+        api.produce(SystemdServicesTasks(to_enable=['device_cio_free.service']))

--- a/repos/system_upgrade/el7toel8/actors/enableddeviceciofreeservices390/tests/test_enableddeviceciofreeservice.py
+++ b/repos/system_upgrade/el7toel8/actors/enableddeviceciofreeservices390/tests/test_enableddeviceciofreeservice.py
@@ -1,0 +1,32 @@
+import pytest
+
+from leapp.libraries.actor import enabledeviceciofreeservice
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import SystemdServicesTasks
+
+
+def test_task_produced_on_s390(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X))
+    monkeypatch.setattr(api, "produce", produce_mocked())
+
+    enabledeviceciofreeservice.process()
+
+    assert api.produce.called
+    assert isinstance(api.produce.model_instances[0], SystemdServicesTasks)
+    assert api.produce.model_instances[0].to_enable == ['device_cio_free.service']
+
+
+@pytest.mark.parametrize('arch', [
+    architecture.ARCH_X86_64,
+    architecture.ARCH_ARM64,
+    architecture.ARCH_PPC64LE,
+])
+def test_task_not_produced_on_non_s390(monkeypatch, arch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=arch))
+    monkeypatch.setattr(api, "produce", produce_mocked())
+
+    enabledeviceciofreeservice.process()
+
+    assert not api.produce.called


### PR DESCRIPTION
After an IPU the device_cio_free.service systemd service (exclusive to s390x) is disabled even though the vendor preset is set to disable. The new actor enables the service.

The service is used to enable devices not explicitly enabled on kernel command line.

The test is broken now until oamg/leapp#680 is merged.

Jira ref.: OAMG-6302
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2032953