### PR TITLE
s390x fixes: zfcp+zipl

### DIFF
--- a/repos/system_upgrade/common/actors/scandasd/tests/unit_test_scandasd.py
+++ b/repos/system_upgrade/common/actors/scandasd/tests/unit_test_scandasd.py
@@ -3,18 +3,18 @@ import os
 import pytest
 
 from leapp.libraries.actor import scandasd
-from leapp.libraries.common.config.architecture import ARCH_S390X
-from leapp.libraries.common.testutils import logger_mocked, produce_mocked
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked, produce_mocked
 from leapp.models import CopyFile, TargetUserSpaceUpgradeTasks, UpgradeInitramfsTasks
 
 
 def test_dasd_exists(monkeypatch):
-    monkeypatch.setattr(scandasd.architecture, 'matches_architecture', lambda dummy: True)
+    monkeypatch.setattr(scandasd.api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X))
     monkeypatch.setattr(scandasd.api, 'current_logger', logger_mocked())
     monkeypatch.setattr(scandasd.api, 'produce', produce_mocked())
     monkeypatch.setattr(os.path, 'isfile', lambda dummy: True)
     scandasd.process()
-    assert not scandasd.api.current_logger.warnmsg
+    assert not scandasd.api.current_logger.infomsg
     assert scandasd.api.produce.called == 2
     tusut_flag = False
     uit_flag = False
@@ -30,12 +30,12 @@ def test_dasd_exists(monkeypatch):
 
 
 def test_dasd_not_found(monkeypatch):
-    monkeypatch.setattr(scandasd.architecture, 'matches_architecture', lambda dummy: True)
+    monkeypatch.setattr(scandasd.api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X))
     monkeypatch.setattr(scandasd.api, 'current_logger', logger_mocked())
     monkeypatch.setattr(os.path, 'isfile', lambda dummy: False)
     monkeypatch.setattr(scandasd.api, 'produce', produce_mocked())
     scandasd.process()
-    assert scandasd.api.current_logger.warnmsg
+    assert scandasd.api.current_logger.infomsg
     assert scandasd.api.produce.called == 1
     assert len(scandasd.api.produce.model_instances) == 1
     assert isinstance(scandasd.api.produce.model_instances[0], TargetUserSpaceUpgradeTasks)
@@ -44,11 +44,16 @@ def test_dasd_not_found(monkeypatch):
 
 
 @pytest.mark.parametrize('isfile', [True, False])
-def test_non_ibmz_arch(monkeypatch, isfile):
-    monkeypatch.setattr(scandasd.architecture, 'matches_architecture', lambda dummy: False)
+@pytest.mark.parametrize('arch', [
+    architecture.ARCH_X86_64,
+    architecture.ARCH_ARM64,
+    architecture.ARCH_PPC64LE,
+])
+def test_non_ibmz_arch(monkeypatch, isfile, arch):
+    monkeypatch.setattr(scandasd.api, 'current_actor', CurrentActorMocked(arch=arch))
     monkeypatch.setattr(scandasd.api, 'current_logger', logger_mocked())
     monkeypatch.setattr(scandasd.api, 'produce', produce_mocked())
     monkeypatch.setattr(os.path, 'isfile', lambda dummy: isfile)
     scandasd.process()
-    assert not scandasd.api.current_logger.warnmsg
+    assert not scandasd.api.current_logger.infomsg
     assert not scandasd.api.produce.called

--- a/repos/system_upgrade/common/actors/scanzfcp/actor.py
+++ b/repos/system_upgrade/common/actors/scanzfcp/actor.py
@@ -1,0 +1,24 @@
+
+from leapp.actors import Actor
+from leapp.libraries.actor import scanzfcp
+from leapp.models import TargetUserSpaceUpgradeTasks, UpgradeInitramfsTasks
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanZFCP(Actor):
+    """
+    In case of s390x architecture, check whether ZFCP is used.
+
+    The current check is based just on existence of the /etc/zfcp.conf file.
+    If it exists, produce UpgradeInitramfsTasks msg to ensure the file
+    is available inside the target userspace to be able to generate the
+    upgrade init ramdisk correctly.
+    """
+
+    name = 'scanzfcp'
+    consumes = ()
+    produces = (TargetUserSpaceUpgradeTasks, UpgradeInitramfsTasks)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        scanzfcp.process()

--- a/repos/system_upgrade/common/actors/scanzfcp/libraries/scanzfcp.py
+++ b/repos/system_upgrade/common/actors/scanzfcp/libraries/scanzfcp.py
@@ -4,22 +4,22 @@ from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 from leapp.models import CopyFile, TargetUserSpaceUpgradeTasks, UpgradeInitramfsTasks
 
-DASD_CONF = '/etc/dasd.conf'
+ZFCP_CONF = '/etc/zfcp.conf'
 
 
 def process():
     if not architecture.matches_architecture(architecture.ARCH_S390X):
         return
     copy_files = []
-    if os.path.isfile(DASD_CONF):
+    if os.path.isfile(ZFCP_CONF):
         # the file has to be copied into the targetuserspace container first,
         # then it can be included into the initramfs ==> both messages are
         # needed to be produced
-        copy_files = [CopyFile(src=DASD_CONF)]
-        api.produce(UpgradeInitramfsTasks(include_files=[DASD_CONF]))
+        copy_files = [CopyFile(src=ZFCP_CONF)]
+        api.produce(UpgradeInitramfsTasks(include_files=[ZFCP_CONF]))
     else:
         api.current_logger().info(
-            "The {} file has not been discovered. DASD not used."
-            .format(DASD_CONF)
+            "The {} file has not been discovered. ZFCP not used."
+            .format(ZFCP_CONF)
         )
     api.produce(TargetUserSpaceUpgradeTasks(copy_files=copy_files, install_rpms=['s390utils-core']))

--- a/repos/system_upgrade/common/actors/scanzfcp/tests/unit_test_scanzfcp.py
+++ b/repos/system_upgrade/common/actors/scanzfcp/tests/unit_test_scanzfcp.py
@@ -1,0 +1,59 @@
+import os
+
+import pytest
+
+from leapp.libraries.actor import scanzfcp
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked, produce_mocked
+from leapp.models import CopyFile, TargetUserSpaceUpgradeTasks, UpgradeInitramfsTasks
+
+
+def test_zfcp_exists(monkeypatch):
+    monkeypatch.setattr(scanzfcp.api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X))
+    monkeypatch.setattr(scanzfcp.api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(scanzfcp.api, 'produce', produce_mocked())
+    monkeypatch.setattr(os.path, 'isfile', lambda dummy: True)
+    scanzfcp.process()
+    assert not scanzfcp.api.current_logger.infomsg
+    assert scanzfcp.api.produce.called == 2
+    tusut_flag = False
+    uit_flag = False
+    for msg in scanzfcp.api.produce.model_instances:
+        if isinstance(msg, TargetUserSpaceUpgradeTasks):
+            assert [CopyFile(src=scanzfcp.ZFCP_CONF)] == msg.copy_files
+            assert msg.install_rpms == ['s390utils-core']
+            tusut_flag = True
+        elif isinstance(msg, UpgradeInitramfsTasks):
+            assert [scanzfcp.ZFCP_CONF] == msg.include_files
+            uit_flag = True
+    assert tusut_flag and uit_flag
+
+
+def test_zfcp_not_found(monkeypatch):
+    monkeypatch.setattr(scanzfcp.api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X))
+    monkeypatch.setattr(scanzfcp.api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(scanzfcp.os.path, 'isfile', lambda dummy: False)
+    monkeypatch.setattr(scanzfcp.api, 'produce', produce_mocked())
+    scanzfcp.process()
+    assert scanzfcp.api.current_logger.infomsg
+    assert scanzfcp.api.produce.called == 1
+    assert len(scanzfcp.api.produce.model_instances) == 1
+    assert isinstance(scanzfcp.api.produce.model_instances[0], TargetUserSpaceUpgradeTasks)
+    assert scanzfcp.api.produce.model_instances[0].install_rpms == ['s390utils-core']
+    assert not scanzfcp.api.produce.model_instances[0].copy_files
+
+
+@pytest.mark.parametrize('isfile', [True, False])
+@pytest.mark.parametrize('arch', [
+    architecture.ARCH_X86_64,
+    architecture.ARCH_ARM64,
+    architecture.ARCH_PPC64LE,
+])
+def test_non_ibmz_arch(monkeypatch, isfile, arch):
+    monkeypatch.setattr(scanzfcp.api, 'current_actor', CurrentActorMocked(arch=arch))
+    monkeypatch.setattr(scanzfcp.api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(scanzfcp.api, 'produce', produce_mocked())
+    monkeypatch.setattr(os.path, 'isfile', lambda dummy: isfile)
+    scanzfcp.process()
+    assert not scanzfcp.api.current_logger.infomsg
+    assert not scanzfcp.api.produce.called

--- a/repos/system_upgrade/el7toel8/actors/ziplconverttoblscfg/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/ziplconverttoblscfg/actor.py
@@ -38,40 +38,40 @@ class ZiplConvertToBLSCFG(Actor):
         # replace the original boot directory inside the container by the host one
         # - as we cannot use zipl* pointing anywhere else than default directory
         # - no, --bls-directory is not solution
-        with mounting.BindMount(source='/boot', target=os.path.join(userspace.path, 'boot')):
+        # also make sure device nodes are available (requirement for zipl-switch-to-blscfg)
+        binds = ['/boot', '/dev']
+        with mounting.NspawnActions(base_dir=userspace.path, binds=binds) as context:
             userspace_zipl_conf = os.path.join(userspace.path, 'etc', 'zipl.conf')
             if os.path.exists(userspace_zipl_conf):
                 os.remove(userspace_zipl_conf)
-            with mounting.NullMount(target=userspace.path) as userspace:
-                with userspace.nspawn() as context:
-                    context.copy_to('/etc/zipl.conf', '/etc/zipl.conf')
-                    # zipl needs this one as well
-                    context.copy_to('/etc/machine-id', '/etc/machine-id')
-                    try:
-                        context.call(['/usr/sbin/zipl-switch-to-blscfg'])
-                        if filecmp.cmp('/etc/zipl.conf', userspace_zipl_conf):
-                            # When the files are same, zipl failed - see the switch script
-                            raise OSError('Failed to convert the ZIPL configuration to BLS.')
-                        context.copy_from('/etc/zipl.conf', '/etc/zipl.conf')
-                    except OSError as e:
-                        self.log.error('Could not call zipl-switch-to-blscfg command.',
-                                       exc_info=True)
-                        raise StopActorExecutionError(
-                            message='Failed to execute zipl-switch-to-blscfg.',
-                            details={'details': str(e)}
-                        )
-                    except CalledProcessError as e:
-                        self.log.error('zipl-switch-to-blscfg execution failed,',
-                                       exc_info=True)
-                        raise StopActorExecutionError(
-                            message='zipl-switch-to-blscfg execution failed with non zero exit code.',
-                            details={'details': str(e), 'stdout': e.stdout, 'stderr': e.stderr}
-                        )
+            context.copy_to('/etc/zipl.conf', '/etc/zipl.conf')
+            # zipl needs this one as well
+            context.copy_to('/etc/machine-id', '/etc/machine-id')
+            try:
+                context.call(['/usr/sbin/zipl-switch-to-blscfg'])
+                if filecmp.cmp('/etc/zipl.conf', userspace_zipl_conf):
+                    # When the files are same, zipl failed - see the switch script
+                    raise OSError('Failed to convert the ZIPL configuration to BLS.')
+                context.copy_from('/etc/zipl.conf', '/etc/zipl.conf')
+            except OSError as e:
+                self.log.error('Could not call zipl-switch-to-blscfg command.',
+                               exc_info=True)
+                raise StopActorExecutionError(
+                    message='Failed to execute zipl-switch-to-blscfg.',
+                    details={'details': str(e)}
+                )
+            except CalledProcessError as e:
+                self.log.error('zipl-switch-to-blscfg execution failed,',
+                               exc_info=True)
+                raise StopActorExecutionError(
+                    message='zipl-switch-to-blscfg execution failed with non zero exit code.',
+                    details={'details': str(e), 'stdout': e.stdout, 'stderr': e.stderr}
+                )
 
-                        # FIXME: we do not want to continue anymore, but we should clean
-                        # better.
-                        # NOTE: Basically, just removal of the /boot/loader dir content inside
-                        # could be enough, but we cannot remove /boot/loader because of boom
-                        # - - if we remove it, we will remove the snapshot as well
-                        # - - on the other hand, we shouldn't keep it there if zipl
-                        # - - has not been converted to BLS
+                # FIXME: we do not want to continue anymore, but we should clean
+                # better.
+                # NOTE: Basically, just removal of the /boot/loader dir content inside
+                # could be enough, but we cannot remove /boot/loader because of boom
+                # - - if we remove it, we will remove the snapshot as well
+                # - - on the other hand, we shouldn't keep it there if zipl
+                # - - has not been converted to BLS


### PR DESCRIPTION
When having systems configured with ZFCP instead of DASD, the disks
are not seen while rebooting because `/etc/zfcp.conf` is missing
in the initramfs.

The conversion of ZIPL to BLS on IBM Z machines failed when
  **a)** the machine was configured using ZFCP instead of DASD
  **b)** /boot was not on a separate partition

**In case a)**, the zipl-switch-to-blscfg script failed as the /dev has
not been propagated to into the el8userspace container and also all required nodes has not been visible inside the upgrade initramfs due to missing `/etc/zfcp.conf` inside the initramfs. Regarding that the script failed the conversion.

With this fix, the /dev is bindmounted into the el8userspace container
using the (systemd-nspawn) `--bind` option. The direct bind mounting
via `leapp.libraries.common.mounting.BindMount` cannot be used in this
case as it blocks the correct start of the container.

Also, when the file exists, it's copied inside the userspace container
and installed in the upgrade initramfs, producing
   TargetUserSpaceUpgradeTasks, UpgradeInitramfsTasks
messages.

**In case b)**, the content of /boot has been removed during the upgrade
due to problems when using BindMount on normal directory (that is not
mountpoint). This has been possibly resolved by this commit also,
as the /boot has been propagated using the --bind (sysmd-nspawn)
option as well.
**NOTE:** The case b) has not been tested yet and this PR primarily targets to fix the case a). As the inhibitor for s390x systems with /boot merged in rootfs, even when the case b) is not tested successfuly, it does not prevent the merge of this PR.

See https://bugzilla.redhat.com/show_bug.cgi?id=2140563