### PR TITLE
Tune tmt tests regexes to align with QE automation

### DIFF
--- a/.github/workflows/pr-welcome-msg.yml
+++ b/.github/workflows/pr-welcome-msg.yml
@@ -27,8 +27,8 @@ jobs:
             To launch regression testing public members of oamg organization can leave the following comment:
             - **/rerun** to schedule basic regression tests using this pr build and leapp\*master\* as artifacts
             - **/rerun 42** to schedule basic regression tests using this pr build and leapp\*PR42\* as artifacts
-            - **/rerun-all** to schedule all tests (including sst) using this pr build and leapp\*master\* as artifacts
-            - **/rerun-all 42** to schedule all tests (including sst) using this pr build and leapp\*PR42\* as artifacts
+            - **/rerun-sst** to schedule sst tests using this pr build and leapp\*master\* as artifacts
+            - **/rerun-sst 42** to schedule sst tests using this pr build and leapp\*PR42\* as artifacts
 
             Please [open ticket](https://url.corp.redhat.com/oamg-ci-issue) in case you experience technical problem with the CI. (RH internal only)
 

--- a/.github/workflows/reuse-copr-build.yml
+++ b/.github/workflows/reuse-copr-build.yml
@@ -88,7 +88,7 @@ jobs:
         id: leapp_pr_regex_match
         with:
           text: ${{ github.event.comment.body }}
-          regex: '^/(rerun|rerun-all)\s+([0-9]+)\s*$'
+          regex: '^/(rerun|rerun-sst)\s+([0-9]+)\s*$'
 
       - name: If leapp_pr was specified in the comment - trigger copr build
         # TODO: XXX FIXME This should schedule copr build for leapp but for now it will be just setting an env var

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
       pull_request_status_name: "7.9to8.4"
 
   call_workflow_tests_79to86_integration:
@@ -25,7 +25,7 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
       variables: 'TARGET_RELEASE=8.6'
       pull_request_status_name: "7.9to8.6"
 
@@ -35,7 +35,7 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*c2r)(?!.*sap)(?!.*8to9)(.*morf)"
+      tmt_plan_regex: "^(/plans/morf)(?!.*sap)"
       pull_request_status_name: "7.9to8.4-sst"
       update_pull_request_status: 'false'
     if: |
@@ -49,7 +49,7 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
       compose: "RHEL-7.9-rhui"
       environment_settings: '{"provisioning": {"post_install_script": "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"}}'
       pull_request_status_name: "7to8-aws-e2e"
@@ -61,7 +61,7 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
       pull_request_status_name: "8.6to9.0"
 
   call_workflow_tests_87to91_integration:
@@ -70,7 +70,7 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
       variables: "LEAPP_DEVEL_TARGET_PRODUCT_TYPE=beta;RHSM_SKU=RH00069;TARGET_RELEASE=9.1;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms"
       compose: "RHEL-8.7.0-Nightly"
       pull_request_status_name: "8.7to9.1"
@@ -82,7 +82,7 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*c2r)(?!.*sap)(?!.*7to8)(.*morf)"
+      tmt_plan_regex: "^(/plans/morf)(?!.*sap)"
       pull_request_status_name: "8to9-sst"
       update_pull_request_status: 'false'
     if: |
@@ -96,7 +96,7 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
       compose: "RHEL-8.6-rhui"
       environment_settings: '{"provisioning": {"post_install_script": "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"}}'
       pull_request_status_name: "8to9-aws-e2e"

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -18,7 +18,7 @@ jobs:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
       pull_request_status_name: "7.9to8.8"
-      variables: 'TARGET_RELEASE=8.8'
+      variables: 'SOURCE_RELEASE=7.9;TARGET_RELEASE=8.8'
     if: |
       github.event.issue.pull_request
       && ! startsWith(github.event.comment.body, '/rerun-sst')
@@ -31,7 +31,7 @@ jobs:
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
-      variables: 'TARGET_RELEASE=8.6'
+      variables: 'SOURCE_RELEASE=7.9;TARGET_RELEASE=8.6'
       pull_request_status_name: "7.9to8.6"
     if: |
       github.event.issue.pull_request
@@ -47,7 +47,7 @@ jobs:
       tmt_plan_regex: "^(/plans/morf)(?!.*sap)"
       pull_request_status_name: "7.9to8.8-sst"
       update_pull_request_status: 'false'
-      variables: 'TARGET_RELEASE=8.8'
+      variables: 'SOURCE_RELEASE=7.9;TARGET_RELEASE=8.8'
     if: |
       github.event.issue.pull_request
       && startsWith(github.event.comment.body, '/rerun-sst')
@@ -63,7 +63,7 @@ jobs:
       compose: "RHEL-7.9-rhui"
       environment_settings: '{"provisioning": {"post_install_script": "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"}}'
       pull_request_status_name: "7to8-aws-e2e"
-      variables: "RHUI=aws"
+      variables: "SOURCE_RELEASE=7.9;TARGET_RELEASE=8.6;RHUI=aws"
     if: |
       github.event.issue.pull_request
       && ! startsWith(github.event.comment.body, '/rerun-sst')
@@ -76,7 +76,7 @@ jobs:
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-      variables: 'TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms'
+      variables: 'SOURCE_RELEASE=8.6;TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms'
       pull_request_status_name: "8.6to9.0"
     if: |
       github.event.issue.pull_request
@@ -90,7 +90,7 @@ jobs:
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-      variables: 'TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms'
+      variables: 'SOURCE_RELEASE=8.7;TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms'
       compose: "RHEL-8.7.0-Nightly"
       pull_request_status_name: "8.7to9.0"
       tmt_context: "distro=rhel-8.7"
@@ -106,7 +106,7 @@ jobs:
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
       tmt_plan_regex: "^(/plans/morf)(?!.*sap)"
-      variables: 'TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms'
+      variables: 'SOURCE_RELEASE=8.6;TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms'
       pull_request_status_name: "8to9-sst"
       update_pull_request_status: 'false'
     if: |
@@ -124,7 +124,7 @@ jobs:
       compose: "RHEL-8.6-rhui"
       environment_settings: '{"provisioning": {"post_install_script": "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"}}'
       pull_request_status_name: "8to9-aws-e2e"
-      variables: 'TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms;RHUI=aws'
+      variables: 'SOURCE_RELEASE=8.6;TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms;RHUI=aws'
     if: |
       github.event.issue.pull_request
       && ! startsWith(github.event.comment.body, '/rerun-sst')

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -10,14 +10,15 @@ jobs:
     uses: ./.github/workflows/reuse-copr-build.yml
     secrets: inherit
 
-  call_workflow_tests_79to84_integration:
+  call_workflow_tests_79to88_integration:
     needs: call_workflow_copr_build
     uses: oamg/leapp/.github/workflows/reuse-tests-7to8.yml@master
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
-      pull_request_status_name: "7.9to8.4"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
+      pull_request_status_name: "7.9to8.8"
+      variables: 'TARGET_RELEASE=8.8'
     if: |
       github.event.issue.pull_request
       && ! startsWith(github.event.comment.body, '/rerun-sst')
@@ -29,7 +30,7 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
       variables: 'TARGET_RELEASE=8.6'
       pull_request_status_name: "7.9to8.6"
     if: |
@@ -37,15 +38,16 @@ jobs:
       && ! startsWith(github.event.comment.body, '/rerun-sst')
       && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
-  call_workflow_tests_79to84_sst:
+  call_workflow_tests_79to88_sst:
     needs: call_workflow_copr_build
     uses: oamg/leapp/.github/workflows/reuse-tests-7to8.yml@master
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
       tmt_plan_regex: "^(/plans/morf)(?!.*sap)"
-      pull_request_status_name: "7.9to8.4-sst"
+      pull_request_status_name: "7.9to8.8-sst"
       update_pull_request_status: 'false'
+      variables: 'TARGET_RELEASE=8.8'
     if: |
       github.event.issue.pull_request
       && startsWith(github.event.comment.body, '/rerun-sst')
@@ -57,7 +59,7 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
       compose: "RHEL-7.9-rhui"
       environment_settings: '{"provisioning": {"post_install_script": "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"}}'
       pull_request_status_name: "7to8-aws-e2e"
@@ -73,36 +75,38 @@ jobs:
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
+      variables: 'TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms'
       pull_request_status_name: "8.6to9.0"
     if: |
       github.event.issue.pull_request
       && ! startsWith(github.event.comment.body, '/rerun-sst')
       && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
-  call_workflow_tests_87to91_integration:
+  call_workflow_tests_87to90_integration:
     needs: call_workflow_copr_build
     uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@master
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
-      variables: "LEAPP_DEVEL_TARGET_PRODUCT_TYPE=beta;RHSM_SKU=RH00069;TARGET_RELEASE=9.1;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(?!.*morf)"
+      variables: 'TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms'
       compose: "RHEL-8.7.0-Nightly"
-      pull_request_status_name: "8.7to9.1"
+      pull_request_status_name: "8.7to9.0"
       tmt_context: "distro=rhel-8.7"
     if: |
       github.event.issue.pull_request
       && ! startsWith(github.event.comment.body, '/rerun-sst')
       && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
-  call_workflow_tests_8to9_sst:
+  call_workflow_tests_86to90_sst:
     needs: call_workflow_copr_build
     uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@master
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
       tmt_plan_regex: "^(/plans/morf)(?!.*sap)"
+      variables: 'TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms'
       pull_request_status_name: "8to9-sst"
       update_pull_request_status: 'false'
     if: |
@@ -110,17 +114,17 @@ jobs:
       && startsWith(github.event.comment.body, '/rerun-sst')
       && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
-  call_workflow_tests_8to9_aws:
+  call_workflow_tests_86to90_aws:
     needs: call_workflow_copr_build
     uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@master
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
-      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
+      tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
       compose: "RHEL-8.6-rhui"
       environment_settings: '{"provisioning": {"post_install_script": "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"}}'
       pull_request_status_name: "8to9-aws-e2e"
-      variables: "RHUI=aws"
+      variables: 'TARGET_RELEASE=9.0;TARGET_KERNEL=el9;RHSM_REPOS=rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms;RHUI=aws'
     if: |
       github.event.issue.pull_request
       && ! startsWith(github.event.comment.body, '/rerun-sst')

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -18,6 +18,10 @@ jobs:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
       pull_request_status_name: "7.9to8.4"
+    if: |
+      github.event.issue.pull_request
+      && ! startsWith(github.event.comment.body, '/rerun-sst')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
   call_workflow_tests_79to86_integration:
     needs: call_workflow_copr_build
@@ -28,6 +32,10 @@ jobs:
       tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
       variables: 'TARGET_RELEASE=8.6'
       pull_request_status_name: "7.9to8.6"
+    if: |
+      github.event.issue.pull_request
+      && ! startsWith(github.event.comment.body, '/rerun-sst')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
   call_workflow_tests_79to84_sst:
     needs: call_workflow_copr_build
@@ -40,7 +48,7 @@ jobs:
       update_pull_request_status: 'false'
     if: |
       github.event.issue.pull_request
-      && startsWith(github.event.comment.body, '/rerun-all')
+      && startsWith(github.event.comment.body, '/rerun-sst')
       && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
   call_workflow_tests_7to8_aws:
@@ -54,6 +62,10 @@ jobs:
       environment_settings: '{"provisioning": {"post_install_script": "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; echo 42; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"}}'
       pull_request_status_name: "7to8-aws-e2e"
       variables: "RHUI=aws"
+    if: |
+      github.event.issue.pull_request
+      && ! startsWith(github.event.comment.body, '/rerun-sst')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
   call_workflow_tests_86to90_integration:
     needs: call_workflow_copr_build
@@ -63,6 +75,10 @@ jobs:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
       tmt_plan_regex: "^(?!.*upgrade_plugin)(?!.*c2r)(?!.*sap)(?!.*8to9)(?!.*morf)"
       pull_request_status_name: "8.6to9.0"
+    if: |
+      github.event.issue.pull_request
+      && ! startsWith(github.event.comment.body, '/rerun-sst')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
   call_workflow_tests_87to91_integration:
     needs: call_workflow_copr_build
@@ -75,6 +91,10 @@ jobs:
       compose: "RHEL-8.7.0-Nightly"
       pull_request_status_name: "8.7to9.1"
       tmt_context: "distro=rhel-8.7"
+    if: |
+      github.event.issue.pull_request
+      && ! startsWith(github.event.comment.body, '/rerun-sst')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
   call_workflow_tests_8to9_sst:
     needs: call_workflow_copr_build
@@ -87,7 +107,7 @@ jobs:
       update_pull_request_status: 'false'
     if: |
       github.event.issue.pull_request
-      && startsWith(github.event.comment.body, '/rerun-all')
+      && startsWith(github.event.comment.body, '/rerun-sst')
       && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
 
   call_workflow_tests_8to9_aws:
@@ -101,3 +121,7 @@ jobs:
       environment_settings: '{"provisioning": {"post_install_script": "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"}}'
       pull_request_status_name: "8to9-aws-e2e"
       variables: "RHUI=aws"
+    if: |
+      github.event.issue.pull_request
+      && ! startsWith(github.event.comment.body, '/rerun-sst')
+      && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)


### PR DESCRIPTION
In order for upstream tests and those launched with QE tooling to produce the comparable set of results it's a wise thing to do.