### PR TITLE
ensure Satellite metapackages are installed after upgrade

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/actor.py
@@ -134,9 +134,11 @@ class SatelliteUpgradeFacts(Actor):
         if has_package(InstalledRPM, 'satellite'):
             repositories_to_enable.append('satellite-6.11-for-rhel-8-x86_64-rpms')
             modules_to_enable.append(Module(name='satellite', stream='el8'))
+            to_install.append('satellite')
         elif has_package(InstalledRPM, 'satellite-capsule'):
             repositories_to_enable.append('satellite-capsule-6.11-for-rhel-8-x86_64-rpms')
             modules_to_enable.append(Module(name='satellite-capsule', stream='el8'))
+            to_install.append('satellite-capsule')
 
         self.produce(RpmTransactionTasks(
             to_remove=to_remove,

--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/tests/unit_test_satellite_upgrade_facts.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrade_facts/tests/unit_test_satellite_upgrade_facts.py
@@ -102,6 +102,22 @@ def test_enables_satellite_capsule_module(current_actor_context):
     assert Module(name='satellite', stream='el8') not in message.modules_to_enable
 
 
+def test_installs_satellite_package(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[FOREMAN_RPM, SATELLITE_RPM]))
+    current_actor_context.run(config_model=mock_configs.CONFIG)
+    message = current_actor_context.consume(RpmTransactionTasks)[0]
+    assert 'satellite' in message.to_install
+    assert 'satellite-capsule' not in message.to_install
+
+
+def test_installs_satellite_capsule_package(current_actor_context):
+    current_actor_context.feed(InstalledRPM(items=[FOREMAN_PROXY_RPM, SATELLITE_CAPSULE_RPM]))
+    current_actor_context.run(config_model=mock_configs.CONFIG)
+    message = current_actor_context.consume(RpmTransactionTasks)[0]
+    assert 'satellite-capsule' in message.to_install
+    assert 'satellite' not in message.to_install
+
+
 def test_detects_local_postgresql(monkeypatch, current_actor_context):
     def mock_stat():
         orig_stat = os.stat


### PR DESCRIPTION
When upgrading from EL7 to EL8, we theoretically can run into the situation where the `satellite` and `satellite-capsule` metapackages are removed during the upgrade due to dependency problems. While we are not aware of any actual occurences of this problem today, let's play safe and explicitly add those packages to the `to_install` set.