### PR TITLE
Automatically register systems with RHSM into Insights

### DIFF
--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -18,6 +18,7 @@ from leapp.utils.output import beautify_actor_exception, report_errors, report_i
 @command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
 @command_opt('no-rhsm', is_flag=True, help='Use only custom repositories and skip actions'
                                            ' with Red Hat Subscription Manager')
+@command_opt('no-insights-register', is_flag=True, help='Do not register into Red Hat Insights')
 @command_opt('enablerepo', action='append', metavar='<repoid>',
              help='Enable specified repository. Can be used multiple times.')
 @command_opt('channel',

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -24,6 +24,7 @@ from leapp.utils.output import beautify_actor_exception, report_errors, report_i
 @command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
 @command_opt('no-rhsm', is_flag=True, help='Use only custom repositories and skip actions'
                                            ' with Red Hat Subscription Manager')
+@command_opt('no-insights-register', is_flag=True, help='Do not register into Red Hat Insights')
 @command_opt('enablerepo', action='append', metavar='<repoid>',
              help='Enable specified repository. Can be used multiple times.')
 @command_opt('channel',

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -193,6 +193,10 @@ def prepare_configuration(args):
         os.environ['LEAPP_NO_RHSM'] = '1'
     elif os.getenv('LEAPP_NO_RHSM') != '1':
         os.environ['LEAPP_NO_RHSM'] = os.getenv('LEAPP_DEVEL_SKIP_RHSM', '0')
+
+    if args.no_insights_register:
+        os.environ['LEAPP_NO_INSIGHTS_REGISTER'] = '1'
+
     if args.enablerepo:
         os.environ['LEAPP_ENABLE_REPOS'] = ','.join(args.enablerepo)
 

--- a/repos/system_upgrade/common/actors/checkinsightsautoregister/actor.py
+++ b/repos/system_upgrade/common/actors/checkinsightsautoregister/actor.py
@@ -1,0 +1,29 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkinsightsautoregister
+from leapp.models import InstalledRPM, RpmTransactionTasks
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckInsightsAutoregister(Actor):
+    """
+    Checks if system can be automatically registered into Red Hat Insights
+
+    The registration is skipped if NO_INSIGHTS_REGISTER=1 environment variable
+    is set, the --no-insights-register command line argument present. if the
+    system isn't registered with subscription-manager.
+
+    Additionally, the insights-client package is required. If it's missing an
+    RpmTransactionTasks is produced to install it during the upgrade.
+
+    A report is produced informing about the automatic registration and
+    eventual insights-client package installation.
+    """
+
+    name = 'check_insights_auto_register'
+    consumes = (InstalledRPM,)
+    produces = (Report, RpmTransactionTasks)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        checkinsightsautoregister.process()

--- a/repos/system_upgrade/common/actors/checkinsightsautoregister/libraries/checkinsightsautoregister.py
+++ b/repos/system_upgrade/common/actors/checkinsightsautoregister/libraries/checkinsightsautoregister.py
@@ -1,0 +1,53 @@
+from leapp import reporting
+from leapp.libraries.common import rhsm
+from leapp.libraries.common.config import get_env
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledRPM, RpmTransactionTasks
+
+INSIGHTS_CLIENT_PKG = "insights-client"
+
+
+def _ensure_package(package):
+    """
+    Produce install tasks if the given package is missing
+
+    :return: True if the install task is produced else False
+    """
+    has_client_package = has_package(InstalledRPM, package)
+    if not has_client_package:
+        api.produce(RpmTransactionTasks(to_install=[package]))
+
+    return not has_client_package
+
+
+def _report_registration_info(installing_client):
+    pkg_msg = " The '{}' package required for the registration will be installed during the upgrade."
+
+    title = "Automatic registration into Red Hat Insights"
+    summary = (
+        "After the upgrade, this system will be automatically registered into Red Hat Insights."
+        "{}"
+        " To skip the automatic registration, use the '--no-insights-autoregister' command line option or"
+        " set the NO_INSIGHTS_AUTOREGISTER environment variable."
+    ).format(pkg_msg.format(INSIGHTS_CLIENT_PKG) if installing_client else "")
+
+    reporting.create_report(
+        [
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.INFO),
+            reporting.Groups([reporting.Groups.SERVICES]),
+        ]
+    )
+
+
+def process():
+    if rhsm.skip_rhsm():
+        return
+
+    if get_env("LEAPP_NO_INSIGHTS_REGISTER", "0") == "1":
+        return
+
+    installing_client = _ensure_package(INSIGHTS_CLIENT_PKG)
+    _report_registration_info(installing_client)

--- a/repos/system_upgrade/common/actors/checkinsightsautoregister/tests/test_reportinsightsautoregister.py
+++ b/repos/system_upgrade/common/actors/checkinsightsautoregister/tests/test_reportinsightsautoregister.py
@@ -1,0 +1,80 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import checkinsightsautoregister
+from leapp.libraries.common import rhsm
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+
+
+@pytest.mark.parametrize(
+    ("skip_rhsm", "no_register", "should_report"),
+    [
+        (False, False, True),
+        (False, True, False),
+        (True, False, False),
+        (True, True, False),
+    ],
+)
+def test_should_report(monkeypatch, skip_rhsm, no_register, should_report):
+
+    monkeypatch.setattr(rhsm, "skip_rhsm", lambda: skip_rhsm)
+    monkeypatch.setattr(
+        api,
+        "current_actor",
+        CurrentActorMocked(
+            envars={"LEAPP_NO_INSIGHTS_REGISTER": "1" if no_register else "0"}
+        ),
+    )
+
+    def ensure_package_mocked(package):
+        assert package == checkinsightsautoregister.INSIGHTS_CLIENT_PKG
+        return False
+
+    monkeypatch.setattr(
+        checkinsightsautoregister, "_ensure_package", ensure_package_mocked
+    )
+
+    called = [False]
+
+    def _report_registration_info_mocked(_):
+        called[0] = True
+
+    monkeypatch.setattr(
+        checkinsightsautoregister,
+        "_report_registration_info",
+        _report_registration_info_mocked,
+    )
+
+    checkinsightsautoregister.process()
+
+    assert called[0] == should_report
+
+
+@pytest.mark.parametrize(
+    "already_installed, should_install", [(True, False), (False, True)]
+)
+def test_install_task_produced(monkeypatch, already_installed, should_install):
+
+    def has_package_mocked(*args, **kwargs):
+        return already_installed
+
+    monkeypatch.setattr(checkinsightsautoregister, "has_package", has_package_mocked)
+    monkeypatch.setattr(api, "produce", produce_mocked())
+
+    checkinsightsautoregister._ensure_package(
+        checkinsightsautoregister.INSIGHTS_CLIENT_PKG
+    )
+
+    assert api.produce.called == should_install
+
+
+@pytest.mark.parametrize("installing_client", (True, False))
+def test_report_created(monkeypatch, installing_client):
+
+    created_reports = create_report_mocked()
+    monkeypatch.setattr(reporting, "create_report", created_reports)
+
+    checkinsightsautoregister._report_registration_info(installing_client)
+
+    assert created_reports.called

--- a/repos/system_upgrade/common/actors/insightsautoregister/actor.py
+++ b/repos/system_upgrade/common/actors/insightsautoregister/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import insightsautoregister
+from leapp.models import InstalledRPM
+from leapp.reporting import Report
+from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
+
+
+class InsightsAutoregister(Actor):
+    """
+    Automatically registers system into Red Hat Insights
+
+    The registration is skipped if NO_INSIGHTS_REGISTER=1 environment variable
+    is set, the --no-insights-register command line argument present or the
+    system isn't registered with subscription-manager.
+    """
+
+    name = 'insights_auto_register'
+    consumes = (InstalledRPM,)
+    produces = (Report,)
+    tags = (FirstBootPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        insightsautoregister.process()

--- a/repos/system_upgrade/common/actors/insightsautoregister/libraries/insightsautoregister.py
+++ b/repos/system_upgrade/common/actors/insightsautoregister/libraries/insightsautoregister.py
@@ -1,0 +1,25 @@
+from leapp.libraries.common import rhsm
+from leapp.libraries.common.config import get_env
+from leapp.libraries.stdlib import api, CalledProcessError, run
+
+
+def _insights_register():
+    try:
+        run(['insights-client', '--register'])
+        api.current_logger().info('Automatically registered into Red Hat Insights')
+    except (CalledProcessError) as err:
+        # TODO(mmatuska) produce post-upgrade report?
+        api.current_logger().error(
+            'Automatic registration into Red Hat Insights failed: {}'.format(err)
+        )
+
+
+def process():
+    if rhsm.skip_rhsm() or get_env('LEAPP_NO_INSIGHTS_REGISTER', '0') == '1':
+        api.current_logger().debug(
+            'Skipping registration into Insights due to --no-insights-register'
+            ' or LEAPP_NO_INSIGHTS_REGISTER=1 set'
+        )
+        return
+
+    _insights_register()

--- a/repos/system_upgrade/common/actors/insightsautoregister/tests/test_insightsautoregister.py
+++ b/repos/system_upgrade/common/actors/insightsautoregister/tests/test_insightsautoregister.py
@@ -1,0 +1,73 @@
+import pytest
+
+from leapp.libraries.actor import insightsautoregister
+from leapp.libraries.common import rhsm
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
+from leapp.libraries.stdlib import api, CalledProcessError
+
+
+@pytest.mark.parametrize(
+    ('skip_rhsm', 'no_register', 'should_register'),
+    [
+        (False, False, True),
+        (False, True, False),
+        (True, False, False),
+        (True, True, False),
+    ]
+)
+def test_should_register(monkeypatch, skip_rhsm, no_register, should_register):
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: skip_rhsm)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        envars={'LEAPP_NO_INSIGHTS_REGISTER': '1' if no_register else '0'}
+        ))
+
+    called = []
+
+    def _insights_register_mocked():
+        called.append(True)
+
+    monkeypatch.setattr(
+        insightsautoregister,
+        '_insights_register',
+        _insights_register_mocked
+    )
+
+    insightsautoregister.process()
+
+    assert len(called) == should_register
+
+
+def test_insights_register_success_logged(monkeypatch):
+
+    def run_mocked(cmd, **kwargs):
+        return {
+            'stdout': 'Successfully registered into Insights',
+            'stderr': '',
+            'exit_code': 0
+        }
+
+    monkeypatch.setattr(insightsautoregister, 'run', run_mocked)
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    insightsautoregister._insights_register()
+
+    assert api.current_logger.infomsg
+    assert not api.current_logger.errmsg
+
+
+def test_insights_register_failure_logged(monkeypatch):
+
+    def run_mocked(cmd, **kwargs):
+        raise CalledProcessError(
+            message='A Leapp Command Error occurred.',
+            command=cmd,
+            result={'signal': None, 'exit_code': 1, 'pid': 0, 'stdout': 'fake', 'stderr': 'fake'}
+        )
+
+    monkeypatch.setattr(insightsautoregister, 'run', run_mocked)
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    insightsautoregister._insights_register()
+
+    assert not api.current_logger.infomsg
+    assert api.current_logger.errmsg


### PR DESCRIPTION
If system uses rhsm it is automatically registered into Red Hat Insights
at the end of the upgrade process.
For the registration the `insights-client` package is requiered and will
be installed during the upgrade if missing.

This can be skipped by setting the `LEAPP_NO_INSIGHTS_REGISTER=1`
environment variable or `--no-insights-register` CLI option.

A report is generated informing about the registration and eventual
`insights-client` package installation.

Jira ref.: OAMG-7872