### PR TITLE
assets: check for what leapp version are assets meant for

### DIFF
--- a/repos/system_upgrade/common/actors/checkconsumedassets/actor.py
+++ b/repos/system_upgrade/common/actors/checkconsumedassets/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import check_consumed_assets
+from leapp.models import ConsumedDataAsset, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckConsumedAssets(Actor):
+    """
+    Check whether Leapp is using correct data assets.
+    """
+
+    name = 'check_consumed_assets'
+    consumes = (ConsumedDataAsset,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        check_consumed_assets.inhibit_if_assets_with_incorrect_version()

--- a/repos/system_upgrade/common/actors/checkconsumedassets/libraries/check_consumed_assets.py
+++ b/repos/system_upgrade/common/actors/checkconsumedassets/libraries/check_consumed_assets.py
@@ -1,0 +1,162 @@
+import re
+from collections import defaultdict, namedtuple
+
+from leapp import reporting
+from leapp.libraries.common.config import get_consumed_data_stream_id
+from leapp.libraries.common.fetch import ASSET_PROVIDED_DATA_STREAMS_FIELD
+from leapp.libraries.stdlib import api
+from leapp.models import ConsumedDataAsset
+
+
+def compose_summary_for_incompatible_assets(assets, incompatibility_reason):
+    if not assets:
+        return []
+
+    summary_lines = ['The following assets are {reason}'.format(reason=incompatibility_reason)]
+    for asset in assets:
+        if asset.provided_data_streams is None:  # Assets with missing streams are placed only in .outdated bucket
+            details = (' - The asset {what_asset} is missing information about provided data streams '
+                       'in its metadata header')
+            details = details.format(what_asset=asset.filename)
+        else:
+            article, multiple_suffix = ('the ', '') if len(asset.provided_data_streams) == 1 else ('', 's')
+            details = ' - The asset {what_asset} provides {article}data stream{mult_suffix} {provided_streams}'
+            details = details.format(what_asset=asset.filename,
+                                     provided_streams=', '.join(asset.provided_data_streams),
+                                     article=article, mult_suffix=multiple_suffix)
+        summary_lines.append(details)
+    return summary_lines
+
+
+def make_report_entries_with_unique_urls(docs_url_to_title_map):
+    report_urls = []
+    # Add every unique asset URL into the report
+    urls_with_multiple_titles = []
+    for url, titles in docs_url_to_title_map.items():
+        if len(titles) > 1:
+            urls_with_multiple_titles.append(url)
+
+        report_entry = reporting.ExternalLink(title=titles[0], url=url)
+        report_urls.append(report_entry)
+
+    if urls_with_multiple_titles:
+        msg = 'Docs URLs {urls} are used with inconsistent URL titles, picking one.'
+        api.current_logger().warning(msg.format(urls=', '.join(urls_with_multiple_titles)))
+
+    return report_urls
+
+
+def report_incompatible_assets(assets):
+    if not any((assets.outdated, assets.too_new, assets.unknown)):
+        return
+
+    title = 'Incompatible Leapp data assets are present'
+
+    docs_url_to_title_map = defaultdict(list)
+    required_data_stream = get_consumed_data_stream_id()
+    summary_prelude = ('The currently installed Leapp consumes data stream {consumed_data_stream}, but the '
+                       'following assets provide different streams:')
+    summary_lines = [summary_prelude.format(consumed_data_stream=required_data_stream)]
+
+    assets_with_shared_summary_entry = [
+        ('outdated', assets.outdated),
+        ('intended for a newer leapp', assets.too_new),
+        ('has an incorrect version', assets.unknown)
+    ]
+
+    doc_url_to_title = defaultdict(list)  # To make sure we do not spam the user with the same URLs
+    for reason, incompatible_assets in assets_with_shared_summary_entry:
+        summary_lines += compose_summary_for_incompatible_assets(incompatible_assets, reason)
+
+        for asset in incompatible_assets:
+            doc_url_to_title[asset.docs_url].append(asset.docs_title)
+
+    report_parts = [
+        reporting.Title(title),
+        reporting.Summary('\n'.join(summary_lines)),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.REPOSITORY]),
+    ]
+
+    report_parts += make_report_entries_with_unique_urls(docs_url_to_title_map)
+    reporting.create_report(report_parts)
+
+
+def report_malformed_assets(malformed_assets):
+    if not malformed_assets:
+        return
+
+    title = 'Detected malformed Leapp data assets'
+    summary_lines = ['The following assets are malformed:']
+
+    docs_url_to_title_map = defaultdict(list)
+    for asset in malformed_assets:
+        if not asset.provided_data_streams:
+            details = (' - The asset file {filename} contains no values in its "{provided_data_streams_field}" '
+                       'field, or the field does not contain a list')
+            details = details.format(filename=asset.filename,
+                                     provided_data_streams_field=ASSET_PROVIDED_DATA_STREAMS_FIELD)
+        else:
+            # The asset is malformed because we failed to convert its major versions to ints
+            details = ' - The asset file {filename} contains invalid value in its "{data_streams_field}"'
+            details = details.format(filename=asset.filename, data_streams_field=ASSET_PROVIDED_DATA_STREAMS_FIELD)
+        summary_lines.append(details)
+        docs_url_to_title_map[asset.docs_url].append(asset.docs_title)
+
+    report_parts = [
+        reporting.Title(title),
+        reporting.Summary('\n'.join(summary_lines)),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.REPOSITORY]),
+    ]
+
+    report_parts += make_report_entries_with_unique_urls(docs_url_to_title_map)
+    reporting.create_report(report_parts)
+
+
+def inhibit_if_assets_with_incorrect_version():
+    required_data_stream = get_consumed_data_stream_id()
+    required_data_stream_major = int(required_data_stream.split('.', 1)[0])
+
+    # The assets are collected according to why are they considered incompatible, so that a single report is created
+    # for every class
+    IncompatibleAssetsByType = namedtuple('IncompatibleAssets', ('outdated', 'too_new', 'malformed', 'unknown'))
+    incompatible_assets = IncompatibleAssetsByType(outdated=[], too_new=[], malformed=[], unknown=[])
+
+    datastream_version_re = re.compile(r'\d+\.\d+$')
+
+    for consumed_asset in api.consume(ConsumedDataAsset):
+        if consumed_asset.provided_data_streams is None:  # There is no provided_data_streams field
+            # Most likely an old file that predates the introduction of versioning to data assets
+            incompatible_assets.outdated.append(consumed_asset)
+            continue
+
+        # Ignore minor stream numbers and search only for a stream matching the same major number
+        if all((datastream_version_re.match(stream) for stream in consumed_asset.provided_data_streams)):
+            provided_major_data_streams = sorted(
+                int(stream.split('.', 1)[0]) for stream in consumed_asset.provided_data_streams
+            )
+        else:
+            incompatible_assets.malformed.append(consumed_asset)
+            continue
+
+        if required_data_stream_major in provided_major_data_streams:
+            continue
+
+        if not provided_major_data_streams:
+            # The field contained [], or something that was not a list, but it was corrected to [] to satisfy model
+            incompatible_assets.malformed.append(consumed_asset)
+            continue
+
+        if required_data_stream_major > max(provided_major_data_streams):
+            incompatible_assets.outdated.append(consumed_asset)
+        elif required_data_stream_major < min(provided_major_data_streams):
+            incompatible_assets.too_new.append(consumed_asset)
+        else:
+            # Since the `provided_data_vers` is a list of values, it is possible that the asset provide, e.g., 4.0
+            # and 6.0,  but the leapp consumes 5.0, thus we need to be careful when to say that an asset is too
+            # new/outdated/none.
+            incompatible_assets.unknown.append(consumed_asset)
+
+    report_incompatible_assets(incompatible_assets)
+    report_malformed_assets(incompatible_assets.malformed)

--- a/repos/system_upgrade/common/actors/checkconsumedassets/tests/test_asset_version_checking.py
+++ b/repos/system_upgrade/common/actors/checkconsumedassets/tests/test_asset_version_checking.py
@@ -1,0 +1,47 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import check_consumed_assets as check_consumed_assets_lib
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import ConsumedDataAsset
+from leapp.utils.report import is_inhibitor
+
+
+@pytest.mark.parametrize(('asset_data_streams', 'inhibit_reason'),
+                         ((['10.0'], None),
+                          (['9.3', '10.1', '11.0'], None),
+                          (['11.1'], 'incompatible'),
+                          (['3.1', '4.0'], 'incompatible'),
+                          (['11.1', '12.0'], 'incompatible'),
+                          ([], 'malformed'),
+                          (['malformed'], 'malformed')))
+def test_asset_version_correctness_assessment(monkeypatch, asset_data_streams, inhibit_reason):
+
+    monkeypatch.setattr(check_consumed_assets_lib, 'get_consumed_data_stream_id', lambda: '10.0')
+    used_asset = ConsumedDataAsset(filename='asset.json',
+                                   fulltext_name='',
+                                   docs_url='',
+                                   docs_title='',
+                                   provided_data_streams=asset_data_streams)
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[used_asset]))
+    create_report_mock = create_report_mocked()
+    monkeypatch.setattr(reporting, 'create_report', create_report_mock)
+
+    check_consumed_assets_lib.inhibit_if_assets_with_incorrect_version()
+
+    expected_report_count = 1 if inhibit_reason else 0
+    assert create_report_mock.called == expected_report_count
+    if inhibit_reason:
+        report = create_report_mock.reports[0]
+        assert is_inhibitor(report)
+        assert inhibit_reason in report['title'].lower()
+
+
+def test_make_report_entries_with_unique_urls():
+    # Check that multiple titles produce one report
+    docs_url_to_title_map = {'/path/to/asset1': ['asset1_title1', 'asset1_title2'],
+                             '/path/to/asset2': ['asset2_title']}
+    report_urls = check_consumed_assets_lib.make_report_entries_with_unique_urls(docs_url_to_title_map)
+    assert set([ru.value['url'] for ru in report_urls]) == {'/path/to/asset1', '/path/to/asset2'}

--- a/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/actor.py
+++ b/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import deviceanddriverdeprecationdataload
-from leapp.models import DeviceDriverDeprecationData
+from leapp.models import ConsumedDataAsset, DeviceDriverDeprecationData
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
@@ -14,7 +14,7 @@ class LoadDeviceDriverDeprecationData(Actor):
 
     name = 'load_device_driver_deprecation_data'
     consumes = ()
-    produces = (DeviceDriverDeprecationData,)
+    produces = (DeviceDriverDeprecationData, ConsumedDataAsset)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
     def process(self, *args, **kwargs):

--- a/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/libraries/deviceanddriverdeprecationdataload.py
+++ b/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/libraries/deviceanddriverdeprecationdataload.py
@@ -1,21 +1,6 @@
-import json
-
-from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import fetch
 from leapp.libraries.stdlib import api
 from leapp.models import DeviceDriverDeprecationData, DeviceDriverDeprecationEntry
-
-
-def _load_file():
-    try:
-        return json.loads(
-            fetch.read_or_fetch('device_driver_deprecation_data.json'))
-    except ValueError:
-        raise StopActorExecutionError(
-            'The device driver deprecation data file is invalid: file does not contain a valid JSON object.',
-            details={'hint': ('Read documentation at the following link for more'
-                              ' information about how to retrieve the valid file:'
-                              ' https://access.redhat.com/articles/3664871')})
 
 
 def process():
@@ -26,11 +11,20 @@ def process():
     """
     # This is how you get the StringEnum choices value, so we can filter based on the model definition
     supported_device_types = set(DeviceDriverDeprecationEntry.device_type.serialize()['choices'])
+
+    data_file_name = 'device_driver_deprecation_data.json'
+    deprecation_data = fetch.load_data_asset(api.current_actor(),
+                                             data_file_name,
+                                             asset_fulltext_name='Device driver deprecation data',
+                                             docs_url='https://access.redhat.com/articles/3664871',
+                                             docs_title=('Leapp utility metadata in-place upgrades of RHEL '
+                                                         'for disconnected upgrades (including Satellite)'))
+
     api.produce(
         DeviceDriverDeprecationData(
             entries=[
                 DeviceDriverDeprecationEntry(**entry)
-                for entry in _load_file()['data']
+                for entry in deprecation_data['data']
                 if entry.get('device_type') in supported_device_types
             ]
         )

--- a/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/tests/test_ddddload.py
+++ b/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/tests/test_ddddload.py
@@ -1,4 +1,5 @@
 from leapp.libraries.actor import deviceanddriverdeprecationdataload as ddddload
+from leapp.libraries.common import fetch
 
 TEST_DATA = {
     'data': [
@@ -44,7 +45,11 @@ TEST_DATA = {
 
 def test_filtered_load(monkeypatch):
     produced = []
-    monkeypatch.setattr(ddddload, '_load_file', lambda: TEST_DATA)
+
+    def load_data_asset_mock(*args, **kwargs):
+        return TEST_DATA
+
+    monkeypatch.setattr(fetch, 'load_data_asset', load_data_asset_mock)
     monkeypatch.setattr(ddddload.api, 'produce', lambda *v: produced.extend(v))
 
     ddddload.process()

--- a/repos/system_upgrade/common/actors/peseventsscanner/actor.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/actor.py
@@ -1,6 +1,7 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.pes_events_scanner import process
 from leapp.models import (
+    ConsumedDataAsset,
     EnabledModules,
     InstalledRedHatSignedRPM,
     PESRpmTransactionTasks,
@@ -33,7 +34,7 @@ class PesEventsScanner(Actor):
         RHUIInfo,
         RpmTransactionTasks,
     )
-    produces = (PESRpmTransactionTasks, RepositoriesSetupTasks, Report)
+    produces = (ConsumedDataAsset, PESRpmTransactionTasks, RepositoriesSetupTasks, Report)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
     def process(self):

--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
@@ -482,6 +482,9 @@ def apply_transaction_configuration(source_pkgs):
 def process():
     # Retrieve data - installed_pkgs, transaction configuration, pes events
     events = get_pes_events('/etc/leapp/files', 'pes-events.json')
+    if not events:
+        return
+
     releases = get_relevant_releases(events)
     source_pkgs = get_installed_pkgs()
     source_pkgs = apply_transaction_configuration(source_pkgs)

--- a/repos/system_upgrade/common/actors/peseventsscanner/tests/test_event_parsing.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/tests/test_event_parsing.py
@@ -17,6 +17,7 @@ from leapp.libraries.actor.pes_event_parsing import (
 from leapp.libraries.common import fetch
 from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
 from leapp.libraries.stdlib import api
+from leapp.models import ConsumedDataAsset
 
 CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -155,10 +156,10 @@ def test_parse_pes_events_with_modulestreams(current_actor_context):
 
 
 def test_get_pes_events_invalid_data_reported(monkeypatch):
-    def read_or_fetch_mocked(*args, **kwargs):
+    def load_data_asset_mocked(*args, **kwargs):
         raise ValueError()
 
-    monkeypatch.setattr(fetch, 'read_or_fetch', read_or_fetch_mocked)
+    monkeypatch.setattr(fetch, 'load_data_asset', load_data_asset_mocked)
     created_reports = create_report_mocked()
     monkeypatch.setattr(reporting, "create_report", created_reports)
     monkeypatch.setattr(api, "current_actor", CurrentActorMocked())

--- a/repos/system_upgrade/common/actors/repositoriesmapping/actor.py
+++ b/repos/system_upgrade/common/actors/repositoriesmapping/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.repositoriesmapping import scan_repositories
-from leapp.models import RepositoriesMapping
+from leapp.models import ConsumedDataAsset, RepositoriesMapping
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 
@@ -14,7 +14,7 @@ class RepositoriesMappingScanner(Actor):
 
     name = 'repository_mapping'
     consumes = ()
-    produces = (RepositoriesMapping,)
+    produces = (ConsumedDataAsset, RepositoriesMapping,)
     tags = (IPUWorkflowTag, FactsPhaseTag)
 
     def process(self):

--- a/repos/system_upgrade/common/libraries/config/__init__.py
+++ b/repos/system_upgrade/common/libraries/config/__init__.py
@@ -3,6 +3,7 @@ from leapp.libraries.stdlib import api
 
 # The devel variable for target product channel can also contain 'beta'
 SUPPORTED_TARGET_CHANNELS = {'ga', 'tuv', 'e4s', 'eus', 'aus'}
+CONSUMED_DATA_STREAM_ID = '1.0'
 
 
 def get_env(name, default=None):
@@ -91,3 +92,8 @@ def get_target_product_channel(default='ga'):
         return target_product_channel
 
     return default
+
+
+def get_consumed_data_stream_id():
+    """Get the identifier of the asset family used by leapp."""
+    return CONSUMED_DATA_STREAM_ID

--- a/repos/system_upgrade/common/libraries/fetch.py
+++ b/repos/system_upgrade/common/libraries/fetch.py
@@ -1,15 +1,18 @@
 import io  # Python2/Python3 compatible IO (open etc.)
+import json
 import os
 
 import requests
 
+from leapp import models
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common.config import get_env
+from leapp.libraries.common.config import get_consumed_data_stream_id, get_env
 from leapp.libraries.stdlib import api
 
 SERVICE_HOST_DEFAULT = "https://cert.cloud.redhat.com"
 REQUEST_TIMEOUT = (5, 30)
 MAX_ATTEMPTS = 3
+ASSET_PROVIDED_DATA_STREAMS_FIELD = 'provided_data_streams'
 
 
 def _raise_error(local_path, details):
@@ -49,13 +52,19 @@ def _request_data(service_path, cert, proxies, timeout=REQUEST_TIMEOUT):
             )
 
 
-def read_or_fetch(filename, directory="/etc/leapp/files", service=None, allow_empty=False, encoding='utf-8'):
+def read_or_fetch(filename,
+                  directory="/etc/leapp/files",
+                  service=None,
+                  allow_empty=False,
+                  encoding='utf-8',
+                  data_stream=None):
     """
     Return the contents of a text file or fetch them from an online service if the file does not exist.
 
     :param str filename: The name of the file to read or fetch.
     :param str directory: Directory that should contain the file.
     :param str service: URL to the service providing the data if the file is missing.
+    :param Optional[str] with_leapp_version: Inject the given leapp version when fetching from a service.
     :param bool allow_empty: Raise an error if the resulting data are empty.
     :param str encoding: Encoding to use when decoding the raw binary data.
     :returns: Text contents of the file. Text is decoded using the provided encoding.
@@ -82,7 +91,11 @@ def read_or_fetch(filename, directory="/etc/leapp/files", service=None, allow_em
 
     # if the data is not present locally, fetch it from the online service
     service = service or get_env("LEAPP_SERVICE_HOST", default=SERVICE_HOST_DEFAULT)
-    service_path = "{s}/api/pes/{f}".format(s=service, f=filename)
+    if data_stream:
+        service_path = "{s}/api/pes/{stream}/{f}".format(s=service, stream=data_stream, f=filename)
+    else:
+        service_path = "{s}/api/pes/{f}".format(s=service, f=filename)
+
     proxy = get_env("LEAPP_PROXY_HOST")
     proxies = {"https": proxy} if proxy else None
     cert = ("/etc/pki/consumer/cert.pem", "/etc/pki/consumer/key.pem")
@@ -108,3 +121,63 @@ def read_or_fetch(filename, directory="/etc/leapp/files", service=None, allow_em
         sp=service_path, l=len(response.content)))
 
     return response.content.decode(encoding)
+
+
+def load_data_asset(actor_requesting_asset,
+                    asset_filename,
+                    asset_fulltext_name,
+                    docs_url,
+                    docs_title):
+    """
+    Load the content of the data asset with given asset_filename
+
+    :param Actor actor_requesting_asset: The actor instance requesting the asset file. It is necessary for the actor
+                                         to be able to produce ConsumedDataAsset message in order for leapp to be able
+                                         to uniformly report assets with incorrect versions.
+    :param str asset_filename: The file name of the asset to load.
+    :param str asset_fulltext_name: A human readable asset name to display in error messages.
+    :param str docs_url: Docs url to provide if an asset is malformed or outdated.
+    :param str docs_title: Title of the documentation to where `docs_url` points to.
+    :returns: A dict with asset contents (a parsed JSON), or None if the asset was outdated.
+    """
+
+    # Check that the actor that is attempting to obtain the asset meets the contract to call this function
+    if models.ConsumedDataAsset not in actor_requesting_asset.produces:
+        raise StopActorExecutionError('The supplied `actor_requesting_asset` does not produce ConsumedDataAsset.')
+
+    if docs_url:
+        error_hint = {'hint': ('Read documentation at the following link for more information about how to retrieve '
+                               'the valid file: {0}'.format(docs_url))}
+    else:
+        error_hint = {}
+
+    data_stream_id = get_consumed_data_stream_id()
+    data_stream_major = data_stream_id.split('.', 1)[0]
+    api.current_logger().info(
+        'Attempting to load the asset {0} (data_stream={1})'.format(asset_filename, data_stream_id)
+    )
+
+    try:
+        # The asset family ID has the form (major, minor), include only `major` in the URL
+        raw_asset_contents = read_or_fetch(asset_filename, data_stream=data_stream_major)
+        asset_contents = json.loads(raw_asset_contents)
+    except ValueError:
+        msg = 'The {0} file (at {1}) does not contain a valid JSON object.'.format(asset_fulltext_name, asset_filename)
+        raise StopActorExecutionError(msg, details=error_hint)
+
+    if not isinstance(asset_contents, dict):
+        # Should be unlikely
+        msg = 'The {0} file (at {1}) is invalid - it does not contain a JSON object at the topmost level.'
+        raise StopActorExecutionError(msg.format(asset_fulltext_name, asset_filename), details=error_hint)
+
+    provided_data_streams = asset_contents.get(ASSET_PROVIDED_DATA_STREAMS_FIELD)
+    if provided_data_streams and not isinstance(provided_data_streams, list):
+        provided_data_streams = []  # The asset will be later reported as malformed
+
+    api.produce(models.ConsumedDataAsset(filename=asset_filename,
+                                         fulltext_name=asset_fulltext_name,
+                                         docs_url=docs_url,
+                                         docs_title=docs_title,
+                                         provided_data_streams=provided_data_streams))
+
+    return asset_contents

--- a/repos/system_upgrade/common/models/assets.py
+++ b/repos/system_upgrade/common/models/assets.py
@@ -1,0 +1,13 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemFactsTopic
+
+
+class ConsumedDataAsset(Model):
+    """Information about a used data asset."""
+    topic = SystemFactsTopic
+
+    filename = fields.String()
+    fulltext_name = fields.String()
+    docs_url = fields.String()
+    docs_title = fields.String()
+    provided_data_streams = fields.Nullable(fields.List(fields.String()))


### PR DESCRIPTION
## Introduction of versions to leapp data assets

This patch introduces a mechanism allowing specifying that certain versions of leapp data assets are meant for a particular version of leapp. The motivation is being able to pair assets with a corresponding leapp version that passed QA verification.
To provide this functionality, every asset file was extended with a new JSON field `"provided_data_assets": ["X.Y", "XX.YY"]`. Additional logic checking assets was also added accordingly (`load_asset`). Assets with invalid versions are reported together.

Ref: OAMG-7989