### PR TITLE
Packit: specify srpm_build_deps to allow builds with Packit again

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,6 +8,11 @@ downstream_package_name: leapp-repository
 upstream_tag_template: 'v{version}'
 merge_pr_in_ci: false
 
+# keep the empty list for now (the same is used for the leapp project).
+# the list is mandatory and currently we still build srpm via the Makefile.
+# but it's supposed to be (most likely) updated in upcoming months.
+srpm_build_deps: []
+
 # This is just for the build from the CLI - all other builds for jobs use own
 # actions
 actions:


### PR DESCRIPTION
The option / list is mandatory now for Packit, however we can keep it empty for now as it looks like as we build the srpm via the Makefile still. The same is used now in the leapp project.

It's expected we update the list in upcoming months most likely, when we integrate this project better with the current Packit best practices.