### PR TITLE
Overshadowing mount points in /etc/fstab

### DIFF
--- a/repos/system_upgrade/common/actors/checkfstabmountorder/actor.py
+++ b/repos/system_upgrade/common/actors/checkfstabmountorder/actor.py
@@ -1,0 +1,19 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.checkfstabmountorder import check_fstab_mount_order
+from leapp.models import StorageInfo
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckFstabMountOrder(Actor):
+    """
+    Checks order of entries in /etc/fstab based on their mount point and inhibits upgrade if overshadowing is detected.
+    """
+
+    name = "check_fstab_mount_order"
+    consumes = (StorageInfo,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        check_fstab_mount_order()

--- a/repos/system_upgrade/common/actors/checkfstabmountorder/libraries/checkfstabmountorder.py
+++ b/repos/system_upgrade/common/actors/checkfstabmountorder/libraries/checkfstabmountorder.py
@@ -1,0 +1,93 @@
+import os
+
+from leapp import reporting
+from leapp.libraries.stdlib import api
+from leapp.models import StorageInfo
+
+
+def _get_common_path(path1, path2):
+    """
+    Return the longest common absolute sub-path for pair of given absolute paths.
+
+    Note that this function implements similar functionality as os.path.commonpath(), however this function is not
+    available in python2.7, thus can't be used here.
+    """
+
+    if path1 == '' or path2 == '':
+        return ''
+
+    path1 = path1.strip('/').split('/')
+    path2 = path2.strip('/').split('/')
+
+    common_path = []
+    for path1_part, path2_part in zip(path1, path2):
+        if path1_part != path2_part:
+            break
+        common_path.append(path1_part)
+    return '/' + '/'.join(common_path)
+
+
+def _get_incorrectly_ordered_fstab_entries(fstab_entries):
+    """
+    Retrieve pairs of incorrectly ordered entries in /etc/fstab based on mount point overshadowing.
+
+    :param list[FstabEntry] fstab_entries: fstab entries from StorageInfo
+    :returns: pairs of fstab entries with incorrect order
+    """
+
+    for i, fstab_entry in enumerate(fstab_entries):
+        mount_point = os.path.abspath(fstab_entry.fs_file)
+
+        for overshadowing_fstab_entry in fstab_entries[i+1:]:
+            overshadowing_mount_point = os.path.abspath(overshadowing_fstab_entry.fs_file)
+
+            if _get_common_path(mount_point, overshadowing_mount_point) == overshadowing_mount_point:
+                yield fstab_entry, overshadowing_fstab_entry
+
+
+def check_fstab_mount_order():
+    storage_info = next(api.consume(StorageInfo), None)
+
+    if storage_info:
+        overshadowing_pairs = list(_get_incorrectly_ordered_fstab_entries(storage_info.fstab))
+        if overshadowing_pairs:
+            mount_points = [fstab_entry.fs_file for fstab_entry in storage_info.fstab]
+
+            duplicates = set()
+            overshadowing = set()
+            for overshadowed_entry, overshadowing_entry in overshadowing_pairs:
+                if overshadowed_entry == overshadowing_entry:
+                    duplicates.add(overshadowed_entry.fs_file)
+                overshadowing.add(overshadowed_entry.fs_file)
+                overshadowing.add(overshadowing_entry.fs_file)
+
+            overshadowing_in_order = []
+            for mount_point in mount_points:
+                if mount_point in overshadowing:
+                    overshadowing_in_order.append(mount_point)
+
+            summary = (
+                'Leapp detected incorrect order of entries in /etc/fstab that causes '
+                'overshadowing of mount points.\nDetected order of overshadowing mount points:\n{}'
+            ).format(', '.join(overshadowing_in_order))
+
+            if duplicates:
+                summary += ',\nDetected duplicate mount points:\n{}'.format(', '.join(duplicates))
+
+            hint = (
+                'To prevent the overshadowing reorder the entries in /etc/fstab and remove any duplicates. '
+                'Possible order of mount points without overshadowing:\n{}'
+            ).format(', '.join(sorted(overshadowing, key=len)))
+
+            reporting.create_report([
+                reporting.Title(
+                    'Detected incorrect order of entries or duplicate entries in /etc/fstab, preventing a successful '
+                    'in-place upgrade.'
+                ),
+                reporting.Summary(summary),
+                reporting.Remediation(hint=hint),
+                reporting.RelatedResource('file', '/etc/fstab'),
+                reporting.Severity(reporting.Severity.HIGH),
+                reporting.Groups([reporting.Groups.FILESYSTEM]),
+                reporting.Groups([reporting.Groups.INHIBITOR]),
+            ])

--- a/repos/system_upgrade/common/actors/checkfstabmountorder/libraries/checkfstabmountorder.py
+++ b/repos/system_upgrade/common/actors/checkfstabmountorder/libraries/checkfstabmountorder.py
@@ -1,3 +1,5 @@
+import os
+
 from leapp import reporting
 from leapp.libraries.stdlib import api
 from leapp.models import StorageInfo
@@ -11,7 +13,7 @@ def _get_common_path(path1, path2):
     available in python2.7, thus can't be used here.
     """
 
-    if path1 == '' or path2 == '':
+    if not path1 or not path2:
         return ''
 
     path1 = path1.strip('/').split('/')
@@ -22,7 +24,7 @@ def _get_common_path(path1, path2):
         if path1_part != path2_part:
             break
         common_path.append(path1_part)
-    return '/' + '/'.join(common_path)
+    return os.path.join('/', *common_path)
 
 
 def _get_overshadowing_mount_points(mount_points):
@@ -30,73 +32,56 @@ def _get_overshadowing_mount_points(mount_points):
     Retrieve set of overshadowing and overshadowed mount points.
 
     :param list[str] mount_points: absolute paths to mount points
-    :returns: set of mount points
+    :returns: set of unique mount points without trailing /
     """
-
     overshadowing = set()
+    mount_points = [mp.rstrip('/') for mp in mount_points]
     for i, mount_point in enumerate(mount_points):
-        if mount_point[-1] == '/':
-            mount_point = mount_point[:-1]
-
         for overshadowing_mount_point in mount_points[i+1:]:
-            if overshadowing_mount_point[-1] == '/':
-                overshadowing_mount_point = overshadowing_mount_point[:-1]
-
             if _get_common_path(mount_point, overshadowing_mount_point) == overshadowing_mount_point:
                 overshadowing.add(overshadowing_mount_point)
                 overshadowing.add(mount_point)
-
     return overshadowing
 
 
 def check_fstab_mount_order():
     storage_info = next(api.consume(StorageInfo), None)
 
-    if storage_info:
+    if not storage_info:
+        return
 
-        mount_points = []
-        for fstab_entry in storage_info.fstab:
-            mount_point = fstab_entry.fs_file
-            if mount_point[-1] == '/':
-                mount_point = mount_point[:-1]
-            mount_points.append(mount_point)
+    mount_points = [fstab_entry.fs_file.rstrip('/') for fstab_entry in storage_info.fstab]
+    overshadowing = _get_overshadowing_mount_points(mount_points)
+    duplicates = {mp for mp in mount_points if mount_points.count(mp) > 1}
 
-        overshadowing = _get_overshadowing_mount_points(mount_points)
+    if not overshadowing:
+        return
 
-        if overshadowing:
+    overshadowing_in_order = [mp for mp in mount_points if mp in overshadowing]
+    overshadowing_fixed = sorted(set(mount_points), key=len)
+    summary = 'Leapp detected incorrect /etc/fstab format that causes overshadowing of mount points.'
+    hint = 'To prevent the overshadowing:'
 
-            overshadowing_in_order = []
-            for mount_point in mount_points:
-                if mount_point in overshadowing:
-                    overshadowing_in_order.append(mount_point)
+    if duplicates:
+        summary += '\nDetected mount points with duplicates:\n{}'.format(', '.join(duplicates))
+        hint += '\nRemove detected duplicates by using unique mount points.'
 
-            duplicates = set()
-            for mount_point in mount_points:
-                if mount_points.count(mount_point) > 1:
-                    duplicates.add(mount_point)
+    if overshadowing:
+        summary += '\nDetected order of overshadowing mount points:\n{}'.format(', '.join(overshadowing_in_order))
+        hint += (
+            '\nReorder the detected overshadowing entries.'
+            '\nPossible order of all mount points without overshadowing:\n{}'
+        ).format(', '.join(overshadowing_fixed))
 
-            summary = (
-                'Leapp detected incorrect order of entries in /etc/fstab that causes '
-                'overshadowing of mount points.\nDetected order of overshadowing mount points:\n{}'
-            ).format(', '.join(overshadowing_in_order))
-
-            if duplicates:
-                summary += ',\nDetected duplicate mount points:\n{}'.format(', '.join(duplicates))
-
-            hint = (
-                'To prevent the overshadowing reorder the entries in /etc/fstab and remove any duplicates. '
-                'Possible order of mount points without overshadowing:\n{}'
-            ).format(', '.join(sorted(overshadowing, key=len)))
-
-            reporting.create_report([
-                reporting.Title(
-                    'Detected incorrect order of entries or duplicate entries in /etc/fstab, preventing a successful '
-                    'in-place upgrade.'
-                ),
-                reporting.Summary(summary),
-                reporting.Remediation(hint=hint),
-                reporting.RelatedResource('file', '/etc/fstab'),
-                reporting.Severity(reporting.Severity.HIGH),
-                reporting.Groups([reporting.Groups.FILESYSTEM]),
-                reporting.Groups([reporting.Groups.INHIBITOR]),
-            ])
+    reporting.create_report([
+        reporting.Title(
+            'Detected incorrect order of entries or duplicate entries in /etc/fstab, preventing a successful '
+            'in-place upgrade.'
+        ),
+        reporting.Summary(summary),
+        reporting.Remediation(hint=hint),
+        reporting.RelatedResource('file', '/etc/fstab'),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.FILESYSTEM]),
+        reporting.Groups([reporting.Groups.INHIBITOR]),
+    ])

--- a/repos/system_upgrade/common/actors/checkfstabmountorder/tests/test_checkfstabmountorder.py
+++ b/repos/system_upgrade/common/actors/checkfstabmountorder/tests/test_checkfstabmountorder.py
@@ -48,7 +48,7 @@ def test_get_common_path(path1, path2, expected_output):
            {'/var/log', '/var'}
         ),
         (
-           ['/var/log', '/home', '/var', '/var/lib/leapp'],
+           ['/var/log', '/home', '/var/', '/var/lib/leapp'],
            {'/var/log', '/var'}
         ),
         (
@@ -68,22 +68,10 @@ def test_get_overshadowing_mount_points(fstab_entries, expected_output):
 @pytest.mark.parametrize(
     ('storage_info', 'should_inhibit'),
     [
-        (
-            StorageInfo(fstab=[]),
-            False
-        ),
-        (
-            StorageInfo(fstab=[VAR_LOG_ENTRY, VAR_ENTRY]),
-            True
-        ),
-        (
-            StorageInfo(fstab=[VAR_LOG_ENTRY, VAR_ENTRY, VAR_DUPLICATE_ENTRY]),
-            True
-        ),
-        (
-            StorageInfo(fstab=[VAR_ENTRY, VAR_LOG_ENTRY]),
-            False
-        ),
+        (StorageInfo(fstab=[]), False),
+        (StorageInfo(fstab=[VAR_LOG_ENTRY, VAR_ENTRY]), True),
+        (StorageInfo(fstab=[VAR_LOG_ENTRY, VAR_ENTRY, VAR_DUPLICATE_ENTRY]), True),
+        (StorageInfo(fstab=[VAR_ENTRY, VAR_LOG_ENTRY]), False),
     ]
 )
 def test_var_lib_leapp_non_persistent_is_detected(monkeypatch, storage_info, should_inhibit):
@@ -97,6 +85,6 @@ def test_var_lib_leapp_non_persistent_is_detected(monkeypatch, storage_info, sho
     if should_inhibit:
         assert created_reports.called == 1
 
-        mount_points = [fstab_entry.fs_file for fstab_entry in storage_info.fstab]
+        mount_points = [fstab_entry.fs_file.rstrip('/') for fstab_entry in storage_info.fstab]
         if len(set(mount_points)) != len(mount_points):
-            assert 'Detected duplicate mount points:' in created_reports.reports[-1]['summary']
+            assert 'Detected mount points with duplicates:' in created_reports.reports[-1]['summary']

--- a/repos/system_upgrade/common/actors/checkfstabmountorder/tests/test_checkfstabmountorder.py
+++ b/repos/system_upgrade/common/actors/checkfstabmountorder/tests/test_checkfstabmountorder.py
@@ -1,0 +1,106 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor.checkfstabmountorder import (
+    _get_common_path,
+    _get_incorrectly_ordered_fstab_entries,
+    check_fstab_mount_order
+)
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import FstabEntry, MountEntry, StorageInfo
+
+VAR_ENTRY = FstabEntry(fs_spec='', fs_file='/var/', fs_vfstype='',
+                       fs_mntops='defaults', fs_freq='0', fs_passno='0')
+VAR_LOG_ENTRY = FstabEntry(fs_spec='', fs_file='/var/log', fs_vfstype='',
+                           fs_mntops='defaults', fs_freq='0', fs_passno='0')
+HOME_ENTRY = FstabEntry(fs_spec='', fs_file='/home', fs_vfstype='',
+                        fs_mntops='defaults', fs_freq='0', fs_passno='0')
+VAR_LIB_LEAPP_ENTRY = FstabEntry(fs_spec='', fs_file='/var/lib/leapp', fs_vfstype='',
+                                 fs_mntops='defaults', fs_freq='0', fs_passno='0')
+VAR_LIB_LEA_ENTRY = FstabEntry(fs_spec='', fs_file='/var/lib/lea/', fs_vfstype='',
+                               fs_mntops='defaults', fs_freq='0', fs_passno='0')
+
+
+@pytest.mark.parametrize(
+    ('path1', 'path2', 'expected_output'),
+    [
+        ('', '', ''),
+        ('/var', '/var', '/var'),
+        ('/var/lib/leapp', '/var/lib', '/var/lib'),
+        ('/var/lib/leapp', '/home', '/'),
+        ('/var/lib/leapp', '/var/lib/lea', '/var/lib'),
+    ]
+)
+def test_get_common_path(path1, path2, expected_output):
+    assert _get_common_path(path1, path2) == expected_output
+
+
+@pytest.mark.parametrize(
+    ('fstab_entries', 'expected_output'),
+    [
+        (
+           [VAR_ENTRY, VAR_LOG_ENTRY],
+           []
+        ),
+        (
+           [VAR_LOG_ENTRY, VAR_ENTRY],
+           [(VAR_LOG_ENTRY, VAR_ENTRY)]
+        ),
+        (
+           [VAR_LOG_ENTRY, VAR_ENTRY, VAR_ENTRY],
+           [(VAR_LOG_ENTRY, VAR_ENTRY), (VAR_LOG_ENTRY, VAR_ENTRY), (VAR_ENTRY, VAR_ENTRY)]
+        ),
+        (
+           [VAR_LOG_ENTRY, HOME_ENTRY, VAR_ENTRY, VAR_LIB_LEAPP_ENTRY],
+           [(VAR_LOG_ENTRY, VAR_ENTRY)]
+        ),
+        (
+           [VAR_LOG_ENTRY, HOME_ENTRY, VAR_LIB_LEAPP_ENTRY, VAR_ENTRY],
+           [(VAR_LOG_ENTRY, VAR_ENTRY), (VAR_LIB_LEAPP_ENTRY, VAR_ENTRY)]
+        ),
+        (
+           [VAR_LOG_ENTRY, HOME_ENTRY, VAR_ENTRY, VAR_LIB_LEA_ENTRY, VAR_LIB_LEAPP_ENTRY],
+           [(VAR_LOG_ENTRY, VAR_ENTRY)]
+        ),
+    ]
+)
+def test_incorrectly_ordered_fstab_entries(fstab_entries, expected_output):
+    assert list(_get_incorrectly_ordered_fstab_entries(fstab_entries)) == expected_output
+
+
+@pytest.mark.parametrize(
+    ('storage_info', 'should_inhibit'),
+    [
+        (
+            StorageInfo(fstab=[]),
+            False
+        ),
+        (
+            StorageInfo(fstab=[VAR_LOG_ENTRY, VAR_ENTRY]),
+            True
+        ),
+        (
+            StorageInfo(fstab=[VAR_LOG_ENTRY, VAR_ENTRY, VAR_ENTRY]),
+            True
+        ),
+        (
+            StorageInfo(fstab=[VAR_ENTRY, VAR_LOG_ENTRY]),
+            False
+        ),
+    ]
+)
+def test_var_lib_leapp_non_persistent_is_detected(monkeypatch, storage_info, should_inhibit):
+
+    created_reports = create_report_mocked()
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[storage_info]))
+    monkeypatch.setattr(reporting, 'create_report', created_reports)
+
+    check_fstab_mount_order()
+
+    if should_inhibit:
+        assert created_reports.called == 1
+
+        mount_points = [fstab_entry.fs_file for fstab_entry in storage_info.fstab]
+        if len(set(mount_points)) != len(mount_points):
+            assert 'Detected duplicate mount points:' in created_reports.reports[-1]['summary']

--- a/repos/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py
+++ b/repos/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py
@@ -139,6 +139,7 @@ def _get_fstab_info(fstab_path):
                     api.current_logger().error(summary)
                     break
 
+                # NOTE: fstab entries are yielded in the same order as in the /etc/fstab
                 fs_spec, fs_file, fs_vfstype, fs_mntops, fs_freq, fs_passno = entries
                 yield FstabEntry(
                     fs_spec=fs_spec,


### PR DESCRIPTION
Checks the order of entries in /etc/fstab based on their mount point and inhibits upgrade if overshadowing is detected.

Jira ref.: OAMG#5090
Bugzilla: [BZ#1972238](https://bugzilla.redhat.com/show_bug.cgi?id=1972238)

