### PR TITLE
Improve the hint in peseventsscanner for unknown repositories

### DIFF
--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
@@ -439,8 +439,14 @@ def replace_pesids_with_repoids_in_packages(packages, source_pkgs_repoids):
             message='packages may not be installed or upgraded due to repositories unknown to leapp:',
             skipped_pkgs=packages_without_known_repoid,
             remediation=(
-                'Please file a bug in http://bugzilla.redhat.com/ for leapp-repository component of '
-                'the Red Hat Enterprise Linux product.'
+                'In case the listed repositories are mirrors of official repositories for RHEL'
+                ' (provided by Red Hat on CDN)'
+                ' and their repositories IDs has been customized, you can change'
+                ' the configuration to use the official IDs instead of fixing the problem.'
+                ' You can also review the projected DNF upgrade transaction result'
+                ' in the logs to see what is going to happen, as this does not necessarily mean'
+                ' that the listed packages will not be upgraded. You can also'
+                ' install any missing packages after the in-place upgrade manually.'
             ),
         )
 


### PR DESCRIPTION
The original msg guided users to open ticket on RHBZ portal, which has been confusing as the repository is used by other linux distributions also and they haven't updated the msg properly, so people has been asking for bugfixes unrelated to RHEL systems

Which could not be fixed by Red Hat (RH) as this is connected to leapp data, which in case of RH covers only official repositories and packages provided by RH. Other distributions are expected to provide the correct leapp data valid for these systems to reflect the content of the used linux distribution.

To fix this problem, we have decided to update the hint to improve UX, so they report the problem as they are used for their distribution. Also the hint has been improved to provide more instructions what user can do on the system
* change the used (custom) repoid to the official one
* review the planned dnf transaction to see whether there is a problem regarding the listed packages
* install missing packages after the upgrade manually