### PR TITLE
Do not create python3 .pyc files

### DIFF
--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -266,7 +266,7 @@ do_upgrade() {
         # all FSTAB partitions. As mount was working before, hopefully will
         # work now as well. Later this should be probably modified as we will
         # need to handle more stuff around storage at all.
-        /usr/bin/systemd-nspawn $NSPAWN_OPTS -D "$NEWROOT" /usr/bin/bash -c "mount -a; /usr/bin/python3 $LEAPP3_BIN upgrade --resume $args"
+        /usr/bin/systemd-nspawn $NSPAWN_OPTS -D "$NEWROOT" /usr/bin/bash -c "mount -a; /usr/bin/python3 -B $LEAPP3_BIN upgrade --resume $args"
         rv=$?
     fi
 

--- a/repos/system_upgrade/common/actors/preparepythonworkround/libraries/workaround.py
+++ b/repos/system_upgrade/common/actors/preparepythonworkround/libraries/workaround.py
@@ -31,7 +31,7 @@ def apply_python3_workaround():
     os.symlink(_get_orig_leapp_path(), leapp_lib_symlink_path)
     with open(py3_leapp, 'w') as f:
         f_content = [
-            '#!/usr/bin/python3',
+            '#!/usr/bin/python3 -B',
             'import sys',
             'sys.path.append(\'{}\')'.format(LEAPP_HOME),
             '',


### PR DESCRIPTION
After the in-place upgrade and removal of `leapp` packages, there are leftover `*cpython.pyc` files in: `/usr/lib/python2.7/site-packages/leapp/` and `/usr/share/leapp-repository/`.

Let's avoid this by not creating them in the first place.

Jira ref.: OAMG-7641