### PR TITLE
Remove obsolete gpg keys

### DIFF
--- a/repos/system_upgrade/common/actors/removeobsoletegpgkeys/actor.py
+++ b/repos/system_upgrade/common/actors/removeobsoletegpgkeys/actor.py
@@ -1,0 +1,24 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import removeobsoleterpmgpgkeys
+from leapp.models import DNFWorkaround, InstalledRPM
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class RemoveObsoleteGpgKeys(Actor):
+    """
+    Remove obsoleted RPM GPG keys.
+
+    New version might make existing RPM GPG keys obsolete. This might be caused
+    for example by the hashing algorithm becoming deprecated or by the key
+    getting replaced.
+
+    A DNFWorkaround is registered to actually remove the keys.
+    """
+
+    name = "remove_obsolete_gpg_keys"
+    consumes = (InstalledRPM,)
+    produces = (DNFWorkaround,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        removeobsoleterpmgpgkeys.process()

--- a/repos/system_upgrade/common/actors/removeobsoletegpgkeys/libraries/removeobsoleterpmgpgkeys.py
+++ b/repos/system_upgrade/common/actors/removeobsoletegpgkeys/libraries/removeobsoleterpmgpgkeys.py
@@ -1,0 +1,47 @@
+from leapp.libraries.common.config.version import get_target_major_version
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import DNFWorkaround, InstalledRPM
+
+# maps target version to keys obsoleted in that version
+OBSOLETED_KEYS_MAP = {
+    7: [],
+    8: [
+        "gpg-pubkey-2fa658e0-45700c69",
+        "gpg-pubkey-37017186-45761324",
+        "gpg-pubkey-db42a60e-37ea5438",
+    ],
+    9: ["gpg-pubkey-d4082792-5b32db75"],
+}
+
+
+def _get_obsolete_keys():
+    """
+    Return keys obsoleted in target and previous versions
+    """
+    keys = []
+    for version in range(7, int(get_target_major_version()) + 1):
+        for key in OBSOLETED_KEYS_MAP[version]:
+            name, version, release = key.rsplit("-", 2)
+            if has_package(InstalledRPM, name, version=version, release=release):
+                keys.append(key)
+
+    return keys
+
+
+def register_dnfworkaround(keys):
+    api.produce(
+        DNFWorkaround(
+            display_name="remove obsolete RPM GPG keys from RPM DB",
+            script_path=api.current_actor().get_common_tool_path("removerpmgpgkeys"),
+            script_args=keys,
+        )
+    )
+
+
+def process():
+    keys = _get_obsolete_keys()
+    if not keys:
+        return
+
+    register_dnfworkaround(keys)

--- a/repos/system_upgrade/common/actors/removeobsoletegpgkeys/tests/test_removeobsoleterpmgpgkeys.py
+++ b/repos/system_upgrade/common/actors/removeobsoletegpgkeys/tests/test_removeobsoleterpmgpgkeys.py
@@ -1,0 +1,94 @@
+import pytest
+
+from leapp.libraries.actor import removeobsoleterpmgpgkeys
+from leapp.libraries.common.config.version import get_target_major_version
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import DNFWorkaround, InstalledRPM, RPM
+
+
+def _get_test_installedrpm():
+    return InstalledRPM(
+        items=[
+            RPM(
+                name='gpg-pubkey',
+                version='d4082792',
+                release='5b32db75',
+                epoch='0',
+                packager='Red Hat, Inc. (auxiliary key 2) <security@redhat.com>',
+                arch='noarch',
+                pgpsig=''
+            ),
+            RPM(
+                name='gpg-pubkey',
+                version='2fa658e0',
+                release='45700c69',
+                epoch='0',
+                packager='Red Hat, Inc. (auxiliary key) <security@redhat.com>',
+                arch='noarch',
+                pgpsig=''
+            ),
+            RPM(
+                name='gpg-pubkey',
+                version='12345678',
+                release='abcdefgh',
+                epoch='0',
+                packager='made up',
+                arch='noarch',
+                pgpsig=''
+            ),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        (9, ["gpg-pubkey-d4082792-5b32db75", "gpg-pubkey-2fa658e0-45700c69"]),
+        (8, ["gpg-pubkey-2fa658e0-45700c69"])
+    ]
+)
+def test_get_obsolete_keys(monkeypatch, version, expected):
+    def get_target_major_version_mocked():
+        return version
+
+    monkeypatch.setattr(
+        removeobsoleterpmgpgkeys,
+        "get_target_major_version",
+        get_target_major_version_mocked,
+    )
+
+    monkeypatch.setattr(
+        api,
+        "current_actor",
+        CurrentActorMocked(
+            msgs=[_get_test_installedrpm()]
+        ),
+    )
+
+    keys = removeobsoleterpmgpgkeys._get_obsolete_keys()
+    assert set(keys) == set(expected)
+
+
+@pytest.mark.parametrize(
+    "keys, should_register",
+    [
+        (["gpg-pubkey-d4082792-5b32db75"], True),
+        ([], False)
+    ]
+)
+def test_workaround_should_register(monkeypatch, keys, should_register):
+    def get_obsolete_keys_mocked():
+        return keys
+
+    monkeypatch.setattr(
+        removeobsoleterpmgpgkeys,
+        '_get_obsolete_keys',
+        get_obsolete_keys_mocked
+    )
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
+
+    removeobsoleterpmgpgkeys.process()
+    assert api.produce.called == should_register

--- a/repos/system_upgrade/common/libraries/rpms.py
+++ b/repos/system_upgrade/common/libraries/rpms.py
@@ -39,7 +39,7 @@ def create_lookup(model, field, keys, context=stdlib.api):
         return set()
 
 
-def has_package(model, package_name, arch=None, context=stdlib.api):
+def has_package(model, package_name, arch=None, version=None, release=None, context=stdlib.api):
     """
     Expects a model InstalledRedHatSignedRPM or InstalledUnsignedRPM.
     Can be useful in cases like a quick item presence check, ex. check in actor that
@@ -48,12 +48,23 @@ def has_package(model, package_name, arch=None, context=stdlib.api):
     :param model: model class
     :param package_name: package to be checked
     :param arch: filter by architecture. None means all arches.
+    :param version: filter by version. None means all versions.
+    :param release: filter by release. None means all releases.
     """
     if not (isinstance(model, type) and issubclass(model, InstalledRPM)):
         return False
-    keys = ('name',) if not arch else ('name', 'arch')
+    keys = ['name']
+    if arch:
+        keys.append('arch')
+    if version:
+        keys.append('version')
+    if release:
+        keys.append('release')
+
+    attributes = [package_name]
+    attributes += [attr for attr in (arch, version, release) if attr is not None]
     rpm_lookup = create_lookup(model, field='items', keys=keys, context=context)
-    return (package_name, arch) in rpm_lookup if arch else (package_name,) in rpm_lookup
+    return tuple(attributes) in rpm_lookup
 
 
 def _read_rpm_modifications(config):

--- a/repos/system_upgrade/common/tools/removerpmgpgkeys
+++ b/repos/system_upgrade/common/tools/removerpmgpgkeys
@@ -1,0 +1,13 @@
+#!/usr/bin/sh
+
+exit_code=0
+
+for key in "$@"; do
+    echo >&2 "Info: Removing RPM GPG key: $key"
+    rpm --erase "$key" || {
+        exit_code=1
+        echo >&2 "Error: Failed to remove RPM GPG key: $key"
+    }
+done
+
+exit $exit_code


### PR DESCRIPTION
Sometimes after in-place uprade there are keys left that are
obsoleted/deprecated in the new version. One example are keys which use
deprecated hashing algorithms.

A new `removeobsoletegpgkeys` actor registers a `DNFWorkaround` to
remove such keys.

Jira ref.: OAMG-8033