### PR TITLE
scaninstalledtargetkernelversion: Detect kernel-core package on RHEL 8+

### DIFF
--- a/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/actor.py
+++ b/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/actor.py
@@ -8,10 +8,10 @@ class ScanInstalledTargetKernelVersion(Actor):
     """
     Scan for the version of the newly installed kernel
 
-    This actor will query rpm for all kernel packages and reports the first
-    matching target system kernel RPM. In case the RHEL Real Time has been detected on
-    the original system, the kernel-rt rpm is searched. If the rpm is missing,
-    fallback for standard kernel RPM.
+    This actor will query rpm for all kernel-core packages and reports the
+    first matching target system kernel RPM. In case the RHEL Real Time has
+    been detected on the original system, the kernel-rt-core rpm is searched.
+    If the rpm is missing, fallback for standard kernel RPM.
     """
 
     name = 'scan_installed_target_kernel_version'

--- a/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/libraries/scankernel.py
+++ b/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/libraries/scankernel.py
@@ -25,13 +25,13 @@ def process():
     # was realtime
 
     if is_rhel_realtime():
-        version = _get_kernel_version('kernel-rt')
+        version = _get_kernel_version('kernel-rt-core')
         if version:
             api.produce(InstalledTargetKernelVersion(version=version))
             return
         else:
             api.current_logger().warning(
-                'The kernel-rt rpm from the target RHEL has not been detected. '
+                'The kernel-rt-core rpm from the target RHEL has not been detected. '
                 'Switching to non-preemptive kernel.'
             )
             # TODO: create report with instructions to install kernel-rt manually
@@ -40,7 +40,7 @@ def process():
             # # is not enabled during the upgrade.
 
     # standard (non-preemptive) kernel
-    version = _get_kernel_version('kernel')
+    version = _get_kernel_version('kernel-core')
     if version:
         api.produce(InstalledTargetKernelVersion(version=version))
     else:

--- a/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/tests/test_scaninstalledkernel_scaninstalledtargetkernelversion.py
+++ b/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/tests/test_scaninstalledkernel_scaninstalledtargetkernelversion.py
@@ -5,12 +5,12 @@ from leapp.libraries.actor import scankernel
 from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
 from leapp.libraries.stdlib import api
 
-TARGET_KERNEL_VERSION = '1.2.3-4.el8.x86_64'
-TARGET_RT_KERNEL_VERSION = '1.2.3-4.rt56.7.el8.x86_64'
-TARGET_KERNEL = 'kernel-{}'.format(TARGET_KERNEL_VERSION)
-TARGET_RT_KERNEL = 'kernel-{}'.format(TARGET_RT_KERNEL_VERSION)
-OLD_KERNEL = 'kernel-0.1.2-3.el7.x86_64'
-OLD_RT_KERNEL = 'kernel-rt-0.1.2-3.rt4.5.el7.x86_64'
+TARGET_KERNEL_VERSION = '1.2.3-4.el9.x86_64'
+TARGET_RT_KERNEL_VERSION = '1.2.3-4.rt56.7.el9.x86_64'
+TARGET_KERNEL = 'kernel-core-{}'.format(TARGET_KERNEL_VERSION)
+TARGET_RT_KERNEL = 'kernel-rt-core-{}'.format(TARGET_RT_KERNEL_VERSION)
+OLD_KERNEL = 'kernel-core-0.1.2-3.el8.x86_64'
+OLD_RT_KERNEL = 'kernel-rt-core-0.1.2-3.rt4.5.el8.x86_64'
 
 
 class MockedRun(object):
@@ -20,30 +20,34 @@ class MockedRun(object):
         self._stdouts = stdouts
 
     def __call__(self, *args, **kwargs):
-        for key in ('kernel', 'kernel-rt'):
+        for key in ('kernel-core', 'kernel-rt-core'):
             if key in args[0]:
                 return {'stdout': self._stdouts.get(key, [])}
         return {'stdout': []}
 
 
 @pytest.mark.parametrize('is_rt,exp_version,stdouts', [
-    (False, TARGET_KERNEL_VERSION, {'kernel': [OLD_KERNEL, TARGET_KERNEL]}),
-    (False, TARGET_KERNEL_VERSION, {'kernel': [TARGET_KERNEL, OLD_KERNEL]}),
+    (False, TARGET_KERNEL_VERSION, {'kernel-core': [OLD_KERNEL, TARGET_KERNEL]}),
+    (False, TARGET_KERNEL_VERSION, {'kernel-core': [TARGET_KERNEL, OLD_KERNEL]}),
     (False, TARGET_KERNEL_VERSION, {
-        'kernel': [TARGET_KERNEL, OLD_KERNEL],
-        'kernel-rt': [TARGET_RT_KERNEL, OLD_RT_KERNEL],
+        'kernel-core': [TARGET_KERNEL, OLD_KERNEL],
+        'kernel-rt-core': [TARGET_RT_KERNEL, OLD_RT_KERNEL],
     }),
-    (True, TARGET_RT_KERNEL_VERSION, {'kernel-rt': [OLD_RT_KERNEL, TARGET_RT_KERNEL]}),
-    (True, TARGET_RT_KERNEL_VERSION, {'kernel-rt': [TARGET_RT_KERNEL, OLD_RT_KERNEL]}),
     (True, TARGET_RT_KERNEL_VERSION, {
-        'kernel': [TARGET_KERNEL, OLD_KERNEL],
-        'kernel-rt': [TARGET_RT_KERNEL, OLD_RT_KERNEL],
+        'kernel-rt-core': [OLD_RT_KERNEL, TARGET_RT_KERNEL]
+    }),
+    (True, TARGET_RT_KERNEL_VERSION, {
+        'kernel-rt-core': [TARGET_RT_KERNEL, OLD_RT_KERNEL]
+    }),
+    (True, TARGET_RT_KERNEL_VERSION, {
+        'kernel-core': [TARGET_KERNEL, OLD_KERNEL],
+        'kernel-rt-core': [TARGET_RT_KERNEL, OLD_RT_KERNEL],
     }),
 ])
 def test_scaninstalledkernel(monkeypatch, is_rt, exp_version, stdouts):
     result = []
-    old_kver = '0.1.2-3.rt4.5.el7.x86_64' if is_rt else 'kernel-0.1.2-3.el7.x86_64'
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=old_kver))
+    old_kver = '0.1.2-3.rt4.5.el8.x86_64' if is_rt else 'kernel-core-0.1.2-3.el88x86_64'
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(dst_ver='9.0', kernel=old_kver))
     monkeypatch.setattr(api, 'produce', result.append)
     monkeypatch.setattr(scankernel, 'run', MockedRun(stdouts))
     scankernel.process()
@@ -52,9 +56,9 @@ def test_scaninstalledkernel(monkeypatch, is_rt, exp_version, stdouts):
 
 def test_scaninstalledkernel_missing_rt(monkeypatch):
     result = []
-    old_kver = '0.1.2-3.rt4.5.el7.x86_64'
-    stdouts = {'kernel': [TARGET_KERNEL], 'kernel-rt': [OLD_RT_KERNEL]}
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=old_kver))
+    old_kver = '0.1.2-3.rt4.5.el8.x86_64'
+    stdouts = {'kernel-core': [TARGET_KERNEL], 'kernel-rt-core': [OLD_RT_KERNEL]}
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(dst_ver='9.0', kernel=old_kver))
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'produce', result.append)
     monkeypatch.setattr(scankernel, 'run', MockedRun(stdouts))
@@ -65,7 +69,7 @@ def test_scaninstalledkernel_missing_rt(monkeypatch):
 
 def test_scaninstalledkernel_missing(monkeypatch):
     result = []
-    old_kver = '0.1.2-3.rt4.5.el7.x86_64'
+    old_kver = '0.1.2-3.rt4.5.el8.x86_64'
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(kernel=old_kver))
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'produce', result.append)


### PR DESCRIPTION
On RHEL 8+ the `kernel` package was split into multiple packages including `kernel-core`. The `kernel` package is just a placeholder there and might not be installed.

The `kernel-rt` package was split similarly.

Let's scan for `kernel-core` and (`kernel-rt-core` on RHEL Real Time) instead which should always be present.

Fixes #1021

Jira ref.: OAMG-8383