### PR TITLE
pes_events_scanner: Fix regression in pes_event_parsing

### DIFF
--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_event_parsing.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_event_parsing.py
@@ -73,7 +73,7 @@ def get_pes_events(pes_json_directory, pes_json_filename):
         return events_matching_arch
     except (ValueError, KeyError):
         title = 'Missing/Invalid PES data file ({}/{})'.format(pes_json_directory, pes_json_filename)
-        summary = ('Read documentation at: https://access.redhat.com/articles/3664871 for more information ',
+        summary = ('Read documentation at: https://access.redhat.com/articles/3664871 for more information '
                    'about how to retrieve the files')
         reporting.create_report([
             reporting.Title(title),


### PR DESCRIPTION
When `/etc/leapp/files/pes-events.json` contains invalid data (e.g. empty, invalid syntax, garbage content) leapp tracebacks.

This commit fixes that and also introduces a test case to make sure we actually produce report and raise the correct `StopActorExecution` exception.

Jira ref.: OAMG-7637