### PR TITLE
Actor for RoCE Detection to inhibit IPU 

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/rocecheck/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/rocecheck/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import rocecheck
+from leapp.models import KernelCmdline, Report, RoceDetected
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class RoceCheck(Actor):
+    """
+    Check whether RoCE is used on the system and well configured for the upgrade.
+
+    This is valid only for IBM Z systems (s390x). If a used RoCE is detected,
+        * system must be RHEL 8.7+ (suggesting 8.8+ due to 8.7 EOL)
+        * and system must be booted with: net.naming-scheme=rhel-8.7
+    otherwise the network is broken due to changed NICs.
+    """
+
+    name = 'roce_check'
+    consumes = (KernelCmdline, RoceDetected)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        rocecheck.process()

--- a/repos/system_upgrade/el8toel9/actors/rocecheck/libraries/rocecheck.py
+++ b/repos/system_upgrade/el8toel9/actors/rocecheck/libraries/rocecheck.py
@@ -1,0 +1,134 @@
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config import architecture, version
+from leapp.libraries.stdlib import api
+from leapp.models import KernelCmdline, RoceDetected
+
+FMT_LIST_SEPARATOR = '\n    - {}'
+DOC_URL = 'https://red.ht/predictable-network-interface-device-names-on-the-system-z-platform'
+
+
+def is_kernel_arg_set():
+    """
+    Return True if the system is booted with net.naming-scheme=rhel-8.7
+
+    Important: it's really expected the argument is rhel-8.7 always.
+    So not rhel-8.8, rhel-9.0, ... etc.
+    """
+    kernel_args = next(api.consume(KernelCmdline), None)
+    if not kernel_args:
+        # This is theoretical. If this happens, something is terribly wrong
+        # already - so raising the hard error.
+        raise StopActorExecutionError('Missing the KernelCmdline message!')
+    for param in kernel_args.parameters:
+        if param.key != 'net.naming-scheme':
+            continue
+        if param.value == 'rhel-8.7':
+            return True
+        api.current_logger().warning(
+            'Detected net.naming-scheme with unexpected value: {}'
+            .format(param.value)
+        )
+        return False
+    return False
+
+
+def _fmt_list(items):
+    return ''.join([FMT_LIST_SEPARATOR.format(i) for i in items])
+
+
+def _report_old_version(roce):
+    roce_nics = roce.roce_nics_connected + roce.roce_nics_connecting
+    reporting.create_report([
+        reporting.Title('A newer version of RHEL 8 is required for the upgrade with RoCE.'),
+        reporting.Summary(
+            'The RHEL 9 system uses different network schemes for NIC names'
+            ' than RHEL 8.'
+            ' RHEL {version} does not provide functionality to be able'
+            ' to set the system configuration in a way the network interface'
+            ' names used by RoCE are persistent on both (RHEL 8 and RHEL 9)'
+            ' systems.'
+            ' The in-place upgrade from the current version of RHEL to RHEL 9'
+            ' will break the RoCE network configuration.'
+            '\n\nRoCE detected on following NICs:{nics}'
+            .format(
+                version=version.get_source_version(),
+                nics=_fmt_list(roce_nics)
+            )
+        ),
+        reporting.Remediation(hint=(
+            'Update the system to RHEL 8.8 or newer using DNF and then reboot'
+            ' the system prior the in-place upgrade to RHEL 9.'
+        )),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([
+            reporting.Groups.INHIBITOR,
+            reporting.Groups.ACCESSIBILITY,
+            reporting.Groups.SANITY,
+        ]),
+    ])
+
+
+def _report_wrong_setup(roce):
+    roce_nics = roce.roce_nics_connected + roce.roce_nics_connecting
+    reporting.create_report([
+        reporting.Title('Invalid RoCE configuration for the in-place upgrade'),
+        reporting.Summary(
+            'The RHEL 9 system uses different network schemes for NIC names'
+            ' than RHEL 8.'
+            ' The below listed RoCE NICs need to be reconfigured to the new'
+            ' interface naming scheme in order to prevent loss of network'
+            ' access to your system via these interfaces after the upgrade.'
+            ' For more information, see: {url}'
+            '\n\nRoCE detected on the following NICs:{nics}'
+            .format(nics=_fmt_list(roce_nics), url=DOC_URL)
+        ),
+        reporting.Remediation(hint=(
+            'Prerequisite for upgrading to RHEL9.x:'
+            'In RHEL 8, all RoCE cards must be configured with the interface'
+            ' names they should have in RHEL9.x.\n'
+            'For more information, see chapter 1.4 of the RHEL8 Product'
+            ' Documentation (see the attached link) and follow these steps:\n'
+            '1.) determine the current interface device names of the RoCE'
+            ' cards that are in "connected to" or in "connecting" state\n'
+            '2.) determine if UID uniqueness is set for these cards\n'
+            '3.) compute new interface device names from the UID or the'
+            ' function ID, respectively\n'
+            '4.) change the network interface device names in ifcfg'
+            ' files\n'
+            '5.) set the kernel parameter net.naming-scheme=rhel-8.7 in the'
+            ' effective .conf file in /boot/loader/entries\n'
+            '6.) adjust other settings that rely on the interface device names'
+            ' (e.g. firewall) by changing the interface device names'
+            ' accordingly\n'
+            '7.) run `zipl -V` and reboot the system\n'
+            '8.) check your network connectivity\n'
+            '\n'
+            'Caution: Creating an incorrect configuration might cause the loss'
+            ' of your network connection after reboot!'
+        )),
+        reporting.ExternalLink(
+            title='Predictable network interface device names on the System z platform',
+            url=DOC_URL),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([
+            reporting.Groups.INHIBITOR,
+            reporting.Groups.ACCESSIBILITY,
+            reporting.Groups.SANITY,
+        ]),
+    ])
+
+
+def process():
+    if not architecture.matches_architecture(architecture.ARCH_S390X):
+        # The check is valid only on S390X architecture
+        return
+    roce = next(api.consume(RoceDetected), None)
+    if not roce or not (roce.roce_nics_connected or roce.roce_nics_connecting):
+        # No used RoCE detected - nothing to do
+        api.current_logger().debug('Skipping RoCE checks: No RoCE card detected.')
+        return
+    if version.matches_source_version('<= 8.6'):
+        _report_old_version(roce)
+    if not is_kernel_arg_set():
+        _report_wrong_setup(roce)

--- a/repos/system_upgrade/el8toel9/actors/rocecheck/tests/unit_test_rocecheck.py
+++ b/repos/system_upgrade/el8toel9/actors/rocecheck/tests/unit_test_rocecheck.py
@@ -1,0 +1,116 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import rocecheck
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import KernelCmdline, KernelCmdlineArg, RoceDetected
+
+
+def _kernel_cmdline(params=None):
+    if params is None:
+        return KernelCmdline(parameters=[])
+    k_params = []
+    for item in params:
+        try:
+            key, value = item.split('=', 1)
+        except ValueError:
+            key = item
+            value = None
+        k_params.append(KernelCmdlineArg(key=key, value=value))
+    return KernelCmdline(parameters=k_params)
+
+
+def _roce(connected, connecting):
+    return RoceDetected(
+        roce_nics_connected=connected,
+        roce_nics_connecting=connecting
+    )
+
+
+@pytest.mark.parametrize('msgs', (
+    [_kernel_cmdline()],
+    [_kernel_cmdline(), _roce([], [])],
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.7']), _roce([], [])],
+))
+def test_no_roce(monkeypatch, msgs):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X, msgs=msgs))
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    rocecheck.process()
+    assert not reporting.create_report.called
+
+
+@pytest.mark.parametrize('arch', (
+    architecture.ARCH_ARM64,
+    architecture.ARCH_X86_64,
+    architecture.ARCH_PPC64LE
+))
+def test_roce_noibmz(monkeypatch, arch):
+    def mocked_do_not_call_me(dummy):
+        assert False, 'Unexpected call on non-IBMz arch (actor should not do anything).'
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=arch))
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    monkeypatch.setattr(rocecheck, '_report_old_version', mocked_do_not_call_me)
+    monkeypatch.setattr(rocecheck, '_report_wrong_setup', mocked_do_not_call_me)
+    monkeypatch.setattr(rocecheck, 'is_kernel_arg_set', mocked_do_not_call_me)
+    monkeypatch.setattr(rocecheck.api, 'consume', mocked_do_not_call_me)
+    rocecheck.process()
+
+
+@pytest.mark.parametrize('msgs', (
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.7']), _roce(['eno'], [])],
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.7']), _roce([], ['eno'])],
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.7']), _roce(['enp0', 'enp1'], ['eno'])],
+    [_kernel_cmdline(['good', 'net.naming-scheme=rhel-8.7']), _roce(['eno'], [])],
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.7', 'good']), _roce(['eno'], [])],
+    [_kernel_cmdline(['foo=bar', 'net.naming-scheme=rhel-8.7', 'foo=bar']), _roce(['eno'], [])],
+))
+@pytest.mark.parametrize('version', ['8.7', '8.8', '8.10'])
+def test_roce_ok(monkeypatch, msgs, version):
+    curr_actor_mocked = CurrentActorMocked(arch=architecture.ARCH_S390X, src_ver=version, msgs=msgs)
+    monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    rocecheck.process()
+    assert not reporting.create_report.called
+
+
+@pytest.mark.parametrize('msgs', (
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.7']), _roce(['eno'], [])],
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.7']), _roce([], ['eno'])],
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.6']), _roce(['eno'], [])],
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.6']), _roce(['eno', 'eno1'], ['enp'])],
+    [_kernel_cmdline(['foo=bar']), _roce(['eno'], [])],
+    [_kernel_cmdline(), _roce(['eno'], [])],
+))
+@pytest.mark.parametrize('version', ['8.0', '8.3', '8.6'])
+def test_roce_old_rhel(monkeypatch, msgs, version):
+    curr_actor_mocked = CurrentActorMocked(arch=architecture.ARCH_S390X, src_ver=version, msgs=msgs)
+    monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    rocecheck.process()
+    assert reporting.create_report.called
+    assert any(['version of RHEL' in report['title'] for report in reporting.create_report.reports])
+
+
+# NOTE: what about the situation when net.naming-scheme is configured multiple times???
+@pytest.mark.parametrize('msgs', (
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.6']), _roce(['eno'], [])],
+    [_kernel_cmdline(['net.naming-scheme=rhel-8.8']), _roce([], ['eno'])],
+    [_kernel_cmdline(['foo=bar', 'net.naming-scheme=rhel-8.8']), _roce([], ['eno'])],
+    [_kernel_cmdline(['foo=bar', 'net.naming-scheme=rhel-8.8', 'foo=bar']), _roce([], ['eno'])],
+    [_kernel_cmdline(['net.naming-scheme']), _roce(['eno'], [])],
+    [_kernel_cmdline(['foo=bar']), _roce(['eno'], [])],
+    [_kernel_cmdline(['foo=bar', 'bar=foo']), _roce(['eno'], [])],
+    [_kernel_cmdline(['rhel-8.7']), _roce([], ['eno'])],
+    [_kernel_cmdline(), _roce(['eno'], [])],
+))
+@pytest.mark.parametrize('version', ['8.6', '8.8'])
+def test_roce_wrong_configuration(monkeypatch, msgs, version):
+    curr_actor_mocked = CurrentActorMocked(arch=architecture.ARCH_S390X, src_ver=version, msgs=msgs)
+    monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    rocecheck.process()
+    assert reporting.create_report.called
+    assert any(['RoCE configuration' in report['title'] for report in reporting.create_report.reports])

--- a/repos/system_upgrade/el8toel9/actors/rocescanner/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/rocescanner/actor.py
@@ -1,0 +1,27 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import rocescanner
+from leapp.models import RoceDetected
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class RoCEScanner(Actor):
+    """
+    Detect active RoCE NICs on IBM Z machines.
+
+    Detect whether RoCE is configured on the system and produce
+    the RoceDetected message with active RoCE NICs - if any exists.
+    The active connections are scanned using NetworkManager (`nmcli`) as
+    RoCE is supposed to be configured via NetworkManager since
+    RHEL 8; see:
+        https://www.ibm.com/docs/en/linux-on-systems?topic=guide-add-additional-roce-interface
+
+    The scan is performed only on IBM Z machines.
+    """
+
+    name = 'roce_scanner'
+    consumes = ()
+    produces = (RoceDetected,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        rocescanner.process()

--- a/repos/system_upgrade/el8toel9/actors/rocescanner/libraries/rocescanner.py
+++ b/repos/system_upgrade/el8toel9/actors/rocescanner/libraries/rocescanner.py
@@ -1,0 +1,71 @@
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import RoceDetected
+
+
+def get_roce_nics_lines():
+    """
+    Return basic info about RoCE NICs using nmcli
+
+    When RoCE is configured on the system, we should find Mellanox a device
+    in the `nmcli` output, which is always specified after status line
+    of an interface, e.g.:
+        # nmcli
+        ens1765: connected to ens1765
+            "Mellanox MT27710"
+            ethernet (mlx5_core), 82:28:9B:1B:28:2C, hw, mtu 1500
+            inet4 192.168.0.1/16
+            route4 192.168.0.1/16
+            inet6 fe80::d8c5:3a67:1abb:dcca/64
+            route6 fe80::/64
+    In this case, the function returns the list of lines with RoCE NICs.
+    So for the example above:
+        ['ens1765: connected to ens1765']
+
+    NOTE: It is unexpected that a NIC itself could contain a 'mellanox'
+    substring. In such a case additional unexpected lines could be returned.
+    However, as we are interested only about lines with 'connected to' and 'connecting'
+    substrings, we know we will filter out any invalid lines later, so it's
+    no problem for us.
+    """
+    # nmcli | grep --no-group-separator -B1 -i "mellanox" | sed -n 1~2p
+    roce_nic_lines = []
+    try:
+        nmcli_output = run(['nmcli'], split=True)['stdout']
+    except (CalledProcessError, OSError) as e:
+        # this is theoretical
+        # If the command fails, most likely the network is not configured
+        # or it is not configured in a 'supported' way - definitely not
+        # for RoCE.
+        api.current_logger().warning(
+            'Cannot examine network connections via NetworkManager.'
+            ' Assuming RoCE is not present. Detail: {}'.format(str(e))
+        )
+        return roce_nic_lines
+
+    for i, line in enumerate(nmcli_output):
+        if 'mellanox' in line.lower() and i > 0:
+            roce_nic_lines.append(nmcli_output[i-1].strip())
+    return roce_nic_lines
+
+
+def _parse_NIC(nmcli_line):
+    return nmcli_line.split(':')[0]
+
+
+def process():
+    if not architecture.matches_architecture(architecture.ARCH_S390X):
+        # The check is valid only on S390X architecture
+        return
+    connected_nics = []
+    connecting_nics = []
+    for line in get_roce_nics_lines():
+        if 'connected to' in line:
+            connected_nics.append(_parse_NIC(line))
+        elif 'connecting' in line:
+            connecting_nics.append(_parse_NIC(line))
+    if connected_nics or connecting_nics:
+        api.produce(RoceDetected(
+           roce_nics_connected=connected_nics,
+           roce_nics_connecting=connecting_nics,
+        ))

--- a/repos/system_upgrade/el8toel9/actors/rocescanner/tests/unit_test_rocescanner.py
+++ b/repos/system_upgrade/el8toel9/actors/rocescanner/tests/unit_test_rocescanner.py
@@ -1,0 +1,154 @@
+import pytest
+
+from leapp.libraries.actor import rocescanner
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked, produce_mocked
+from leapp.libraries.stdlib import CalledProcessError
+
+NMCLI_CON_NIC1 = [
+    'ens1: connected to ens1',
+    '"Mellanox MT27710"',
+    'ethernet (mlx5_core), 82:28:9B:1B:28:2C, hw, mtu 1500',
+    'inet4 192.168.0.2/24',
+    'route4 192.168.0.1/24',
+    'inet6 fe80::d8c5:3a67:1abb:dcca/64',
+    'route6 fe80::/64',
+    ''
+]
+
+NMCLI_CON_NIC2 = [
+    'eno2: connected to eno2',
+    '"mellanox MT27710"',
+    'ethernet (mlx5_core), 82:28:9B:1B:28:2C, hw, mtu 1500',
+    'inet4 172.18.0.2/16',
+    'route4 172.18.0.1/16',
+    'inet6 fe80::d8c5:3a67:1abb:dcca/64',
+    'route6 fe80::/64',
+    ''
+]
+
+NMCLI_DISCON_NIC3 = [
+    'ens3: disconnected',
+    '"Mellanox MT27710"',
+    'ethernet (mlx5_core), 82:28:9B:1B:28:2C, hw, mtu 1500',
+    ''
+]
+
+NMCLI_CON_NIC4 = [
+    'mellanox4: connecting',
+    '"Mellanox MT27710"',
+    'ethernet (mlx5_core), 82:28:9B:1B:28:2C, hw, mtu 1500',
+    'inet4 192.168.0.1/16',
+    'route4 192.168.0.1/16',
+    'inet6 fe80::d8c5:3a67:1abb:dcca/64',
+    'route6 fe80::/64',
+    ''
+]
+
+NMCLI_CON_NIC5_NO_ROCE = [
+    'ens5: connected to ens5',
+    '"Red Hat Virtio"',
+    'ethernet (mlx5_core), 82:28:9B:1B:28:2C, hw, mtu 1500',
+    'inet4 192.168.0.1/16',
+    'route4 192.168.0.1/16',
+    'inet6 fe80::d8c5:3a67:1abb:dcca/64',
+    'route6 fe80::/64',
+    ''
+]
+
+
+@pytest.mark.parametrize('nmcli_stdout,expected', (
+    ([], []),
+    (NMCLI_CON_NIC5_NO_ROCE, []),
+    # simple
+    (NMCLI_CON_NIC1, [NMCLI_CON_NIC1[0]]),
+    (NMCLI_CON_NIC2, [NMCLI_CON_NIC2[0]]),
+    (NMCLI_CON_NIC4, [NMCLI_CON_NIC4[0]]),
+    (NMCLI_DISCON_NIC3, [NMCLI_DISCON_NIC3[0]]),
+    # multiple
+    (
+        NMCLI_CON_NIC1 + NMCLI_CON_NIC2,
+        [NMCLI_CON_NIC1[0], NMCLI_CON_NIC2[0]]
+    ),
+    (
+        NMCLI_CON_NIC1 + NMCLI_DISCON_NIC3,
+        [NMCLI_CON_NIC1[0], NMCLI_DISCON_NIC3[0]]
+    ),
+    (
+        NMCLI_CON_NIC5_NO_ROCE + NMCLI_CON_NIC2,
+        [NMCLI_CON_NIC2[0]]
+    ),
+    (
+        NMCLI_CON_NIC2 + NMCLI_CON_NIC5_NO_ROCE,
+        [NMCLI_CON_NIC2[0]]
+    ),
+))
+def test_get_roce_nics_lines(monkeypatch, nmcli_stdout, expected):
+    def mocked_run(cmd, *args, **kwargs):
+        assert cmd == ['nmcli']
+        return {'stdout': nmcli_stdout}
+    monkeypatch.setattr(rocescanner, 'run', mocked_run)
+    assert rocescanner.get_roce_nics_lines() == expected
+
+
+@pytest.mark.parametrize('raise_exc', (
+    CalledProcessError('foo', {'stdout': '', 'stderr': 'err', 'exit_code': '1'}, ['nmcli']),
+    OSError('foo')
+))
+def test_get_roce_nics_lines_err(monkeypatch, raise_exc):
+    def mocked_run(cmd, *args, **kwargs):
+        assert cmd == ['nmcli']
+        raise raise_exc
+    monkeypatch.setattr(rocescanner, 'run', mocked_run)
+    monkeypatch.setattr(rocescanner.api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(rocescanner.api, 'current_actor', CurrentActorMocked())
+    assert rocescanner.get_roce_nics_lines() == []
+    assert rocescanner.api.current_logger.warnmsg
+
+
+@pytest.mark.parametrize('roce_lines,connected,connecting', (
+    ([], [], []),
+    ([NMCLI_DISCON_NIC3[0]], [], []),
+    ([NMCLI_CON_NIC1[0]], ['ens1'], []),
+    ([NMCLI_CON_NIC2[0]], ['eno2'], []),
+    ([NMCLI_CON_NIC4[0]], [], ['mellanox4']),
+    (
+        [
+            'ens1: connected to ens1',
+            'eno2: connecting',
+            'route6 fe80::/64',
+            '',
+            'ens3: connected to ens3',
+        ],
+        ['ens1', 'ens3'],
+        ['eno2']
+    ),
+))
+def test_roce_detected(monkeypatch, roce_lines, connected, connecting):
+    mocked_produce = produce_mocked()
+    monkeypatch.setattr(rocescanner.api, 'current_actor', CurrentActorMocked(arch=architecture.ARCH_S390X))
+    monkeypatch.setattr(rocescanner.api.current_actor(), 'produce', mocked_produce)
+    monkeypatch.setattr(rocescanner, 'get_roce_nics_lines', lambda: roce_lines)
+    rocescanner.process()
+    if connected or connecting:
+        assert mocked_produce.called
+        msg = mocked_produce.model_instances[0]
+        assert msg.roce_nics_connected == connected
+        assert msg.roce_nics_connecting == connecting
+    else:
+        assert not mocked_produce.called
+
+
+@pytest.mark.parametrize('arch', (
+    architecture.ARCH_ARM64,
+    architecture.ARCH_X86_64,
+    architecture.ARCH_PPC64LE
+))
+def test_roce_noibmz(monkeypatch, arch):
+    def mocked_roce_lines():
+        assert False, 'Unexpected call of get_roce_nics_lines on nonIBMz arch.'
+    mocked_produce = produce_mocked()
+    monkeypatch.setattr(rocescanner.api, 'current_actor', CurrentActorMocked(arch=arch))
+    monkeypatch.setattr(rocescanner.api.current_actor(), 'produce', mocked_produce)
+    monkeypatch.setattr(rocescanner, 'get_roce_nics_lines', lambda: mocked_roce_lines)
+    assert not mocked_produce.called

--- a/repos/system_upgrade/el8toel9/models/roce.py
+++ b/repos/system_upgrade/el8toel9/models/roce.py
@@ -1,0 +1,27 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class RoceDetected(Model):
+    """
+    The model creates a list of
+     - RoCE NICs that are detected as connected, which means, they are
+       configured persistently
+     - RoCE NICs that are in process of connecting (i.e. they are trying
+       to get an IP address - and might become connected upon success)
+    """
+    topic = SystemInfoTopic
+
+    roce_nics_connected = fields.List(fields.String(), default=[])
+    """
+    List of RoCE NICs which are detected as connected.
+
+    e.g. ["ens1234", "eno3456"]
+    """
+
+    roce_nics_connecting = fields.List(fields.String(), default=[])
+    """
+    List of RoCE NICs which are detected as connecting right now.
+
+    (They might become detected as connected, soon.)
+    """


### PR DESCRIPTION
When upgrading RHEL 8 to RHEL 9 on IBM Z systems,
it's important to have correctly configured RoCE
if used, otherwise the network will be down after
the upgrade as the default configuration is not
persistent between RHEL 8 and RHEL 9.

Currently it's possible to configure RoCE in a persistent
way for both RHEL systems since RHEL 8.7 by following
kernel cmdline argument:
    net.naming-scheme=rhel-8.7
RHEL 8.7 and newer has persistent RoCE NICs if booted
with the parameter.

For the detection of active RoCE NICs is used the nmcli tool
(considerring that RoCE needs to be configured via NetworkManager
on RHEL 8+). Detected active RoCE NICs are represented by
the RoceDetected msg.

The upgrade is inhibited if any active RoCE NIC is discovered and:
* source os is RHEL 8.6 or older, or
* the system is booted without `net.naming-scheme=rhel-8.7` on kernel
  cmdline