### PR TITLE
Set RHSM release for non-ga & non-beta channels

### DIFF
--- a/repos/system_upgrade/common/actors/enablerhsmtargetrepos/libraries/enablerhsmtargetrepos.py
+++ b/repos/system_upgrade/common/actors/enablerhsmtargetrepos/libraries/enablerhsmtargetrepos.py
@@ -10,8 +10,8 @@ def set_rhsm_release():
         api.current_logger().debug('Skipping setting the RHSM release due to --no-rhsm or environment variables.')
         return
 
-    if config.get_product_type('target') != 'ga':
-        api.current_logger().debug('Skipping setting the RHSM release as target product is set to beta/htb')
+    if config.get_product_type('target') == 'beta':
+        api.current_logger().debug('Skipping setting the RHSM release as target product is set to beta')
         return
     target_version = api.current_actor().configuration.version.target
     try:


### PR DESCRIPTION
The actor ogirinally set the target release only when the GA channel has been set for the target OS - as originally it has been possible to set only: ga, beta, htb.

However, nowadays we exect additional possibilities, like: eus, aus, e4s, ... and for those we should set the channel as well - especially for these!!

Updating the skip condition, to ignore just 'beta' channel ('htb' does not exist anymore).

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2168953