### PR TITLE
rhui(azure): update azure cloud map and cleanup sap naming

### DIFF
--- a/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
+++ b/repos/system_upgrade/common/actors/redhatsignedrpmscanner/actor.py
@@ -56,7 +56,7 @@ class RedHatSignedRpmScanner(Actor):
 
         upg_path = rhui.get_upg_path()
         # AWS RHUI packages do not have to be whitelisted because they are signed by RedHat
-        whitelisted_cloud_flavours = ('azure', 'azure-eus', 'azure-sap', 'azure-sap-apps', 'google', 'google-sap')
+        whitelisted_cloud_flavours = ('azure', 'azure-eus', 'azure-sap-ha', 'azure-sap-apps', 'google', 'google-sap')
         whitelisted_cloud_pkgs = {
             rhui.RHUI_CLOUD_MAP[upg_path].get(flavour, {}).get('src_pkg') for flavour in whitelisted_cloud_flavours
         }

--- a/repos/system_upgrade/common/actors/setuptargetrepos/tests/test_repomapping.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/tests/test_repomapping.py
@@ -629,7 +629,7 @@ def test_get_expected_target_pesid_repos_with_priority_channel_set(monkeypatch):
             'pesid3': repositories_mapping.repositories[4]} == target_repoids, fail_description
 
 
-@pytest.mark.parametrize('rhui', ('', 'aws', 'aws-sap-e4s', 'azure', 'azure-sap'))
+@pytest.mark.parametrize('rhui', ('', 'aws', 'aws-sap-e4s', 'azure', 'azure-sap-ha', 'azure-sap-apps'))
 def test_multiple_repoids_in_repomapping(monkeypatch, rhui):
     """
     Tests whether a correct repository is selected when running on cloud with multiple repositories having the same ID.
@@ -676,7 +676,8 @@ def test_multiple_repoids_in_repomapping(monkeypatch, rhui):
         'aws': '-aws',
         'aws-sap-e4s': '-aws',
         'azure': '-azure',
-        'azure-sap': '-azure'
+        'azure-sap-apps': '-azure',
+        'azure-sap-ha': '-azure'
     }
 
     assert 'rhel8-rhui' in target_repoids

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -73,23 +73,21 @@ RHUI_CLOUD_MAP = {
             'leapp_pkg': 'leapp-rhui-azure-sap',
             'leapp_pkg_repo': 'leapp-azure-sap-apps.repo',
             'files_map': [
-                ('content-rhel8-eus.crt', RHUI_PKI_PRODUCT_DIR),
-                ('content-rhel8-sapapps.crt', RHUI_PKI_PRODUCT_DIR),
-                ('key-rhel8-eus.pem', RHUI_PKI_DIR),
-                ('key-rhel8-sapapps.pem', RHUI_PKI_DIR),
+                ('content-sapapps.crt', RHUI_PKI_PRODUCT_DIR),
+                ('key-sapapps.pem', RHUI_PKI_PRIVATE_DIR),
                 ('leapp-azure-sap-apps.repo', YUM_REPOS_PATH),
             ],
         },
-        'azure-sap': {
+        'azure-sap-ha': {
             'src_pkg': 'rhui-azure-rhel7-base-sap-ha',
             'target_pkg': 'rhui-azure-rhel8-sap-ha',
             'agent_pkg': 'WALinuxAgent',
             'leapp_pkg': 'leapp-rhui-azure-sap',
-            'leapp_pkg_repo': 'leapp-azure-sap.repo',
+            'leapp_pkg_repo': 'leapp-azure-sap-ha.repo',
             'files_map': [
-                ('content-rhel8-sap-ha.crt', RHUI_PKI_PRODUCT_DIR),
-                ('key-rhel8-sap-ha.pem', RHUI_PKI_DIR),
-                ('leapp-azure-sap.repo', YUM_REPOS_PATH)
+                ('content-sap-ha.crt', RHUI_PKI_PRODUCT_DIR),
+                ('key-sap-ha.pem', RHUI_PKI_PRIVATE_DIR),
+                ('leapp-azure-sap-ha.repo', YUM_REPOS_PATH)
             ],
         },
         'google': {
@@ -174,7 +172,7 @@ RHUI_CLOUD_MAP = {
                 ('leapp-azure.repo', YUM_REPOS_PATH)
             ],
         },
-        'azure-sap': {
+        'azure-sap-ha': {
             'src_pkg': 'rhui-azure-rhel8-sap-ha',
             'target_pkg': 'rhui-azure-rhel9-sap-ha',
             'agent_pkg': 'WALinuxAgent',
@@ -194,9 +192,7 @@ RHUI_CLOUD_MAP = {
             'leapp_pkg_repo': 'leapp-azure-sap-apps.repo',
             'files_map': [
                 ('content-sapapps.crt', RHUI_PKI_PRODUCT_DIR),
-                ('content-eus.crt', RHUI_PKI_PRODUCT_DIR),
-                ('key-sapapps.crt', RHUI_PKI_DIR),
-                ('key-eus.crt', RHUI_PKI_DIR),
+                ('key-sapapps.pem', RHUI_PKI_PRIVATE_DIR),
                 ('leapp-azure-sap-apps.repo', YUM_REPOS_PATH)
             ],
         },


### PR DESCRIPTION
Azure images will rely only on 1 rhui client instead of a pair of them. Therefore, the azure cloud map needed to be modified. The code managing the correct detection of the system variant has not been modified as it does not pose problems and there might still be outdated systems using a combination of the clients. Similarly, removal of clients has been modified so that the vanilla rhel client gets removed if it is installed for safety reasons.

A part of this path also finally fixes on how are sap variants named inside the rhui cloud map. The old naming has been a result of not knowing about the existence of SAP Apps images, and the entries `azure-sap-apps` were added as a part of quickly getting the support for the system. The patch changes the entry `azure-sap` into `azure-sap-ha` so that it matches the system it stands for.