### PR TITLE
fix migration of sendmail configs after the upgrade

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/migratesendmail/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/migratesendmail/actor.py
@@ -1,6 +1,9 @@
+import os
+
 from leapp import reporting
 from leapp.actors import Actor
 from leapp.libraries.actor import migratesendmail
+from leapp.libraries.stdlib import api
 from leapp.models import SendmailMigrationDecision
 from leapp.reporting import create_report, Report
 from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
@@ -21,14 +24,31 @@ class MigrateSendmail(Actor):
         if not decision or not decision.migrate_files:
             return
 
+        not_migrated = []
         for f in decision.migrate_files:
-            migratesendmail.migrate_file(f)
+            if not os.path.exists(f):
+                api.current_logger().error('Cound not migrate file {}, because it does not exist.'.format(f))
+                not_migrated.append(f)
+            else:
+                migratesendmail.migrate_file(f)
+
         list_separator_fmt = '\n    - '
+        title = 'sendmail configuration files migrated'
+        summary = 'Uncompressed IPv6 addresses in: {}{}'.format(list_separator_fmt,
+                                                                list_separator_fmt.join(decision.migrate_files))
+        severity = reporting.Severity.INFO
+
+        if not_migrated:
+            title = 'sendmail configuration files not migrated'
+            summary = ('Could not migrate the configuration files, which might be caused '
+                       'by removal of sendmail package during the upgrade. '
+                       'Following files could not be migrated:{}{}').format(list_separator_fmt,
+                                                                            list_separator_fmt.join(not_migrated))
+            severity = reporting.Severity.MEDIUM
+
         create_report([
-            reporting.Title('sendmail configuration files migrated'),
-            reporting.Summary(
-                'Uncompressed IPv6 addresses in {}'.format(list_separator_fmt.join(decision.migrate_files))
-            ),
-            reporting.Severity(reporting.Severity.LOW),
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Severity(severity),
             reporting.Groups([reporting.Groups.SERVICES, reporting.Groups.EMAIL])
         ])


### PR DESCRIPTION
The ``migrate_sendmail`` actor would cause a traceback if a file marked for migration wasn't found, which would be caused for example by removing the ``sendmail`` package during the upgrade. The actor now checks for existence of files that need to be migrated and also informs when no files have been migrated.

Tested by adding ``sendmail`` package to ``/etc/leapp/transaction/to_remove``.

Jira ref.: OAMG-8311
BZ: [2162703](https://bugzilla.redhat.com/show_bug.cgi?id=2162703)