### PR TITLE
Keep rsyncd.service enabled after IPU

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/enablersyncdservice/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/enablersyncdservice/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import enablersyncdservice
+from leapp.models import SystemdServicesInfoSource, SystemdServicesTasks
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class EnableDeviceCioFreeService(Actor):
+    """
+    Enables rsyncd.service systemd service if it is enabled on source system
+
+    After an upgrade this service ends up disabled even if it was enabled on
+    the source system.
+    """
+
+    name = 'enable_rsyncd_service'
+    consumes = (SystemdServicesInfoSource,)
+    produces = (SystemdServicesTasks,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        enablersyncdservice.process()

--- a/repos/system_upgrade/el7toel8/actors/enablersyncdservice/libraries/enablersyncdservice.py
+++ b/repos/system_upgrade/el7toel8/actors/enablersyncdservice/libraries/enablersyncdservice.py
@@ -1,0 +1,21 @@
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp.models import SystemdServicesInfoSource, SystemdServicesTasks
+
+SERVICE_NAME = "rsyncd.service"
+
+
+def _service_enabled_source(service_info, name):
+    service_file = next((s for s in service_info.service_files if s.name == name), None)
+    return service_file and service_file.state == "enabled"
+
+
+def process():
+    service_info_source = next(api.consume(SystemdServicesInfoSource), None)
+    if not service_info_source:
+        raise StopActorExecutionError(
+            "Expected SystemdServicesInfoSource message, but didn't get any"
+        )
+
+    if _service_enabled_source(service_info_source, SERVICE_NAME):
+        api.produce(SystemdServicesTasks(to_enable=[SERVICE_NAME]))

--- a/repos/system_upgrade/el7toel8/actors/enablersyncdservice/tests/test_enablersyncdservice.py
+++ b/repos/system_upgrade/el7toel8/actors/enablersyncdservice/tests/test_enablersyncdservice.py
@@ -1,0 +1,24 @@
+import pytest
+
+from leapp.libraries.actor import enablersyncdservice
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import SystemdServiceFile, SystemdServicesInfoSource, SystemdServicesTasks
+
+
+@pytest.mark.parametrize('service_file, should_produce', [
+    (SystemdServiceFile(name='rsyncd.service', state='enabled'), True),
+    (SystemdServiceFile(name='rsyncd.service', state='disabled'), False),
+    (SystemdServiceFile(name='not-rsyncd.service', state='enabled'), False),
+    (SystemdServiceFile(name='not-rsyncd.service', state='disabled'), False),
+])
+def test_task_produced(monkeypatch, service_file, should_produce):
+    service_info = SystemdServicesInfoSource(service_files=[service_file])
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[service_info]))
+    monkeypatch.setattr(api, "produce", produce_mocked())
+
+    enablersyncdservice.process()
+
+    assert api.produce.called == should_produce
+    if should_produce:
+        assert api.produce.model_instances[0].to_enable == ['rsyncd.service']


### PR DESCRIPTION
After the 7->8 upgrade the `rsyncd.service` is disabled even though it was enabled on the source system. A new `enablersyncdservice` actor makes sure it is enabled on the target system.

This is a temporary solution until this is handled generally for all services.

Jira ref.: OAMG-8543