### PR TITLE
Include leapp data files in the RPM & repository

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -20,4 +20,8 @@ jobs:
           ignore_words_list: ro,fo,couldn,repositor
           skip: "./repos/system_upgrade/common/actors/storagescanner/tests/files/mounts,\
             ./repos/system_upgrade/el7toel8/actors/networkmanagerreadconfig/tests/files/nm_cfg_file_error,\
-            ./repos/system_upgrade/common/actors/scancpu/tests/files/lscpu_s390x"
+            ./repos/system_upgrade/common/actors/scancpu/tests/files/lscpu_s390x,\
+            ./etc/leapp/files/device_driver_deprecation_data.json,\
+            ./etc/leapp/files/pes-events.json,\
+            ./etc/leapp/files/repomap.json"
+

--- a/etc/leapp/files/device_driver_deprecation_data.json
+++ b/etc/leapp/files/device_driver_deprecation_data.json
@@ -1,0 +1,4774 @@
+{
+  "data": [
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x1002",
+      "device_name": "Mellanox Technologies: MT25400 Family [ConnectX-2 Virtual Function]",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x6340",
+      "device_name": "Mellanox Technologies: MT25408A0-FCC-SI ConnectX, Dual Port 10Gb/s InfiniBand / 10GigE Adapter IC with PCIe 2.0 x8 2.5GT/s Interface",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x634A",
+      "device_name": "Mellanox Technologies: MT25408A0-FCC-DI ConnectX, Dual Port 20Gb/s InfiniBand / 10GigE Adapter IC with PCIe 2.0 x8 2.5GT/s Interface",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x6354",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x6368",
+      "device_name": "Mellanox Technologies: MT25448 [ConnectX EN 10GigE, PCIe 2.0 2.5GT/s]",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x6372",
+      "device_name": "Mellanox Technologies: MT25458 ConnectX EN 10GBASE-T PCIe 2.5 GT/s",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x6732",
+      "device_name": "Mellanox Technologies: MT25408A0-FCC-GI ConnectX, Dual Port 20Gb/s InfiniBand / 10GigE Adapter IC with PCIe 2.0 x8 5.0GT/s Interface",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x673C",
+      "device_name": "Mellanox Technologies: MT25408A0-FCC-QI ConnectX, Dual Port 40Gb/s InfiniBand / 10GigE Adapter IC with PCIe 2.0 x8 5.0GT/s Interface",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x6746",
+      "device_name": "Mellanox Technologies: MT26438 [ConnectX VPI PCIe 2.0 5GT/s - IB QDR / 10GigE Virtualization+]",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x6750",
+      "device_name": "Mellanox Technologies: MT26448 [ConnectX EN 10GigE, PCIe 2.0 5GT/s]",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x675A",
+      "device_name": "Mellanox Technologies: MT26458 ConnectX EN 10GBASE-T PCIe Gen2 5.0 GT/s",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x6764",
+      "device_name": "Mellanox Technologies: MT26468 [ConnectX EN 10GigE, PCIe 2.0 5GT/s Virtualization+]",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x676E",
+      "device_name": "Mellanox Technologies: MT26478 [ConnectX EN 40GigE, PCIe 2.0 5GT/s]",
+      "device_type": "pci",
+      "driver_name": "mlx4_core",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:Ampere:NeoverseN1",
+      "device_name": "Ampere Altra",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        8
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:Ampere:Potenza",
+      "device_name": "Ampere eMAG",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:APM:Potenza",
+      "device_name": "Applied Micro X-Gene",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:AWS:A72",
+      "device_name": "AWS Graviton 1",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:AWS:NeoverseN1",
+      "device_name": "AWS Graviton  2",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:Fujitsu:A64FX",
+      "device_name": "Fujitsu A64FX",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:Fujitsu:NSP",
+      "device_name": "Fujitsu NSP",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:Marvell:ThunderX",
+      "device_name": "Marvell ThunderX1",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:Marvell:ThunderX2",
+      "device_name": "Marvell ThunderX2",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:Mellanox:A72",
+      "device_name": "Nvidia Bluefield",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:Nvidia:Carmel",
+      "device_name": "Nvidia Jetson",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "aarch64:Qualcomm:Falkor",
+      "device_name": "Qualcomm Amberwing",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8
+      ],
+      "deprecation_announced": "",
+      "device_id": "ppc64le:ibm:4b:*",
+      "device_name": "Power8E",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8
+      ],
+      "deprecation_announced": "",
+      "device_id": "ppc64le:ibm:4c:*",
+      "device_name": "Power8NVL",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8
+      ],
+      "deprecation_announced": "",
+      "device_id": "ppc64le:ibm:4d:*",
+      "device_name": "Power8",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "ppc64le:ibm:4e:*",
+      "device_name": "Power9",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "ppc64le:ibm:4f:*",
+      "device_name": "Power9P",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "ppc64le:ibm:80:*",
+      "device_name": "Power10",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8
+      ],
+      "deprecation_announced": "",
+      "device_id": "s390x:ibm:2964:*",
+      "device_name": "z13",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8
+      ],
+      "deprecation_announced": "",
+      "device_id": "s390x:ibm:2965:*",
+      "device_name": "z13s",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "s390x:ibm:3907:*",
+      "device_name": "z14 ZR1",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "s390x:ibm:3906:*",
+      "device_name": "z14",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "s390x:ibm:8561:*",
+      "device_name": "z15",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "s390x:ibm:8562:*",
+      "device_name": "z15 Model T02",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:amd:21:*",
+      "device_name": "AMD Family 15h",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:amd:23:*",
+      "device_name": "AMD Family 17h",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:amd:25:*",
+      "device_name": "AMD Family 19h",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:5:*",
+      "device_name": "All Family 5 Intel Processors",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:102",
+      "device_name": "CANNONLAKE_L",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:106",
+      "device_name": "ICELAKE_X",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:108",
+      "device_name": "ICELAKE_D",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:117",
+      "device_name": "ATOM_AIRMONT_NP",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:122",
+      "device_name": "ATOM_GOLDMONT_PLUS",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:125",
+      "device_name": "ICELAKE",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:126",
+      "device_name": "ICELAKE_L",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:133",
+      "device_name": "XEON_PHI_KNM",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:134",
+      "device_name": "ATOM_TREMONT_D",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:138",
+      "device_name": "LAKEFIELD",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:14",
+      "device_name": "CORE_YONAH",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:140",
+      "device_name": "TIGERLAKE",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:141",
+      "device_name": "TIGERLAKE_L",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:142",
+      "device_name": "KABYLAKE_L",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:143",
+      "device_name": "SAPPHIRE_RAPIDS_X",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:15",
+      "device_name": "CORE2_MEROM",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:150",
+      "device_name": "ATOM_TREMONT",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:151",
+      "device_name": "ALDERLAKE",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:156",
+      "device_name": "ATOM_TREMONT_L",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:157",
+      "device_name": "ICELAKE_NNPI",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:158",
+      "device_name": "KABYLAKE",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:165",
+      "device_name": "COMETLAKE",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:166",
+      "device_name": "COMETLAKE_L",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:167",
+      "device_name": "ROCKETLAKE",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:22",
+      "device_name": "CORE2_MEROM_L",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:23",
+      "device_name": "CORE2_PENRYN",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:26",
+      "device_name": "NEHALEM_EP",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:28",
+      "device_name": "ATOM_BONNELL",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:29",
+      "device_name": "CORE2_DUNNINGTON",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:30",
+      "device_name": "NEHALEM",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:31",
+      "device_name": "NEHALEM_G",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:37",
+      "device_name": "WESTMERE",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:38",
+      "device_name": "ATOM_BONNELL_MID",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:39",
+      "device_name": "ATOM_SALTWELL_MID",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:42",
+      "device_name": "SANDYBRIDGE",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:44",
+      "device_name": "WESTMERE_EP",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:45",
+      "device_name": "SANDYBRIDGE_X",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:46",
+      "device_name": "NEHALEM_EX",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:47",
+      "device_name": "WESTMERE_EX",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:53",
+      "device_name": "ATOM_SALTWELL_TABLET",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:54",
+      "device_name": "ATOM_SALTWELL",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:55",
+      "device_name": "ATOM_SILVERMONT",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:58",
+      "device_name": "IVYBRIDGE",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:60",
+      "device_name": "HASWELL",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:61",
+      "device_name": "BROADWELL",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:62",
+      "device_name": "IVYBRIDGE_X",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:63",
+      "device_name": "HASWELL_X",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:69",
+      "device_name": "HASWELL_L",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:70",
+      "device_name": "HASWELL_G",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:71",
+      "device_name": "BROADWELL_G",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:74",
+      "device_name": "ATOM_SILVERMONT_MID",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:76",
+      "device_name": "ATOM_AIRMONT",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:77",
+      "device_name": "ATOM_SILVERMONT_D",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:78",
+      "device_name": "SKYLAKE_L",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:79",
+      "device_name": "BROADWELL_X",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:85",
+      "device_name": "SKYLAKE_X",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:86",
+      "device_name": "BROADWELL_D",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:87",
+      "device_name": "XEON_PHI_KNL",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:90",
+      "device_name": "ATOM_AIRMONT_MID",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:92",
+      "device_name": "ATOM_GOLDMONT",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:94",
+      "device_name": "SKYLAKE",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "x86_64:intel:6:95",
+      "device_name": "ATOM_GOLDMONT_D",
+      "device_type": "cpu",
+      "driver_name": "",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "3w-9xxx",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "3w-sas",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1011:0x0046:0x103c:0x10c2",
+      "device_name": "Digital Equipment Corporation: DECchip 21554: NetRAID-4M",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1011:0x0046:0x9005:0x0364",
+      "device_name": "Digital Equipment Corporation: DECchip 21554: 5400S (Mustang)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1011:0x0046:0x9005:0x0365",
+      "device_name": "Digital Equipment Corporation: DECchip 21554: 5400S (Mustang)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1011:0x0046:0x9005:0x1364",
+      "device_name": "Digital Equipment Corporation: DECchip 21554: Dell PowerEdge RAID Controller 2",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1028:0x0001:0x1028:0x0001",
+      "device_name": "Dell: PowerEdge Expandable RAID Controller 2/Si: PowerEdge 2400",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1028:0x0002:0x1028:0x0002",
+      "device_name": "Dell: PowerEdge Expandable RAID Controller 3/Di: PowerEdge 4400",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1028:0x0002:0x1028:0x00d1",
+      "device_name": "Dell: PowerEdge Expandable RAID Controller 3/Di: PERC 3/DiV [Viper]",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1028:0x0002:0x1028:0x00d9",
+      "device_name": "Dell: PowerEdge Expandable RAID Controller 3/Di: PERC 3/DiL [Lexus]",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1028:0x0003:0x1028:0x0003",
+      "device_name": "Dell: PowerEdge Expandable RAID Controller 3/Si: PowerEdge 2450",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1028:0x0004:0x1028:0x00d0",
+      "device_name": "Dell: PowerEdge Expandable RAID Controller 3/Di [Iguana]",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1028:0x000a:0x1028:0x0106",
+      "device_name": "Dell: PowerEdge Expandable RAID Controller 3/Di: PERC 3/DiJ [Jaguar]",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1028:0x000a:0x1028:0x011b",
+      "device_name": "Dell: PowerEdge Expandable RAID Controller 3/Di: PERC 3/DiD [Dagger]",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1028:0x000a:0x1028:0x0121",
+      "device_name": "Dell: PowerEdge Expandable RAID Controller 3/Di: PERC 3/DiB [Boxster]",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0200:0x9005:0x0200",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0283:0x9005:0x0283",
+      "device_name": "Adaptec: AAC-RAID: Catapult",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0284:0x9005:0x0284",
+      "device_name": "Adaptec: AAC-RAID: Tomcat",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285",
+      "device_name": "Adaptec: AAC-RAID",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x1014:0x02F2",
+      "device_name": "Adaptec: AAC-RAID: ServeRAID 8i",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x1014:0x0312",
+      "device_name": "Adaptec: AAC-RAID",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x1028",
+      "device_name": "Adaptec: AAC-RAID",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x1028:0x0287",
+      "device_name": "Adaptec: AAC-RAID: PowerEdge Expandable RAID Controller 320/DC",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x103C:0x3227",
+      "device_name": "Adaptec: AAC-RAID: AAR-2610SA",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x17aa",
+      "device_name": "Adaptec: AAC-RAID",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x17aa:0x0286",
+      "device_name": "Adaptec: AAC-RAID: Legend S220 (Legend Crusader)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x17aa:0x0287",
+      "device_name": "Adaptec: AAC-RAID: Legend S230 (Legend Vulcan)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0285",
+      "device_name": "Adaptec: AAC-RAID: 2200S (Vulcan)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0286",
+      "device_name": "Adaptec: AAC-RAID: 2120S (Crusader)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0287",
+      "device_name": "Adaptec: AAC-RAID: 2200S (Vulcan-2m)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0288",
+      "device_name": "Adaptec: AAC-RAID: 3230S (Harrier)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0289",
+      "device_name": "Adaptec: AAC-RAID: 3240S (Tornado)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x028a",
+      "device_name": "Adaptec: AAC-RAID: ASR-2020ZCR",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x028b",
+      "device_name": "Adaptec: AAC-RAID: ASR-2025ZCR (Terminator)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x028e",
+      "device_name": "Adaptec: AAC-RAID: ASR-2020SA (Skyhawk)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x028f",
+      "device_name": "Adaptec: AAC-RAID: ASR-2025SA",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0290",
+      "device_name": "Adaptec: AAC-RAID: AAR-2410SA PCI SATA 4ch (Jaguar II)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0291",
+      "device_name": "Adaptec: AAC-RAID",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0292",
+      "device_name": "Adaptec: AAC-RAID: AAR-2810SA PCI SATA 8ch (Corsair-8)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0293",
+      "device_name": "Adaptec: AAC-RAID: AAR-21610SA PCI SATA 16ch (Corsair-16)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0294",
+      "device_name": "Adaptec: AAC-RAID: ESD SO-DIMM PCI-X SATA ZCR (Prowler)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0296",
+      "device_name": "Adaptec: AAC-RAID: ASR-2240S",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0297",
+      "device_name": "Adaptec: AAC-RAID: ASR-4005SAS",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0298",
+      "device_name": "Adaptec: AAC-RAID: ASR-4000",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x0299",
+      "device_name": "Adaptec: AAC-RAID: ASR-4800SAS",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x029a",
+      "device_name": "Adaptec: AAC-RAID: 4805SAS",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x02a4",
+      "device_name": "Adaptec: AAC-RAID: ICP ICP9085LI",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0285:0x9005:0x02a5",
+      "device_name": "Adaptec: AAC-RAID: ICP ICP5085BR",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286",
+      "device_name": "Adaptec: AAC-RAID (Rocket)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x1014:0x9540",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ServeRAID 8k/8k-l4",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x1014:0x9580",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ServeRAID 8k/8k-l8",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x028c",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ASR-2230S + ASR-2230SLP PCI-X (Lancer)",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x028d",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ASR-2130S",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x029b",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ASR-2820SA",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x029c",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ASR-2620SA",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x029d",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ASR-2420SA",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x029e",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ICP ICP9024R0",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x029f",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ICP ICP9014R0",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x02a0",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ICP ICP9047MA",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x02a1",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ICP ICP9087MA",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x02a2",
+      "device_name": "Adaptec: AAC-RAID (Rocket): 3800",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x02a3",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ICP ICP5445AU",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x02a6",
+      "device_name": "Adaptec: AAC-RAID (Rocket): ICP9067MA",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0286:0x9005:0x0800",
+      "device_name": "Adaptec: AAC-RAID (Rocket): Callisto",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0287:0x9005:0x0800",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x9005:0x0288",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "aacraid",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "acard-ahci",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "aic79xx",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "aoe",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "arcmsr",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x0222",
+      "device_name": "Emulex Corporation: BladeEngine3 10Gb Gen2 PCIe iSCSI Adapter",
+      "device_type": "pci",
+      "driver_name": "be2iscsi",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x0712",
+      "device_name": "Emulex Corporation: OneConnect 10Gb iSCSI Initiator (be3)",
+      "device_type": "pci",
+      "driver_name": "be2iscsi",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x212",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "be2iscsi",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x702",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "be2iscsi",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x703",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "be2iscsi",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x0700",
+      "device_name": "Emulex Corporation: OneConnect OCe10100/OCe10102 Series 10 GbE",
+      "device_type": "pci",
+      "driver_name": "be2net",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x0211",
+      "device_name": "Emulex Corporation: BladeEngine2 10Gb Gen2 PCIe Network Adapter",
+      "device_type": "pci",
+      "driver_name": "be2net",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x0710",
+      "device_name": "Emulex Corporation: OneConnect 10Gb NIC (be3)",
+      "device_type": "pci",
+      "driver_name": "be2net",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x0221",
+      "device_name": "Emulex Corporation: BladeEngine3 10Gb Gen2 PCIe Network Adapter",
+      "device_type": "pci",
+      "driver_name": "be2net",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "bfa",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "",
+      "device_name": "QLogic BCM5706/5708/5709/5716 Driver",
+      "device_type": "pci",
+      "driver_name": "bnx2",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "carl9170",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "cxgb3",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "cxgb3i",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "Intel(R) PRO/1000 Network Driver",
+      "device_type": "pci",
+      "driver_name": "e1000",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "dl2k",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "dlci",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "dnet",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "ethoc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "floppy",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.5",
+      "device_id": "",
+      "device_name": "Driver for HP Smart Array Controller",
+      "device_type": "pci",
+      "driver_name": "hpsa",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "hptiop",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "initio",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "isci",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "iw_cxgb3",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "iwl3945",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "iwl4965",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "libosd",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "liquidio",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "liquidio_vf",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0x1ae5",
+      "device_name": "Emulex Corporation: LP6000 Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xe100",
+      "device_name": "Emulex Corporation: Proteus-X: LightPulse IOV Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xe131",
+      "device_name": "Emulex Corporation: LightPulse 8Gb/s PCIe Shared I/O Fibre Channel Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xe180",
+      "device_name": "Emulex Corporation: Proteus-X: LightPulse IOV Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xe260",
+      "device_name": "Emulex Corporation: OneConnect FCoE Initiator (Lancer)",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf095",
+      "device_name": "Emulex Corporation: LP952 Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf098",
+      "device_name": "Emulex Corporation: LP982 Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf0a1",
+      "device_name": "Emulex Corporation: Thor LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf0a5",
+      "device_name": "Emulex Corporation: Thor LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf0d1",
+      "device_name": "Emulex Corporation: Helios LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf0d5",
+      "device_name": "Emulex Corporation: Helios LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf0e1",
+      "device_name": "Emulex Corporation: Zephyr LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf0e5",
+      "device_name": "Emulex Corporation: Zephyr LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf0f5",
+      "device_name": "Emulex Corporation: Neptune LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf0f6",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf0f7",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf180",
+      "device_name": "Emulex Corporation: LPSe12002 EmulexSecure Fibre Channel Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf700",
+      "device_name": "Emulex Corporation: LP7000 Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf800",
+      "device_name": "Emulex Corporation: LP8000 Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf900",
+      "device_name": "Emulex Corporation: LP9000 Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xf980",
+      "device_name": "Emulex Corporation: LP9802 Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfa00",
+      "device_name": "Emulex Corporation: Thor-X LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfb00",
+      "device_name": "Emulex Corporation: Viper LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfc00",
+      "device_name": "Emulex Corporation: Thor-X LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfc10",
+      "device_name": "Emulex Corporation: Helios-X LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfc20",
+      "device_name": "Emulex Corporation: Zephyr-X LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfc50",
+      "device_name": "Emulex Corporation: Proteus-X: LightPulse IOV Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfd00",
+      "device_name": "Emulex Corporation: Helios-X LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfd11",
+      "device_name": "Emulex Corporation: Helios-X LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfd12",
+      "device_name": "Emulex Corporation: Helios-X LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfe00",
+      "device_name": "Emulex Corporation: Zephyr-X LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfe05",
+      "device_name": "Emulex Corporation: Zephyr-X: LightPulse FCoE Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfe11",
+      "device_name": "Emulex Corporation: Zephyr-X LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x10df:0xfe12",
+      "device_name": "Emulex Corporation: Zephyr-X LightPulse FCoE Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x0704",
+      "device_name": "Emulex Corporation: OneConnect OCe10100/OCe10102 Series 10 GbE CNA",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x19a2:0x0714",
+      "device_name": "Emulex Corporation: OneConnect 10Gb FCoE Initiator (be3)",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x10df:0x0724",
+      "device_name": "Emulex Corporation: OneConnect FCoE Initiator (Skyhawk)",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x10df:0xe200",
+      "device_name": "Emulex Corporation: LPe15000/LPe16000 Series 8Gb/16Gb Fibre Channel Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x10df:0xe220",
+      "device_name": "Emulex Corporation: OneConnect NIC (Lancer)",
+      "device_type": "pci",
+      "driver_name": "be2net",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x10df:0xf011",
+      "device_name": "Emulex Corporation: Saturn: LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x10df:0xf015",
+      "device_name": "Emulex Corporation: Saturn: LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x10df:0xf100",
+      "device_name": "Emulex Corporation: LPe12000 Series 8Gb Fibre Channel Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x10df:0xfc40",
+      "device_name": "Emulex Corporation: Saturn-X: LightPulse Fibre Channel Host Adapter",
+      "device_type": "pci",
+      "driver_name": "lpfc",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1000:0x005b",
+      "device_name": "Broadcom / LSI: MegaRAID SAS 2208 [Thunderbolt]",
+      "device_type": "pci",
+      "driver_name": "megaraid_sas",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0060",
+      "device_name": "Broadcom / LSI: MegaRAID SAS 1078",
+      "device_type": "pci",
+      "driver_name": "megaraid_sas",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0071",
+      "device_name": "Broadcom / LSI: MR SAS HBA 2004",
+      "device_type": "pci",
+      "driver_name": "megaraid_sas",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0073",
+      "device_name": "Broadcom / LSI: MegaRAID SAS 2008 [Falcon]",
+      "device_type": "pci",
+      "driver_name": "megaraid_sas",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0078",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "megaraid_sas",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0079",
+      "device_name": "Broadcom / LSI: MegaRAID SAS 2108 [Liberator]",
+      "device_type": "pci",
+      "driver_name": "megaraid_sas",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x007C",
+      "device_name": "Broadcom / LSI: MegaRAID SAS 1078DE",
+      "device_type": "pci",
+      "driver_name": "megaraid_sas",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0411",
+      "device_name": "Broadcom / LSI: MegaRAID SAS 1068",
+      "device_type": "pci",
+      "driver_name": "megaraid_sas",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0413",
+      "device_name": "Broadcom / LSI: MegaRAID SAS 1068 [Verde ZCR]",
+      "device_type": "pci",
+      "driver_name": "megaraid_sas",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1028:0x0015",
+      "device_name": "Dell: PowerEdge Expandable RAID controller 5",
+      "device_type": "pci",
+      "driver_name": "megaraid_sas",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0064",
+      "device_name": "Broadcom / LSI: SAS2116 PCI-Express Fusion-MPT SAS-2 [Meteor]",
+      "device_type": "pci",
+      "driver_name": "mpt2sas (mpt3sas)",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0065",
+      "device_name": "Broadcom / LSI: SAS2116 PCI-Express Fusion-MPT SAS-2 [Meteor]",
+      "device_type": "pci",
+      "driver_name": "mpt2sas (mpt3sas)",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0070",
+      "device_name": "Broadcom / LSI: SAS2004 PCI-Express Fusion-MPT SAS-2 [Spitfire]",
+      "device_type": "pci",
+      "driver_name": "mpt2sas (mpt3sas)",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0072",
+      "device_name": "Broadcom / LSI: SAS2008 PCI-Express Fusion-MPT SAS-2 [Falcon]",
+      "device_type": "pci",
+      "driver_name": "mpt2sas (mpt3sas)",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0074",
+      "device_name": "Broadcom / LSI: SAS2108 PCI-Express Fusion-MPT SAS-2 [Liberator]",
+      "device_type": "pci",
+      "driver_name": "mpt2sas (mpt3sas)",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0076",
+      "device_name": "Broadcom / LSI: SAS2108 PCI-Express Fusion-MPT SAS-2 [Liberator]",
+      "device_type": "pci",
+      "driver_name": "mpt2sas (mpt3sas)",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x0077",
+      "device_name": "Broadcom / LSI: SAS2108 PCI-Express Fusion-MPT SAS-2 [Liberator]",
+      "device_type": "pci",
+      "driver_name": "mpt2sas (mpt3sas)",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1000:0x007E",
+      "device_name": "Broadcom / LSI: SSS6200 PCI-Express Flash SSD",
+      "device_type": "pci",
+      "driver_name": "mpt2sas (mpt3sas)",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1000:0x006E",
+      "device_name": "Broadcom / LSI: SAS2308 PCI-Express Fusion-MPT SAS-2",
+      "device_type": "pci",
+      "driver_name": "mpt3sas",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1000:0x0080",
+      "device_name": "Broadcom / LSI: SAS2208 PCI-Express Fusion-MPT SAS-2",
+      "device_type": "pci",
+      "driver_name": "mpt3sas",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1000:0x0081",
+      "device_name": "Broadcom / LSI: SAS2208 PCI-Express Fusion-MPT SAS-2",
+      "device_type": "pci",
+      "driver_name": "mpt3sas",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1000:0x0082",
+      "device_name": "Broadcom / LSI: SAS2208 PCI-Express Fusion-MPT SAS-2",
+      "device_type": "pci",
+      "driver_name": "mpt3sas",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1000:0x0083",
+      "device_name": "Broadcom / LSI: SAS2208 PCI-Express Fusion-MPT SAS-2",
+      "device_type": "pci",
+      "driver_name": "mpt3sas",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1000:0x0084",
+      "device_name": "Broadcom / LSI: SAS2208 PCI-Express Fusion-MPT SAS-2",
+      "device_type": "pci",
+      "driver_name": "mpt3sas",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1000:0x0085",
+      "device_name": "Broadcom / LSI: SAS2208 PCI-Express Fusion-MPT SAS-2",
+      "device_type": "pci",
+      "driver_name": "mpt3sas",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1000:0x0086",
+      "device_name": "Broadcom / LSI: SAS2308 PCI-Express Fusion-MPT SAS-2",
+      "device_type": "pci",
+      "driver_name": "mpt3sas",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1000:0x0087",
+      "device_name": "Broadcom / LSI: SAS2308 PCI-Express Fusion-MPT SAS-2",
+      "device_type": "pci",
+      "driver_name": "mpt3sas",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "Fusion MPT base driver",
+      "device_type": "pci",
+      "driver_name": "mptbase",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "mptctl",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "mptsas",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "Fusion MPT SCSI Host driver",
+      "device_type": "pci",
+      "driver_name": "mptscsih",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "Fusion MPT SPI Host driver",
+      "device_type": "pci",
+      "driver_name": "mptspi",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "mthca",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "mtip32xx",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "mvsas",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "mvumi",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "mwl8k",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "",
+      "device_name": "Myricom 10G driver (10GbE)",
+      "device_type": "pci",
+      "driver_name": "myri10ge",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "",
+      "device_name": "QLogic/NetXen (1/10) GbE Intelligent Ethernet Driver",
+      "device_type": "pci",
+      "driver_name": "netxen_nic",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "osd",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "osst",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_acpi",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_ali",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_amd",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_arasan_cf",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_artop",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_atiixp",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_atp867x",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_cmd64x",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_cs5536",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_hpt366",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_hpt37x",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_hpt3x2n",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_hpt3x3",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_it8213",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_it821x",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_jmicron",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_marvell",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_netcell",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_ninja32",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_oldpiix",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_pdc2027x",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_pdc202xx_old",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_piccolo",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_rdc",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_sch",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_serverworks",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_sil680",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_sis",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pata_via",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pdc_adma",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pm80xx(pm8001)",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "pmcraid",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1077:0x2031",
+      "device_name": "QLogic Corp.: ISP8324-based 16Gb Fibre Channel to PCI Express Adapter",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x2422",
+      "device_name": "QLogic Corp.: ISP2422-based 4Gb Fibre Channel to PCI-X HBA",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x2432",
+      "device_name": "QLogic Corp.: ISP2432-based 4Gb Fibre Channel to PCI Express HBA",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1077:0x2532",
+      "device_name": "QLogic Corp.: ISP2532-based 8Gb Fibre Channel to PCI Express HBA",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x5422",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x5432",
+      "device_name": "QLogic Corp.: SP232-based 4Gb Fibre Channel to PCI Express HBA",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x8001",
+      "device_name": "QLogic Corp.: 10GbE Converged Network Adapter (FCoE)",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x8021",
+      "device_name": "QLogic Corp.: 8200 Series 10GbE Converged Network Adapter (FCoE)",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1077:0x8031",
+      "device_name": "QLogic Corp.: 8300 Series 10GbE Converged Network Adapter (FCoE)",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x8044",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x8432",
+      "device_name": "QLogic Corp.: ISP2432M-based 10GbE Converged Network Adapter (CNA)",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0xF000",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "qla2xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "QLogic ISP3XXX Network Driver",
+      "device_type": "pci",
+      "driver_name": "qla3xxx",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x8022",
+      "device_name": "QLogic Corp.: 8200 Series 10GbE Converged Network Adapter (iSCSI)",
+      "device_type": "pci",
+      "driver_name": "qla4xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x8032",
+      "device_name": "QLogic Corp.: 8300 Series 10GbE Converged Network Adapter (iSCSI)",
+      "device_type": "pci",
+      "driver_name": "qla4xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x1077:0x8042",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "qla4xxx",
+      "maintained_in_rhel": [
+        7
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "qlcnic",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "qlge",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "rt61pci",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "rt73usb",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "rtl8187",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_mv",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_nv",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_promise",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_qstor",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_sil",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_sil24",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_sis",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_svw",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_sx4",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_uli",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_via",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sata_vsc",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1924:0x0803",
+      "device_name": "Solarflare Communications: SFC9020 10G Ethernet Controller",
+      "device_type": "pci",
+      "driver_name": "sfc",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9
+      ],
+      "deprecation_announced": "8.4",
+      "device_id": "0x1924:0x0813",
+      "device_name": "Solarflare Communications: SFL9021 10GBASE-T Ethernet Controller",
+      "device_type": "pci",
+      "driver_name": "sfc",
+      "maintained_in_rhel": [
+        7,
+        8
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "stex",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "sx8",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "tulip",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "ufshcd",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        7
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "",
+      "device_type": "pci",
+      "driver_name": "wil6210",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
+        8
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "HNS GE/10GE/25GE/50GE/100GE RDMA Network Controller",
+      "device_type": "pci",
+      "driver_name": "hns_roce",
+      "maintained_in_rhel": [
+        8
+      ]
+    }
+  ],
+  "provided_data_streams": [
+    "1.0"
+  ]
+}

--- a/etc/leapp/files/repomap.json
+++ b/etc/leapp/files/repomap.json
@@ -1,0 +1,3657 @@
+{
+    "datetime": "202303072246Z",
+    "version_format": "1.0.0",
+    "mapping": [
+        {
+            "source_major_version": "7",
+            "target_major_version": "8",
+            "entries": [
+                {
+                    "source": "rhel7-base",
+                    "target": [
+                        "rhel8-AppStream",
+                        "rhel8-BaseOS"
+                    ]
+                },
+                {
+                    "source": "rhel7-optional",
+                    "target": [
+                        "rhel8-CRB"
+                    ]
+                },
+                {
+                    "source": "rhel7-supplementary",
+                    "target": [
+                        "rhel8-Supplementary"
+                    ]
+                },
+                {
+                    "source": "rhel7-extras",
+                    "target": [
+                        "rhel8-AppStream",
+                        "rhel8-BaseOS"
+                    ]
+                },
+                {
+                    "source": "rhel7-rt",
+                    "target": [
+                        "rhel8-RT"
+                    ]
+                },
+                {
+                    "source": "rhel7-nfv",
+                    "target": [
+                        "rhel8-NFV"
+                    ]
+                },
+                {
+                    "source": "rhel7-sap",
+                    "target": [
+                        "rhel8-SAP-NetWeaver"
+                    ]
+                },
+                {
+                    "source": "rhel7-sap-hana",
+                    "target": [
+                        "rhel8-SAP-Solutions"
+                    ]
+                },
+                {
+                    "source": "rhel7-rhui-microsoft-azure-sap-apps",
+                    "target": [
+                        "rhel8-SAP-Solutions",
+                        "rhel8-SAP-NetWeaver",
+                        "rhel8-rhui-microsoft-azure-sap-apps"
+                    ]
+                },
+                {
+                    "source": "rhel7-highavailability",
+                    "target": [
+                        "rhel8-HighAvailability"
+                    ]
+                },
+                {
+                    "source": "rhel7-ansible-2",
+                    "target": [
+                        "rhel8-ansible-2"
+                    ]
+                },
+                {
+                    "source": "rhel7-rhui-client-config-server-7",
+                    "target": [
+                        "rhel8-rhui-client-config-server-8"
+                    ]
+                },
+                {
+                    "source": "rhel7-rhui-client-config-server-7-sap",
+                    "target": [
+                        "rhel8-rhui-client-config-server-8-sap"
+                    ]
+                },
+                {
+                    "source": "rhel7-rhui-microsoft-azure-rhel7",
+                    "target": [
+                        "rhel8-rhui-microsoft-azure-rhel8"
+                    ]
+                },
+                {
+                    "source": "rhel7-rhui-microsoft-sap-ha",
+                    "target": [
+                        "rhel8-rhui-microsoft-sap-ha"
+                    ]
+                },
+                {
+                    "source": "rhel7-rhui-google-compute-engine",
+                    "target": [
+                        "rhel8-rhui-google-compute-engine-leapp"
+                    ]
+                }
+            ]
+        },
+        {
+            "source_major_version": "8",
+            "target_major_version": "9",
+            "entries": [
+                {
+                    "source": "rhel8-BaseOS",
+                    "target": [
+                        "rhel9-BaseOS"
+                    ]
+                },
+                {
+                    "source": "rhel8-AppStream",
+                    "target": [
+                        "rhel9-AppStream"
+                    ]
+                },
+                {
+                    "source": "rhel8-CRB",
+                    "target": [
+                        "rhel9-CRB"
+                    ]
+                },
+                {
+                    "source": "rhel8-rhui-client-config-server-8-ha",
+                    "target": [
+                        "rhel9-rhui-client-config-server-9"
+                    ]
+                },
+                {
+                    "source": "rhel8-rhui-client-config-server-8",
+                    "target": [
+                        "rhel9-rhui-client-config-server-9"
+                    ]
+                },
+                {
+                    "source": "rhel8-Supplementary",
+                    "target": [
+                        "rhel9-Supplementary"
+                    ]
+                },
+                {
+                    "source": "rhel8-RT",
+                    "target": [
+                        "rhel9-RT"
+                    ]
+                },
+                {
+                    "source": "rhel8-NFV",
+                    "target": [
+                        "rhel9-NFV"
+                    ]
+                },
+                {
+                    "source": "rhel8-SAP-NetWeaver",
+                    "target": [
+                        "rhel9-SAP-NetWeaver"
+                    ]
+                },
+                {
+                    "source": "rhel8-SAP-Solutions",
+                    "target": [
+                        "rhel9-SAP-Solutions"
+                    ]
+                },
+                {
+                    "source": "rhel8-HighAvailability",
+                    "target": [
+                        "rhel9-HighAvailability"
+                    ]
+                },
+                {
+                    "source": "rhel8-Advanced-Virt",
+                    "target": [
+                        "rhel9-AppStream"
+                    ]
+                },
+                {
+                    "source": "rhel8-Advanced-Virt-CRB",
+                    "target": [
+                        "rhel9-CRB"
+                    ]
+                },
+                {
+                    "source": "rhel8-rhui-client-config-server-8-sap",
+                    "target": [
+                        "rhel9-rhui-client-config-server-9-sap"
+                    ]
+                },
+                {
+                    "source": "rhel8-rhui-microsoft-azure-rhel8",
+                    "target": [
+                        "rhel9-rhui-microsoft-azure-rhel9"
+                    ]
+                },
+                {
+                    "source": "rhel8-rhui-microsoft-azure-sap-apps",
+                    "target": [
+                        "rhel9-rhui-microsoft-azure-sap-apps"
+                    ]
+                },
+                {
+                    "source": "rhel8-rhui-microsoft-sap-ha",
+                    "target": [
+                        "rhel9-rhui-microsoft-sap-ha"
+                    ]
+                },
+                {
+                    "source": "rhel8-rhui-google-compute-engine",
+                    "target": [
+                        "rhel9-rhui-google-compute-engine-leapp"
+                    ]
+                }
+            ]
+        }
+    ],
+    "repositories": [
+        {
+            "pesid": "rhel7-base",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-arm-64-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-arm-64-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-9-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-a-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-aus-rpms",
+                    "arch": "x86_64",
+                    "channel": "aus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-releases-rhui-beta",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-7-server-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-7-server-rhui-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-optional",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-arm-64-optional-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-arm-64-rhui-optional-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-9-optional-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-e4s-optional-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-eus-optional-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-optional-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-optional-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-a-optional-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-eus-optional-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-optional-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-optional-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-aus-optional-rpms",
+                    "arch": "x86_64",
+                    "channel": "aus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-e4s-optional-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-e4s-optional-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-eus-optional-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-optional-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-optional-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-releases-rhui-optional-beta",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-eus-optional-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-optional-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-optional-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-7-server-e4s-optional-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-7-server-rhui-optional-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-supplementary",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-9-supplementary-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-eus-supplementary-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-supplementary-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-eus-supplementary-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-supplementary-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-eus-supplementary-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-eus-supplementary-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-supplementary-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-supplementary-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-supplementary-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-7-server-rhui-supplementary-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-extras",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-arm-64-extras-beta-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-arm-64-extras-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-arm-64-extras-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-9-extras-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-9-extras-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-extras-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-power-le-extras-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-a-extras-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-a-extras-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-extras-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-for-system-z-extras-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-extras-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-extras-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-extras-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rhui-extras-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-7-server-rhui-extras-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-rt",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-eus-rt-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rt-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-rt-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-nfv",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-nfv-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-sap",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-for-power-le-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-for-power-le-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-for-power-le-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-for-system-z-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-for-system-z-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-for-system-z-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-server-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-server-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-server-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-server-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-server-rhui-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-for-rhel-7-server-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-sap-for-rhel-7-server-rhui-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-sap-for-rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-sap-hana",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-for-power-le-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-for-power-le-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-for-power-le-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-server-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-server-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-server-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-server-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-server-rhui-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-sap-hana-for-rhel-7-server-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-sap-hana-for-rhel-7-server-rhui-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-sap-hana-for-rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-highavailability",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-ha-for-rhel-7-for-system-z-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-ha-for-rhel-7-for-system-z-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-ha-for-rhel-7-server-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-ha-for-rhel-7-server-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-ha-for-rhel-7-server-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-ha-for-rhel-7-server-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-ha-for-rhel-7-server-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-ha-for-rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-ha-for-rhel-7-server-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-ha-for-rhel-7-server-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-ha-for-rhel-7-server-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-ansible-2",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhel-7-server-ansible-2-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-rhui-client-config-server-7",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-client-config-server-7",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-client-config-server-7-arm",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-rhui-client-config-server-7-sap",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-client-config-server-7-sap-bundle",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-rhui-microsoft-azure-rhel7",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-microsoft-azure-rhel7",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-microsoft-azure-rhel7-eus",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-rhui-microsoft-sap-ha",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-microsoft-azure-rhel7-base-sap-ha",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-rhui-google-compute-engine",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "google-compute-engine",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel7-rhui-microsoft-azure-sap-apps",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-microsoft-azure-rhel7-base-sap-apps",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-BaseOS",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-baseos-beta-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-baseos-beta-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-baseos-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-baseos-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-baseos-beta-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-baseos-eus-rpms",
+                    "arch": "aarch64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-baseos-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-baseos-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-baseos-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-baseos-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-baseos-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-baseos-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-baseos-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-baseos-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-baseos-aus-rpms",
+                    "arch": "x86_64",
+                    "channel": "aus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-baseos-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-baseos-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-baseos-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-baseos-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-baseos-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-baseos-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-baseos-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-baseos-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-baseos-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-baseos-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-baseos-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-baseos-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-AppStream",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-appstream-beta-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-appstream-beta-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-appstream-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-appstream-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-appstream-beta-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-appstream-eus-rpms",
+                    "arch": "aarch64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-appstream-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-appstream-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-appstream-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-appstream-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-appstream-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-appstream-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-appstream-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-appstream-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-appstream-aus-rpms",
+                    "arch": "x86_64",
+                    "channel": "aus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-appstream-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-appstream-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-appstream-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-appstream-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-appstream-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-appstream-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-appstream-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-appstream-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-appstream-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-appstream-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-appstream-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-appstream-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-CRB",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-beta-for-rhel-8-aarch64-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-beta-for-rhel-8-ppc64le-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-beta-for-rhel-8-s390x-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-beta-for-rhel-8-x86_64-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-aarch64-eus-rpms",
+                    "arch": "aarch64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-aarch64-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-ppc64le-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-ppc64le-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-s390x-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-s390x-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-x86_64-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-x86_64-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "codeready-builder-for-rhel-8-x86_64-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-codeready-builder-for-rhel-8-x86_64-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-codeready-builder-for-rhel-8-x86_64-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-Supplementary",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-supplementary-beta-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-supplementary-eus-rpms",
+                    "arch": "aarch64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-supplementary-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-supplementary-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-supplementary-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-supplementary-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-supplementary-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-supplementary-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-supplementary-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-supplementary-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-supplementary-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-supplementary-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-supplementary-beta-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-supplementary-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-supplementary-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-supplementary-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-RT",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-rt-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-rt-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-NFV",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-nfv-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-nfv-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-SAP-NetWeaver",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-sap-netweaver-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-sap-netweaver-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-sap-netweaver-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-sap-netweaver-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-sap-netweaver-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-sap-netweaver-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-sap-netweaver-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-netweaver-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-netweaver-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-netweaver-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-netweaver-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-netweaver-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-netweaver-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-netweaver-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-netweaver-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-sap-netweaver-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-SAP-Solutions",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-sap-solutions-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-sap-solutions-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-sap-solutions-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-sap-solutions-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-solutions-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-solutions-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-solutions-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-solutions-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-solutions-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-solutions-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-sap-solutions-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-sap-solutions-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-HighAvailability",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-highavailability-beta-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-highavailability-eus-rpms",
+                    "arch": "aarch64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-aarch64-highavailability-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-highavailability-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-highavailability-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-highavailability-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-ppc64le-highavailability-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-highavailability-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-highavailability-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-s390x-highavailability-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-highavailability-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-highavailability-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-highavailability-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-highavailability-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-highavailability-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-highavailability-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-highavailability-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhel-8-for-x86_64-highavailability-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-highavailability-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-rhel-8-for-x86_64-highavailability-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-ansible-2",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "ansible-2-for-rhel-8-x86_64-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-rhui-client-config-server-8",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-client-config-server-8",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-client-config-server-8",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-rhui-client-config-server-8-sap",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-client-config-server-8-sap-bundle",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-rhui-microsoft-azure-rhel8",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-microsoft-azure-rhel8",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-microsoft-azure-rhel8-eus",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-rhui-microsoft-sap-ha",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-microsoft-azure-rhel8-sap-ha",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-rhui-microsoft-azure-sap-apps",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-microsoft-azure-rhel8-sapapps",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-rhui-client-config-server-8-ha",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "rhui-client-config-server-8-ha",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-rhui-google-compute-engine",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "google-compute-engine",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-rhui-google-compute-engine-leapp",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "google-compute-engine-leapp",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-Advanced-Virt",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-for-rhel-8-aarch64-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-for-rhel-8-ppc64le-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-for-rhel-8-ppc64le-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-for-rhel-8-s390x-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-for-rhel-8-s390x-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-for-rhel-8-x86_64-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-for-rhel-8-x86_64-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel8-Advanced-Virt-CRB",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-crb-for-rhel-8-aarch64-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-crb-for-rhel-8-ppc64le-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-crb-for-rhel-8-s390x-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "advanced-virt-crb-for-rhel-8-x86_64-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-BaseOS",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-baseos-beta-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-baseos-beta-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-baseos-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-baseos-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-baseos-beta-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-baseos-e4s-rpms",
+                    "arch": "aarch64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-baseos-eus-rpms",
+                    "arch": "aarch64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-baseos-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-baseos-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-baseos-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-baseos-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-baseos-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-baseos-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-baseos-e4s-rpms",
+                    "arch": "s390x",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-baseos-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-baseos-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-baseos-aus-rpms",
+                    "arch": "x86_64",
+                    "channel": "aus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-baseos-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-baseos-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-baseos-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-baseos-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-baseos-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-baseos-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-baseos-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-baseos-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-rhel-9-for-x86_64-baseos-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-rhel-9-for-x86_64-baseos-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-AppStream",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-appstream-beta-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-appstream-beta-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-appstream-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-appstream-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-appstream-beta-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-appstream-e4s-rpms",
+                    "arch": "aarch64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-appstream-eus-rpms",
+                    "arch": "aarch64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-appstream-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-appstream-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-appstream-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-appstream-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-appstream-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-appstream-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-appstream-e4s-rpms",
+                    "arch": "s390x",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-appstream-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-appstream-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-appstream-aus-rpms",
+                    "arch": "x86_64",
+                    "channel": "aus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-appstream-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-appstream-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-appstream-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-appstream-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-appstream-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-appstream-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-appstream-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-appstream-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-rhel-9-for-x86_64-appstream-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-rhel-9-for-x86_64-appstream-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-CRB",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-beta-for-rhel-9-aarch64-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-beta-for-rhel-9-ppc64le-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-beta-for-rhel-9-s390x-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-beta-for-rhel-9-x86_64-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-aarch64-eus-rpms",
+                    "arch": "aarch64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-aarch64-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-ppc64le-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-ppc64le-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-s390x-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-s390x-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-x86_64-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-x86_64-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "codeready-builder-for-rhel-9-x86_64-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-codeready-builder-for-rhel-9-x86_64-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-Supplementary",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-supplementary-beta-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-supplementary-eus-rpms",
+                    "arch": "aarch64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-supplementary-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-supplementary-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-supplementary-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-supplementary-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-supplementary-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-supplementary-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-supplementary-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-supplementary-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-supplementary-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-supplementary-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-supplementary-beta-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-supplementary-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-rhel-9-for-x86_64-supplementary-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-RT",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-rt-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-rt-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-rt-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-NFV",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-nfv-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-nfv-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-nfv-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-SAP-NetWeaver",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-sap-netweaver-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-sap-netweaver-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-sap-netweaver-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-sap-netweaver-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-sap-netweaver-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-sap-netweaver-e4s-rpms",
+                    "arch": "s390x",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-sap-netweaver-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-sap-netweaver-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-netweaver-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-netweaver-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-netweaver-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-netweaver-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-netweaver-eus-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-netweaver-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-netweaver-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-rhel-9-for-x86_64-sap-netweaver-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-SAP-Solutions",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-sap-solutions-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-sap-solutions-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-solutions-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-solutions-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-solutions-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-sap-solutions-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-rhel-9-for-x86_64-sap-solutions-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-HighAvailability",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-highavailability-beta-rpms",
+                    "arch": "aarch64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-highavailability-e4s-rpms",
+                    "arch": "aarch64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-highavailability-eus-rpms",
+                    "arch": "aarch64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-highavailability-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-highavailability-beta-rpms",
+                    "arch": "ppc64le",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-highavailability-e4s-rpms",
+                    "arch": "ppc64le",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-highavailability-eus-rpms",
+                    "arch": "ppc64le",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-ppc64le-highavailability-rpms",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-highavailability-beta-rpms",
+                    "arch": "s390x",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-highavailability-e4s-rpms",
+                    "arch": "s390x",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-highavailability-eus-rpms",
+                    "arch": "s390x",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-s390x-highavailability-rpms",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-highavailability-beta-rpms",
+                    "arch": "x86_64",
+                    "channel": "beta",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-highavailability-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-highavailability-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-highavailability-e4s-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-highavailability-eus-rpms",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-highavailability-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-rhel-9-for-x86_64-highavailability-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-rhel-9-for-x86_64-highavailability-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-rhui-client-config-server-9",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-client-config-server-9",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-client-config-server-9",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-rhui-client-config-server-9-sap",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-client-config-server-9-sap-bundle",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "aws"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-rhui-microsoft-azure-rhel9",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-microsoft-azure-rhel9",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-rhui-microsoft-azure-sap-apps",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-microsoft-azure-rhel9-sapapps",
+                    "arch": "x86_64",
+                    "channel": "eus",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-rhui-microsoft-sap-ha",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "rhui-microsoft-azure-rhel9-sap-ha",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-rhui-google-compute-engine",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "google-compute-engine",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel9-rhui-google-compute-engine-leapp",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "google-compute-engine-leapp",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                }
+            ]
+        }
+    ],
+    "provided_data_streams": [
+        "1.0"
+    ]
+}

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -215,6 +215,7 @@ install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/repos.d/
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/transaction/
 install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/files/
 install -m 0644 etc/leapp/transaction/* %{buildroot}%{_sysconfdir}/leapp/transaction
+install -m 0644 etc/leapp/files/* %{buildroot}%{_sysconfdir}/leapp/files
 
 # install CLI commands for the leapp utility on the expected path
 install -m 0755 -d %{buildroot}%{leapp_python_sitelib}/leapp/cli/
@@ -261,6 +262,7 @@ done;
 %dir %{repositorydir}
 %dir %{custom_repositorydir}
 %dir %{leapp_python_sitelib}/leapp/cli/commands
+%config %{_sysconfdir}/leapp/files/*
 %{_sysconfdir}/leapp/repos.d/*
 %{_sysconfdir}/leapp/transaction/*
 %{repositorydir}/*


### PR DESCRIPTION
In the past it was needed to obtain the data by
* automatic download of data files from RH Insights
  (cloud.redhat.com)
  - which required access to the server & have the system registered
* manual download from the article:
    https://access.redhat.com/articles/3664871
  which required to login to the portal, download the archive
  and install its content manually on the system

Additional problem was with the syncing of data, as because of the separation of data from the code, people had ensure they are using the right combination of data and SW manually - in case the data has not been downloaded automatically from RH Insights.

Having the data in the RPM makes our lives easier so let's install them to `/etc/leapp/files/` via the package directly.
Set /etc/leapp/files/* as configuration files to ensure that modified files will be backed up with *.rpmsave suffix as
expected for configuration files. This could be important in case users manually updated e.g. repomap.json file to reflect their internal settings of the satellite server.

The complete table how the configuration files are handled during
rpm installation/upgrade/... is here:
*    https://www.cl.cam.ac.uk/~jw35/docs/rpm_config.html

Keeping original functionality still available, so if people remove the files from the system, data can be still downloaded from the server automatically. It seems it does not make sense, but we could still use the possibility to download more up-to-date data from RH Insights.

Configure codespell to ignore .etc/leapp/files