### PR TITLE
# Release 0.18.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -41,7 +41,7 @@ py2_byte_compile "%1" "%2"}
 # RHEL 8+ packages to be consistent with other leapp projects in future.
 
 Name:           leapp-repository
-Version:        0.17.0
+Version:        0.18.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Packaging
- Requires cpio (#979)
- Requires python3-gobject-base, NetworkManager-libnm (#969)
- Bump leapp-repository-dependencies to 9 (#969, #979)

## Upgrade handling
### Fixes
- Add leapp RHUI packages to an allowlist to drop confusing reports (#995)
- Check only mounted XFS partitions (#1027)
- Detect the kernel-core RPM instead of kernel to prevent an error during post-upgrade phases (#1024)
- Disable the amazon-id DNF plugin on AWS during the upgrade stage to omit error messages during the upgrade process caused by missing network connection (#990)
- Do not create new *pyc files when running leapp after the DNF upgrade transaction (#1017)
- Enable upgrades on s390x when /boot is part of rootfs (#991)
- Extend the allow list of RHUI clients by azure-sap-apps to omit confusing report (#974)
- Filter out PES events unrelated for the used upgrade path and handle overlapping events (#1008)
- Fix scan of ceph volumes on systems without ceph-osd (#1011)
- Fix scan of ceph volumes when ceph-osd container is not found (#986)
- Fix systemd symlinks that become incorrect during the IPU (#972)
- Fix the check of memory (RAM) limits (#984)
- Fix the upgrade of IBM Z machines configured with ZFCP (#983)
- Ignore external accounts in /etc/passwd (#958)
- Inhibit the upgrade when entries in /etc/fstab cause overshadowing during the upgrade (#1009)
- Prevent leapp failures caused by re-run of leapp in the upgrade initramfs after previous failure, which causes additional confusing error message hiding original bugs (#996)
- Prevent the upgrade with RHSM when a baseos and an appstream target repositories are not discovered (#1001)
- RHUI(Azure) handle correctly various SAP images (#1037)
- Rework the network configuration handling and parse the configuration data properly (#969)
- Set RHSM release for non-ga and non-beta channels (#1033)
- Use the "grub" library to find the GRUB device (#989)
- [IPU 7 -> 8] Detect corrupted grubenv file (#1012)
- [IPU 7 -> 8] Ensure that rsyncd stays enabled if it is enabled prior the upgrade(#1043)
- [IPU 7 -> 8] Ensure that satellite metapackages are installed after the upgrade (#994)
- [IPU 7 -> 8] Ensure the device_cio_free service stays enabled on s390x after the upgrade (#977)
- [IPU 7 -> 8] Fixed checks for RHEL SAP IPU 7.9 -> 8.6 (#978)
- [IPU 7 -> 8] Fixed migration of ntp to chrony when the ntp service is masked (#966)
- [IPU 7 -> 8] Prevent the traceback during migration of sendmail configuration files when the package is not installed (#1041)
- [IPU 7 -> 8] Satellite: reindex all related databases to fix issues due to new locales in RHEL 8 (#1007, #1018)
- [IPU 7 -> 8] Use the correct domain name in SSSD reports (#1040)
- [IPU 8 -> 9] Added checks for RHEL SAP IPU 8.6 -> 9.0 (#978)
- [IPU 8 -> 9] CheckVDO: Ask user for the confirmation only on failures and undetermined devices (#961)
- [IPU 8 -> 9] Fix the kernel detection during initramfs creation for new kernel on RHEL 9.2+ (#1048)
- [IPU 8 -> 9] Fix the upgrade on Azure using RHUI for SAP Apps images (#975)
- [IPU 8 -> 9] Handle correctly firewalld version 0.8 (#963)

### Enhancements
- Set new upgrade paths (#988): -- RHEL 7.9 -> 8.8, 8.6 (default: 8.8)
  - RHEL 8.6 -> 9.0
  - RHEL 8.8 -> 9.2
- Check that used leapp data are valid and compatible with the installed leapp-repository (#1003)
- Detect a proxy configuration in YUM/DNF and adjust an error msg on issues caused by the configuration (#914)
- Detect and report systemd symlinks that are broken before the upgrade (#972)
- Drop obsoleted upgrade paths (#1047)
- Improve remediation instructions for packages in unknown repositories (#1010)
- Improve the error message to guide users when discovered more space is needed (#956)
- Introduce --nogpgcheck option to skip checking of RPM signatures (#910)
- Introduced an option to use an ISO file as a target RHEL version content source (#979)
- Introduced possibility to specify what systemd services should be enabled/disabled on the upgraded system (#964)
- Map the target repositories also based on the installed content (#967)
- Provide common information about systemd services (#959)
- Register subscribed systems automatically to Red Hat Insights unless --no-insights-register is used (#1000)
- Remove obsoleted GPG keys provided by RH after the upgrade to prevent errors (#1022)
- Run upgrade process with checking RPM signatures by default (#910, #993, #1025)
- Save breadcrumbs results as RHSM facts (#1002)
- Small improvements in various reports (#1038, #1039, #1032)
- [IPU 8 -> 9] Detect CIFS also when upgrading from RHEL8 to RHEL9 (#1035)
- [IPU 8 -> 9] Detect RoCE on IBM Z machines and check the configuration is safe for the upgrade (#1030)
- [IPU 8 -> 9] Enable upgrades of RHEL 8 for SAP HANA to RHEL 9 on ppc64le (#1042)
- [IPU 8 -> 9] Improve the handling of blocklisted certificates (#992)

## Additional changes interesting for devels
- Started work on bringing up networking inside the upgrade initramfs - currently available for testing and development purposes when LEAPP_DEVEL_INITRAM_NETWORK is set (#960)
- Add leapp debug tools to the upgrade initramfs - dracut upgrade module (#997)
- Enable disabling of DNF plugins in the dnfplugin library (#990)