### PR TITLE
Update codespell ignorelist: couldn,repositor

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: codespell-project/actions-codespell@master
         with:
-          ignore_words_list: ro,fo
+          ignore_words_list: ro,fo,couldn,repositor
           skip: "./repos/system_upgrade/common/actors/storagescanner/tests/files/mounts,\
             ./repos/system_upgrade/el7toel8/actors/networkmanagerreadconfig/tests/files/nm_cfg_file_error,\
             ./repos/system_upgrade/common/actors/scancpu/tests/files/lscpu_s390x"


### PR DESCRIPTION
The new version of codespell contains additional "typos" for the detection in the dictionary, which produces FP fails in tests as typos are detected also in cases like:
    couldn\'t
    repositor{suffix}
etc. For now, we will just update the ignorelist, but in future it would be ideal to not generate such cases. Doing differences between singular/plural is not providing big benefit in report. Escaping is not so problematic I would say, but in case of issues, we could just switch to longer form - like "could not". But there is no beenfit to update the existing code now, so let's focus in future on better texts and keep the existing strings as they are until they are reworded due to additional wanted changes (I mean, if there is any additional reason in future to change them).

FYI:
  https://github.com/codespell-project/codespell/issues/2786