### PR TITLE
[WIP] checkfips: Allow FIPS upgrades in 8.8

### DIFF
--- a/repos/system_upgrade/common/actors/checkfips/tests/unit_test_checkfips.py
+++ b/repos/system_upgrade/common/actors/checkfips/tests/unit_test_checkfips.py
@@ -1,5 +1,6 @@
 import pytest
 
+from leapp.libraries.common.config import version
 from leapp.models import KernelCmdline, KernelCmdlineArg, Report
 from leapp.snactor.fixture import current_actor_context
 
@@ -19,16 +20,22 @@ ballast2 = [KernelCmdlineArg(key=k, value=v) for k, v in [
     ('LANG', 'en_US.UTF-8')]]
 
 
-@pytest.mark.parametrize('parameters,expected_report', [
-    ([], False),
-    ([KernelCmdlineArg(key='fips', value='')], False),
-    ([KernelCmdlineArg(key='fips', value='0')], False),
-    ([KernelCmdlineArg(key='fips', value='1')], True),
-    ([KernelCmdlineArg(key='fips', value='11')], False),
-    ([KernelCmdlineArg(key='fips', value='yes')], False)
+@pytest.mark.parametrize('src_v,parameters,expected_report', [
+    ("8.7", [], False),
+    ("8.7", [KernelCmdlineArg(key='fips', value='')], False),
+    ("8.7", [KernelCmdlineArg(key='fips', value='0')], False),
+    ("8.7", [KernelCmdlineArg(key='fips', value='1')], True),
+    ("8.7", [KernelCmdlineArg(key='fips', value='11')], False),
+    ("8.7", [KernelCmdlineArg(key='fips', value='yes')], False),
+    ("8.8", [KernelCmdlineArg(key='fips', value='')], False),
+    ("8.8", [KernelCmdlineArg(key='fips', value='0')], False),
+    ("8.8", [KernelCmdlineArg(key='fips', value='1')], False),
+    ("8.8", [KernelCmdlineArg(key='fips', value='11')], False),
+    ("8.8", [KernelCmdlineArg(key='fips', value='yes')], False)
 ])
-def test_check_fips(current_actor_context, parameters, expected_report):
+def test_check_fips(monkeypatch, current_actor_context, src_v, parameters, expected_report):
     cmdline = KernelCmdline(parameters=ballast1+parameters+ballast2)
+    monkeypatch.setattr(version, 'get_source_version', lambda: src_v)
     current_actor_context.feed(cmdline)
     current_actor_context.run()
     if expected_report:


### PR DESCRIPTION
The `addupgradebootentry` actor does already preserve `fips=1` on the kernel command line, so the upgrade initramfs is correctly booted in FIPS mode.

The upgrade initramfs does not correctly enable FIPS mode for all libraries due to a bug in dracut that also affects all normal boot environments generated by dracut. See rhbz#2176560 for a report of this problem. Once this is fixed, we can enable leapp upgrades in FIPS mode.

The systemd-nspawn container in the upgrade initramfs does correctly pass `/proc` and has the required files (OpenSSL FIPS provider, OpenSSL configuration file, crypto-policies, GnuTLS HMAC integrity checksums) installed, so that part already behaves as expected in a FIPS uprgade scenario.

See: OAMG-7824