### PR TITLE
Use the updated Leapp output API - reports summary

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,6 +7,7 @@ disable=
  no-member,
  no-name-in-module,
  raising-bad-type,
+ redundant-keyword-arg,  # it's one or the other, this one is not so bad at all
 # "W" Warnings for stylistic problems or minor programming issues
  no-absolute-import,
  arguments-differ,

--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -80,7 +80,8 @@ def preupgrade(args, breadcrumbs):
     report_inhibitors(context)
     report_files = util.get_cfg_files('report', cfg)
     log_files = util.get_cfg_files('logs', cfg)
-    report_info(report_files, log_files, answerfile_path, fail=workflow.failure)
+    report_info(context, report_files, log_files, answerfile_path, fail=workflow.failure)
+
     if workflow.failure:
         sys.exit(1)
 

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -110,7 +110,7 @@ def upgrade(args, breadcrumbs):
     util.generate_report_files(context, report_schema)
     report_files = util.get_cfg_files('report', cfg)
     log_files = util.get_cfg_files('logs', cfg)
-    report_info(report_files, log_files, answerfile_path, fail=workflow.failure)
+    report_info(context, report_files, log_files, answerfile_path, fail=workflow.failure)
 
     if workflow.failure:
         sys.exit(1)

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -100,7 +100,7 @@ Requires:       leapp-repository-dependencies = %{leapp_repo_deps}
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' instead of the real framework rpm version.
-Requires:       leapp-framework >= 3.1, leapp-framework < 4
+Requires:       leapp-framework >= 4.0, leapp-framework < 5
 
 # Since we provide sub-commands for the leapp utility, we expect the leapp
 # tool to be installed as well.


### PR DESCRIPTION
Use the updated Leapp output API introduced in oamg/leapp#818.
Leapp output will now include a summary of reports and also a list of titles of HIGH and MEDIUM severity reports.