### PR TITLE
Fix trace with impossible LEAPP_DEVEL_TARGET_RELEASE

### DIFF
--- a/commands/upgrade/breadcrumbs.py
+++ b/commands/upgrade/breadcrumbs.py
@@ -127,6 +127,10 @@ class _BreadCrumbs(object):
         return []
 
     def _verify_leapp_pkgs(self):
+        if not os.environ.get('LEAPP_IPU_IN_PROGRESS'):
+            # NOTE(ivasilev) this can happen if LEAPP_DEVEL_TARGET_RELEASE is specified and pointing to an impossible
+            # version
+            return []
         upg_path = os.environ.get('LEAPP_IPU_IN_PROGRESS').split('to')
         cmd = ['/bin/bash', '-c', 'rpm -V leapp leapp-upgrade-el{}toel{}'.format(upg_path[0], upg_path[1])]
         res = _call(cmd, lambda x, y: None, lambda x, y: None)


### PR DESCRIPTION
With this change the (pre)upgrade will correctly handle impossible target release version, no more ugly trace will be shown.

example of the traceback:
```
error: argument --target: invalid choice: '8.4.badversion' (choose from '9.0')
PASSED
test_target_option.py::test_devel_version Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/leapp/cli/commands/upgrade/breadcrumbs.py", line 159, in wrapper
    return f(*args, breadcrumbs=breadcrumbs, **kwargs)
  File "/usr/lib/python3.6/site-packages/leapp/cli/commands/upgrade/__init__.py", line 78, in upgrade
    configuration = util.prepare_configuration(args)
  File "/usr/lib/python3.6/site-packages/leapp/cli/commands/upgrade/util.py", line 220, in prepare_configuration
    target_version, flavor = command_utils.vet_upgrade_path(args)
  File "/usr/lib/python3.6/site-packages/leapp/cli/commands/command_utils.py", line 132, in vet_upgrade_path
    check_version(env_version_override)
  File "/usr/lib/python3.6/site-packages/leapp/cli/commands/command_utils.py", line 28, in check_version
    raise CommandError('Unexpected format of target version: {}'.format(version))
leapp.exceptions.CommandError: Unexpected format of target version: 8.4.0bad

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/leapp", line 11, in <module>
    load_entry_point('leapp==0.15.1', 'console_scripts', 'leapp')()
  File "/usr/lib/python3.6/site-packages/leapp/cli/__init__.py", line 45, in main
    cli.command.execute('leapp version {}'.format(VERSION))
  File "/usr/lib/python3.6/site-packages/leapp/utils/clicmd.py", line 111, in execute
    args.func(args)
  File "/usr/lib/python3.6/site-packages/leapp/utils/clicmd.py", line 133, in called
    self.target(args)
  File "/usr/lib/python3.6/site-packages/leapp/cli/commands/upgrade/breadcrumbs.py", line 168, in wrapper
    breadcrumbs.save()
  File "/usr/lib/python3.6/site-packages/leapp/cli/commands/upgrade/breadcrumbs.py", line 90, in save
    self._crumbs['leapp_file_changes'].extend(self._verify_leapp_pkgs())
  File "/usr/lib/python3.6/site-packages/leapp/cli/commands/upgrade/breadcrumbs.py", line 130, in _verify_leapp_pkgs
    upg_path = os.environ.get('LEAPP_IPU_IN_PROGRESS').split('to')
AttributeError: 'NoneType' object has no attribute 'split'
FAILED
```

OAMG-8651