### PR TITLE
BZ#2188239 - better detect already migrated PostgreSQL data

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrade_check/tests/unit_test_satellite_upgrade_check.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrade_check/tests/unit_test_satellite_upgrade_check.py
@@ -28,8 +28,27 @@ def test_no_old_data(monkeypatch):
     assert reporting.create_report.called == 1
 
     expected_title = 'Satellite PostgreSQL data migration'
+    expected_intro = 'PostgreSQL on RHEL 8 expects its data in /var/lib/pgsql/data.'
 
     assert expected_title == reporting.create_report.report_fields['title']
+    assert expected_intro in reporting.create_report.report_fields['summary']
+
+
+def test_migrated_data(monkeypatch):
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+
+    satellite_upgrade_check(SatelliteFacts(has_foreman=True,
+                            postgresql=SatellitePostgresqlFacts(local_postgresql=True, scl_pgsql_data=False)))
+
+    assert reporting.create_report.called == 1
+
+    expected_title = 'Satellite PostgreSQL data migration'
+    expected_summary = 'Your PostgreSQL data seems to be already migrated to the new location.'
+    expected_reindex = 'PostgreSQL on RHEL 8 requires a rebuild of all database indexes'
+
+    assert expected_title == reporting.create_report.report_fields['title']
+    assert expected_summary in reporting.create_report.report_fields['summary']
+    assert expected_reindex in reporting.create_report.report_fields['summary']
 
 
 def test_same_disk(monkeypatch):
@@ -42,7 +61,7 @@ def test_same_disk(monkeypatch):
 
     expected_title = 'Satellite PostgreSQL data migration'
     expected_summary = 'Your PostgreSQL data will be automatically migrated.'
-    expected_reindex = 'all databases will require a REINDEX'
+    expected_reindex = 'PostgreSQL on RHEL 8 requires a rebuild of all database indexes'
 
     assert expected_title == reporting.create_report.report_fields['title']
     assert expected_summary in reporting.create_report.report_fields['summary']
@@ -60,7 +79,7 @@ def test_different_disk_sufficient_storage(monkeypatch):
 
     expected_title = 'Satellite PostgreSQL data migration'
     expected_summary = 'You currently have enough free storage to move the data'
-    expected_reindex = 'all databases will require a REINDEX'
+    expected_reindex = 'PostgreSQL on RHEL 8 requires a rebuild of all database indexes'
 
     assert expected_title == reporting.create_report.report_fields['title']
     assert expected_summary in reporting.create_report.report_fields['summary']

--- a/repos/system_upgrade/el7toel8/actors/satellite_upgrade_data_migration/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/satellite_upgrade_data_migration/actor.py
@@ -40,7 +40,7 @@ class SatelliteUpgradeDataMigration(Actor):
                 except Exception as e:  # pylint: disable=broad-except
                     self.log.warning('Failed disabling service {}: {}'.format(service, e))
 
-        if facts.postgresql.local_postgresql and os.path.exists(POSTGRESQL_SCL_DATA_PATH):
+        if facts.postgresql.local_postgresql and facts.postgresql.scl_pgsql_data:
             # we can assume POSTGRESQL_DATA_PATH exists and is empty
             # move PostgreSQL data to the new home
             for item in glob.glob(os.path.join(POSTGRESQL_SCL_DATA_PATH, '*')):

--- a/repos/system_upgrade/el7toel8/models/satellite.py
+++ b/repos/system_upgrade/el7toel8/models/satellite.py
@@ -9,6 +9,8 @@ class SatellitePostgresqlFacts(Model):
     """ Whether or not PostgreSQL is installed on the same system """
     old_var_lib_pgsql_data = fields.Boolean(default=False)
     """ Whether or not there is old PostgreSQL data in /var/lib/pgsql/data """
+    scl_pgsql_data = fields.Boolean(default=True)
+    """ Whether or not there is data in the SCL PostgreSQL path """
     same_partition = fields.Boolean(default=True)
     """ Whether or not target and source postgresql data will stay on the same partition """
     space_required = fields.Nullable(fields.Integer())


### PR DESCRIPTION
Users can (and in some cases have to) manually move the PostgreSQL data to the new location. In the case when they would completely delete the old location, the facts code would previously error out:

    Traceback (most recent call last):
      File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
        self.run()
      File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
        self._target(*self._args, **self._kwargs)
      File "/usr/lib/python2.7/site-packages/leapp/repository/actor_definition.py", line 72, in _do_run
        actor_instance.run(*args, **kwargs)
      File "/usr/lib/python2.7/site-packages/leapp/actors/init.py", line 289, in run
        self.process(*args)
      File "/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/satellite_upgrade_facts/actor.py", line 96, in process
        scl_psql_stat = os.stat(POSTGRESQL_SCL_DATA_PATH)
    OSError: [Errno 2] No such file or directory: '/var/opt/rh/rh-postgresql12/lib/pgsql/data/'

However, if the user already has migrated the data, we don't have to do it in the actor and thus can skip all that detection code.

Also adjust the report to say the data looks migrated (but still needs a reindex).