### PR TITLE
Add el8toel9 actor to handle directory -> symlink with ruby IRB.

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/registerrubyirbadjustment/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/registerrubyirbadjustment/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.models import DNFWorkaround
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class RegisterRubyIRBAdjustment(Actor):
+    """
+    Registers a workaround which will adjust the Ruby IRB directories during the upgrade.
+    """
+
+    name = 'register_ruby_irb_adjustment'
+    consumes = ()
+    produces = (DNFWorkaround,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        self.produce(
+            DNFWorkaround(
+                display_name='IRB directory fix',
+                script_path=self.get_tool_path('handlerubyirbsymlink'),
+            )
+        )

--- a/repos/system_upgrade/el8toel9/actors/registerrubyirbadjustment/tests/test_register_ruby_irb_adjustments.py
+++ b/repos/system_upgrade/el8toel9/actors/registerrubyirbadjustment/tests/test_register_ruby_irb_adjustments.py
@@ -1,0 +1,11 @@
+import os.path
+
+from leapp.models import DNFWorkaround
+
+
+def test_register_ruby_irb_adjustments(current_actor_context):
+    current_actor_context.run()
+    assert len(current_actor_context.consume(DNFWorkaround)) == 1
+    assert current_actor_context.consume(DNFWorkaround)[0].display_name == 'IRB directory fix'
+    assert os.path.basename(current_actor_context.consume(DNFWorkaround)[0].script_path) == 'handlerubyirbsymlink'
+    assert os.path.exists(current_actor_context.consume(DNFWorkaround)[0].script_path)

--- a/repos/system_upgrade/el8toel9/tools/handlerubyirbsymlink
+++ b/repos/system_upgrade/el8toel9/tools/handlerubyirbsymlink
@@ -1,0 +1,23 @@
+#!/usr/bin/bash -e
+
+# just in case of hidden files.. not sure why would someone do that, it's more
+# like forgotten cache file possibility, but rather do that..
+shopt -s dotglob
+
+handle_dir() {
+    # Check that $1 is not already a symlink
+    # then remove the directory so that RPM can freely create the
+    # symlink.
+    if [ "$(readlink "$1")" == "/usr/share/gems/gems/irb-1.3.5" ]; then
+        return
+    fi
+
+    # There is no configuration or anything that the user should ever customize
+    # and expect to retain.
+    rm -rf "$1"
+
+    return 0
+}
+
+
+handle_dir /usr/share/ruby/irb


### PR DESCRIPTION
A symlink to directory conversion halts DNF update with a transaction error.

As this was not handled on the RPM component level, the simplest fix now is to either uninstall the package first and then, or simply upgrade delete the offending directory.

The directory `/usr/share/ruby/irb` can be freely deleted as it does not hold any sort of configuration or similar. It is simply only containing code provided by the package.

Related BZ bug: https://bugzilla.redhat.com/show_bug.cgi?id=2030627