### PR TITLE
el8toel9: Warn about deprecated Xorg drivers

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -20,6 +20,9 @@ jobs:
           ignore_words_list: ro,fo,couldn,repositor
           skip: "./repos/system_upgrade/common/actors/storagescanner/tests/files/mounts,\
             ./repos/system_upgrade/el7toel8/actors/networkmanagerreadconfig/tests/files/nm_cfg_file_error,\
+            ./repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/files/journalctl-xorg-intel,\
+            ./repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/files/journalctl-xorg-qxl,\
+            ./repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/files/journalctl-xorg-without-qxl,\
             ./repos/system_upgrade/common/actors/scancpu/tests/files/lscpu_s390x,\
             ./etc/leapp/files/device_driver_deprecation_data.json,\
             ./etc/leapp/files/pes-events.json,\

--- a/repos/system_upgrade/el8toel9/actors/xorgdrvcheck/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/xorgdrvcheck/actor.py
@@ -1,0 +1,52 @@
+from leapp import reporting
+from leapp.actors import Actor
+from leapp.models import XorgDrvFacts
+from leapp.reporting import create_report, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+SUMMARY_XORG_DEPRECATE_DRIVERS_FMT = (
+    'Leapp has detected the use of some deprecated Xorg drivers. '
+    'Using these drivers could lead to a broken graphical session after the upgrade. '
+    'Any custom configuration related to these drivers will be ignored. '
+    'The list of used deprecated drivers: {}')
+
+SUMMARY_XORG_DEPRECATE_DRIVERS_HINT = (
+    'Please uninstall the Xorg driver and remove the corresponding driver '
+    'customisation entries from the X.Org configuration files and directories, '
+    'such as `/etc/X11/xorg.conf` and `/etc/X11/xorg.conf.d/` and reboot before '
+    'upgrading to make sure you have a graphical session after upgrading.'
+)
+FMT_LIST_SEPARATOR = '\n    - {}'
+
+
+def _printable_drv(facts):
+    output = ''
+    for fact in facts:
+        for driver in fact.xorg_drivers:
+            output += FMT_LIST_SEPARATOR.format(driver.driver)
+            if driver.has_options:
+                output += ' (with custom driver options)'
+    return output
+
+
+class XorgDrvCheck8to9(Actor):
+    """
+    Warn if Xorg deprecated drivers are in use.
+    """
+
+    name = 'xorgdrvcheck8to9'
+    consumes = (XorgDrvFacts,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        facts = self.consume(XorgDrvFacts)
+        deprecated_drivers = _printable_drv(facts)
+        if len(deprecated_drivers) > 0:
+            create_report([
+                reporting.Title('Deprecated Xorg driver detected'),
+                reporting.Summary(SUMMARY_XORG_DEPRECATE_DRIVERS_FMT.format(deprecated_drivers)),
+                reporting.Severity(reporting.Severity.MEDIUM),
+                reporting.Groups([reporting.Groups.DRIVERS]),
+                reporting.Remediation(hint=SUMMARY_XORG_DEPRECATE_DRIVERS_HINT)
+                ])

--- a/repos/system_upgrade/el8toel9/actors/xorgdrvcheck/tests/test_xorgdrvcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/xorgdrvcheck/tests/test_xorgdrvcheck.py
@@ -1,0 +1,19 @@
+from leapp.models import XorgDrv, XorgDrvFacts
+from leapp.reporting import Report
+
+
+def test_actor_with_deprecated_driver(current_actor_context):
+    for driver in ['RADEON', 'ATI', 'AMDGPU', 'MACH64', 'intel', 'spiceqxl', 'qxl', 'NOUVEAU', 'NV', 'VESA']:
+        xorg_drv = [XorgDrv(driver=driver, has_options=False)]
+
+        current_actor_context.feed(XorgDrvFacts(xorg_drivers=xorg_drv))
+        current_actor_context.run()
+        assert current_actor_context.consume(Report)
+
+
+def test_actor_without_deprecated_driver(current_actor_context):
+    xorg_drv = []
+
+    current_actor_context.feed(XorgDrvFacts(xorg_drivers=xorg_drv))
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)

--- a/repos/system_upgrade/el8toel9/actors/xorgdrvfact/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/xorgdrvfact/actor.py
@@ -1,0 +1,28 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.xorgdriverlib import check_drv_and_options, get_xorg_logs_from_journal
+from leapp.libraries.stdlib import api
+from leapp.models import XorgDrvFacts
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class XorgDrvFacts8to9(Actor):
+    """
+    Check the journal logs for deprecated Xorg drivers.
+
+    This actor checks the journal logs and looks for deprecated Xorg drivers.
+    """
+
+    name = 'xorgdrvfacts8to9'
+    consumes = ()
+    produces = (XorgDrvFacts,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        xorg_logs = get_xorg_logs_from_journal()
+        deprecated_drivers = []
+        for driver in ['RADEON', 'ATI', 'AMDGPU', 'MACH64', 'intel', 'spiceqxl', 'qxl', 'NOUVEAU', 'NV', 'VESA']:
+            deprecated_driver = check_drv_and_options(driver, xorg_logs)
+            if deprecated_driver:
+                deprecated_drivers.append(deprecated_driver)
+
+        api.produce(XorgDrvFacts(xorg_drivers=deprecated_drivers))

--- a/repos/system_upgrade/el8toel9/actors/xorgdrvfact/libraries/xorgdriverlib.py
+++ b/repos/system_upgrade/el8toel9/actors/xorgdrvfact/libraries/xorgdriverlib.py
@@ -1,0 +1,36 @@
+#
+# Helper functions
+#
+
+import re
+
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import XorgDrv
+
+
+def check_drv_and_options(driver, logs):
+    regex_driver = re.compile(''.join([driver, '.*DPI set to']))
+    regex_options = re.compile(''.join([r'\(\*\*\)', '.*', driver]))
+    has_driver = False
+    has_options = False
+
+    for line in logs:
+        if re.search(regex_driver, line):
+            has_driver = True
+        if re.search(regex_options, line):
+            has_options = True
+
+    if not has_driver:
+        return None
+
+    return XorgDrv(driver=driver, has_options=has_options)
+
+
+def get_xorg_logs_from_journal():
+    try:
+        output = run(['/usr/bin/journalctl', '/usr/libexec/Xorg', '-o', 'cat', '-b', '0'], split=True)
+    except CalledProcessError:
+        api.current_logger().debug('No Xorg logs found in journal.')
+        return []
+
+    return output['stdout']

--- a/repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/files/journalctl-xorg-intel
+++ b/repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/files/journalctl-xorg-intel
@@ -1,0 +1,461 @@
+(--) Log file renamed from "/home/johndoe/.local/share/xorg/Xorg.pid-1694.log" to "/home/johndoe/.local/share/xorg/Xorg.0.log"
+X.Org X Server 1.20.11
+X Protocol Version 11, Revision 0
+Build Operating System:  4.18.0-305.17.1.el8_4.x86_64
+Current Operating System: Linux el8 4.18.0-409.el8.x86_64 #1 SMP Tue Jul 12 00:42:37 EDT 2022 x86_64
+Kernel command line: BOOT_IMAGE=(hd0,msdos1)/vmlinuz-4.18.0-409.el8.x86_64 root=/dev/mapper/rhel_el8-root ro resume=/dev/mapper/rhel_el8-swap rd.lvm.lv=rhel_el8/root rd.lvm.lv=rhel_el8/swap rhgb quiet
+Build Date: 09 June 2022  04:30:21PM
+Build ID: xorg-x11-server 1.20.11-8.el8
+Current version of pixman: 0.38.4
+	Before reporting problems, check http://wiki.x.org
+	to make sure that you have the latest version.
+Markers: (--) probed, (**) from config file, (==) default setting,
+	(++) from command line, (!!) notice, (II) informational,
+	(WW) warning, (EE) error, (NI) not implemented, (??) unknown.
+(==) Log file: "/home/johndoe/.local/share/xorg/Xorg.2.log", Time: Wed May 10 10:21:00 2023
+(==) Using config directory: "/etc/X11/xorg.conf.d"
+(==) Using system config directory "/usr/share/X11/xorg.conf.d"
+(==) No Layout section.  Using the first Screen section.
+(==) No screen section available. Using defaults.
+(**) |-->Screen "Default Screen Section" (0)
+(**) |   |-->Monitor "<default monitor>"
+(==) No device specified for screen "Default Screen Section".
+	Using the first device section listed.
+(**) |   |-->Device "Intel Graphics"
+(==) No monitor specified for screen "Default Screen Section".
+	Using a default monitor configuration.
+(==) Automatically adding devices
+(==) Automatically enabling devices
+(==) Automatically adding GPU devices
+(==) Automatically binding GPU devices
+(==) Max clients allowed: 256, resource mask: 0x1fffff
+(==) FontPath set to:
+	catalogue:/etc/X11/fontpath.d,
+	built-ins
+(==) ModulePath set to "/usr/lib64/xorg/modules"
+(II) The server relies on udev to provide the list of input devices.
+	If no devices become available, reconfigure udev or disable AutoAddDevices.
+(II) Loader magic: 0x564b9143fa80
+(II) Module ABI versions:
+	X.Org ANSI C Emulation: 0.4
+	X.Org Video Driver: 24.1
+	X.Org XInput driver : 24.1
+	X.Org Server Extension : 10.0
+(++) using VT number 3
+(II) systemd-logind: took control of session /org/freedesktop/login1/session/_37
+(II) xfree86: Adding drm device (/dev/dri/card0)
+(II) systemd-logind: got fd for /dev/dri/card0 226:0 fd 16 paused 0
+(--) PCI:*(0@0:2:0) 8086:5917:17aa:2258 rev 7, Mem @ 0xeb000000/16777216, 0xa0000000/268435456, I/O @ 0x0000e000/64, BIOS @ 0x????????/65536
+(II) LoadModule: "glx"
+(II) Loading /usr/lib64/xorg/modules/extensions/libglx.so
+(II) Module glx: vendor="X.Org Foundation"
+	compiled for 1.20.14, module version = 1.0.0
+	ABI class: X.Org Server Extension, version 10.0
+(II) LoadModule: "intel"
+(II) Loading /usr/lib64/xorg/modules/drivers/intel_drv.so
+(II) Module intel: vendor="X.Org Foundation"
+	compiled for 1.20.14, module version = 2.99.917
+	Module class: X.Org Video Driver
+	ABI class: X.Org Video Driver, version 24.1
+(II) intel: Driver for Intel(R) Integrated Graphics Chipsets:
+	i810, i810-dc100, i810e, i815, i830M, 845G, 854, 852GM/855GM, 865G,
+	915G, E7221 (i915), 915GM, 945G, 945GM, 945GME, Pineview GM,
+	Pineview G, 965G, G35, 965Q, 946GZ, 965GM, 965GME/GLE, G33, Q35, Q33,
+	GM45, 4 Series, G45/G43, Q45/Q43, G41, B43
+(II) intel: Driver for Intel(R) HD Graphics
+(II) intel: Driver for Intel(R) Iris(TM) Graphics
+(II) intel: Driver for Intel(R) Iris(TM) Pro Graphics
+(II) intel(0): Using Kernel Mode Setting driver: i915, version 1.6.0 20201103
+(WW) VGA arbiter: cannot open kernel arbiter, no multi-card support
+(--) intel(0): gen9 engineering sample
+(--) intel(0): CPU: x86-64, sse2, sse3, ssse3, sse4.1, sse4.2, avx, avx2; using a maximum of 4 threads
+(II) intel(0): Creating default Display subsection in Screen section
+	"Default Screen Section" for depth/fbbpp 24/32
+(==) intel(0): Depth 24, (--) framebuffer bpp 32
+(==) intel(0): RGB weight 888
+(==) intel(0): Default visual is TrueColor
+(**) intel(0): Option "DRI" "3"
+(**) intel(0): Option "TearFree" "true"
+(II) intel(0): Output eDP1 has no monitor section
+(**) intel(0): Found backlight control interface intel_backlight (type 'raw') for output eDP1
+(II) intel(0): Enabled output eDP1
+(II) intel(0): Output DP1 has no monitor section
+(II) intel(0): Enabled output DP1
+(II) intel(0): Output HDMI1 has no monitor section
+(II) intel(0): Enabled output HDMI1
+(II) intel(0): Output DP2 has no monitor section
+(II) intel(0): Enabled output DP2
+(II) intel(0): Output HDMI2 has no monitor section
+(II) intel(0): Enabled output HDMI2
+(II) intel(0): Output DP1-1 has no monitor section
+(II) intel(0): Enabled output DP1-1
+(II) intel(0): Output DP1-2 has no monitor section
+(II) intel(0): Enabled output DP1-2
+(II) intel(0): Output DP1-3 has no monitor section
+(II) intel(0): Enabled output DP1-3
+(--) intel(0): Using a maximum size of 256x256 for hardware cursors
+(II) intel(0): Output VIRTUAL1 has no monitor section
+(II) intel(0): Enabled output VIRTUAL1
+(--) intel(0): Output eDP1 using initial mode 1920x1080 on pipe 0
+(--) intel(0): Output DP1-1 using initial mode 1920x1200 on pipe 1
+(**) intel(0): TearFree enabled
+(==) intel(0): Using gamma correction (1.0, 1.0, 1.0)
+(==) intel(0): DPI set to (96, 96)
+(II) Loading sub module "dri3"
+(II) LoadModule: "dri3"
+(II) Module "dri3" already built-in
+(II) Loading sub module "dri2"
+(II) LoadModule: "dri2"
+(II) Module "dri2" already built-in
+(II) Loading sub module "present"
+(II) LoadModule: "present"
+(II) Module "present" already built-in
+(II) intel(0): SNA initialized with Kabylake (gen9) backend
+(==) intel(0): Backing store enabled
+(==) intel(0): Silken mouse enabled
+(II) intel(0): HW Cursor enabled
+(==) intel(0): DPMS enabled
+(==) intel(0): Display hotplug detection enabled
+(II) intel(0): [DRI2] Setup complete
+(II) intel(0): [DRI2]   DRI driver: i965
+(II) intel(0): [DRI2]   VDPAU driver: va_gl
+(II) intel(0): direct rendering: DRI2 DRI3 enabled
+(II) intel(0): hardware support for Present enabled
+(II) Initializing extension Generic Event Extension
+(II) Initializing extension SHAPE
+(II) Initializing extension MIT-SHM
+(II) Initializing extension XInputExtension
+(II) Initializing extension XTEST
+(II) Initializing extension BIG-REQUESTS
+(II) Initializing extension SYNC
+(II) Initializing extension XKEYBOARD
+(II) Initializing extension XC-MISC
+(II) Initializing extension SECURITY
+(II) Initializing extension XFIXES
+(II) Initializing extension RENDER
+(II) Initializing extension RANDR
+(II) Initializing extension COMPOSITE
+(II) Initializing extension DAMAGE
+(II) Initializing extension MIT-SCREEN-SAVER
+(II) Initializing extension DOUBLE-BUFFER
+(II) Initializing extension RECORD
+(II) Initializing extension DPMS
+(II) Initializing extension Present
+(II) Initializing extension DRI3
+(II) Initializing extension X-Resource
+(II) Initializing extension XVideo
+(II) Initializing extension XVideo-MotionCompensation
+(II) Initializing extension SELinux
+(II) SELinux: Disabled by boolean
+(II) Initializing extension GLX
+(EE) AIGLX error: dlopen of /usr/lib64/dri/i965_dri.so failed (/usr/lib64/dri/i965_dri.so: cannot open shared object file: No such file or directory)
+(EE) AIGLX error: unable to load driver i965
+(II) IGLX: Loaded and initialized swrast
+(II) GLX: Initialized DRISWRAST GL provider for screen 0
+(II) Initializing extension XFree86-VidModeExtension
+(II) Initializing extension XFree86-DGA
+(II) Initializing extension DRI2
+(II) intel(0): switch to mode 1920x1080@60.0 on eDP1 using pipe 0, position (0, 0), rotation normal, reflection none
+(II) intel(0): switch to mode 1920x1200@60.0 on DP1-1 using pipe 1, position (0, 0), rotation normal, reflection none
+(II) intel(0): Setting screen physical size to 508 x 317
+(II) config/udev: Adding input device Power Button (/dev/input/event2)
+(**) Power Button: Applying InputClass "evdev keyboard catchall"
+(**) Power Button: Applying InputClass "libinput keyboard catchall"
+(**) Power Button: Applying InputClass "system-keyboard"
+(II) LoadModule: "libinput"
+(II) Loading /usr/lib64/xorg/modules/input/libinput_drv.so
+(II) Module libinput: vendor="X.Org Foundation"
+	compiled for 1.20.14, module version = 1.3.0
+	Module class: X.Org XInput Driver
+	ABI class: X.Org XInput driver, version 24.1
+(II) Using input driver 'libinput' for 'Power Button'
+(II) systemd-logind: got fd for /dev/input/event2 13:66 fd 26 paused 0
+(**) Power Button: always reports core events
+(**) Option "Device" "/dev/input/event2"
+(II) event2  - Power Button: is tagged by udev as: Keyboard
+(II) event2  - Power Button: device is a keyboard
+(II) event2  - Power Button: device removed
+(**) Option "config_info" "udev:/sys/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2/event2"
+(II) XINPUT: Adding extended input device "Power Button" (type: KEYBOARD, id 6)
+(**) Option "xkb_layout" "gb,fr"
+(**) Option "xkb_variant" ",oss"
+(II) event2  - Power Button: is tagged by udev as: Keyboard
+(II) event2  - Power Button: device is a keyboard
+(II) config/udev: Adding input device Video Bus (/dev/input/event10)
+(**) Video Bus: Applying InputClass "evdev keyboard catchall"
+(**) Video Bus: Applying InputClass "libinput keyboard catchall"
+(**) Video Bus: Applying InputClass "system-keyboard"
+(II) Using input driver 'libinput' for 'Video Bus'
+(II) systemd-logind: got fd for /dev/input/event10 13:74 fd 29 paused 0
+(**) Video Bus: always reports core events
+(**) Option "Device" "/dev/input/event10"
+(II) event10 - Video Bus: is tagged by udev as: Keyboard
+(II) event10 - Video Bus: device is a keyboard
+(II) event10 - Video Bus: device removed
+(**) Option "config_info" "udev:/sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/LNXVIDEO:00/input/input11/event10"
+(II) XINPUT: Adding extended input device "Video Bus" (type: KEYBOARD, id 7)
+(**) Option "xkb_layout" "gb,fr"
+(**) Option "xkb_variant" ",oss"
+(II) event10 - Video Bus: is tagged by udev as: Keyboard
+(II) event10 - Video Bus: device is a keyboard
+(II) config/udev: Adding input device Lid Switch (/dev/input/event1)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device Sleep Button (/dev/input/event0)
+(**) Sleep Button: Applying InputClass "evdev keyboard catchall"
+(**) Sleep Button: Applying InputClass "libinput keyboard catchall"
+(**) Sleep Button: Applying InputClass "system-keyboard"
+(II) Using input driver 'libinput' for 'Sleep Button'
+(II) systemd-logind: got fd for /dev/input/event0 13:64 fd 30 paused 0
+(**) Sleep Button: always reports core events
+(**) Option "Device" "/dev/input/event0"
+(II) event0  - Sleep Button: is tagged by udev as: Keyboard
+(II) event0  - Sleep Button: device is a keyboard
+(II) event0  - Sleep Button: device removed
+(**) Option "config_info" "udev:/sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0C0E:00/input/input0/event0"
+(II) XINPUT: Adding extended input device "Sleep Button" (type: KEYBOARD, id 8)
+(**) Option "xkb_layout" "gb,fr"
+(**) Option "xkb_variant" ",oss"
+(II) event0  - Sleep Button: is tagged by udev as: Keyboard
+(II) event0  - Sleep Button: device is a keyboard
+(II) config/udev: Adding input device Yubico Yubico Yubikey II (/dev/input/event4)
+(**) Yubico Yubico Yubikey II: Applying InputClass "evdev keyboard catchall"
+(**) Yubico Yubico Yubikey II: Applying InputClass "libinput keyboard catchall"
+(**) Yubico Yubico Yubikey II: Applying InputClass "system-keyboard"
+(II) Using input driver 'libinput' for 'Yubico Yubico Yubikey II'
+(II) systemd-logind: got fd for /dev/input/event4 13:68 fd 31 paused 0
+(**) Yubico Yubico Yubikey II: always reports core events
+(**) Option "Device" "/dev/input/event4"
+(II) event4  - Yubico Yubico Yubikey II: is tagged by udev as: Keyboard
+(II) event4  - Yubico Yubico Yubikey II: device is a keyboard
+(II) event4  - Yubico Yubico Yubikey II: device removed
+(**) Option "config_info" "udev:/sys/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1:1.0/0003:1050:0010.0001/input/input6/event4"
+(II) XINPUT: Adding extended input device "Yubico Yubico Yubikey II" (type: KEYBOARD, id 9)
+(**) Option "xkb_layout" "gb,fr"
+(**) Option "xkb_variant" ",oss"
+(II) event4  - Yubico Yubico Yubikey II: is tagged by udev as: Keyboard
+(II) event4  - Yubico Yubico Yubikey II: device is a keyboard
+(II) config/udev: Adding input device Integrated Camera: Integrated C (/dev/input/event17)
+(**) Integrated Camera: Integrated C: Applying InputClass "evdev keyboard catchall"
+(**) Integrated Camera: Integrated C: Applying InputClass "libinput keyboard catchall"
+(**) Integrated Camera: Integrated C: Applying InputClass "system-keyboard"
+(II) Using input driver 'libinput' for 'Integrated Camera: Integrated C'
+(II) systemd-logind: got fd for /dev/input/event17 13:81 fd 32 paused 0
+(**) Integrated Camera: Integrated C: always reports core events
+(**) Option "Device" "/dev/input/event17"
+(II) event17 - Integrated Camera: Integrated C: is tagged by udev as: Keyboard
+(II) event17 - Integrated Camera: Integrated C: device is a keyboard
+(II) event17 - Integrated Camera: Integrated C: device removed
+(**) Option "config_info" "udev:/sys/devices/pci0000:00/0000:00:14.0/usb1/1-8/1-8:1.0/input/input22/event17"
+(II) XINPUT: Adding extended input device "Integrated Camera: Integrated C" (type: KEYBOARD, id 10)
+(**) Option "xkb_layout" "gb,fr"
+(**) Option "xkb_variant" ",oss"
+(II) event17 - Integrated Camera: Integrated C: is tagged by udev as: Keyboard
+(II) event17 - Integrated Camera: Integrated C: device is a keyboard
+(II) config/udev: Adding input device Lenovo ThinkPad Thunderbolt 3 Dock USB Audio (/dev/input/event6)
+(**) Lenovo ThinkPad Thunderbolt 3 Dock USB Audio: Applying InputClass "evdev keyboard catchall"
+(**) Lenovo ThinkPad Thunderbolt 3 Dock USB Audio: Applying InputClass "libinput keyboard catchall"
+(**) Lenovo ThinkPad Thunderbolt 3 Dock USB Audio: Applying InputClass "system-keyboard"
+(II) Using input driver 'libinput' for 'Lenovo ThinkPad Thunderbolt 3 Dock USB Audio'
+(II) systemd-logind: got fd for /dev/input/event6 13:70 fd 33 paused 0
+(**) Lenovo ThinkPad Thunderbolt 3 Dock USB Audio: always reports core events
+(**) Option "Device" "/dev/input/event6"
+(II) event6  - Lenovo ThinkPad Thunderbolt 3 Dock USB Audio: is tagged by udev as: Keyboard
+(II) event6  - Lenovo ThinkPad Thunderbolt 3 Dock USB Audio: device is a keyboard
+(II) event6  - Lenovo ThinkPad Thunderbolt 3 Dock USB Audio: device removed
+(**) Option "config_info" "udev:/sys/devices/pci0000:00/0000:00:1c.4/0000:04:00.0/0000:05:01.0/0000:07:00.0/0000:08:00.0/0000:09:00.0/usb3/3-1/3-1:1.3/0003:17EF:306A.0003/input/input8/event6"
+(II) XINPUT: Adding extended input device "Lenovo ThinkPad Thunderbolt 3 Dock USB Audio" (type: KEYBOARD, id 11)
+(**) Option "xkb_layout" "gb,fr"
+(**) Option "xkb_variant" ",oss"
+(II) event6  - Lenovo ThinkPad Thunderbolt 3 Dock USB Audio: is tagged by udev as: Keyboard
+(II) event6  - Lenovo ThinkPad Thunderbolt 3 Dock USB Audio: device is a keyboard
+(II) config/udev: Adding input device USB OPTICAL MOUSE  (/dev/input/event5)
+(**) USB OPTICAL MOUSE : Applying InputClass "evdev pointer catchall"
+(**) USB OPTICAL MOUSE : Applying InputClass "libinput pointer catchall"
+(II) Using input driver 'libinput' for 'USB OPTICAL MOUSE '
+(II) systemd-logind: got fd for /dev/input/event5 13:69 fd 34 paused 0
+(**) USB OPTICAL MOUSE : always reports core events
+(**) Option "Device" "/dev/input/event5"
+(II) event5  - USB OPTICAL MOUSE : is tagged by udev as: Mouse
+(II) event5  - USB OPTICAL MOUSE : device is a pointer
+(II) event5  - USB OPTICAL MOUSE : device removed
+(II) libinput: USB OPTICAL MOUSE : Step value 0 was provided, libinput Fallback acceleration function is used.
+(II) libinput: USB OPTICAL MOUSE : Step value 0 was provided, libinput Fallback acceleration function is used.
+(II) libinput: USB OPTICAL MOUSE : Step value 0 was provided, libinput Fallback acceleration function is used.
+(**) Option "config_info" "udev:/sys/devices/pci0000:00/0000:00:1c.4/0000:04:00.0/0000:05:01.0/0000:07:00.0/0000:08:02.0/0000:0b:00.0/usb5/5-3/5-3:1.0/0003:30FA:0400.0002/input/input7/event5"
+(II) XINPUT: Adding extended input device "USB OPTICAL MOUSE " (type: MOUSE, id 12)
+(**) Option "AccelerationScheme" "none"
+(**) USB OPTICAL MOUSE : (accel) selected scheme none/0
+(**) USB OPTICAL MOUSE : (accel) acceleration factor: 2.000
+(**) USB OPTICAL MOUSE : (accel) acceleration threshold: 4
+(II) event5  - USB OPTICAL MOUSE : is tagged by udev as: Mouse
+(II) event5  - USB OPTICAL MOUSE : device is a pointer
+(II) config/udev: Adding input device USB OPTICAL MOUSE  (/dev/input/mouse0)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device HID 046a:0011 (/dev/input/event9)
+(**) HID 046a:0011: Applying InputClass "evdev keyboard catchall"
+(**) HID 046a:0011: Applying InputClass "libinput keyboard catchall"
+(**) HID 046a:0011: Applying InputClass "system-keyboard"
+(II) Using input driver 'libinput' for 'HID 046a:0011'
+(II) systemd-logind: got fd for /dev/input/event9 13:73 fd 35 paused 0
+(**) HID 046a:0011: always reports core events
+(**) Option "Device" "/dev/input/event9"
+(II) event9  - HID 046a:0011: is tagged by udev as: Keyboard
+(II) event9  - HID 046a:0011: device is a keyboard
+(II) event9  - HID 046a:0011: device removed
+(**) Option "config_info" "udev:/sys/devices/pci0000:00/0000:00:1c.4/0000:04:00.0/0000:05:01.0/0000:07:00.0/0000:08:02.0/0000:0b:00.0/usb5/5-4/5-4:1.0/0003:046A:0011.0004/input/input10/event9"
+(II) XINPUT: Adding extended input device "HID 046a:0011" (type: KEYBOARD, id 13)
+(**) Option "xkb_layout" "gb,fr"
+(**) Option "xkb_variant" ",oss"
+(II) event9  - HID 046a:0011: is tagged by udev as: Keyboard
+(II) event9  - HID 046a:0011: device is a keyboard
+(II) config/udev: Adding input device HDA Intel PCH Mic (/dev/input/event8)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device HDA Intel PCH Headphone (/dev/input/event11)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device HDA Intel PCH HDMI/DP,pcm=3 (/dev/input/event12)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device HDA Intel PCH HDMI/DP,pcm=7 (/dev/input/event13)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device HDA Intel PCH HDMI/DP,pcm=8 (/dev/input/event14)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device Elan Touchpad (/dev/input/event15)
+(**) Elan Touchpad: Applying InputClass "evdev touchpad catchall"
+(**) Elan Touchpad: Applying InputClass "libinput touchpad catchall"
+(II) Using input driver 'libinput' for 'Elan Touchpad'
+(II) systemd-logind: got fd for /dev/input/event15 13:79 fd 36 paused 0
+(**) Elan Touchpad: always reports core events
+(**) Option "Device" "/dev/input/event15"
+(II) event15 - Elan Touchpad: is tagged by udev as: Touchpad
+(II) event15 - Elan Touchpad: device is a touchpad
+(II) event15 - Elan Touchpad: device removed
+(II) libinput: Elan Touchpad: Step value 0 was provided, libinput Fallback acceleration function is used.
+(II) libinput: Elan Touchpad: Step value 0 was provided, libinput Fallback acceleration function is used.
+(II) libinput: Elan Touchpad: Step value 0 was provided, libinput Fallback acceleration function is used.
+(**) Option "config_info" "udev:/sys/devices/pci0000:00/0000:00:1f.4/i2c-8/8-0015/input/input20/event15"
+(II) XINPUT: Adding extended input device "Elan Touchpad" (type: TOUCHPAD, id 14)
+(**) Option "AccelerationScheme" "none"
+(**) Elan Touchpad: (accel) selected scheme none/0
+(**) Elan Touchpad: (accel) acceleration factor: 2.000
+(**) Elan Touchpad: (accel) acceleration threshold: 4
+(II) event15 - Elan Touchpad: is tagged by udev as: Touchpad
+(II) event15 - Elan Touchpad: device is a touchpad
+(II) config/udev: Adding input device Elan Touchpad (/dev/input/mouse1)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device Elan TrackPoint (/dev/input/event16)
+(**) Elan TrackPoint: Applying InputClass "evdev pointer catchall"
+(**) Elan TrackPoint: Applying InputClass "libinput pointer catchall"
+(II) Using input driver 'libinput' for 'Elan TrackPoint'
+(II) systemd-logind: got fd for /dev/input/event16 13:80 fd 37 paused 0
+(**) Elan TrackPoint: always reports core events
+(**) Option "Device" "/dev/input/event16"
+(II) event16 - Elan TrackPoint: is tagged by udev as: Mouse Pointingstick
+(II) event16 - Elan TrackPoint: device is a pointer
+(II) event16 - Elan TrackPoint: device removed
+(II) libinput: Elan TrackPoint: Step value 0 was provided, libinput Fallback acceleration function is used.
+(II) libinput: Elan TrackPoint: Step value 0 was provided, libinput Fallback acceleration function is used.
+(II) libinput: Elan TrackPoint: Step value 0 was provided, libinput Fallback acceleration function is used.
+(**) Option "config_info" "udev:/sys/devices/pci0000:00/0000:00:1f.4/i2c-8/8-0015/input/input21/event16"
+(II) XINPUT: Adding extended input device "Elan TrackPoint" (type: MOUSE, id 15)
+(**) Option "AccelerationScheme" "none"
+(**) Elan TrackPoint: (accel) selected scheme none/0
+(**) Elan TrackPoint: (accel) acceleration factor: 2.000
+(**) Elan TrackPoint: (accel) acceleration threshold: 4
+(II) event16 - Elan TrackPoint: is tagged by udev as: Mouse Pointingstick
+(II) event16 - Elan TrackPoint: device is a pointer
+(II) config/udev: Adding input device Elan TrackPoint (/dev/input/mouse2)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device AT Translated Set 2 keyboard (/dev/input/event3)
+(**) AT Translated Set 2 keyboard: Applying InputClass "evdev keyboard catchall"
+(**) AT Translated Set 2 keyboard: Applying InputClass "libinput keyboard catchall"
+(**) AT Translated Set 2 keyboard: Applying InputClass "system-keyboard"
+(II) Using input driver 'libinput' for 'AT Translated Set 2 keyboard'
+(II) systemd-logind: got fd for /dev/input/event3 13:67 fd 38 paused 0
+(**) AT Translated Set 2 keyboard: always reports core events
+(**) Option "Device" "/dev/input/event3"
+(II) event3  - AT Translated Set 2 keyboard: is tagged by udev as: Keyboard
+(II) event3  - AT Translated Set 2 keyboard: device is a keyboard
+(II) event3  - AT Translated Set 2 keyboard: device removed
+(**) Option "config_info" "udev:/sys/devices/platform/i8042/serio0/input/input3/event3"
+(II) XINPUT: Adding extended input device "AT Translated Set 2 keyboard" (type: KEYBOARD, id 16)
+(**) Option "xkb_layout" "gb,fr"
+(**) Option "xkb_variant" ",oss"
+(II) event3  - AT Translated Set 2 keyboard: is tagged by udev as: Keyboard
+(II) event3  - AT Translated Set 2 keyboard: device is a keyboard
+(II) config/udev: Adding input device ThinkPad Extra Buttons (/dev/input/event7)
+(**) ThinkPad Extra Buttons: Applying InputClass "evdev keyboard catchall"
+(**) ThinkPad Extra Buttons: Applying InputClass "libinput keyboard catchall"
+(**) ThinkPad Extra Buttons: Applying InputClass "system-keyboard"
+(II) Using input driver 'libinput' for 'ThinkPad Extra Buttons'
+(II) systemd-logind: got fd for /dev/input/event7 13:71 fd 39 paused 0
+(**) ThinkPad Extra Buttons: always reports core events
+(**) Option "Device" "/dev/input/event7"
+(II) event7  - ThinkPad Extra Buttons: is tagged by udev as: Keyboard Switch
+(II) event7  - ThinkPad Extra Buttons: device is a keyboard
+(II) event7  - ThinkPad Extra Buttons: device removed
+(**) Option "config_info" "udev:/sys/devices/platform/thinkpad_acpi/input/input12/event7"
+(II) XINPUT: Adding extended input device "ThinkPad Extra Buttons" (type: KEYBOARD, id 17)
+(**) Option "xkb_layout" "gb,fr"
+(**) Option "xkb_variant" ",oss"
+(II) event7  - ThinkPad Extra Buttons: is tagged by udev as: Keyboard Switch
+(II) event7  - ThinkPad Extra Buttons: device is a keyboard
+(II) intel(0): EDID vendor "CMN", prod id 5321
+(II) intel(0): Printing DDC gathered Modelines:
+(II) intel(0): Modeline "1920x1080"x0.0  152.84  1920 2000 2060 2250  1080 1086 1094 1132 -hsync -vsync (67.9 kHz eP)
+(**) Option "fd" "26"
+(II) event2  - Power Button: device removed
+(**) Option "fd" "29"
+(II) event10 - Video Bus: device removed
+(**) Option "fd" "30"
+(II) event0  - Sleep Button: device removed
+(**) Option "fd" "31"
+(II) event4  - Yubico Yubico Yubikey II: device removed
+(**) Option "fd" "32"
+(II) event17 - Integrated Camera: Integrated C: device removed
+(**) Option "fd" "33"
+(II) event6  - Lenovo ThinkPad Thunderbolt 3 Dock USB Audio: device removed
+(**) Option "fd" "34"
+(II) event5  - USB OPTICAL MOUSE : device removed
+(**) Option "fd" "35"
+(II) event9  - HID 046a:0011: device removed
+(**) Option "fd" "36"
+(II) event15 - Elan Touchpad: device removed
+(**) Option "fd" "37"
+(II) event16 - Elan TrackPoint: device removed
+(**) Option "fd" "38"
+(II) event3  - AT Translated Set 2 keyboard: device removed
+(**) Option "fd" "39"
+(II) event7  - ThinkPad Extra Buttons: device removed
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:71
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:67
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:80
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:79
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:73
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:69
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:70
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:81
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:68
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:64
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:74
+(II) UnloadModule: "libinput"
+(II) systemd-logind: releasing fd for 13:66
+(II) Server terminated successfully (0). Closing log file.

--- a/repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/files/journalctl-xorg-qxl
+++ b/repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/files/journalctl-xorg-qxl
@@ -1,0 +1,309 @@
+(--) Log file renamed from "/home/johndoe/.local/share/xorg/Xorg.pid-1694.log" to "/home/johndoe/.local/share/xorg/Xorg.0.log"
+X.Org X Server 1.20.11
+X Protocol Version 11, Revision 0
+Build Operating System:  4.18.0-305.17.1.el8_4.x86_64
+Current Operating System: Linux el8 4.18.0-409.el8.x86_64 #1 SMP Tue Jul 12 00:42:37 EDT 2022 x86_64
+Kernel command line: BOOT_IMAGE=(hd0,msdos1)/vmlinuz-4.18.0-409.el8.x86_64 root=/dev/mapper/rhel_el8-root ro resume=/dev/mapper/rhel_el8-swap rd.lvm.lv=rhel_el8/root rd.lvm.lv=rhel_el8/swap rhgb quiet
+Build Date: 09 June 2022  04:30:21PM
+Build ID: xorg-x11-server 1.20.11-8.el8
+Current version of pixman: 0.38.4
+	Before reporting problems, check http://wiki.x.org
+	to make sure that you have the latest version.
+Markers: (--) probed, (**) from config file, (==) default setting,
+	(++) from command line, (!!) notice, (II) informational,
+	(WW) warning, (EE) error, (NI) not implemented, (??) unknown.
+(==) Log file: "/home/johndoe/.local/share/xorg/Xorg.2.log", Time: Wed May 10 10:21:00 2023
+(==) Using config directory: "/etc/X11/xorg.conf.d"
+(==) Using system config directory "/usr/share/X11/xorg.conf.d"
+(==) No Layout section.  Using the first Screen section.
+(==) No screen section available. Using defaults.
+(**) |-->Screen "Default Screen Section" (0)
+(**) |   |-->Monitor "<default monitor>"
+(==) No monitor specified for screen "Default Screen Section".
+	Using a default monitor configuration.
+(==) Automatically adding devices
+(==) Automatically enabling devices
+(==) Automatically adding GPU devices
+(==) Automatically binding GPU devices
+(==) Max clients allowed: 256, resource mask: 0x1fffff
+(==) FontPath set to:
+	catalogue:/etc/X11/fontpath.d,
+	built-ins
+(==) ModulePath set to "/usr/lib64/xorg/modules"
+(II) The server relies on udev to provide the list of input devices.
+	If no devices become available, reconfigure udev or disable AutoAddDevices.
+(II) Loader magic: 0x56380b065020
+(II) Module ABI versions:
+	X.Org ANSI C Emulation: 0.4
+	X.Org Video Driver: 24.1
+	X.Org XInput driver : 24.1
+	X.Org Server Extension : 10.0
+(++) using VT number 2
+(II) systemd-logind: took control of session /org/freedesktop/login1/session/_32
+(II) xfree86: Adding drm device (/dev/dri/card0)
+(II) Platform probe for /sys/devices/pci0000:00/0000:00:02.0/drm/card0
+(II) systemd-logind: got fd for /dev/dri/card0 226:0 fd 12 paused 0
+(--) PCI:*(0@0:2:0) 1b36:0100:1af4:1100 rev 4, Mem @ 0xf4000000/67108864, 0xf8000000/67108864, 0xfc054000/8192, I/O @ 0x0000c080/32, BIOS @ 0x????????/65536
+(II) LoadModule: "glx"
+(II) Loading /usr/lib64/xorg/modules/extensions/libglx.so
+(II) Module glx: vendor="X.Org Foundation"
+	compiled for 1.20.11, module version = 1.0.0
+	ABI class: X.Org Server Extension, version 10.0
+(==) Matched qxl as autoconfigured driver 0
+(==) Matched modesetting as autoconfigured driver 1
+(==) Matched fbdev as autoconfigured driver 2
+(==) Matched vesa as autoconfigured driver 3
+(==) Assigned the driver to the xf86ConfigLayout
+(II) LoadModule: "qxl"
+(II) Loading /usr/lib64/xorg/modules/drivers/qxl_drv.so
+(II) Module qxl: vendor="X.Org Foundation"
+	compiled for 1.20.3, module version = 0.1.5
+	Module class: X.Org Video Driver
+	ABI class: X.Org Video Driver, version 24.0
+(II) LoadModule: "modesetting"
+(II) Loading /usr/lib64/xorg/modules/drivers/modesetting_drv.so
+(II) Module modesetting: vendor="X.Org Foundation"
+	compiled for 1.20.11, module version = 1.20.11
+	Module class: X.Org Video Driver
+	ABI class: X.Org Video Driver, version 24.1
+(II) LoadModule: "fbdev"
+(II) Loading /usr/lib64/xorg/modules/drivers/fbdev_drv.so
+(II) Module fbdev: vendor="X.Org Foundation"
+	compiled for 1.20.1, module version = 0.5.0
+	Module class: X.Org Video Driver
+	ABI class: X.Org Video Driver, version 24.0
+(II) LoadModule: "vesa"
+(II) Loading /usr/lib64/xorg/modules/drivers/vesa_drv.so
+(II) Module vesa: vendor="X.Org Foundation"
+	compiled for 1.20.2, module version = 2.4.0
+	Module class: X.Org Video Driver
+	ABI class: X.Org Video Driver, version 24.0
+(II) qxl: Driver for QXL virtual graphics: QXL 1
+(II) modesetting: Driver for Modesetting Kernel Drivers: kms
+(II) FBDEV: driver for framebuffer: fbdev
+(II) VESA: driver for VESA chipsets: vesa
+xf86EnableIOPorts: failed to set IOPL for I/O (Operation not permitted)
+(II) [KMS] Kernel modesetting enabled.
+(WW) Falling back to old probe method for modesetting
+(WW) Falling back to old probe method for fbdev
+(II) Loading sub module "fbdevhw"
+(II) LoadModule: "fbdevhw"
+(II) Loading /usr/lib64/xorg/modules/libfbdevhw.so
+(II) Module fbdevhw: vendor="X.Org Foundation"
+	compiled for 1.20.11, module version = 0.0.2
+	ABI class: X.Org Video Driver, version 24.1
+(EE) open /dev/fb0: Permission denied
+(WW) VGA arbiter: cannot open kernel arbiter, no multi-card support
+(II) qxl(0): Creating default Display subsection in Screen section
+	"Default Screen Section" for depth/fbbpp 24/32
+(==) qxl(0): Depth 24, (--) framebuffer bpp 32
+(==) qxl(0): RGB weight 888
+(==) qxl(0): Default visual is TrueColor
+(==) qxl(0): Using gamma correction (1.0, 1.0, 1.0)
+(II) qxl(0): Deferred Frames: Disabled
+(II) qxl(0): Offscreen Surfaces: Enabled
+(II) qxl(0): Image Cache: Enabled
+(II) qxl(0): Fallback Cache: Enabled
+(==) qxl(0): DPI set to (96, 96)
+(II) Loading sub module "fb"
+(II) LoadModule: "fb"
+(II) Loading /usr/lib64/xorg/modules/libfb.so
+(II) Module fb: vendor="X.Org Foundation"
+	compiled for 1.20.11, module version = 1.0.0
+	ABI class: X.Org ANSI C Emulation, version 0.4
+(II) Loading sub module "ramdac"
+(II) LoadModule: "ramdac"
+(II) Module "ramdac" already built-in
+(II) qxl(0): Output Virtual-0 has no monitor section
+(II) qxl(0): Output Virtual-1 has no monitor section
+(II) qxl(0): Output Virtual-2 has no monitor section
+(II) qxl(0): Output Virtual-3 has no monitor section
+(II) qxl(0): EDID for output Virtual-0
+(II) qxl(0): Printing probed modes for output Virtual-0
+(II) qxl(0): Modeline "1024x768"x60.0   65.00  1024 1048 1184 1344  768 771 777 806 -hsync -vsync (48.4 kHz eP)
+(II) qxl(0): Modeline "2560x1600"x60.0  348.50  2560 2752 3032 3504  1600 1603 1609 1658 -hsync +vsync (99.5 kHz e)
+(II) qxl(0): Modeline "2560x1600"x60.0  268.50  2560 2608 2640 2720  1600 1603 1609 1646 +hsync -vsync (98.7 kHz e)
+(II) qxl(0): Modeline "1920x1440"x60.0  234.00  1920 2048 2256 2600  1440 1441 1444 1500 -hsync +vsync (90.0 kHz e)
+(II) qxl(0): Modeline "1856x1392"x60.0  218.25  1856 1952 2176 2528  1392 1393 1396 1439 -hsync +vsync (86.3 kHz e)
+(II) qxl(0): Modeline "1792x1344"x60.0  204.75  1792 1920 2120 2448  1344 1345 1348 1394 -hsync +vsync (83.6 kHz e)
+(II) qxl(0): Modeline "2048x1152"x60.0  162.00  2048 2074 2154 2250  1152 1153 1156 1200 +hsync +vsync (72.0 kHz e)
+(II) qxl(0): Modeline "1920x1200"x59.9  193.25  1920 2056 2256 2592  1200 1203 1209 1245 -hsync +vsync (74.6 kHz e)
+(II) qxl(0): Modeline "1920x1200"x60.0  154.00  1920 1968 2000 2080  1200 1203 1209 1235 +hsync -vsync (74.0 kHz e)
+(II) qxl(0): Modeline "1920x1080"x60.0  148.50  1920 2008 2052 2200  1080 1084 1089 1125 -hsync -vsync (67.5 kHz e)
+(II) qxl(0): Modeline "1600x1200"x60.0  162.00  1600 1664 1856 2160  1200 1201 1204 1250 +hsync +vsync (75.0 kHz e)
+(II) qxl(0): Modeline "1680x1050"x60.0  146.25  1680 1784 1960 2240  1050 1053 1059 1089 -hsync +vsync (65.3 kHz e)
+(II) qxl(0): Modeline "1680x1050"x59.9  119.00  1680 1728 1760 1840  1050 1053 1059 1080 +hsync -vsync (64.7 kHz e)
+(II) qxl(0): Modeline "1400x1050"x60.0  121.75  1400 1488 1632 1864  1050 1053 1057 1089 -hsync +vsync (65.3 kHz e)
+(II) qxl(0): Modeline "1400x1050"x59.9  101.00  1400 1448 1480 1560  1050 1053 1057 1080 +hsync -vsync (64.7 kHz e)
+(II) qxl(0): Modeline "1600x900"x60.0  108.00  1600 1624 1704 1800  900 901 904 1000 +hsync +vsync (60.0 kHz e)
+(II) qxl(0): Modeline "1280x1024"x60.0  108.00  1280 1328 1440 1688  1024 1025 1028 1066 +hsync +vsync (64.0 kHz e)
+(II) qxl(0): Modeline "1440x900"x59.9  106.50  1440 1520 1672 1904  900 903 909 934 -hsync +vsync (55.9 kHz e)
+(II) qxl(0): Modeline "1440x900"x59.9   88.75  1440 1488 1520 1600  900 903 909 926 +hsync -vsync (55.5 kHz e)
+(II) qxl(0): Modeline "1280x960"x60.0  108.00  1280 1376 1488 1800  960 961 964 1000 +hsync +vsync (60.0 kHz e)
+(II) qxl(0): Modeline "1280x854"x60.0   89.34  1280 1352 1480 1680  854 857 867 887 -hsync +vsync (53.2 kHz)
+(II) qxl(0): Modeline "1366x768"x59.8   85.50  1366 1436 1579 1792  768 771 774 798 +hsync +vsync (47.7 kHz e)
+(II) qxl(0): Modeline "1366x768"x60.0   72.00  1366 1380 1436 1500  768 769 772 800 +hsync +vsync (48.0 kHz e)
+(II) qxl(0): Modeline "1360x768"x60.0   85.50  1360 1424 1536 1792  768 771 777 795 +hsync +vsync (47.7 kHz e)
+(II) qxl(0): Modeline "1280x800"x59.8   83.50  1280 1352 1480 1680  800 803 809 831 -hsync +vsync (49.7 kHz e)
+(II) qxl(0): Modeline "1280x800"x59.9   71.00  1280 1328 1360 1440  800 803 809 823 +hsync -vsync (49.3 kHz e)
+(II) qxl(0): Modeline "1280x768"x59.9   79.50  1280 1344 1472 1664  768 771 778 798 -hsync +vsync (47.8 kHz e)
+(II) qxl(0): Modeline "1280x768"x60.0   68.25  1280 1328 1360 1440  768 771 778 790 +hsync -vsync (47.4 kHz e)
+(II) qxl(0): Modeline "1280x720"x60.0   74.25  1280 1390 1430 1650  720 725 730 750 +hsync +vsync (45.0 kHz e)
+(II) qxl(0): Modeline "1152x768"x59.9   71.95  1152 1216 1328 1504  768 771 781 798 -hsync +vsync (47.8 kHz)
+(II) qxl(0): Modeline "800x600"x60.3   40.00  800 840 968 1056  600 601 605 628 +hsync +vsync (37.9 kHz e)
+(II) qxl(0): Modeline "800x600"x56.2   36.00  800 824 896 1024  600 601 603 625 +hsync +vsync (35.2 kHz e)
+(II) qxl(0): Modeline "848x480"x60.0   33.75  848 864 976 1088  480 486 494 517 +hsync +vsync (31.0 kHz e)
+(II) qxl(0): Modeline "720x480"x59.9   26.85  720 744 808 896  480 483 493 500 -hsync +vsync (30.0 kHz)
+(II) qxl(0): Modeline "640x480"x59.9   25.18  640 656 752 800  480 490 492 525 -hsync -vsync (31.5 kHz e)
+(II) qxl(0): EDID for output Virtual-1
+(II) qxl(0): EDID for output Virtual-2
+(II) qxl(0): EDID for output Virtual-3
+(II) qxl(0): Output Virtual-0 connected
+(II) qxl(0): Output Virtual-1 disconnected
+(II) qxl(0): Output Virtual-2 disconnected
+(II) qxl(0): Output Virtual-3 disconnected
+(II) qxl(0): Using exact sizes for initial modes
+(II) qxl(0): Output Virtual-0 using initial mode 1024x768 +0+0
+(II) qxl(0): PreInit complete
+(II) qxl(0): git commit 499e30d
+(II) UnloadModule: "modesetting"
+(II) Unloading modesetting
+(II) UnloadModule: "fbdev"
+(II) Unloading fbdev
+(II) UnloadSubModule: "fbdevhw"
+(II) Unloading fbdevhw
+(II) UnloadModule: "vesa"
+(II) Unloading vesa
+(II) UXA(0): Driver registered support for the following operations:
+(II)         solid
+(II)         copy
+(II)         composite (RENDER acceleration)
+(II)         put_image
+resizing primary to 1024x768
+primary is 0x56380ba8b930
+(II) Initializing extension Generic Event Extension
+(II) Initializing extension SHAPE
+(II) Initializing extension MIT-SHM
+(II) Initializing extension XInputExtension
+(II) Initializing extension XTEST
+(II) Initializing extension BIG-REQUESTS
+(II) Initializing extension SYNC
+(II) Initializing extension XKEYBOARD
+(II) Initializing extension XC-MISC
+(II) Initializing extension SECURITY
+(II) Initializing extension XFIXES
+(II) Initializing extension RENDER
+(II) Initializing extension RANDR
+(II) Initializing extension COMPOSITE
+(II) Initializing extension DAMAGE
+(II) Initializing extension MIT-SCREEN-SAVER
+(II) Initializing extension DOUBLE-BUFFER
+(II) Initializing extension RECORD
+(II) Initializing extension DPMS
+(II) Initializing extension Present
+(II) Initializing extension DRI3
+(II) Initializing extension X-Resource
+(II) Initializing extension XVideo
+(II) Initializing extension XVideo-MotionCompensation
+(II) Initializing extension SELinux
+(II) SELinux: Disabled on system
+(II) Initializing extension GLX
+(II) AIGLX: Screen 0 is not DRI2 capable
+(II) IGLX: Loaded and initialized swrast
+(II) GLX: Initialized DRISWRAST GL provider for screen 0
+(II) Initializing extension XFree86-VidModeExtension
+(II) Initializing extension XFree86-DGA
+(II) Initializing extension XFree86-DRI
+(II) Initializing extension DRI2
+(II) qxl(0): Setting screen physical size to 270 x 203
+(II) config/udev: Adding input device Power Button (/dev/input/event0)
+(**) Power Button: Applying InputClass "evdev keyboard catchall"
+(**) Power Button: Applying InputClass "libinput keyboard catchall"
+(**) Power Button: Applying InputClass "system-keyboard"
+(II) LoadModule: "libinput"
+(II) Loading /usr/lib64/xorg/modules/input/libinput_drv.so
+(II) Module libinput: vendor="X.Org Foundation"
+	compiled for 1.20.3, module version = 0.29.0
+	Module class: X.Org XInput Driver
+	ABI class: X.Org XInput driver, version 24.1
+(II) Using input driver 'libinput' for 'Power Button'
+(II) systemd-logind: got fd for /dev/input/event0 13:64 fd 20 paused 0
+(**) Power Button: always reports core events
+(**) Option "Device" "/dev/input/event0"
+(**) Option "_source" "server/udev"
+(II) event0  - Power Button: is tagged by udev as: Keyboard
+(II) event0  - Power Button: device is a keyboard
+(II) event0  - Power Button: device removed
+(**) Option "config_info" "udev:/sys/devices/LNXSYSTM:00/LNXPWRBN:00/input/input0/event0"
+(II) XINPUT: Adding extended input device "Power Button" (type: KEYBOARD, id 6)
+(**) Option "xkb_model" "pc105"
+(**) Option "xkb_layout" "gb"
+(**) Option "xkb_options" "terminate:ctrl_alt_bksp"
+(II) event0  - Power Button: is tagged by udev as: Keyboard
+(II) event0  - Power Button: device is a keyboard
+(II) config/udev: Adding input device QEMU QEMU USB Tablet (/dev/input/event2)
+(**) QEMU QEMU USB Tablet: Applying InputClass "evdev pointer catchall"
+(**) QEMU QEMU USB Tablet: Applying InputClass "libinput pointer catchall"
+(II) Using input driver 'libinput' for 'QEMU QEMU USB Tablet'
+(II) systemd-logind: got fd for /dev/input/event2 13:66 fd 23 paused 0
+(**) QEMU QEMU USB Tablet: always reports core events
+(**) Option "Device" "/dev/input/event2"
+(**) Option "_source" "server/udev"
+(II) event2  - QEMU QEMU USB Tablet: is tagged by udev as: Mouse
+(II) event2  - QEMU QEMU USB Tablet: device is a pointer
+(II) event2  - QEMU QEMU USB Tablet: device removed
+(**) Option "config_info" "udev:/sys/devices/pci0000:00/0000:00:05.7/usb1/1-1/1-1:1.0/0003:0627:0001.0001/input/input4/event2"
+(II) XINPUT: Adding extended input device "QEMU QEMU USB Tablet" (type: MOUSE, id 7)
+(**) Option "AccelerationScheme" "none"
+(**) QEMU QEMU USB Tablet: (accel) selected scheme none/0
+(**) QEMU QEMU USB Tablet: (accel) acceleration factor: 2.000
+(**) QEMU QEMU USB Tablet: (accel) acceleration threshold: 4
+(II) event2  - QEMU QEMU USB Tablet: is tagged by udev as: Mouse
+(II) event2  - QEMU QEMU USB Tablet: device is a pointer
+(II) config/udev: Adding input device QEMU QEMU USB Tablet (/dev/input/mouse0)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device AT Translated Set 2 keyboard (/dev/input/event1)
+(**) AT Translated Set 2 keyboard: Applying InputClass "evdev keyboard catchall"
+(**) AT Translated Set 2 keyboard: Applying InputClass "libinput keyboard catchall"
+(**) AT Translated Set 2 keyboard: Applying InputClass "system-keyboard"
+(II) Using input driver 'libinput' for 'AT Translated Set 2 keyboard'
+(II) systemd-logind: got fd for /dev/input/event1 13:65 fd 24 paused 0
+(**) AT Translated Set 2 keyboard: always reports core events
+(**) Option "Device" "/dev/input/event1"
+(**) Option "_source" "server/udev"
+(II) event1  - AT Translated Set 2 keyboard: is tagged by udev as: Keyboard
+(II) event1  - AT Translated Set 2 keyboard: device is a keyboard
+(II) event1  - AT Translated Set 2 keyboard: device removed
+(**) Option "config_info" "udev:/sys/devices/platform/i8042/serio0/input/input1/event1"
+(II) XINPUT: Adding extended input device "AT Translated Set 2 keyboard" (type: KEYBOARD, id 8)
+(**) Option "xkb_model" "pc105"
+(**) Option "xkb_layout" "gb"
+(**) Option "xkb_options" "terminate:ctrl_alt_bksp"
+(II) event1  - AT Translated Set 2 keyboard: is tagged by udev as: Keyboard
+(II) event1  - AT Translated Set 2 keyboard: device is a keyboard
+(II) config/udev: Adding input device ImExPS/2 Generic Explorer Mouse (/dev/input/event3)
+(**) ImExPS/2 Generic Explorer Mouse: Applying InputClass "evdev pointer catchall"
+(**) ImExPS/2 Generic Explorer Mouse: Applying InputClass "libinput pointer catchall"
+(II) Using input driver 'libinput' for 'ImExPS/2 Generic Explorer Mouse'
+(II) systemd-logind: got fd for /dev/input/event3 13:67 fd 25 paused 0
+(**) ImExPS/2 Generic Explorer Mouse: always reports core events
+(**) Option "Device" "/dev/input/event3"
+(**) Option "_source" "server/udev"
+(II) event3  - ImExPS/2 Generic Explorer Mouse: is tagged by udev as: Mouse
+(II) event3  - ImExPS/2 Generic Explorer Mouse: device is a pointer
+(II) event3  - ImExPS/2 Generic Explorer Mouse: device removed
+(**) Option "config_info" "udev:/sys/devices/platform/i8042/serio1/input/input3/event3"
+(II) XINPUT: Adding extended input device "ImExPS/2 Generic Explorer Mouse" (type: MOUSE, id 9)
+(**) Option "AccelerationScheme" "none"
+(**) ImExPS/2 Generic Explorer Mouse: (accel) selected scheme none/0
+(**) ImExPS/2 Generic Explorer Mouse: (accel) acceleration factor: 2.000
+(**) ImExPS/2 Generic Explorer Mouse: (accel) acceleration threshold: 4
+(II) event3  - ImExPS/2 Generic Explorer Mouse: is tagged by udev as: Mouse
+(II) event3  - ImExPS/2 Generic Explorer Mouse: device is a pointer
+(II) config/udev: Adding input device ImExPS/2 Generic Explorer Mouse (/dev/input/mouse1)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device PC Speaker (/dev/input/event4)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.

--- a/repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/files/journalctl-xorg-without-qxl
+++ b/repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/files/journalctl-xorg-without-qxl
@@ -1,0 +1,305 @@
+(--) Log file renamed from "/home/johndoe/.local/share/xorg/Xorg.pid-1677.log" to "/home/johndoe/.local/share/xorg/Xorg.0.log"
+X.Org X Server 1.20.11
+X Protocol Version 11, Revision 0
+Build Operating System:  4.18.0-305.17.1.el8_4.x86_64
+Current Operating System: Linux el8 4.18.0-409.el8.x86_64 #1 SMP Tue Jul 12 00:42:37 EDT 2022 x86_64
+Kernel command line: BOOT_IMAGE=(hd0,msdos1)/vmlinuz-4.18.0-409.el8.x86_64 root=/dev/mapper/rhel_el8-root ro resume=/dev/mapper/rhel_el8-swap rd.lvm.lv=rhel_el8/root rd.lvm.lv=rhel_el8/swap rhgb quiet
+Build Date: 09 June 2022  04:30:21PM
+Build ID: xorg-x11-server 1.20.11-8.el8
+Current version of pixman: 0.38.4
+	Before reporting problems, check http://wiki.x.org
+	to make sure that you have the latest version.
+Markers: (--) probed, (**) from config file, (==) default setting,
+	(++) from command line, (!!) notice, (II) informational,
+	(WW) warning, (EE) error, (NI) not implemented, (??) unknown.
+(==) Log file: "/home/johndoe/.local/share/xorg/Xorg.0.log", Time: Tue May 30 15:33:30 2023
+(==) Using config directory: "/etc/X11/xorg.conf.d"
+(==) Using system config directory "/usr/share/X11/xorg.conf.d"
+(==) No Layout section.  Using the first Screen section.
+(==) No screen section available. Using defaults.
+(**) |-->Screen "Default Screen Section" (0)
+(**) |   |-->Monitor "<default monitor>"
+(==) No monitor specified for screen "Default Screen Section".
+	Using a default monitor configuration.
+(==) Automatically adding devices
+(==) Automatically enabling devices
+(==) Automatically adding GPU devices
+(==) Automatically binding GPU devices
+(==) Max clients allowed: 256, resource mask: 0x1fffff
+(==) FontPath set to:
+	catalogue:/etc/X11/fontpath.d,
+	built-ins
+(==) ModulePath set to "/usr/lib64/xorg/modules"
+(II) The server relies on udev to provide the list of input devices.
+	If no devices become available, reconfigure udev or disable AutoAddDevices.
+(II) Loader magic: 0x556bf9d4f020
+(II) Module ABI versions:
+	X.Org ANSI C Emulation: 0.4
+	X.Org Video Driver: 24.1
+	X.Org XInput driver : 24.1
+	X.Org Server Extension : 10.0
+(++) using VT number 2
+(II) systemd-logind: took control of session /org/freedesktop/login1/session/_32
+(II) xfree86: Adding drm device (/dev/dri/card0)
+(II) Platform probe for /sys/devices/pci0000:00/0000:00:02.0/drm/card0
+(II) systemd-logind: got fd for /dev/dri/card0 226:0 fd 12 paused 0
+(--) PCI:*(0@0:2:0) 1b36:0100:1af4:1100 rev 4, Mem @ 0xf4000000/67108864, 0xf8000000/67108864, 0xfc054000/8192, I/O @ 0x0000c080/32, BIOS @ 0x????????/65536
+(II) LoadModule: "glx"
+(II) Loading /usr/lib64/xorg/modules/extensions/libglx.so
+(II) Module glx: vendor="X.Org Foundation"
+	compiled for 1.20.11, module version = 1.0.0
+	ABI class: X.Org Server Extension, version 10.0
+(==) Matched qxl as autoconfigured driver 0
+(==) Matched modesetting as autoconfigured driver 1
+(==) Matched fbdev as autoconfigured driver 2
+(==) Matched vesa as autoconfigured driver 3
+(==) Assigned the driver to the xf86ConfigLayout
+(II) LoadModule: "qxl"
+(WW) Warning, couldn't open module qxl
+(EE) Failed to load module "qxl" (module does not exist, 0)
+(II) LoadModule: "modesetting"
+(II) Loading /usr/lib64/xorg/modules/drivers/modesetting_drv.so
+(II) Module modesetting: vendor="X.Org Foundation"
+	compiled for 1.20.11, module version = 1.20.11
+	Module class: X.Org Video Driver
+	ABI class: X.Org Video Driver, version 24.1
+(II) LoadModule: "fbdev"
+(II) Loading /usr/lib64/xorg/modules/drivers/fbdev_drv.so
+(II) Module fbdev: vendor="X.Org Foundation"
+	compiled for 1.20.1, module version = 0.5.0
+	Module class: X.Org Video Driver
+	ABI class: X.Org Video Driver, version 24.0
+(II) LoadModule: "vesa"
+(II) Loading /usr/lib64/xorg/modules/drivers/vesa_drv.so
+(II) Module vesa: vendor="X.Org Foundation"
+	compiled for 1.20.2, module version = 2.4.0
+	Module class: X.Org Video Driver
+	ABI class: X.Org Video Driver, version 24.0
+(II) modesetting: Driver for Modesetting Kernel Drivers: kms
+(II) FBDEV: driver for framebuffer: fbdev
+(II) VESA: driver for VESA chipsets: vesa
+xf86EnableIOPorts: failed to set IOPL for I/O (Operation not permitted)
+(II) modeset(0): using drv /dev/dri/card0
+(WW) Falling back to old probe method for fbdev
+(II) Loading sub module "fbdevhw"
+(II) LoadModule: "fbdevhw"
+(II) Loading /usr/lib64/xorg/modules/libfbdevhw.so
+(II) Module fbdevhw: vendor="X.Org Foundation"
+	compiled for 1.20.11, module version = 0.0.2
+	ABI class: X.Org Video Driver, version 24.1
+(EE) open /dev/fb0: Permission denied
+(WW) VGA arbiter: cannot open kernel arbiter, no multi-card support
+(II) modeset(0): Creating default Display subsection in Screen section
+	"Default Screen Section" for depth/fbbpp 24/32
+(==) modeset(0): Depth 24, (==) framebuffer bpp 32
+(==) modeset(0): RGB weight 888
+(==) modeset(0): Default visual is TrueColor
+(II) Loading sub module "glamoregl"
+(II) LoadModule: "glamoregl"
+(II) Loading /usr/lib64/xorg/modules/libglamoregl.so
+(II) Module glamoregl: vendor="X.Org Foundation"
+	compiled for 1.20.11, module version = 1.0.1
+	ABI class: X.Org ANSI C Emulation, version 0.4
+pci id for fd 12: 1b36:0100, driver (null)
+MESA-LOADER: failed to open qxl: /usr/lib64/dri/qxl_dri.so: cannot open shared object file: No such file or directory (search paths /usr/lib64/dri, suffix _dri)
+failed to load driver: qxl
+MESA-LOADER: failed to open zink: /usr/lib64/dri/zink_dri.so: cannot open shared object file: No such file or directory (search paths /usr/lib64/dri, suffix _dri)
+failed to load driver: zink
+(II) modeset(0): Refusing to try glamor on llvmpipe
+(II) modeset(0): glamor initialization failed
+(II) modeset(0): ShadowFB: preferred NO, enabled NO
+(II) modeset(0): Output Virtual-1 has no monitor section
+(II) modeset(0): Output Virtual-2 has no monitor section
+(II) modeset(0): Output Virtual-3 has no monitor section
+(II) modeset(0): Output Virtual-4 has no monitor section
+(II) modeset(0): EDID for output Virtual-1
+(II) modeset(0): Printing probed modes for output Virtual-1
+(II) modeset(0): Modeline "1024x768"x60.0   65.00  1024 1048 1184 1344  768 771 777 806 -hsync -vsync (48.4 kHz eP)
+(II) modeset(0): Modeline "2560x1600"x60.0  348.50  2560 2752 3032 3504  1600 1603 1609 1658 -hsync +vsync (99.5 kHz e)
+(II) modeset(0): Modeline "2560x1600"x60.0  268.50  2560 2608 2640 2720  1600 1603 1609 1646 +hsync -vsync (98.7 kHz e)
+(II) modeset(0): Modeline "1920x1440"x60.0  234.00  1920 2048 2256 2600  1440 1441 1444 1500 -hsync +vsync (90.0 kHz e)
+(II) modeset(0): Modeline "1856x1392"x60.0  218.25  1856 1952 2176 2528  1392 1393 1396 1439 -hsync +vsync (86.3 kHz e)
+(II) modeset(0): Modeline "1792x1344"x60.0  204.75  1792 1920 2120 2448  1344 1345 1348 1394 -hsync +vsync (83.6 kHz e)
+(II) modeset(0): Modeline "2048x1152"x60.0  162.00  2048 2074 2154 2250  1152 1153 1156 1200 +hsync +vsync (72.0 kHz e)
+(II) modeset(0): Modeline "1920x1200"x59.9  193.25  1920 2056 2256 2592  1200 1203 1209 1245 -hsync +vsync (74.6 kHz e)
+(II) modeset(0): Modeline "1920x1200"x60.0  154.00  1920 1968 2000 2080  1200 1203 1209 1235 +hsync -vsync (74.0 kHz e)
+(II) modeset(0): Modeline "1920x1080"x60.0  148.50  1920 2008 2052 2200  1080 1084 1089 1125 -hsync -vsync (67.5 kHz e)
+(II) modeset(0): Modeline "1600x1200"x60.0  162.00  1600 1664 1856 2160  1200 1201 1204 1250 +hsync +vsync (75.0 kHz e)
+(II) modeset(0): Modeline "1680x1050"x60.0  146.25  1680 1784 1960 2240  1050 1053 1059 1089 -hsync +vsync (65.3 kHz e)
+(II) modeset(0): Modeline "1680x1050"x59.9  119.00  1680 1728 1760 1840  1050 1053 1059 1080 +hsync -vsync (64.7 kHz e)
+(II) modeset(0): Modeline "1400x1050"x60.0  121.75  1400 1488 1632 1864  1050 1053 1057 1089 -hsync +vsync (65.3 kHz e)
+(II) modeset(0): Modeline "1400x1050"x59.9  101.00  1400 1448 1480 1560  1050 1053 1057 1080 +hsync -vsync (64.7 kHz e)
+(II) modeset(0): Modeline "1600x900"x60.0  108.00  1600 1624 1704 1800  900 901 904 1000 +hsync +vsync (60.0 kHz e)
+(II) modeset(0): Modeline "1280x1024"x60.0  108.00  1280 1328 1440 1688  1024 1025 1028 1066 +hsync +vsync (64.0 kHz e)
+(II) modeset(0): Modeline "1440x900"x59.9  106.50  1440 1520 1672 1904  900 903 909 934 -hsync +vsync (55.9 kHz e)
+(II) modeset(0): Modeline "1440x900"x59.9   88.75  1440 1488 1520 1600  900 903 909 926 +hsync -vsync (55.5 kHz e)
+(II) modeset(0): Modeline "1280x960"x60.0  108.00  1280 1376 1488 1800  960 961 964 1000 +hsync +vsync (60.0 kHz e)
+(II) modeset(0): Modeline "1280x854"x60.0   89.34  1280 1352 1480 1680  854 857 867 887 -hsync +vsync (53.2 kHz)
+(II) modeset(0): Modeline "1366x768"x59.8   85.50  1366 1436 1579 1792  768 771 774 798 +hsync +vsync (47.7 kHz e)
+(II) modeset(0): Modeline "1366x768"x60.0   72.00  1366 1380 1436 1500  768 769 772 800 +hsync +vsync (48.0 kHz e)
+(II) modeset(0): Modeline "1360x768"x60.0   85.50  1360 1424 1536 1792  768 771 777 795 +hsync +vsync (47.7 kHz e)
+(II) modeset(0): Modeline "1280x800"x59.8   83.50  1280 1352 1480 1680  800 803 809 831 -hsync +vsync (49.7 kHz e)
+(II) modeset(0): Modeline "1280x800"x59.9   71.00  1280 1328 1360 1440  800 803 809 823 +hsync -vsync (49.3 kHz e)
+(II) modeset(0): Modeline "1280x768"x59.9   79.50  1280 1344 1472 1664  768 771 778 798 -hsync +vsync (47.8 kHz e)
+(II) modeset(0): Modeline "1280x768"x60.0   68.25  1280 1328 1360 1440  768 771 778 790 +hsync -vsync (47.4 kHz e)
+(II) modeset(0): Modeline "1280x720"x60.0   74.25  1280 1390 1430 1650  720 725 730 750 +hsync +vsync (45.0 kHz e)
+(II) modeset(0): Modeline "1152x768"x59.9   71.95  1152 1216 1328 1504  768 771 781 798 -hsync +vsync (47.8 kHz)
+(II) modeset(0): Modeline "800x600"x60.3   40.00  800 840 968 1056  600 601 605 628 +hsync +vsync (37.9 kHz e)
+(II) modeset(0): Modeline "800x600"x56.2   36.00  800 824 896 1024  600 601 603 625 +hsync +vsync (35.2 kHz e)
+(II) modeset(0): Modeline "848x480"x60.0   33.75  848 864 976 1088  480 486 494 517 +hsync +vsync (31.0 kHz e)
+(II) modeset(0): Modeline "720x480"x59.9   26.85  720 744 808 896  480 483 493 500 -hsync +vsync (30.0 kHz)
+(II) modeset(0): Modeline "640x480"x59.9   25.18  640 656 752 800  480 490 492 525 -hsync -vsync (31.5 kHz e)
+(II) modeset(0): EDID for output Virtual-2
+(II) modeset(0): EDID for output Virtual-3
+(II) modeset(0): EDID for output Virtual-4
+(II) modeset(0): Output Virtual-1 connected
+(II) modeset(0): Output Virtual-2 disconnected
+(II) modeset(0): Output Virtual-3 disconnected
+(II) modeset(0): Output Virtual-4 disconnected
+(II) modeset(0): Using exact sizes for initial modes
+(II) modeset(0): Output Virtual-1 using initial mode 1024x768 +0+0
+(==) modeset(0): Using gamma correction (1.0, 1.0, 1.0)
+(==) modeset(0): DPI set to (96, 96)
+(II) Loading sub module "fb"
+(II) LoadModule: "fb"
+(II) Loading /usr/lib64/xorg/modules/libfb.so
+(II) Module fb: vendor="X.Org Foundation"
+	compiled for 1.20.11, module version = 1.0.0
+	ABI class: X.Org ANSI C Emulation, version 0.4
+(II) UnloadModule: "fbdev"
+(II) Unloading fbdev
+(II) UnloadSubModule: "fbdevhw"
+(II) Unloading fbdevhw
+(II) UnloadModule: "vesa"
+(II) Unloading vesa
+(==) modeset(0): Backing store enabled
+(==) modeset(0): Silken mouse enabled
+(II) modeset(0): Initializing kms color map for depth 24, 8 bpc.
+(==) modeset(0): DPMS enabled
+(II) Initializing extension Generic Event Extension
+(II) Initializing extension SHAPE
+(II) Initializing extension MIT-SHM
+(II) Initializing extension XInputExtension
+(II) Initializing extension XTEST
+(II) Initializing extension BIG-REQUESTS
+(II) Initializing extension SYNC
+(II) Initializing extension XKEYBOARD
+(II) Initializing extension XC-MISC
+(II) Initializing extension SECURITY
+(II) Initializing extension XFIXES
+(II) Initializing extension RENDER
+(II) Initializing extension RANDR
+(II) Initializing extension COMPOSITE
+(II) Initializing extension DAMAGE
+(II) Initializing extension MIT-SCREEN-SAVER
+(II) Initializing extension DOUBLE-BUFFER
+(II) Initializing extension RECORD
+(II) Initializing extension DPMS
+(II) Initializing extension Present
+(II) Initializing extension DRI3
+(II) Initializing extension X-Resource
+(II) Initializing extension XVideo
+(II) Initializing extension XVideo-MotionCompensation
+(II) Initializing extension SELinux
+(II) SELinux: Disabled on system
+(II) Initializing extension GLX
+(II) AIGLX: Screen 0 is not DRI2 capable
+(II) IGLX: Loaded and initialized swrast
+(II) GLX: Initialized DRISWRAST GL provider for screen 0
+(II) Initializing extension XFree86-VidModeExtension
+(II) Initializing extension XFree86-DGA
+(II) Initializing extension XFree86-DRI
+(II) Initializing extension DRI2
+(II) modeset(0): Damage tracking initialized
+(II) modeset(0): Setting screen physical size to 270 x 203
+(II) config/udev: Adding input device Power Button (/dev/input/event0)
+(**) Power Button: Applying InputClass "evdev keyboard catchall"
+(**) Power Button: Applying InputClass "libinput keyboard catchall"
+(**) Power Button: Applying InputClass "system-keyboard"
+(II) LoadModule: "libinput"
+(II) Loading /usr/lib64/xorg/modules/input/libinput_drv.so
+(II) Module libinput: vendor="X.Org Foundation"
+	compiled for 1.20.3, module version = 0.29.0
+	Module class: X.Org XInput Driver
+	ABI class: X.Org XInput driver, version 24.1
+(II) Using input driver 'libinput' for 'Power Button'
+(II) systemd-logind: got fd for /dev/input/event0 13:64 fd 21 paused 0
+(**) Power Button: always reports core events
+(**) Option "Device" "/dev/input/event0"
+(**) Option "_source" "server/udev"
+(II) event0  - Power Button: is tagged by udev as: Keyboard
+(II) event0  - Power Button: device is a keyboard
+(II) event0  - Power Button: device removed
+(**) Option "config_info" "udev:/sys/devices/LNXSYSTM:00/LNXPWRBN:00/input/input0/event0"
+(II) XINPUT: Adding extended input device "Power Button" (type: KEYBOARD, id 6)
+(**) Option "xkb_model" "pc105"
+(**) Option "xkb_layout" "gb"
+(**) Option "xkb_options" "terminate:ctrl_alt_bksp"
+(II) event0  - Power Button: is tagged by udev as: Keyboard
+(II) event0  - Power Button: device is a keyboard
+(II) config/udev: Adding input device QEMU QEMU USB Tablet (/dev/input/event2)
+(**) QEMU QEMU USB Tablet: Applying InputClass "evdev pointer catchall"
+(**) QEMU QEMU USB Tablet: Applying InputClass "libinput pointer catchall"
+(II) Using input driver 'libinput' for 'QEMU QEMU USB Tablet'
+(II) systemd-logind: got fd for /dev/input/event2 13:66 fd 24 paused 0
+(**) QEMU QEMU USB Tablet: always reports core events
+(**) Option "Device" "/dev/input/event2"
+(**) Option "_source" "server/udev"
+(II) event2  - QEMU QEMU USB Tablet: is tagged by udev as: Mouse
+(II) event2  - QEMU QEMU USB Tablet: device is a pointer
+(II) event2  - QEMU QEMU USB Tablet: device removed
+(**) Option "config_info" "udev:/sys/devices/pci0000:00/0000:00:05.7/usb1/1-1/1-1:1.0/0003:0627:0001.0001/input/input4/event2"
+(II) XINPUT: Adding extended input device "QEMU QEMU USB Tablet" (type: MOUSE, id 7)
+(**) Option "AccelerationScheme" "none"
+(**) QEMU QEMU USB Tablet: (accel) selected scheme none/0
+(**) QEMU QEMU USB Tablet: (accel) acceleration factor: 2.000
+(**) QEMU QEMU USB Tablet: (accel) acceleration threshold: 4
+(II) event2  - QEMU QEMU USB Tablet: is tagged by udev as: Mouse
+(II) event2  - QEMU QEMU USB Tablet: device is a pointer
+(II) config/udev: Adding input device QEMU QEMU USB Tablet (/dev/input/mouse0)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device AT Translated Set 2 keyboard (/dev/input/event1)
+(**) AT Translated Set 2 keyboard: Applying InputClass "evdev keyboard catchall"
+(**) AT Translated Set 2 keyboard: Applying InputClass "libinput keyboard catchall"
+(**) AT Translated Set 2 keyboard: Applying InputClass "system-keyboard"
+(II) Using input driver 'libinput' for 'AT Translated Set 2 keyboard'
+(II) systemd-logind: got fd for /dev/input/event1 13:65 fd 25 paused 0
+(**) AT Translated Set 2 keyboard: always reports core events
+(**) Option "Device" "/dev/input/event1"
+(**) Option "_source" "server/udev"
+(II) event1  - AT Translated Set 2 keyboard: is tagged by udev as: Keyboard
+(II) event1  - AT Translated Set 2 keyboard: device is a keyboard
+(II) event1  - AT Translated Set 2 keyboard: device removed
+(**) Option "config_info" "udev:/sys/devices/platform/i8042/serio0/input/input1/event1"
+(II) XINPUT: Adding extended input device "AT Translated Set 2 keyboard" (type: KEYBOARD, id 8)
+(**) Option "xkb_model" "pc105"
+(**) Option "xkb_layout" "gb"
+(**) Option "xkb_options" "terminate:ctrl_alt_bksp"
+(II) event1  - AT Translated Set 2 keyboard: is tagged by udev as: Keyboard
+(II) event1  - AT Translated Set 2 keyboard: device is a keyboard
+(II) config/udev: Adding input device ImExPS/2 Generic Explorer Mouse (/dev/input/event3)
+(**) ImExPS/2 Generic Explorer Mouse: Applying InputClass "evdev pointer catchall"
+(**) ImExPS/2 Generic Explorer Mouse: Applying InputClass "libinput pointer catchall"
+(II) Using input driver 'libinput' for 'ImExPS/2 Generic Explorer Mouse'
+(II) systemd-logind: got fd for /dev/input/event3 13:67 fd 26 paused 0
+(**) ImExPS/2 Generic Explorer Mouse: always reports core events
+(**) Option "Device" "/dev/input/event3"
+(**) Option "_source" "server/udev"
+(II) event3  - ImExPS/2 Generic Explorer Mouse: is tagged by udev as: Mouse
+(II) event3  - ImExPS/2 Generic Explorer Mouse: device is a pointer
+(II) event3  - ImExPS/2 Generic Explorer Mouse: device removed
+(**) Option "config_info" "udev:/sys/devices/platform/i8042/serio1/input/input3/event3"
+(II) XINPUT: Adding extended input device "ImExPS/2 Generic Explorer Mouse" (type: MOUSE, id 9)
+(**) Option "AccelerationScheme" "none"
+(**) ImExPS/2 Generic Explorer Mouse: (accel) selected scheme none/0
+(**) ImExPS/2 Generic Explorer Mouse: (accel) acceleration factor: 2.000
+(**) ImExPS/2 Generic Explorer Mouse: (accel) acceleration threshold: 4
+(II) event3  - ImExPS/2 Generic Explorer Mouse: is tagged by udev as: Mouse
+(II) event3  - ImExPS/2 Generic Explorer Mouse: device is a pointer
+(II) config/udev: Adding input device ImExPS/2 Generic Explorer Mouse (/dev/input/mouse1)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.
+(II) config/udev: Adding input device PC Speaker (/dev/input/event4)
+(II) No input driver specified, ignoring this device.
+(II) This device may have been added with another device file.

--- a/repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/test_xorgdrvfact.py
+++ b/repos/system_upgrade/el8toel9/actors/xorgdrvfact/tests/test_xorgdrvfact.py
@@ -1,0 +1,77 @@
+import os
+
+from leapp.libraries.actor import xorgdriverlib
+from leapp.models import XorgDrv, XorgDrvFacts
+
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def _read_log_file(path):
+    """
+    Read a log file in text mode and return the contents as an array.
+
+    :param path: Log file path
+    """
+    with open(path, 'r') as f:
+        return f.read().splitlines()
+
+
+def test_check_drv_and_options_qxl_driver(monkeypatch):
+
+    def get_xorg_logs_from_journal_mocked():
+        return _read_log_file(os.path.join(CUR_DIR, 'files/journalctl-xorg-qxl'))
+
+    monkeypatch.setattr(xorgdriverlib, 'get_xorg_logs_from_journal', get_xorg_logs_from_journal_mocked)
+    xorg_logs = xorgdriverlib.get_xorg_logs_from_journal()
+    expected = XorgDrv(driver='qxl', has_options=False)
+    actual = xorgdriverlib.check_drv_and_options('qxl', xorg_logs)
+    assert expected == actual
+
+
+def test_check_drv_and_options_intel_driver(monkeypatch):
+
+    def get_xorg_logs_from_journal_mocked():
+        return _read_log_file(os.path.join(CUR_DIR, 'files/journalctl-xorg-intel'))
+
+    monkeypatch.setattr(xorgdriverlib, 'get_xorg_logs_from_journal', get_xorg_logs_from_journal_mocked)
+    xorg_logs = xorgdriverlib.get_xorg_logs_from_journal()
+    expected = XorgDrv(driver='intel', has_options=True)
+    actual = xorgdriverlib.check_drv_and_options('intel', xorg_logs)
+    assert expected == actual
+
+
+def test_actor_with_deprecated_driver_without_options(current_actor_context, monkeypatch):
+
+    def get_xorg_logs_from_journal_mocked():
+        return _read_log_file(os.path.join(CUR_DIR, 'files/journalctl-xorg-qxl'))
+
+    monkeypatch.setattr(xorgdriverlib, 'get_xorg_logs_from_journal', get_xorg_logs_from_journal_mocked)
+    current_actor_context.run()
+    facts = list(current_actor_context.consume(XorgDrvFacts))
+    assert facts and len(facts[0].xorg_drivers) == 1
+    assert (facts[0].xorg_drivers)[0].driver == 'qxl'
+    assert (facts[0].xorg_drivers)[0].has_options is False
+
+
+def test_actor_with_deprecated_driver_with_options(current_actor_context, monkeypatch):
+
+    def get_xorg_logs_from_journal_mocked():
+        return _read_log_file(os.path.join(CUR_DIR, 'files/journalctl-xorg-intel'))
+
+    monkeypatch.setattr(xorgdriverlib, 'get_xorg_logs_from_journal', get_xorg_logs_from_journal_mocked)
+    current_actor_context.run()
+    facts = list(current_actor_context.consume(XorgDrvFacts))
+    assert facts and len(facts[0].xorg_drivers) == 1
+    assert (facts[0].xorg_drivers)[0].driver == 'intel'
+    assert (facts[0].xorg_drivers)[0].has_options is True
+
+
+def test_actor_without_deprecated_driver(current_actor_context, monkeypatch):
+
+    def get_xorg_logs_from_journal_mocked():
+        return _read_log_file(os.path.join(CUR_DIR, 'files/journalctl-xorg-without-qxl'))
+
+    monkeypatch.setattr(xorgdriverlib, 'get_xorg_logs_from_journal', get_xorg_logs_from_journal_mocked)
+    current_actor_context.run()
+    facts = current_actor_context.consume(XorgDrvFacts)
+    assert facts and len(facts[0].xorg_drivers) == 0

--- a/repos/system_upgrade/el8toel9/models/xorgdrv.py
+++ b/repos/system_upgrade/el8toel9/models/xorgdrv.py
@@ -1,0 +1,24 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemFactsTopic
+
+
+class XorgDrv(Model):
+    """
+    Name of the Xorg driver in use and whether it has custom options set.
+
+    This model is not expected to be used as a message (produced/consumed by actors).
+    It is used from within the XorgDrvFacts model.
+    """
+    topic = SystemFactsTopic
+
+    driver = fields.String()
+    has_options = fields.Boolean(default=False)
+
+
+class XorgDrvFacts(Model):
+    """
+    List of Xorg drivers.
+    """
+    topic = SystemFactsTopic
+
+    xorg_drivers = fields.List(fields.Model(XorgDrv))


### PR DESCRIPTION
Some Xorg drivers have been deprecated in favor of the "modesetting" driver.

If Xorg is configured to use those drivers, it may not be able to work properly after the upgrade.

Add a new actor to check in the journal whether such Xorg drivers are in use and in that case, also warn if there are custom Xorg config options.

Known limitation: This actor checks the journal logs since the last boot, meaning that if Xorg was started manually from a console or if the system has been rebooted after a graphical Xorg session was used, the actor will not be able to detect the use of deprecated drivers.