### PR TITLE
[draft] Err msg when not enough space detected (solution: revert)

### DIFF
--- a/repos/system_upgrade/common/actors/dnfupgradetransaction/actor.py
+++ b/repos/system_upgrade/common/actors/dnfupgradetransaction/actor.py
@@ -11,8 +11,7 @@ from leapp.models import (
     StorageInfo,
     TargetUserSpaceInfo,
     TransactionCompleted,
-    UsedTargetRepositories,
-    XFSPresence
+    UsedTargetRepositories
 )
 from leapp.tags import IPUWorkflowTag, RPMUpgradePhaseTag
 
@@ -34,7 +33,6 @@ class DnfUpgradeTransaction(Actor):
         StorageInfo,
         TargetUserSpaceInfo,
         UsedTargetRepositories,
-        XFSPresence
     )
     produces = (TransactionCompleted,)
     tags = (RPMUpgradePhaseTag, IPUWorkflowTag)
@@ -50,11 +48,10 @@ class DnfUpgradeTransaction(Actor):
         plugin_info = list(self.consume(DNFPluginTask))
         tasks = next(self.consume(FilteredRpmTransactionTasks), FilteredRpmTransactionTasks())
         target_userspace_info = next(self.consume(TargetUserSpaceInfo), None)
-        xfs_info = next(self.consume(XFSPresence), XFSPresence())
 
         dnfplugin.perform_transaction_install(
             tasks=tasks, used_repos=used_repos, storage_info=storage_info, target_userspace_info=target_userspace_info,
-            plugin_info=plugin_info, xfs_info=xfs_info
+            plugin_info=plugin_info
         )
         self.produce(TransactionCompleted())
         userspace = next(self.consume(TargetUserSpaceInfo), None)

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -206,22 +206,6 @@ def prepare_target_userspace(context, userspace_dir, enabled_repos, packages):
             message = 'Unable to install RHEL {} userspace packages.'.format(target_major_version)
             details = {'details': str(exc), 'stderr': exc.stderr}
 
-            xfs_info = next(api.consume(XFSPresence), XFSPresence())
-            if 'more space needed on the' in exc.stderr:
-                # The stderr contains this error summary:
-                # Disk Requirements:
-                #   At least <size> more space needed on the <path> filesystem.
-
-                article_section = 'Generic case'
-                if xfs_info.present and xfs_info.without_ftype:
-                    article_section = 'XFS ftype=0 case'
-
-                message = ('There is not enough space on the file system hosting /var/lib/leapp directory '
-                           'to extract the packages.')
-                details = {'hint': "Please follow the instructions in the '{}' section of the article at: "
-                                   "link: https://access.redhat.com/solutions/5057391".format(article_section)}
-                raise StopActorExecutionError(message=message, details=details)
-
             # If a proxy was set in dnf config, it should be the reason why dnf
             # failed since leapp does not support updates behind proxy yet.
             for manager_info in api.consume(PkgManagerInfo):


### PR DESCRIPTION
This reverts commit 00d06d5217848d384e4b70ebf3c5eb5e4f7fa3e6.

Discussing the change and problems with CEE after the release, the change is currently for them even more problematic than before. Regarding our timeline, let's revert this change for now. We are working currently on the proper solution for the next version of leapp-repository.

## Note:
Any such errors printed by actors executed before the reboot, are missleading

## Examples
```
============================================================
                           ERRORS
============================================================

2023-05-26 06:03:26.539380 [ERROR] Actor: <any-actor>
Message: DNF execution failed with non zero exit code.
STDOUT:
Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, groups-manager, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync, rhel-upgrade, system-upgrade
DNF version: 4.14.0
cachedir: /var/cache/dnf
..[snip]..

STDERR:
warning: Found bdb_ro Packages database while attempting sqlite backend: using bdb_ro backend.
..[snip]..
  installing package rootfiles-8.1-31.el9.noarch needs 500MB more space on the / filesystem
  installing package kbd-legacy-2.4.0-8.el9.noarch needs 501MB more space on the / filesystem

Error Summary
-------------
Disk Requirements:
   At least 501MB more space needed on the / filesystem.

```