### PR TITLE
[draft] Err msg when not enough space detected (solution: correct-err-msgs)

### DIFF
--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -216,10 +216,16 @@ def prepare_target_userspace(context, userspace_dir, enabled_repos, packages):
                 if xfs_info.present and xfs_info.without_ftype:
                     article_section = 'XFS ftype=0 case'
 
-                message = ('There is not enough space on the file system hosting /var/lib/leapp directory '
-                           'to extract the packages.')
-                details = {'hint': "Please follow the instructions in the '{}' section of the article at: "
-                                   "link: https://access.redhat.com/solutions/5057391".format(article_section)}
+                message = 'There is not enough space to extract the packages.'
+                hint = (
+                    "Either the file system hosting /var/lib/leapp directory is not large"
+                    " enough or created temporary virtual disk images need to be bigger"
+                    " (the LEAPP_OVL_SIZE environment variable)."
+                    " Please follow the instructions in the '{}' section of the article at"
+                    " link: https://access.redhat.com/solutions/5057391"
+                    .format(article_section)
+                )
+                details = {'hint': hint}
                 raise StopActorExecutionError(message=message, details=details)
 
             # If a proxy was set in dnf config, it should be the reason why dnf


### PR DESCRIPTION
Currently we inform users they do not have enough space on a partition hosting the /var/lib/leapp directory when our dnf upgrade plugin ends with non-zero exit code and the err msg contains string like:
    At least <size> more space needed on the <path> filesystem.

This is true only during phases prior the reboot when a partition is not represented by disk images, which we create to handle partitions with XFS filesystems without ftype attributes. Such images have size 2GiB unless the LEAPP_OVL_SIZE envar is specified.

In general, the real missing space is currently not known during the phases prior the reboot as we "emulate" the original storage using overlayfs. So let's provide better correct error msg for these disk space errors during phases prior the reboot.

But during the upgrade phase, when the DNF transaction is going to be performed, the host storage is not exposed to the DNF plugin and so error messages informing about needed more space are really correct - in such a case, does not try to interpret the error msg in any additional way and expose raw data about the error.

tl;dr;
* Switch to the generic error msg always during the upgrade phase, exposing the raw error msg without trying to interpret it.
* Interpret correctly the error msg for such disk space issues during phases before the system reboot, when the real host storage is emulated.

## Example

Actors prior the reboot:
```
============================================================
                           ERRORS
============================================================
2023-05-26 06:03:26.539380 [ERROR] Actor: <an-actor-executed-prior-reboot>
Message: There is not enough space to extract the packages.
Summary:
    Hint:  Either the file system hosting /var/lib/leapp directory is not large enough or created temporary virtual disk images need to be bigger (the LEAPP_OVL_SIZE environment variable). Please follow the instructions in the 'Generic case' section of the article at: link: https://access.redhat.com/solutions/5057391
```

Actor performing the upgrade transaction:
```
============================================================
                           ERRORS
============================================================

2023-05-26 06:03:26.539380 [ERROR] Actor: dnf_upgrade_transaction
Message: DNF execution failed with non zero exit code.
STDOUT:
Loaded plugins: builddep, changelog, config-manager, copr, debug, debuginfo-install, download, generate_completion_cache, groups-manager, needs-restarting, playground, repoclosure, repodiff, repograph, repomanage, reposync, rhel-upgrade, system-upgrade
DNF version: 4.14.0
cachedir: /var/cache/dnf
..[snip]..

STDERR:
warning: Found bdb_ro Packages database while attempting sqlite backend: using bdb_ro backend.
..[snip]..
  installing package rootfiles-8.1-31.el9.noarch needs 500MB more space on the / filesystem
  installing package kbd-legacy-2.4.0-8.el9.noarch needs 501MB more space on the / filesystem

Error Summary
-------------
Disk Requirements:
   At least 501MB more space needed on the / filesystem.

```