### PR TITLE
update URLs to docs: fix links and use shortened URLs when needed

### DIFF
--- a/repos/system_upgrade/common/actors/checktargetrepos/libraries/checktargetrepos.py
+++ b/repos/system_upgrade/common/actors/checktargetrepos/libraries/checktargetrepos.py
@@ -30,12 +30,9 @@ def process():
     target_major_version = get_target_major_version()
 
     if target_major_version == '8':
-        ipu_doc_url = (
-            'https://access.redhat.com/documentation/en-us/'
-            'red_hat_enterprise_linux/8/html-single/upgrading_from_rhel_7_to_rhel_8/index'
-        )
+        ipu_doc_url = 'https://red.ht/upgrading-rhel7-to-rhel8-main-official-doc'
     elif target_major_version == '9':
-        ipu_doc_url = 'TBA'
+        ipu_doc_url = 'https://red.ht/upgrading-rhel8-to-rhel9-main-official-doc'
 
     rhui_info = next(api.consume(RHUIInfo), None)
 

--- a/repos/system_upgrade/common/actors/localreposinhibit/actor.py
+++ b/repos/system_upgrade/common/actors/localreposinhibit/actor.py
@@ -82,8 +82,7 @@ class LocalReposInhibit(Actor):
                             "in-place upgrade"
                         ),
                         url=(
-                            "https://access.redhat.com/articles/4977891/"
-                            "#repos-known-issues"
+                            "https://red.ht/ipu-customisation-repos-known-issues"
                         ),
                     ),
                 ]

--- a/repos/system_upgrade/common/actors/verifydialogs/libraries/verifydialogs.py
+++ b/repos/system_upgrade/common/actors/verifydialogs/libraries/verifydialogs.py
@@ -8,7 +8,7 @@ def check_dialogs(inhibit_if_no_userchoice=True):
     for dialog in results:
         sections = dialog.answerfile_sections
         summary = ('One or more sections in answerfile are missing user choices: {}\n'
-                   'For more information consult https://leapp.readthedocs.io/en/latest/dialogs.html')
+                   'For more information consult https://red.ht/leapp-dialogs.')
         dialog_resources = [reporting.RelatedResource('dialog', s) for s in sections]
         dialogs_remediation = ('Please register user choices with leapp answer cli command or by manually editing '
                                'the answerfile.')

--- a/repos/system_upgrade/el7toel8/actors/checkbtrfs/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkbtrfs/actor.py
@@ -35,7 +35,7 @@ class CheckBtrfs(Actor):
                         ),
                         reporting.ExternalLink(
                             title='Considerations in adopting RHEL 8 - btrfs has been removed.',
-                            url='https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/file-systems-and-storage_considerations-in-adopting-rhel-8#btrfs-has-been-removed_file-systems-and-storage'  # noqa: E501; pylint: disable=line-too-long
+                            url='https://red.ht/file-systems-and-storage-removed-btrfs-rhel-8'
                         ),
                         reporting.ExternalLink(
                             title='How do I prevent a kernel module from loading automatically?',

--- a/repos/system_upgrade/el7toel8/actors/postgresqlcheck/libraries/postgresqlcheck.py
+++ b/repos/system_upgrade/el7toel8/actors/postgresqlcheck/libraries/postgresqlcheck.py
@@ -18,7 +18,7 @@ report_server_inst_hint = (
 )
 
 # Link URL for postgresql-server report
-report_server_inst_link_url = 'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/deploying_different_types_of_servers/index#migrating-to-a-rhel-8-version-of-postgresql_using-postgresql'  # noqa: E501; pylint: disable=line-too-long
+report_server_inst_link_url = 'https://red.ht/rhel-8-migrate-postgresql-server'
 
 # List of dropped extensions from postgresql-contrib package
 report_contrib_inst_dropext = ['dummy_seclabel', 'test_parser', 'tsearch2']

--- a/repos/system_upgrade/el7toel8/actors/pythoninformuser/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/pythoninformuser/actor.py
@@ -12,7 +12,7 @@ class PythonInformUser(Actor):
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 
     def process(self):
-        url = "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/#using-python3"  # noqa: E501; pylint: disable=line-too-long
+        url = "https://red.ht/rhel-8-python"
         title = "Difference in Python versions and support in RHEL 8"
         summary = ("In RHEL 8, there is no 'python' command."
                    " Python 3 (backward incompatible) is the primary Python version"

--- a/repos/system_upgrade/el7toel8/actors/quaggareport/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/quaggareport/actor.py
@@ -32,10 +32,7 @@ class QuaggaReport(Actor):
             create_report([
                 reporting.Title('Babeld is not available in FRR'),
                 reporting.ExternalLink(
-                    url='https://access.redhat.com/'
-                        'documentation/en-us/red_hat_enterprise_linux/8/html/'
-                        'configuring_and_managing_networking/setting-your-rou'
-                        'ting-protocols_configuring-and-managing-networking',
+                    url='https://red.ht/rhel-8-configuring-routing-protocols',
                     title='Setting routing protocols in RHEL8'),
                 reporting.Summary(
                     'babeld daemon which was a part of quagga implementation in RHEL7 '

--- a/repos/system_upgrade/el8toel9/actors/checkifcfg/libraries/checkifcfg_ifcfg.py
+++ b/repos/system_upgrade/el8toel9/actors/checkifcfg/libraries/checkifcfg_ifcfg.py
@@ -119,7 +119,7 @@ def process():
             reporting.RelatedResource('package', 'NetworkManager'),
             reporting.ExternalLink(
                 title='nm-settings-ifcfg-rh - Description of ifcfg-rh settings plugin',
-                url='https://networkmanager.dev/docs/api/latest/nm-settings-ifcfg-rh.html',
+                url='https://red.ht/nm-settings-ifcfg-rh',
             ),
         ] + [
             reporting.RelatedResource('file', fname)

--- a/repos/system_upgrade/el8toel9/actors/checkmicroarchitecture/libraries/checkmicroarchitecture.py
+++ b/repos/system_upgrade/el8toel9/actors/checkmicroarchitecture/libraries/checkmicroarchitecture.py
@@ -17,8 +17,7 @@ def _inhibit_upgrade(missing_flags):
         reporting.Title(title),
         reporting.Summary(summary),
         reporting.ExternalLink(title='Building Red Hat Enterprise Linux 9 for the x86-64-v2 microarchitecture level',
-                               url=('https://developers.redhat.com/blog/2021/01/05/'
-                                    'building-red-hat-enterprise-linux-9-for-the-x86-64-v2-microarchitecture-level')),
+                               url='https://red.ht/rhel-9-intel-microarchitectures'),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Groups([reporting.Groups.INHIBITOR]),
         reporting.Groups([reporting.Groups.SANITY]),

--- a/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/libraries/opensshsubsystemsftp.py
+++ b/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/libraries/opensshsubsystemsftp.py
@@ -26,7 +26,7 @@ def process(openssh_messages):
             ),
             reporting.ExternalLink(
                 title="OpenSSH SCP deprecation in RHEL 9: What you need to know ",
-                url="https://www.redhat.com/en/blog/openssh-scp-deprecation-rhel-9-what-you-need-know",
+                url="https://red.ht/rhel-9-blog-openssh-scp-deprecation",
             ),
         ]
         reporting.create_report([

--- a/repos/system_upgrade/el8toel9/actors/postgresqlcheck/libraries/postgresqlcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/postgresqlcheck/libraries/postgresqlcheck.py
@@ -18,7 +18,7 @@ report_server_inst_hint = (
 )
 
 # Link URL for postgresql-server report
-report_server_inst_link_url = 'https://access.redhat.com/articles/6654721'  # noqa: E501; pylint: disable=line-too-long
+report_server_inst_link_url = 'https://access.redhat.com/articles/6654721'
 
 
 def _report_server_installed():


### PR DESCRIPTION
It happened several times that a link we used in reports became invalid over time, so it could not provide expected help to customers. The fix of such links require update of the code, which does not have to be possible on existing releases. Instead of that, we rather decided to use shortnened URLs when possible and when it makes sense to reduce the risk. The benefit is that we are able to change the target destination of such https://red.ht/... URLs so we can fix such issues without the need to update the code (and rpms).

### New shortened URLs:
  * https://red.ht/upgrading-rhel7-to-rhel8-main-official-doc
  * https://red.ht/upgrading-rhel8-to-rhel9-main-official-doc
  * https://red.ht/ipu-customisation-repos-known-issues
  * https://red.ht/leapp-dialogs
  * https://red.ht/file-systems-and-storage-removed-btrfs-rhel-8
  * https://red.ht/rhel-8-migrate-postgresql-server
  * https://red.ht/rhel-8-python
  * https://red.ht/rhel-8-configuring-routing-protocols
  * https://red.ht/nm-settings-ifcfg-rh
  * https://red.ht/rhel-9-intel-microarchitectures
  * https://red.ht/rhel-9-blog-openssh-scp-deprecation

### Additional changes:
  * checktargetrepos: replace "TBA" by valid URL for 8 -> 9 docs
  * dropped unneeded pylint skips

### Another info
In some cases (at least in targetuserspacecreator - and possibly only in this one case) we have just links to our rhel8 documentation instead of dynamically point people to el8 or el9 docs (if they exists). I am considering to keep this as part of a future changes. In this one PR I do not want to do any changes in behavior.