### PR TITLE
Preupgrade fails with a devtmpfs entry in fstab

### DIFF
--- a/repos/system_upgrade/common/libraries/overlaygen.py
+++ b/repos/system_upgrade/common/libraries/overlaygen.py
@@ -7,7 +7,7 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import mounting, utils
 from leapp.libraries.stdlib import api, CalledProcessError, run
 
-OVERLAY_DO_NOT_MOUNT = ('tmpfs', 'devpts', 'sysfs', 'proc', 'cramfs', 'sysv', 'vfat')
+OVERLAY_DO_NOT_MOUNT = ('tmpfs', 'devtmpfs', 'devpts', 'sysfs', 'proc', 'cramfs', 'sysv', 'vfat')
 
 
 MountPoints = namedtuple('MountPoints', ['fs_file', 'fs_vfstype'])


### PR DESCRIPTION
systemd-nspawn fails when a devtmpfs entry is present in /etc/fstab
   mknod(/var/lib/leapp/scratch/mounts/root_/system_overlay/dev/null) failed: File exists

Ignoring such vfstype fixes the issue rhbz#2215027

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2215027
JIRA: OAMG-9299