### PR TITLE
Include mdadm configuration in the upgrade initramfs

### DIFF
--- a/repos/system_upgrade/common/actors/checkraid/actor.py
+++ b/repos/system_upgrade/common/actors/checkraid/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkraid
+from leapp.models import RAIDInfo, TargetUserSpaceUpgradeTasks
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckRaid(Actor):
+    """
+    Ensure RAID configuration files are available in the target userspace.
+
+    If mdadm software RAID is in use, copies present mdadm configuration
+    files and directories into the target userspace container so that
+    dracut can include them in the upgrade initramfs.
+    """
+
+    name = 'check_raid'
+    consumes = (RAIDInfo,)
+    produces = (TargetUserSpaceUpgradeTasks,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        checkraid.process()

--- a/repos/system_upgrade/common/actors/checkraid/libraries/checkraid.py
+++ b/repos/system_upgrade/common/actors/checkraid/libraries/checkraid.py
@@ -1,0 +1,33 @@
+import os
+
+from leapp.libraries.stdlib import api
+from leapp.models import CopyFile, RAIDInfo, TargetUserSpaceUpgradeTasks
+
+# Host paths for mdadm configuration (see mdadm.conf(5) FILES section).
+MDADM_CONFIG_PATHS = (
+    '/etc/mdadm.conf',
+    '/etc/mdadm.conf.d',
+    '/etc/mdadm/mdadm.conf',
+    '/etc/mdadm/mdadm.conf.d',
+)
+
+
+def _mdadm_config_paths_present():
+    for path in MDADM_CONFIG_PATHS:
+        if os.path.isfile(path) or os.path.isdir(path):
+            yield path
+
+
+def process():
+    raid_info = next(api.consume(RAIDInfo), None)
+    if not raid_info or not raid_info.md_arrays:
+        return
+
+    copy_files = [CopyFile(src=path) for path in _mdadm_config_paths_present()]
+    if not copy_files:
+        api.current_logger().warning(
+            'mdadm software RAID is in use but no mdadm configuration was found under: %s',
+            ', '.join(MDADM_CONFIG_PATHS),
+        )
+    else:
+        api.produce(TargetUserSpaceUpgradeTasks(copy_files=copy_files))

--- a/repos/system_upgrade/common/actors/checkraid/tests/test_checkraid.py
+++ b/repos/system_upgrade/common/actors/checkraid/tests/test_checkraid.py
@@ -1,0 +1,112 @@
+import os
+
+from leapp.libraries.actor import checkraid
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import MDArray, RAIDInfo, TargetUserSpaceUpgradeTasks
+
+
+def _mock_path_checks(monkeypatch, files=(), directories=()):
+    def isfile(path):
+        return path in files
+
+    def isdir(path):
+        return path in directories
+
+    monkeypatch.setattr(os.path, 'isfile', isfile)
+    monkeypatch.setattr(os.path, 'isdir', isdir)
+
+
+def _md_arrays(*uuids):
+    return [MDArray(uuid=uuid) for uuid in uuids]
+
+
+def test_md_arrays_with_conf_dir(monkeypatch):
+    _mock_path_checks(
+        monkeypatch,
+        files=('/etc/mdadm.conf',),
+        directories=('/etc/mdadm.conf.d',),
+    )
+
+    msgs = [RAIDInfo(md_arrays=_md_arrays('aaa:bbb'))]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkraid.process()
+
+    assert api.produce.called == 1
+    copy_tasks = [m for m in api.produce.model_instances if isinstance(m, TargetUserSpaceUpgradeTasks)]
+    assert len(copy_tasks) == 1
+    assert [task.src for task in copy_tasks[0].copy_files] == [
+        '/etc/mdadm.conf',
+        '/etc/mdadm.conf.d',
+    ]
+
+
+def test_md_arrays_without_conf_dir(monkeypatch):
+    _mock_path_checks(monkeypatch, files=('/etc/mdadm.conf',))
+
+    msgs = [RAIDInfo(md_arrays=_md_arrays('aaa:bbb'))]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkraid.process()
+
+    copy_tasks = [m for m in api.produce.model_instances if isinstance(m, TargetUserSpaceUpgradeTasks)]
+    assert len(copy_tasks) == 1
+    assert [task.src for task in copy_tasks[0].copy_files] == ['/etc/mdadm.conf']
+
+
+def test_md_arrays_alternative_mdadm_conf(monkeypatch):
+    _mock_path_checks(
+        monkeypatch,
+        files=('/etc/mdadm/mdadm.conf',),
+        directories=('/etc/mdadm/mdadm.conf.d',),
+    )
+
+    msgs = [RAIDInfo(md_arrays=_md_arrays('aaa:bbb'))]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkraid.process()
+
+    copy_tasks = [m for m in api.produce.model_instances if isinstance(m, TargetUserSpaceUpgradeTasks)]
+    assert len(copy_tasks) == 1
+    assert [task.src for task in copy_tasks[0].copy_files] == [
+        '/etc/mdadm/mdadm.conf',
+        '/etc/mdadm/mdadm.conf.d',
+    ]
+
+
+def test_md_arrays_no_config_paths(monkeypatch):
+    _mock_path_checks(monkeypatch)
+
+    msgs = [RAIDInfo(md_arrays=_md_arrays('aaa:bbb'))]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkraid.process()
+
+    copy_tasks = [m for m in api.produce.model_instances if isinstance(m, TargetUserSpaceUpgradeTasks)]
+    assert not copy_tasks
+    assert not api.produce.called
+
+
+def test_no_raid_info(monkeypatch):
+    msgs = []
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkraid.process()
+
+    assert not api.produce.called
+
+
+def test_no_md_arrays(monkeypatch):
+    msgs = [RAIDInfo(md_arrays=[])]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkraid.process()
+
+    assert not api.produce.called

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/actor.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/actor.py
@@ -7,7 +7,7 @@ from leapp.models import (
     FIPSInfo,
     LiveModeConfig,
     LVMConfig,
-    RaidInfo,
+    RAIDInfo,
     TargetOSInstallationImage,
     TargetUserSpaceInfo,
     TargetUserSpaceUpgradeTasks,
@@ -34,7 +34,7 @@ class UpgradeInitramfsGenerator(Actor):
         FIPSInfo,
         LiveModeConfig,
         LVMConfig,
-        RaidInfo,
+        RAIDInfo,
         RequiredUpgradeInitramPackages,  # deprecated
         TargetOSInstallationImage,
         TargetUserSpaceInfo,

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/actor.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/actor.py
@@ -7,6 +7,7 @@ from leapp.models import (
     FIPSInfo,
     LiveModeConfig,
     LVMConfig,
+    RaidInfo,
     TargetOSInstallationImage,
     TargetUserSpaceInfo,
     TargetUserSpaceUpgradeTasks,
@@ -33,6 +34,7 @@ class UpgradeInitramfsGenerator(Actor):
         FIPSInfo,
         LiveModeConfig,
         LVMConfig,
+        RaidInfo,
         RequiredUpgradeInitramPackages,  # deprecated
         TargetOSInstallationImage,
         TargetUserSpaceInfo,

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/libraries/upgradeinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/libraries/upgradeinitramfsgenerator.py
@@ -14,7 +14,7 @@ from leapp.models import (
     BootContent,
     LiveModeConfig,
     LVMConfig,
-    RaidInfo,
+    RAIDInfo,
     TargetOSInstallationImage,
     TargetUserSpaceInfo,
     TargetUserSpaceUpgradeTasks,
@@ -25,6 +25,7 @@ from leapp.utils.deprecation import suppress_deprecation
 
 INITRAM_GEN_SCRIPT_NAME = 'generate-initram.sh'
 DRACUT_DIR = '/dracut'
+LEAPP_CMDLINE_CONF_PATH = '/etc/cmdline.d/50-leapp.conf'
 DEDICATED_LEAPP_PART_URL = 'https://access.redhat.com/solutions/7011704'
 
 
@@ -329,6 +330,32 @@ def _check_free_space(context):
         )
 
 
+def write_md_uuid_cmdline_conf(context):
+    """
+    Write /etc/cmdline.d/50-leapp.conf into the target userspace when MD RAID is in use.
+
+    :returns: Path of the written file, or None if no file was written.
+    :rtype: str or None
+    """
+    raid_info = next(api.consume(RAIDInfo), None)
+    if not raid_info or not raid_info.md_arrays:
+        return None
+
+    md_uuids = ['rd.md.uuid={}'.format(md_array.uuid) for md_array in raid_info.md_arrays]
+    content = '{}\n'.format(' '.join(md_uuids))
+
+    context.makedirs(os.path.dirname(LEAPP_CMDLINE_CONF_PATH), exists_ok=True)
+    with context.open(LEAPP_CMDLINE_CONF_PATH, mode='w') as cmdline_conf:
+        cmdline_conf.write(content)
+
+    api.current_logger().debug(
+        'Written {path} with content: {content}'.format(
+            path=LEAPP_CMDLINE_CONF_PATH, content=content.rstrip('\n')
+        )
+    )
+    return LEAPP_CMDLINE_CONF_PATH
+
+
 InitramfsIncludes = namedtuple('InitramfsIncludes', ('files', 'dracut_modules', 'kernel_modules'))
 
 
@@ -375,6 +402,10 @@ def generate_initram_disk(context):
     def fmt_module_list(module_list):
         return ','.join(mod.name for mod in module_list)
 
+    md_cmdline_conf = write_md_uuid_cmdline_conf(context)
+    if md_cmdline_conf:
+        initramfs_includes.files.append(md_cmdline_conf)
+
     env_variables = [
         'LEAPP_KERNEL_VERSION={kernel_version}',
         'LEAPP_ADD_DRACUT_MODULES="{dracut_modules}"',
@@ -386,8 +417,7 @@ def generate_initram_disk(context):
     if next(api.consume(LVMConfig), None):
         env_variables.append('LEAPP_DRACUT_LVMCONF="1"')
 
-    raid_info = next(api.consume(RaidInfo), None)
-    if raid_info and raid_info.md_arrays:
+    if md_cmdline_conf:
         env_variables.append('LEAPP_DRACUT_MDADMCONF="1"')
 
     env_variables = ' '.join(env_variables)
@@ -452,6 +482,10 @@ def _generate_livemode_initramfs(context, userspace_initramfs_dest, target_kerne
 
     copy_dracut_modules(context, initramfs_includes.dracut_modules)
     copy_kernel_modules(context, initramfs_includes.kernel_modules)
+
+    md_cmdline_conf = write_md_uuid_cmdline_conf(context)
+    if md_cmdline_conf:
+        initramfs_includes.files.append(md_cmdline_conf)
 
     dracut_modules = ['livenet', 'dmsquash-live'] + [mod.name for mod in initramfs_includes.dracut_modules]
 

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/libraries/upgradeinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/libraries/upgradeinitramfsgenerator.py
@@ -14,6 +14,7 @@ from leapp.models import (
     BootContent,
     LiveModeConfig,
     LVMConfig,
+    RaidInfo,
     TargetOSInstallationImage,
     TargetUserSpaceInfo,
     TargetUserSpaceUpgradeTasks,
@@ -384,6 +385,10 @@ def generate_initram_disk(context):
 
     if next(api.consume(LVMConfig), None):
         env_variables.append('LEAPP_DRACUT_LVMCONF="1"')
+
+    raid_info = next(api.consume(RaidInfo), None)
+    if raid_info and raid_info.md_arrays:
+        env_variables.append('LEAPP_DRACUT_MDADMCONF="1"')
 
     env_variables = ' '.join(env_variables)
     env_variables = env_variables.format(

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/tests/unit_test_upgradeinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/tests/unit_test_upgradeinitramfsgenerator.py
@@ -17,6 +17,8 @@ from leapp.models import (  # isort:skip
     CopyFile,
     DracutModule,
     KernelModule,
+    MDArray,
+    RAIDInfo,
     TargetUserSpaceUpgradeTasks,
     UpgradeInitramfsTasks,
 )
@@ -89,6 +91,7 @@ class MockedContext:
         self.called_copy_to = []
         self.called_call = []
         self.called_makedirs = []
+        self.written_files = {}
         self.content = set()
         self.base_dir = "/base/dir"
         """
@@ -134,6 +137,25 @@ class MockedContext:
 
     def full_path(self, path):
         return os.path.join(self.base_dir, os.path.abspath(path).lstrip('/'))
+
+    def open(self, path, *args, mode='r', **kwargs):  # pylint: disable=no-self-use
+        if 'w' not in mode:
+            raise NotImplementedError('MockedContext.open only supports write mode')
+
+        written_files = self.written_files
+        contents = []
+
+        class _Writer:
+            def write(self, data):  # pylint: disable=no-self-use
+                contents.append(data)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *dummy):
+                written_files[path] = ''.join(contents)
+
+        return _Writer()
 
 
 class MockedLogger(logger_mocked):
@@ -184,6 +206,58 @@ class MockedCopyArgs:
 
 def _sort_files(copy_files):
     return sorted(copy_files, key=lambda x: (x.src, x.dst))
+
+
+@pytest.mark.parametrize('raid_info,expected_path,expected_content', [
+    (None, None, None),
+    (RAIDInfo(md_arrays=[]), None, None),
+    (
+        RAIDInfo(md_arrays=[MDArray(uuid='aaa:bbb')]),
+        upgradeinitramfsgenerator.LEAPP_CMDLINE_CONF_PATH,
+        'rd.md.uuid=aaa:bbb\n',
+    ),
+    (
+        RAIDInfo(md_arrays=[MDArray(uuid='aaa:bbb'), MDArray(uuid='ccc:ddd')]),
+        upgradeinitramfsgenerator.LEAPP_CMDLINE_CONF_PATH,
+        'rd.md.uuid=aaa:bbb rd.md.uuid=ccc:ddd\n',
+    ),
+])
+def test_write_md_uuid_cmdline_conf(monkeypatch, raid_info, expected_path, expected_content):
+    context = MockedContext()
+    msgs = [raid_info] if raid_info is not None else []
+    monkeypatch.setattr(upgradeinitramfsgenerator.api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    result = upgradeinitramfsgenerator.write_md_uuid_cmdline_conf(context)
+
+    assert result == expected_path
+    if expected_path:
+        assert '/etc/cmdline.d' in context.called_makedirs
+        assert context.written_files[expected_path] == expected_content
+    else:
+        assert not context.written_files
+        assert not context.called_makedirs
+
+
+def test_generate_initram_disk_includes_md_cmdline_conf(monkeypatch):
+    context = MockedContext()
+    raid_info = RAIDInfo(md_arrays=[MDArray(uuid='aaa:bbb')])
+    input_msgs = gen_UDM_list(MODULES[0]) + [raid_info]
+    curr_actor = CurrentActorMocked(msgs=input_msgs, arch=architecture.ARCH_X86_64)
+    monkeypatch.setattr(upgradeinitramfsgenerator.api, 'current_actor', curr_actor)
+    monkeypatch.setattr(upgradeinitramfsgenerator, 'copy_dracut_modules', MockedCopyArgs())
+    monkeypatch.setattr(upgradeinitramfsgenerator, '_get_target_kernel_version', lambda _: '1.0-1.x86_64')
+    monkeypatch.setattr(upgradeinitramfsgenerator, 'copy_kernel_modules', MockedCopyArgs())
+    monkeypatch.setattr(upgradeinitramfsgenerator, 'copy_boot_files', lambda dummy: None)
+    monkeypatch.setattr(upgradeinitramfsgenerator, '_get_fspace', MockedGetFspace(2*2**30))
+
+    upgradeinitramfsgenerator.generate_initram_disk(context)
+
+    assert context.written_files[upgradeinitramfsgenerator.LEAPP_CMDLINE_CONF_PATH] == 'rd.md.uuid=aaa:bbb\n'
+    assert len(context.called_call) == 1
+    shell_cmd = context.called_call[0][0][0][2]
+    assert 'LEAPP_DRACUT_INSTALL_FILES="{path}"'.format(
+        path=upgradeinitramfsgenerator.LEAPP_CMDLINE_CONF_PATH
+    ) in shell_cmd
+    assert 'LEAPP_DRACUT_MDADMCONF="1"' in shell_cmd
 
 
 def test_prepare_userspace_for_initram_no_script(monkeypatch):

--- a/repos/system_upgrade/common/actors/scanraid/actor.py
+++ b/repos/system_upgrade/common/actors/scanraid/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scanraid
+from leapp.models import DistributionSignedRPM, RAIDInfo
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanRaid(Actor):
+    """
+    Detect whether software RAID is in use on the system.
+
+    Checks if the mdadm package is installed and whether any MD arrays
+    are currently assembled and active by scanning mdadm configuration.
+    """
+
+    name = 'scan_raid'
+    consumes = (DistributionSignedRPM,)
+    produces = (RAIDInfo,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        scanraid.process()

--- a/repos/system_upgrade/common/actors/scanraid/libraries/scanraid.py
+++ b/repos/system_upgrade/common/actors/scanraid/libraries/scanraid.py
@@ -1,0 +1,40 @@
+import re
+
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import DistributionSignedRPM, MDArray, RAIDInfo
+
+MDADM_SCAN_CMD = ['mdadm', '--detail', '--scan', '--verbose']
+UUID_PATTERN = re.compile(r'UUID=([0-9a-fA-F:]+)')
+
+
+def _scan_md_array_uuids():
+    try:
+        result = run(MDADM_SCAN_CMD)
+    except CalledProcessError as err:
+        api.current_logger().warning('Failed to scan mdadm arrays: %s', err)
+        return []
+
+    uuids = []
+    for line in result['stdout'].splitlines():
+        if not line.startswith('ARRAY '):
+            continue
+        match = UUID_PATTERN.search(line)
+        if match:
+            uuids.append(match.group(1))
+
+    return uuids
+
+
+def process():
+    if not has_package(DistributionSignedRPM, 'mdadm'):
+        api.current_logger().debug('The mdadm package is not installed. Skipping.')
+        return
+
+    uuids = _scan_md_array_uuids()
+    if not uuids:
+        api.current_logger().debug('No active mdadm software RAID arrays found.')
+        return
+
+    api.current_logger().info('Detected active mdadm software RAID arrays.')
+    api.produce(RAIDInfo(md_arrays=[MDArray(uuid=uuid) for uuid in uuids]))

--- a/repos/system_upgrade/common/actors/scanraid/tests/test_scanraid.py
+++ b/repos/system_upgrade/common/actors/scanraid/tests/test_scanraid.py
@@ -1,0 +1,122 @@
+import pytest
+
+from leapp.libraries.actor import scanraid
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked, produce_mocked
+from leapp.libraries.stdlib import api, CalledProcessError
+from leapp.models import DistributionSignedRPM, MDArray, RAIDInfo, RPM
+
+_MDADM_RPM = RPM(
+    name='mdadm',
+    version='4.2',
+    release='1.el9',
+    epoch='0',
+    packager='',
+    arch='x86_64',
+    pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51'
+)
+
+MDADM_SCAN_WITH_ARRAY = (
+    'ARRAY /dev/md0 level=raid1 num-devices=2 metadata=1.2 '
+    'name=localhost.localdomain:0 UUID=c4acea6e:d56e1598:91822e3f:fb26832c\n'
+)
+
+MDADM_SCAN_WITH_TWO_ARRAYS = (
+    'ARRAY /dev/md0 metadata=1.2 UUID=c4acea6e:d56e1598:91822e3f:fb26832c\n'
+    'ARRAY /dev/md1 metadata=1.2 UUID=5eb8cf98:a8d13c2e:3e91b4ca:2e1ac678\n'
+)
+
+
+class RunMocked:
+
+    def __init__(self, stdout='', raise_err=False):
+        self.called = 0
+        self.args = None
+        self.stdout = stdout
+        self.raise_err = raise_err
+
+    def __call__(self, args, encoding=None):
+        self.called += 1
+        self.args = args
+        if self.raise_err:
+            raise CalledProcessError(
+                message='A Leapp Command Error occurred.',
+                command=args,
+                result={'signal': None, 'exit_code': 1, 'pid': 0, 'stdout': 'fake', 'stderr': 'fake'}
+            )
+        assert args == scanraid.MDADM_SCAN_CMD
+        return {'stdout': self.stdout}
+
+
+def test_mdadm_not_installed(monkeypatch):
+    msgs = [DistributionSignedRPM(items=[])]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    scanraid.process()
+
+    assert not api.produce.called
+
+
+def test_mdadm_installed_with_active_arrays(monkeypatch):
+    run_mocked = RunMocked(stdout=MDADM_SCAN_WITH_ARRAY)
+    monkeypatch.setattr(scanraid, 'run', run_mocked)
+
+    msgs = [DistributionSignedRPM(items=[_MDADM_RPM])]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    scanraid.process()
+
+    assert run_mocked.called == 1
+    assert api.produce.called == 1
+    assert len(api.produce.model_instances) == 1
+    produced = api.produce.model_instances[0]
+    assert isinstance(produced, RAIDInfo)
+    assert produced.md_arrays == [MDArray(uuid='c4acea6e:d56e1598:91822e3f:fb26832c')]
+
+
+def test_mdadm_installed_with_multiple_arrays(monkeypatch):
+    run_mocked = RunMocked(stdout=MDADM_SCAN_WITH_TWO_ARRAYS)
+    monkeypatch.setattr(scanraid, 'run', run_mocked)
+
+    msgs = [DistributionSignedRPM(items=[_MDADM_RPM])]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    scanraid.process()
+
+    produced = api.produce.model_instances[0]
+    assert [md_array.uuid for md_array in produced.md_arrays] == [
+        'c4acea6e:d56e1598:91822e3f:fb26832c',
+        '5eb8cf98:a8d13c2e:3e91b4ca:2e1ac678',
+    ]
+
+
+def test_mdadm_installed_no_active_arrays(monkeypatch):
+    run_mocked = RunMocked(stdout='')
+    monkeypatch.setattr(scanraid, 'run', run_mocked)
+
+    msgs = [DistributionSignedRPM(items=[_MDADM_RPM])]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    scanraid.process()
+
+    assert run_mocked.called == 1
+    assert not api.produce.called
+
+
+def test_mdadm_installed_scan_failure(monkeypatch):
+    run_mocked = RunMocked(raise_err=True)
+    monkeypatch.setattr(scanraid, 'run', run_mocked)
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    msgs = [DistributionSignedRPM(items=[_MDADM_RPM])]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    scanraid.process()
+
+    assert run_mocked.called == 1
+    assert not api.produce.called
+    assert api.current_logger.warnmsg

--- a/repos/system_upgrade/common/models/raidinfo.py
+++ b/repos/system_upgrade/common/models/raidinfo.py
@@ -1,0 +1,19 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class MDArray(Model):
+    """Information about a single mdadm software RAID array."""
+
+    topic = SystemInfoTopic
+
+    uuid = fields.String()
+    """UUID of the mdadm array."""
+
+
+class RAIDInfo(Model):
+    """Information about RAID usage on the source system."""
+    topic = SystemInfoTopic
+
+    md_arrays = fields.List(fields.Model(MDArray), default=[])
+    """List of active mdadm software RAID arrays."""


### PR DESCRIPTION
Currently, the mdadm configuration (`/etc/mdadm.conf` and the alternative
location and config dirs, see `man mdadm.conf`#Files) is explicitly set to not
be included in upgrade initramfs (via `--nomdadmconf` dracut option).
However, this might cause errors when there are md raid devices on the
system.

The configuration files should be compatible between RHEL 7, 8, 9.

For example, if md array locations are used in fstab instead of UUIDs:
```
$ cat /etc/mdadm.conf
ARRAY /dev/md/boot level=raid1 num-devices=2 UUID=531cea9d:bcb23190:ef4a0f87:65bf90d7
ARRAY /dev/md/root level=raid1 num-devices=2 UUID=4d920d36:ac04845a:2f67ffd8:a6f7a521

$ cat /etc/fstab
/dev/md/root /                       xfs     defaults        0 0
/dev/md/boot /boot                   xfs     defaults        0 0
```
In this case `/boot` and `/` can't be properly mounted, because their
location is specified in `mdadm.conf`.

Inclusion of `mdadm.conf` in the upgrade initramfs should fix such problems.
The file existence check in the target userspace is performed by dracut.
Without the `--mdadmconf` flag the file wouldn't be included at all since
the upgrade initramfs is `--nohostonly`.

Jira: RHEL-3279, RHEL-36249