### PR TITLE
Removing the config state for the data files at /etc/leapp/files/*.json

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -262,7 +262,7 @@ done;
 %dir %{repositorydir}
 %dir %{custom_repositorydir}
 %dir %{leapp_python_sitelib}/leapp/cli/commands
-%config %{_sysconfdir}/leapp/files/*
+%{_sysconfdir}/leapp/files/*
 %{_sysconfdir}/leapp/repos.d/*
 %{_sysconfdir}/leapp/transaction/*
 %{repositorydir}/*


### PR DESCRIPTION
With the config option applied, these files are not replaced when packages are reinstalled.