### PR TITLE
Further narrow down packit tests

### DIFF
--- a/.github/workflows/pr-welcome-msg.yml
+++ b/.github/workflows/pr-welcome-msg.yml
@@ -26,7 +26,12 @@ jobs:
 
             Packit will automatically schedule regression tests for this PR's build and latest upstream leapp build. If you need a different version of leapp from PR#42, use `/packit test oamg/leapp#42`
 
-            To launch regression testing public members of oamg organization can leave the following comment:
+            It is possible to schedule specific on-demand tests as well. Currently 2 test sets are supported, `beaker-minimal` and `kernel-rt`, both can be used to be run on all upgrade paths or just a couple of specific ones.
+            To launch on-demand tests with packit:
+            - **/packit test --labels kernel-rt** to schedule `kernel-rt` tests set for all upgrade paths
+            - **/packit test --labels beaker-minimal-8.9to9.3,kernel-rt-8.9to9.3** to schedule `kernel-rt` and `beaker-minimal` test sets for 8.9->9.3 upgrade path
+
+            [Deprecated] To launch on-demand regression testing public members of oamg organization can leave the following comment:
             - **/rerun** to schedule basic regression tests using this pr build and latest upstream leapp build as artifacts
             - **/rerun 42** to schedule basic regression tests using this pr build and leapp\*PR42\* as artifacts
             - **/rerun-sst** to schedule sst tests using this pr build and latest upstream leapp build as artifacts

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -85,18 +85,18 @@ jobs:
     # builds from master branch should start with 100 release, to have high priority
     - bash -c "sed -i \"s/1%{?dist}/100%{?dist}/g\" packaging/leapp-repository.spec"
 
-- &default-79to86
+- &sanity-79to86
   job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
   labels:
-    - default
+    - sanity
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
-  identifier: tests-7.9to8.6
+  identifier: sanity-7.9to8.6
   tmt_plan: "sanity_plan"
   tf_extra_params:
     environments:
@@ -114,15 +114,15 @@ jobs:
     TARGET_RELEASE: "8.6"
     LEAPPDATA_BRANCH: "upstream"
 
-- &default-79to86-aws
-  <<: *default-79to86
+- &sanity-79to86-aws
+  <<: *sanity-79to86
   labels:
-    - default
+    - sanity
     - aws
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-rhui]
-  identifier: tests-7to8-aws-e2e
+  identifier: sanity-7to8-aws-e2e
   tmt_plan: "(?!.*sap)(.*e2e)"
   tf_extra_params:
     environments:
@@ -143,12 +143,13 @@ jobs:
 
 # On-demand minimal beaker tests
 - &beaker-minimal-79to86
-  <<: *default-79to86
+  <<: *sanity-79to86
   manual_trigger: True
   labels:
     - beaker-minimal
     - beaker-minimal-7.9to8.6
-  identifier: tests-7.9to8.6-beaker-minimal
+    - 7.9to8.6
+  identifier: sanity-7.9to8.6-beaker-minimal
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi|.*oamg4250_lvm_var_xfs_ftype0)"
 
 # On-demand kernel-rt tests
@@ -157,12 +158,13 @@ jobs:
   labels:
     - kernel-rt
     - kernel-rt-7.9to8.6
-  identifier: tests-7.9to8.6-kernel-rt
+    - 7.9to8.6
+  identifier: sanity-7.9to8.6-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
-- &default-79to88
-  <<: *default-79to86
-  identifier: tests-7.9to8.8
+- &sanity-79to88
+  <<: *sanity-79to86
+  identifier: sanity-7.9to8.8
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.8"
@@ -174,7 +176,8 @@ jobs:
   labels:
     - beaker-minimal
     - beaker-minimal-7.9to8.8
-  identifier: tests-7.9to8.8-beaker-minimal
+    - 7.9to8.8
+  identifier: sanity-7.9to8.8-beaker-minimal
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.8"
@@ -186,12 +189,13 @@ jobs:
   labels:
     - kernel-rt
     - kernel-rt-7.9to8.8
-  identifier: tests-7.9to8.8-kernel-rt
+    - 7.9to8.8
+  identifier: sanity-7.9to8.8-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
-- &default-79to89
-  <<: *default-79to86
-  identifier: tests-7.9to8.9
+- &sanity-79to89
+  <<: *sanity-79to86
+  identifier: sanity-7.9to8.9
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.9"
@@ -203,7 +207,8 @@ jobs:
   labels:
     - beaker-minimal
     - beaker-minimal-7.9to8.9
-  identifier: tests-7.9to8.9-beaker-minimal
+    - 7.9to8.9
+  identifier: sanity-7.9to8.9-beaker-minimal
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.9"
@@ -215,15 +220,16 @@ jobs:
   labels:
     - kernel-rt
     - kernel-rt-7.9to8.9
-  identifier: tests-7.9to8.9-kernel-rt
+    - 7.9to8.9
+  identifier: sanity-7.9to8.9-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
-- &default-86to90
-  <<: *default-79to86
+- &sanity-86to90
+  <<: *sanity-79to86
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.6.0-Nightly]
-  identifier: tests-8.6to9.0
+  identifier: sanity-8.6to9.0
   tf_extra_params:
     environments:
       - tmt:
@@ -247,10 +253,11 @@ jobs:
   labels:
     - beaker-minimal
     - beaker-minimal-8.6to9.0
+    - 8.6to9.0
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.6.0-Nightly]
-  identifier: tests-8.6to9.0-beaker-minimal
+  identifier: sanity-8.6to9.0-beaker-minimal
   tf_extra_params:
     environments:
       - tmt:
@@ -274,15 +281,16 @@ jobs:
   labels:
     - kernel-rt
     - kernel-rt-8.6to9.0
-  identifier: tests-8.6to9.0-kernel-rt
+    - 8.6to9.0
+  identifier: sanity-8.6to9.0-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
-- &default-88to92
-  <<: *default-86to90
+- &sanity-88to92
+  <<: *sanity-86to90
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
-  identifier: tests-8.8to9.2
+  identifier: sanity-8.8to9.2
   tf_extra_params:
     environments:
       - tmt:
@@ -307,10 +315,11 @@ jobs:
   labels:
     - beaker-minimal
     - beaker-minimal-8.8to9.2
+    - 8.6to9.2
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
-  identifier: tests-8.8to9.2-beaker-minimal
+  identifier: sanity-8.8to9.2-beaker-minimal
   tf_extra_params:
     environments:
       - tmt:
@@ -335,15 +344,16 @@ jobs:
   labels:
     - kernel-rt
     - kernel-rt-8.8to9.2
-  identifier: tests-8.8to9.2-kernel-rt
+    - 8.8to9.2
+  identifier: sanity-8.8to9.2-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
-- &default-89to93
-  <<: *default-88to92
+- &sanity-89to93
+  <<: *sanity-88to92
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.9.0-Nightly]
-  identifier: tests-8.9to9.3
+  identifier: sanity-8.9to9.3
   tf_extra_params:
     environments:
       - tmt:
@@ -368,10 +378,11 @@ jobs:
   labels:
     - beaker-minimal
     - beaker-minimal-8.9to9.3
+    - 8.9to9.3
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.9.0-Nightly]
-  identifier: tests-8.9to9.3-beaker-minimal
+  identifier: sanity-8.9to9.3-beaker-minimal
   tf_extra_params:
     environments:
       - tmt:
@@ -396,15 +407,16 @@ jobs:
   labels:
     - kernel-rt
     - kernel-rt-8.9to9.3
-  identifier: tests-8.9to9.3-kernel-rt
+    - 8.9to9.3
+  identifier: sanity-8.9to9.3-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
-- &default-86to90-aws
-  <<: *default-79to86-aws
+- &sanity-86to90-aws
+  <<: *sanity-79to86-aws
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.6-rhui]
-  identifier: tests-8to9-aws-e2e
+  identifier: sanity-8to9-aws-e2e
   tf_extra_params:
     environments:
       - tmt:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -97,7 +97,7 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-7.9to8.6
-  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(?!.*oamg4250_lvm_var_xfs_ftype0)(?!.*kernel-rt)(.*tier1)"
+  tmt_plan: "sanity_plan"
   tf_extra_params:
     environments:
       - tmt:
@@ -151,6 +151,14 @@ jobs:
   identifier: tests-7.9to8.6-minimal-beaker
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi|.*oamg4250_lvm_var_xfs_ftype0)"
 
+# On-demand kernel-rt tests
+- &kernel-rt-79to86
+  <<: *beaker-minimal-79to86
+  labels:
+    - kernel-rt
+  identifier: tests-7.9to8.6-kernel-rt
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
+
 - &default-79to88
   <<: *default-79to86
   identifier: tests-7.9to8.8
@@ -171,6 +179,14 @@ jobs:
     TARGET_RELEASE: "8.8"
     LEAPPDATA_BRANCH: "upstream"
 
+# On-demand kernel-rt tests
+- &kernel-rt-79to88
+  <<: *beaker-minimal-79to88
+  labels:
+    - kernel-rt
+  identifier: tests-7.9to8.8-kernel-rt
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
+
 - &default-79to89
   <<: *default-79to86
   identifier: tests-7.9to8.9
@@ -190,6 +206,14 @@ jobs:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.9"
     LEAPPDATA_BRANCH: "upstream"
+
+# On-demand kernel-rt tests
+- &kernel-rt-79to89
+  <<: *beaker-minimal-79to89
+  labels:
+    - kernel-rt
+  identifier: tests-7.9to8.9-kernel-rt
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
 - &default-86to90
   <<: *default-79to86
@@ -240,6 +264,14 @@ jobs:
     TARGET_RELEASE: "9.0"
     RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
     LEAPPDATA_BRANCH: "upstream"
+
+# On-demand kernel-rt tests
+- &kernel-rt-86to90
+  <<: *beaker-minimal-86to90
+  labels:
+    - kernel-rt
+  identifier: tests-8.6to9.0-kernel-rt
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
 - &default-88to92
   <<: *default-86to90
@@ -293,6 +325,14 @@ jobs:
     LEAPPDATA_BRANCH: "upstream"
     LEAPP_DEVEL_TARGET_RELEASE: "9.2"
 
+# On-demand kernel-rt tests
+- &kernel-rt-88to92
+  <<: *beaker-minimal-88to92
+  labels:
+    - kernel-rt
+  identifier: tests-8.8to9.2-kernel-rt
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
+
 - &default-89to93
   <<: *default-88to92
   targets:
@@ -344,6 +384,14 @@ jobs:
     RHSM_REPOS: "rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-beta-rpms"
     LEAPPDATA_BRANCH: "upstream"
     LEAPP_DEVEL_TARGET_RELEASE: "9.3"
+
+# On-demand kernel-rt tests
+- &kernel-rt-89to93
+  <<: *beaker-minimal-89to93
+  labels:
+    - kernel-rt
+  identifier: tests-8.9to9.3-kernel-rt
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
 - &default-86to90-aws
   <<: *default-79to86-aws

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -94,7 +94,7 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-7.9to8.6
-  tmt_plan: "((?!.*uefi_upgrade)(?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*uefi_upgrade)(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
   tf_extra_params:
     environments:
       - tmt:
@@ -120,7 +120,7 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-7.9to8.8
-  tmt_plan: "((?!.*uefi_upgrade)(?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*uefi_upgrade)(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
   tf_extra_params:
     environments:
       - tmt:
@@ -193,7 +193,7 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-8.6to9.0
-  tmt_plan: "((?!.*uefi_upgrade)(?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*uefi_upgrade)(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
   tf_extra_params:
     environments:
       - tmt:
@@ -220,7 +220,7 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
   identifier: tests-8.8to9.2
-  tmt_plan: "((?!.*uefi_upgrade)(?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*uefi_upgrade)(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
   tf_extra_params:
     environments:
       - tmt:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -146,9 +146,9 @@ jobs:
   <<: *default-79to86
   manual_trigger: True
   labels:
-    - minimal-beaker
-    - minimal-beaker-7.9to8.6
-  identifier: tests-7.9to8.6-minimal-beaker
+    - beaker-minimal
+    - beaker-minimal-7.9to8.6
+  identifier: tests-7.9to8.6-beaker-minimal
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi|.*oamg4250_lvm_var_xfs_ftype0)"
 
 # On-demand kernel-rt tests
@@ -156,6 +156,7 @@ jobs:
   <<: *beaker-minimal-79to86
   labels:
     - kernel-rt
+    - kernel-rt-7.9to8.6
   identifier: tests-7.9to8.6-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
@@ -171,9 +172,9 @@ jobs:
 - &beaker-minimal-79to88
   <<: *beaker-minimal-79to86
   labels:
-    - minimal-beaker
-    - minimal-beaker-7.9to8.8
-  identifier: tests-7.9to8.8-minimal-beaker
+    - beaker-minimal
+    - beaker-minimal-7.9to8.8
+  identifier: tests-7.9to8.8-beaker-minimal
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.8"
@@ -184,6 +185,7 @@ jobs:
   <<: *beaker-minimal-79to88
   labels:
     - kernel-rt
+    - kernel-rt-7.9to8.8
   identifier: tests-7.9to8.8-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
@@ -199,9 +201,9 @@ jobs:
 - &beaker-minimal-79to89
   <<: *beaker-minimal-79to86
   labels:
-    - minimal-beaker
-    - minimal-beaker-7.9to8.9
-  identifier: tests-7.9to8.9-minimal-beaker
+    - beaker-minimal
+    - beaker-minimal-7.9to8.9
+  identifier: tests-7.9to8.9-beaker-minimal
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.9"
@@ -212,6 +214,7 @@ jobs:
   <<: *beaker-minimal-79to89
   labels:
     - kernel-rt
+    - kernel-rt-7.9to8.9
   identifier: tests-7.9to8.9-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
@@ -242,12 +245,12 @@ jobs:
 - &beaker-minimal-86to90
   <<: *beaker-minimal-79to86
   labels:
-    - minimal-beaker
-    - minimal-beaker-8.6to9.0
+    - beaker-minimal
+    - beaker-minimal-8.6to9.0
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.6.0-Nightly]
-  identifier: tests-8.6to9.0-minimal-beaker
+  identifier: tests-8.6to9.0-beaker-minimal
   tf_extra_params:
     environments:
       - tmt:
@@ -270,6 +273,7 @@ jobs:
   <<: *beaker-minimal-86to90
   labels:
     - kernel-rt
+    - kernel-rt-8.6to9.0
   identifier: tests-8.6to9.0-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
@@ -301,12 +305,12 @@ jobs:
 - &beaker-minimal-88to92
   <<: *beaker-minimal-86to90
   labels:
-    - minimal-beaker
-    - minimal-beaker-8.8to9.2
+    - beaker-minimal
+    - beaker-minimal-8.8to9.2
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
-  identifier: tests-8.8to9.2-minimal-beaker
+  identifier: tests-8.8to9.2-beaker-minimal
   tf_extra_params:
     environments:
       - tmt:
@@ -330,6 +334,7 @@ jobs:
   <<: *beaker-minimal-88to92
   labels:
     - kernel-rt
+    - kernel-rt-8.8to9.2
   identifier: tests-8.8to9.2-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 
@@ -361,12 +366,12 @@ jobs:
 - &beaker-minimal-89to93
   <<: *beaker-minimal-88to92
   labels:
-    - minimal-beaker
-    - minimal-beaker-8.9to9.3
+    - beaker-minimal
+    - beaker-minimal-8.9to9.3
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.9.0-Nightly]
-  identifier: tests-8.9to9.3-minimal-beaker
+  identifier: tests-8.9to9.3-beaker-minimal
   tf_extra_params:
     environments:
       - tmt:
@@ -390,6 +395,7 @@ jobs:
   <<: *beaker-minimal-89to93
   labels:
     - kernel-rt
+    - kernel-rt-8.9to9.3
   identifier: tests-8.9to9.3-kernel-rt
   tmt_plan: "(?!.*max_sst)(.*tier1)(.*kernel-rt)"
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -94,7 +94,7 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-7.9to8.6
-  tmt_plan: "^(?!.*max_sst)(.*tier1)"
+  tmt_plan: "((?!.*uefi_upgrade)(?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*uefi_upgrade)(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
   tf_extra_params:
     environments:
       - tmt:
@@ -120,7 +120,7 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-7.9to8.8
-  tmt_plan: "^(?!.*max_sst)(.*tier1)"
+  tmt_plan: "((?!.*uefi_upgrade)(?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*uefi_upgrade)(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
   tf_extra_params:
     environments:
       - tmt:
@@ -193,7 +193,7 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-8.6to9.0
-  tmt_plan: "^(?!.*max_sst)(.*tier1)"
+  tmt_plan: "((?!.*uefi_upgrade)(?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*uefi_upgrade)(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
   tf_extra_params:
     environments:
       - tmt:
@@ -220,7 +220,7 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
   identifier: tests-8.8to9.2
-  tmt_plan: "^(?!.*max_sst)(.*tier1)"
+  tmt_plan: "((?!.*uefi_upgrade)(?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*uefi_upgrade)(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
   tf_extra_params:
     environments:
       - tmt:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -85,6 +85,7 @@ jobs:
     # builds from master branch should start with 100 release, to have high priority
     - bash -c "sed -i \"s/1%{?dist}/100%{?dist}/g\" packaging/leapp-repository.spec"
 
+
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
   fmf_ref: "master"
@@ -94,7 +95,37 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-7.9to8.6
-  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-7.9"
+        # tag resources as sst_upgrades to enable cost metrics collection
+        settings:
+          provisioning:
+            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+            tags:
+              BusinessUnit: sst_upgrades
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.6"
+    LEAPPDATA_BRANCH: "upstream"
+
+# On-demand minimal beaker tests
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  manual_trigger: True
+  labels:
+    - minimal-beaker
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-ZStream]
+  identifier: tests-7.9to8.6-minimal-beaker
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
   tf_extra_params:
     environments:
       - tmt:
@@ -120,7 +151,37 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-7.9to8.8
-  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-7.9"
+        # tag resources as sst_upgrades to enable cost metrics collection
+        settings:
+          provisioning:
+            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+            tags:
+              BusinessUnit: sst_upgrades
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.8"
+    LEAPPDATA_BRANCH: "upstream"
+
+# On-demand minimal beaker tests
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  manual_trigger: True
+  labels:
+    - minimal-beaker
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-ZStream]
+  identifier: tests-7.9to8.8-minimal-beaker
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
   tf_extra_params:
     environments:
       - tmt:
@@ -146,7 +207,37 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-7.9to8.9
-  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-7.9"
+        # tag resources as sst_upgrades to enable cost metrics collection
+        settings:
+          provisioning:
+            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+            tags:
+              BusinessUnit: sst_upgrades
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.9"
+    LEAPPDATA_BRANCH: "upstream"
+
+# On-demand minimal beaker tests
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  manual_trigger: True
+  labels:
+    - minimal-beaker
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-ZStream]
+  identifier: tests-7.9to8.9-minimal-beaker
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
   tf_extra_params:
     environments:
       - tmt:
@@ -199,7 +290,38 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-8.6to9.0
-  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-8.6"
+        # tag resources as sst_upgrades to enable cost metrics collection
+        settings:
+          provisioning:
+            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+            tags:
+              BusinessUnit: sst_upgrades
+  env:
+    SOURCE_RELEASE: "8.6"
+    TARGET_RELEASE: "9.0"
+    RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
+    LEAPPDATA_BRANCH: "upstream"
+
+# On-demand minimal beaker tests
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  manual_trigger: True
+  labels:
+    - minimal-beaker
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.6.0-Nightly]
+  identifier: tests-8.6to9.0-minimal-beaker
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
   tf_extra_params:
     environments:
       - tmt:
@@ -226,7 +348,39 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
   identifier: tests-8.8to9.2
-  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-8.8"
+        # tag resources as sst_upgrades to enable cost metrics collection
+        settings:
+          provisioning:
+            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+            tags:
+              BusinessUnit: sst_upgrades
+  env:
+    SOURCE_RELEASE: "8.8"
+    TARGET_RELEASE: "9.2"
+    RHSM_REPOS: "rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-beta-rpms"
+    LEAPPDATA_BRANCH: "upstream"
+    LEAPP_DEVEL_TARGET_RELEASE: "9.2"
+
+# On-demand minimal beaker tests
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  manual_trigger: True
+  labels:
+    - minimal-beaker
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.8.0-Nightly]
+  identifier: tests-8.8to9.2-minimal-beaker
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
   tf_extra_params:
     environments:
       - tmt:
@@ -254,7 +408,39 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.9.0-Nightly]
   identifier: tests-8.9to9.3
-  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-8.9"
+        # tag resources as sst_upgrades to enable cost metrics collection
+        settings:
+          provisioning:
+            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+            tags:
+              BusinessUnit: sst_upgrades
+  env:
+    SOURCE_RELEASE: "8.9"
+    TARGET_RELEASE: "9.3"
+    RHSM_REPOS: "rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-beta-rpms"
+    LEAPPDATA_BRANCH: "upstream"
+    LEAPP_DEVEL_TARGET_RELEASE: "9.3"
+
+# On-demand minimal beaker tests
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  manual_trigger: True
+  labels:
+    - minimal-beaker
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.9.0-Nightly]
+  identifier: tests-8.9to9.3-minimal-beaker
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
   tf_extra_params:
     environments:
       - tmt:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -103,12 +103,12 @@ jobs:
       - tmt:
           context:
             distro: "rhel-7.9"
-        # tag resources as sst_upgrades to enable cost metrics collection
+        # tag resources as sst_upgrades@leapp_upstream_test to enable cost metrics collection
         settings:
           provisioning:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
             tags:
-              BusinessUnit: sst_upgrades
+              BusinessUnit: sst_upgrades@leapp_upstream_test
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.6"
@@ -129,12 +129,12 @@ jobs:
       - tmt:
           context:
             distro: "rhel-7.9"
-        # tag resources as sst_upgrades to enable cost metrics collection
+        # tag resources as sst_upgrades@leapp_upstream_test to enable cost metrics collection
         settings:
           provisioning:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
             tags:
-              BusinessUnit: sst_upgrades
+              BusinessUnit: sst_upgrades@leapp_upstream_test
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.6"
@@ -235,16 +235,16 @@ jobs:
       - tmt:
           context:
             distro: "rhel-8.6"
-        # tag resources as sst_upgrades to enable cost metrics collection
+        # tag resources as sst_upgrades@leapp_upstream_test to enable cost metrics collection
         settings:
           provisioning:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
             tags:
-              BusinessUnit: sst_upgrades
+              BusinessUnit: sst_upgrades@leapp_upstream_test
   env:
     SOURCE_RELEASE: "8.6"
     TARGET_RELEASE: "9.0"
-    RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
+    RHSM_REPOS_EUS: "eus"
     LEAPPDATA_BRANCH: "upstream"
 
 # On-demand minimal beaker tests
@@ -263,16 +263,16 @@ jobs:
       - tmt:
           context:
             distro: "rhel-8.6"
-        # tag resources as sst_upgrades to enable cost metrics collection
+        # tag resources as sst_upgrades@leapp_upstream_test to enable cost metrics collection
         settings:
           provisioning:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
             tags:
-              BusinessUnit: sst_upgrades
+              BusinessUnit: sst_upgrades@leapp_upstream_test
   env:
     SOURCE_RELEASE: "8.6"
     TARGET_RELEASE: "9.0"
-    RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
+    RHSM_REPOS_EUS: "eus"
     LEAPPDATA_BRANCH: "upstream"
 
 # On-demand kernel-rt tests
@@ -296,16 +296,16 @@ jobs:
       - tmt:
           context:
             distro: "rhel-8.8"
-        # tag resources as sst_upgrades to enable cost metrics collection
+        # tag resources as sst_upgrades@leapp_upstream_test to enable cost metrics collection
         settings:
           provisioning:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
             tags:
-              BusinessUnit: sst_upgrades
+              BusinessUnit: sst_upgrades@leapp_upstream_test
   env:
     SOURCE_RELEASE: "8.8"
     TARGET_RELEASE: "9.2"
-    RHSM_REPOS: "rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-beta-rpms"
+    RHSM_REPOS_EUS: "eus"
     LEAPPDATA_BRANCH: "upstream"
     LEAPP_DEVEL_TARGET_RELEASE: "9.2"
 
@@ -325,16 +325,15 @@ jobs:
       - tmt:
           context:
             distro: "rhel-8.8"
-        # tag resources as sst_upgrades to enable cost metrics collection
+        # tag resources as sst_upgrades@leapp_upstream_test to enable cost metrics collection
         settings:
           provisioning:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
             tags:
-              BusinessUnit: sst_upgrades
+              BusinessUnit: sst_upgrades@leapp_upstream_test
   env:
     SOURCE_RELEASE: "8.8"
     TARGET_RELEASE: "9.2"
-    RHSM_REPOS: "rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-beta-rpms"
     LEAPPDATA_BRANCH: "upstream"
     LEAPP_DEVEL_TARGET_RELEASE: "9.2"
 
@@ -359,12 +358,12 @@ jobs:
       - tmt:
           context:
             distro: "rhel-8.9"
-        # tag resources as sst_upgrades to enable cost metrics collection
+        # tag resources as sst_upgrades@leapp_upstream_test to enable cost metrics collection
         settings:
           provisioning:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
             tags:
-              BusinessUnit: sst_upgrades
+              BusinessUnit: sst_upgrades@leapp_upstream_test
   env:
     SOURCE_RELEASE: "8.9"
     TARGET_RELEASE: "9.3"
@@ -388,12 +387,12 @@ jobs:
       - tmt:
           context:
             distro: "rhel-8.9"
-        # tag resources as sst_upgrades to enable cost metrics collection
+        # tag resources as sst_upgrades@leapp_upstream_test to enable cost metrics collection
         settings:
           provisioning:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
             tags:
-              BusinessUnit: sst_upgrades
+              BusinessUnit: sst_upgrades@leapp_upstream_test
   env:
     SOURCE_RELEASE: "8.9"
     TARGET_RELEASE: "9.3"
@@ -422,12 +421,12 @@ jobs:
       - tmt:
           context:
             distro: "rhel-8.6"
-        # tag resources as sst_upgrades to enable cost metrics collection
+        # tag resources as sst_upgrades@leapp_upstream_test to enable cost metrics collection
         settings:
           provisioning:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
             tags:
-              BusinessUnit: sst_upgrades
+              BusinessUnit: sst_upgrades@leapp_upstream_test
   env:
     SOURCE_RELEASE: "8.6"
     TARGET_RELEASE: "9.0"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -85,8 +85,8 @@ jobs:
     # builds from master branch should start with 100 release, to have high priority
     - bash -c "sed -i \"s/1%{?dist}/100%{?dist}/g\" packaging/leapp-repository.spec"
 
-
-- job: tests
+- &default-79to86
+  job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
   fmf_ref: "master"
   use_internal_tf: True
@@ -97,7 +97,7 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
   identifier: tests-7.9to8.6
-  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
+  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(?!.*oamg4250_lvm_var_xfs_ftype0)(?!.*kernel-rt)(.*tier1)"
   tf_extra_params:
     environments:
       - tmt:
@@ -114,160 +114,8 @@ jobs:
     TARGET_RELEASE: "8.6"
     LEAPPDATA_BRANCH: "upstream"
 
-# On-demand minimal beaker tests
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/tmt-plans"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  manual_trigger: True
-  labels:
-    - minimal-beaker
-    - minimal-beaker-7.9to8.6
-  targets:
-    epel-7-x86_64:
-      distros: [RHEL-7.9-ZStream]
-  identifier: tests-7.9to8.6-minimal-beaker
-  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
-  tf_extra_params:
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-7.9"
-        # tag resources as sst_upgrades to enable cost metrics collection
-        settings:
-          provisioning:
-            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-            tags:
-              BusinessUnit: sst_upgrades
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.6"
-    LEAPPDATA_BRANCH: "upstream"
-
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  labels:
-    - default
-  targets:
-    epel-7-x86_64:
-      distros: [RHEL-7.9-ZStream]
-  identifier: tests-7.9to8.8
-  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
-  tf_extra_params:
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-7.9"
-        # tag resources as sst_upgrades to enable cost metrics collection
-        settings:
-          provisioning:
-            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-            tags:
-              BusinessUnit: sst_upgrades
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.8"
-    LEAPPDATA_BRANCH: "upstream"
-
-# On-demand minimal beaker tests
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  manual_trigger: True
-  labels:
-    - minimal-beaker
-    - minimal-beaker-7.9to8.8
-  targets:
-    epel-7-x86_64:
-      distros: [RHEL-7.9-ZStream]
-  identifier: tests-7.9to8.8-minimal-beaker
-  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
-  tf_extra_params:
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-7.9"
-        # tag resources as sst_upgrades to enable cost metrics collection
-        settings:
-          provisioning:
-            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-            tags:
-              BusinessUnit: sst_upgrades
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.8"
-    LEAPPDATA_BRANCH: "upstream"
-
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  labels:
-    - default
-  targets:
-    epel-7-x86_64:
-      distros: [RHEL-7.9-ZStream]
-  identifier: tests-7.9to8.9
-  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
-  tf_extra_params:
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-7.9"
-        # tag resources as sst_upgrades to enable cost metrics collection
-        settings:
-          provisioning:
-            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-            tags:
-              BusinessUnit: sst_upgrades
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.9"
-    LEAPPDATA_BRANCH: "upstream"
-
-# On-demand minimal beaker tests
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  manual_trigger: True
-  labels:
-    - minimal-beaker
-    - minimal-beaker-7.9to8.9
-  targets:
-    epel-7-x86_64:
-      distros: [RHEL-7.9-ZStream]
-  identifier: tests-7.9to8.9-minimal-beaker
-  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
-  tf_extra_params:
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-7.9"
-        # tag resources as sst_upgrades to enable cost metrics collection
-        settings:
-          provisioning:
-            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-            tags:
-              BusinessUnit: sst_upgrades
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.9"
-    LEAPPDATA_BRANCH: "upstream"
-
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
+- &default-79to86-aws
+  <<: *default-79to86
   labels:
     - default
     - aws
@@ -275,7 +123,7 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-rhui]
   identifier: tests-7to8-aws-e2e
-  tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*8to9)(.*e2e)"
+  tmt_plan: "(?!.*sap)(.*e2e)"
   tf_extra_params:
     environments:
       - tmt:
@@ -293,18 +141,62 @@ jobs:
     RHUI: "aws"
     LEAPPDATA_BRANCH: "upstream"
 
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
+# On-demand minimal beaker tests
+- &beaker-minimal-79to86
+  <<: *default-79to86
+  manual_trigger: True
   labels:
-    - default
+    - minimal-beaker
+    - minimal-beaker-7.9to8.6
+  identifier: tests-7.9to8.6-minimal-beaker
+  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi|.*oamg4250_lvm_var_xfs_ftype0)"
+
+- &default-79to88
+  <<: *default-79to86
+  identifier: tests-7.9to8.8
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.8"
+    LEAPPDATA_BRANCH: "upstream"
+
+# On-demand minimal beaker tests
+- &beaker-minimal-79to88
+  <<: *beaker-minimal-79to86
+  labels:
+    - minimal-beaker
+    - minimal-beaker-7.9to8.8
+  identifier: tests-7.9to8.8-minimal-beaker
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.8"
+    LEAPPDATA_BRANCH: "upstream"
+
+- &default-79to89
+  <<: *default-79to86
+  identifier: tests-7.9to8.9
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.9"
+    LEAPPDATA_BRANCH: "upstream"
+
+# On-demand minimal beaker tests
+- &beaker-minimal-79to89
+  <<: *beaker-minimal-79to86
+  labels:
+    - minimal-beaker
+    - minimal-beaker-7.9to8.9
+  identifier: tests-7.9to8.9-minimal-beaker
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.9"
+    LEAPPDATA_BRANCH: "upstream"
+
+- &default-86to90
+  <<: *default-79to86
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-8.6to9.0
-  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
   tf_extra_params:
     environments:
       - tmt:
@@ -323,12 +215,8 @@ jobs:
     LEAPPDATA_BRANCH: "upstream"
 
 # On-demand minimal beaker tests
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  manual_trigger: True
+- &beaker-minimal-86to90
+  <<: *beaker-minimal-79to86
   labels:
     - minimal-beaker
     - minimal-beaker-8.6to9.0
@@ -336,7 +224,6 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.6.0-Nightly]
   identifier: tests-8.6to9.0-minimal-beaker
-  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
   tf_extra_params:
     environments:
       - tmt:
@@ -354,18 +241,12 @@ jobs:
     RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
     LEAPPDATA_BRANCH: "upstream"
 
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  labels:
-    - default
+- &default-88to92
+  <<: *default-86to90
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
   identifier: tests-8.8to9.2
-  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
   tf_extra_params:
     environments:
       - tmt:
@@ -385,12 +266,8 @@ jobs:
     LEAPP_DEVEL_TARGET_RELEASE: "9.2"
 
 # On-demand minimal beaker tests
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  manual_trigger: True
+- &beaker-minimal-88to92
+  <<: *beaker-minimal-86to90
   labels:
     - minimal-beaker
     - minimal-beaker-8.8to9.2
@@ -398,7 +275,6 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
   identifier: tests-8.8to9.2-minimal-beaker
-  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
   tf_extra_params:
     environments:
       - tmt:
@@ -417,18 +293,12 @@ jobs:
     LEAPPDATA_BRANCH: "upstream"
     LEAPP_DEVEL_TARGET_RELEASE: "9.2"
 
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  labels:
-    - default
+- &default-89to93
+  <<: *default-88to92
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.9.0-Nightly]
   identifier: tests-8.9to9.3
-  tmt_plan: "(?!.*uefi)(?!.*max_sst)(?!.*partitioning)(.*tier1)"
   tf_extra_params:
     environments:
       - tmt:
@@ -448,12 +318,8 @@ jobs:
     LEAPP_DEVEL_TARGET_RELEASE: "9.3"
 
 # On-demand minimal beaker tests
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  manual_trigger: True
+- &beaker-minimal-89to93
+  <<: *beaker-minimal-88to92
   labels:
     - minimal-beaker
     - minimal-beaker-8.9to9.3
@@ -461,7 +327,6 @@ jobs:
     epel-8-x86_64:
       distros: [RHEL-8.9.0-Nightly]
   identifier: tests-8.9to9.3-minimal-beaker
-  tmt_plan: "(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog|.*uefi)"
   tf_extra_params:
     environments:
       - tmt:
@@ -480,19 +345,12 @@ jobs:
     LEAPPDATA_BRANCH: "upstream"
     LEAPP_DEVEL_TARGET_RELEASE: "9.3"
 
-- job: tests
-  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
-  use_internal_tf: True
-  trigger: pull_request
-  labels:
-    - default
-    - aws
+- &default-86to90-aws
+  <<: *default-79to86-aws
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.6-rhui]
   identifier: tests-8to9-aws-e2e
-  tmt_plan: "^(?!.*upgrade_plugin)(?!.*tier[2-3].*)(?!.*rhsm)(?!.*c2r)(?!.*sap)(?!.*7to8)(.*e2e)"
   tf_extra_params:
     environments:
       - tmt:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -91,6 +91,8 @@ jobs:
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
+  labels:
+    - default
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
@@ -121,6 +123,7 @@ jobs:
   manual_trigger: True
   labels:
     - minimal-beaker
+    - minimal-beaker-7.9to8.6
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
@@ -147,6 +150,8 @@ jobs:
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
+  labels:
+    - default
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
@@ -177,6 +182,7 @@ jobs:
   manual_trigger: True
   labels:
     - minimal-beaker
+    - minimal-beaker-7.9to8.8
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
@@ -203,6 +209,8 @@ jobs:
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
+  labels:
+    - default
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
@@ -233,6 +241,7 @@ jobs:
   manual_trigger: True
   labels:
     - minimal-beaker
+    - minimal-beaker-7.9to8.9
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
@@ -259,6 +268,9 @@ jobs:
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
+  labels:
+    - default
+    - aws
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-rhui]
@@ -286,6 +298,8 @@ jobs:
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
+  labels:
+    - default
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.6.0-Nightly]
@@ -317,6 +331,7 @@ jobs:
   manual_trigger: True
   labels:
     - minimal-beaker
+    - minimal-beaker-8.6to9.0
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.6.0-Nightly]
@@ -344,6 +359,8 @@ jobs:
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
+  labels:
+    - default
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
@@ -376,6 +393,7 @@ jobs:
   manual_trigger: True
   labels:
     - minimal-beaker
+    - minimal-beaker-8.8to9.2
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
@@ -404,6 +422,8 @@ jobs:
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
+  labels:
+    - default
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.9.0-Nightly]
@@ -436,6 +456,7 @@ jobs:
   manual_trigger: True
   labels:
     - minimal-beaker
+    - minimal-beaker-8.9to9.3
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.9.0-Nightly]
@@ -464,6 +485,9 @@ jobs:
   fmf_ref: "master"
   use_internal_tf: True
   trigger: pull_request
+  labels:
+    - default
+    - aws
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.6-rhui]

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -137,25 +137,31 @@ jobs:
     TARGET_RELEASE: "8.8"
     LEAPPDATA_BRANCH: "upstream"
 
-# - job: tests
-#   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-#   fmf_ref: "master"
-#   use_internal_tf: True
-#   trigger: pull_request
-#   targets:
-#     epel-7-x86_64:
-#       distros: [RHEL-7.9-ZStream]
-#   identifier: tests-7.9to8.8-sst
-#   tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
-#   tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-#   tf_extra_params:
-#     environments:
-#       - tmt:
-#           context:
-#             distro: "rhel-7.9"
-#   env:
-#     SOURCE_RELEASE: "7.9"
-#     TARGET_RELEASE: "8.8"
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-7-x86_64:
+      distros: [RHEL-7.9-ZStream]
+  identifier: tests-7.9to8.9
+  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-7.9"
+        # tag resources as sst_upgrades to enable cost metrics collection
+        settings:
+          provisioning:
+            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+            tags:
+              BusinessUnit: sst_upgrades
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.9"
+    LEAPPDATA_BRANCH: "upstream"
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
@@ -239,27 +245,33 @@ jobs:
     LEAPPDATA_BRANCH: "upstream"
     LEAPP_DEVEL_TARGET_RELEASE: "9.2"
 
-# - job: tests
-#   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-#   fmf_ref: "master"
-#   use_internal_tf: True
-#   trigger: pull_request
-#   targets:
-#     epel-8-x86_64:
-#       distros: [RHEL-8.6.0-Nightly]
-#   identifier: tests-8.6to9.0-sst
-#   tmt_plan: "^(?!.*tier[2-3].*)(.*max_sst.*)"
-#   tf_post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-#   tf_extra_params:
-#     environments:
-#       - tmt:
-#           context:
-#             distro: "rhel-8.6"
-#   env:
-#     SOURCE_RELEASE: "8.6"
-#     TARGET_RELEASE: "9.0"
-#     RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
-#     LEAPPDATA_BRANCH: "upstream"
+- job: tests
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "master"
+  use_internal_tf: True
+  trigger: pull_request
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.9.0-Nightly]
+  identifier: tests-8.9to9.3
+  tmt_plan: "((?!.*max_sst)(?!.*partitioning)(.*tier1)|(?!.*max_sst)(.*tier1)(.*partitioning_monolithic|.*separate_var_usr_varlog))"
+  tf_extra_params:
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-8.9"
+        # tag resources as sst_upgrades to enable cost metrics collection
+        settings:
+          provisioning:
+            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+            tags:
+              BusinessUnit: sst_upgrades
+  env:
+    SOURCE_RELEASE: "8.9"
+    TARGET_RELEASE: "9.3"
+    RHSM_REPOS: "rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-beta-rpms"
+    LEAPPDATA_BRANCH: "upstream"
+    LEAPP_DEVEL_TARGET_RELEASE: "9.3"
 
 - job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"


### PR DESCRIPTION
- Get rid of the sad uefi_upgrade test for now;
- Reduce time consuming partitioning tests to 3.

in demand /rerun command-scheduled tests will still be running the full destructive test set (no max_sst though).