### PR TITLE
grub2mkconfigonppc64: Do not touch grubenv when generating new grub2 config

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/grub2mkconfigonppc64/libraries/grub2mkconfigonppc64.py
+++ b/repos/system_upgrade/el8toel9/actors/grub2mkconfigonppc64/libraries/grub2mkconfigonppc64.py
@@ -29,7 +29,10 @@ def process():
         grub.is_blscfg_enabled_in_defaultgrub(default_grub_msg)
     ):
         try:
-            run(['grub2-mkconfig', '-o', GRUB_CFG_PATH])
+            # NOTE: added --no-grubenv-update to handle issues for upgrade to 9.3+
+            # The option is present on all RHEL 9 versions so it's safe to use
+            # it always.
+            run(['grub2-mkconfig', '-o', GRUB_CFG_PATH, '--no-grubenv-update'])
         except CalledProcessError as e:
             api.current_logger().error(
                 'Command grub2-mkconfig -o {} failed: {}'.format(GRUB_CFG_PATH, e)

--- a/repos/system_upgrade/el8toel9/actors/grub2mkconfigonppc64/tests/test_grub2mkconfigonppc64.py
+++ b/repos/system_upgrade/el8toel9/actors/grub2mkconfigonppc64/tests/test_grub2mkconfigonppc64.py
@@ -70,6 +70,6 @@ def test_run_grub2mkconfig(monkeypatch, cmd_issued):
     monkeypatch.setattr(grub2mkconfigonppc64, 'open', _mock_open, False)
     grub2mkconfigonppc64.process()
     if cmd_issued:
-        assert mocked_run.commands == [['grub2-mkconfig', '-o', '/boot/grub2/grub.cfg']]
+        assert mocked_run.commands == [['grub2-mkconfig', '-o', '/boot/grub2/grub.cfg', '--no-grubenv-update']]
     else:
         assert not mocked_run.commands


### PR DESCRIPTION
When we call grub2-mkconfig for upgrades to RHEL 9.3+, we need to add also the --no-grubenv-update option also so we do not overwrite already updated grubenv file again. This lead to the situation that the crashkernel kernel cmdline option could contain invalid arguments originally used on RHEL 8.

* The comand is called only on virtualized Power machines.
* The use of the option is ok also on RHEL 9.2 (most likely also on RHEL 9.0, as it is present there too)

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2231343
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2221543