### PR TITLE
pcidevicescanner: skip test_actor_execution if lspci is not installed

### DIFF
--- a/repos/system_upgrade/common/actors/pcidevicesscanner/tests/test_pcidevicesscanner.py
+++ b/repos/system_upgrade/common/actors/pcidevicesscanner/tests/test_pcidevicesscanner.py
@@ -1,3 +1,7 @@
+import os
+
+import pytest
+
 from leapp.libraries.actor.pcidevicesscanner import parse_pci_devices, produce_pci_devices
 from leapp.models import PCIDevice, PCIDevices
 
@@ -202,6 +206,8 @@ def test_produce_no_devices():
     assert not output[0].devices
 
 
+# TODO(pstodulk): update the test - drop current_actor_context and use monkeypatch
+@pytest.mark.skipif(not os.path.exists('/usr/sbin/lspci'), reason='lspci not installed on the system')
 def test_actor_execution(current_actor_context):
     current_actor_context.run()
     assert current_actor_context.consume(PCIDevices)


### PR DESCRIPTION
Checking the test it does not have so big value. The original functionality has been extended and the particular tests does not reflect it. Majority of the functionality is tested in unit tests around, so regarding that, I prefer for now to skip the test if lspci utility is not installed and get back to it later.

Note: also regarding running of integration tests, I think this particular unit test is not so important anymore. But there is no hard reason to drop it completely. The skip is better option in this case.