### PR TITLE
Use new leapp output apis

### DIFF
--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -9,7 +9,7 @@ from leapp.exceptions import CommandError, LeappError
 from leapp.logger import configure_logger
 from leapp.utils.audit import Execution
 from leapp.utils.clicmd import command, command_opt
-from leapp.utils.output import beautify_actor_exception, report_errors, report_info, report_inhibitors
+from leapp.utils.output import beautify_actor_exception, report_errors, report_info
 
 
 @command('preupgrade', help='Generate preupgrade report')
@@ -77,10 +77,9 @@ def preupgrade(args, breadcrumbs):
     workflow.save_answers(answerfile_path, userchoices_path)
     util.generate_report_files(context, report_schema)
     report_errors(workflow.errors)
-    report_inhibitors(context)
     report_files = util.get_cfg_files('report', cfg)
     log_files = util.get_cfg_files('logs', cfg)
-    report_info(context, report_files, log_files, answerfile_path, fail=workflow.failure)
+    report_info(context, report_files, log_files, answerfile_path, fail=workflow.failure, errors=workflow.errors)
 
     if workflow.failure:
         sys.exit(1)

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -9,7 +9,7 @@ from leapp.exceptions import CommandError, LeappError
 from leapp.logger import configure_logger
 from leapp.utils.audit import Execution
 from leapp.utils.clicmd import command, command_opt
-from leapp.utils.output import beautify_actor_exception, report_errors, report_info, report_inhibitors
+from leapp.utils.output import beautify_actor_exception, report_errors, report_info
 
 # NOTE:
 # If you are adding new parameters please ensure that they are set in the upgrade function invocation in `rerun`
@@ -106,11 +106,10 @@ def upgrade(args, breadcrumbs):
     logger.info("Answerfile will be created at %s", answerfile_path)
     workflow.save_answers(answerfile_path, userchoices_path)
     report_errors(workflow.errors)
-    report_inhibitors(context)
     util.generate_report_files(context, report_schema)
     report_files = util.get_cfg_files('report', cfg)
     log_files = util.get_cfg_files('logs', cfg)
-    report_info(context, report_files, log_files, answerfile_path, fail=workflow.failure)
+    report_info(context, report_files, log_files, answerfile_path, fail=workflow.failure, errors=workflow.errors)
 
     if workflow.failure:
         sys.exit(1)

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -144,8 +144,8 @@ def generate_report_files(context, report_schema):
                                             'leapp-report.{}'.format(f)) for f in ['txt', 'json']]
     # fetch all report messages as a list of dicts
     messages = fetch_upgrade_report_messages(context)
-    generate_report_file(messages, context, report_json, report_schema)
     generate_report_file(messages, context, report_txt, report_schema)
+    generate_report_file(messages, context, report_json, report_schema)
 
 
 def get_cfg_files(section, cfg, must_exist=True):

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -100,7 +100,7 @@ Requires:       leapp-repository-dependencies = %{leapp_repo_deps}
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' instead of the real framework rpm version.
-Requires:       leapp-framework >= 4.0, leapp-framework < 5
+Requires:       leapp-framework >= 5.0, leapp-framework < 6
 
 # Since we provide sub-commands for the leapp utility, we expect the leapp
 # tool to be installed as well.


### PR DESCRIPTION
Leapp introduced new output apis (and removed some other).
See https://github.com/oamg/leapp/pull/840 for details.

The calls to `generate_report_file()` in `commands/upgrade/utils.py` are
swapped to workaround a bug in the framework where the json report
generation modifies messages passed to it.

Jira: OAMG-9663