### PR TITLE
updategrubcore: Skip on IBM Z systems and cover non-grub2 systems in general

### DIFF
--- a/repos/system_upgrade/common/actors/updategrubcore/actor.py
+++ b/repos/system_upgrade/common/actors/updategrubcore/actor.py
@@ -1,7 +1,5 @@
 from leapp.actors import Actor
-from leapp.libraries.actor.updategrubcore import update_grub_core
-from leapp.libraries.common import grub
-from leapp.libraries.stdlib import api
+from leapp.libraries.actor import updategrubcore
 from leapp.models import FirmwareFacts, TransactionCompleted
 from leapp.reporting import Report
 from leapp.tags import IPUWorkflowTag, RPMUpgradePhaseTag
@@ -9,6 +7,8 @@ from leapp.tags import IPUWorkflowTag, RPMUpgradePhaseTag
 
 class UpdateGrubCore(Actor):
     """
+    Update GRUB2 core on legacy BIOS systems.
+
     On legacy (BIOS) systems, GRUB core (located in the gap between the MBR and the
     first partition), does not get automatically updated when GRUB is upgraded.
     """
@@ -19,10 +19,4 @@ class UpdateGrubCore(Actor):
     tags = (RPMUpgradePhaseTag, IPUWorkflowTag)
 
     def process(self):
-        ff = next(self.consume(FirmwareFacts), None)
-        if ff and ff.firmware == 'bios':
-            grub_devs = grub.get_grub_devices()
-            if grub_devs:
-                update_grub_core(grub_devs)
-            else:
-                api.current_logger().warning('Leapp could not detect GRUB devices')
+        updategrubcore.process()

--- a/repos/system_upgrade/common/actors/updategrubcore/libraries/updategrubcore.py
+++ b/repos/system_upgrade/common/actors/updategrubcore/libraries/updategrubcore.py
@@ -1,5 +1,8 @@
 from leapp import reporting
+from leapp.libraries.common import grub
+from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api, CalledProcessError, config, run
+from leapp.models import FirmwareFacts
 
 
 def update_grub_core(grub_devs):
@@ -51,3 +54,15 @@ def update_grub_core(grub_devs):
             reporting.Groups([reporting.Groups.BOOT]),
             reporting.Severity(reporting.Severity.INFO)
         ])
+
+
+def process():
+    if architecture.matches_architecture(architecture.ARCH_S390X):
+        return
+    ff = next(api.consume(FirmwareFacts), None)
+    if ff and ff.firmware == 'bios':
+        grub_devs = grub.get_grub_devices()
+        if grub_devs:
+            update_grub_core(grub_devs)
+        else:
+            api.current_logger().warning('Leapp could not detect GRUB devices')

--- a/repos/system_upgrade/common/actors/updategrubcore/tests/test_updategrubcore.py
+++ b/repos/system_upgrade/common/actors/updategrubcore/tests/test_updategrubcore.py
@@ -1,9 +1,12 @@
 import pytest
 
 from leapp import reporting
+from leapp.exceptions import StopActorExecution
 from leapp.libraries.actor import updategrubcore
 from leapp.libraries.common import testutils
-from leapp.libraries.stdlib import api, CalledProcessError
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import CalledProcessError
+from leapp.models import FirmwareFacts
 from leapp.reporting import Report
 
 UPDATE_OK_TITLE = 'GRUB core successfully updated'
@@ -19,21 +22,22 @@ def raise_call_error(args=None):
 
 
 class run_mocked(object):
-    def __init__(self, raise_err=False):
+    def __init__(self, raise_err=False, raise_callback=raise_call_error):
         self.called = 0
         self.args = []
         self.raise_err = raise_err
+        self.raise_callback = raise_callback
 
     def __call__(self, *args):
         self.called += 1
         self.args.append(args)
         if self.raise_err:
-            raise_call_error(args)
+            self.raise_callback(args)
 
 
 @pytest.mark.parametrize('devices', [['/dev/vda'], ['/dev/vda', '/dev/vdb']])
 def test_update_grub(monkeypatch, devices):
-    monkeypatch.setattr(reporting, "create_report", testutils.create_report_mocked())
+    monkeypatch.setattr(reporting, 'create_report', testutils.create_report_mocked())
     monkeypatch.setattr(updategrubcore, 'run', run_mocked())
     updategrubcore.update_grub_core(devices)
     assert reporting.create_report.called
@@ -43,7 +47,7 @@ def test_update_grub(monkeypatch, devices):
 
 @pytest.mark.parametrize('devices', [['/dev/vda'], ['/dev/vda', '/dev/vdb']])
 def test_update_grub_failed(monkeypatch, devices):
-    monkeypatch.setattr(reporting, "create_report", testutils.create_report_mocked())
+    monkeypatch.setattr(reporting, 'create_report', testutils.create_report_mocked())
     monkeypatch.setattr(updategrubcore, 'run', run_mocked(raise_err=True))
     updategrubcore.update_grub_core(devices)
     assert reporting.create_report.called
@@ -53,7 +57,7 @@ def test_update_grub_failed(monkeypatch, devices):
 
 
 def test_update_grub_partial_success(monkeypatch):
-    monkeypatch.setattr(reporting, "create_report", testutils.create_report_mocked())
+    monkeypatch.setattr(reporting, 'create_report', testutils.create_report_mocked())
 
     def run_mocked(args):
         if args == ['grub2-install', '/dev/vdb']:
@@ -73,6 +77,48 @@ def test_update_grub_partial_success(monkeypatch):
     assert 'however GRUB update failed on the following devices: /dev/vdb' in summary
 
 
-def test_update_grub_negative(current_actor_context):
-    current_actor_context.run()
-    assert not current_actor_context.consume(Report)
+@pytest.mark.parametrize('msgs', [
+    [],
+    [FirmwareFacts(firmware='efi')]
+])
+def test_update_no_bios(monkeypatch, msgs):
+
+    monkeypatch.setattr(reporting, 'create_report', testutils.create_report_mocked())
+    monkeypatch.setattr(updategrubcore, 'run', run_mocked())
+
+    curr_actor_mocked = testutils.CurrentActorMocked(msgs=msgs)
+    monkeypatch.setattr(updategrubcore.api, 'current_actor', curr_actor_mocked)
+    updategrubcore.process()
+    assert not updategrubcore.run.called
+    assert not reporting.create_report.called
+
+
+def test_update_grub_nogrub_system_ibmz(monkeypatch):
+    monkeypatch.setattr(reporting, 'create_report', testutils.create_report_mocked())
+    monkeypatch.setattr(updategrubcore, 'run', run_mocked())
+
+    msgs = [FirmwareFacts(firmware='bios')]
+    curr_actor_mocked = testutils.CurrentActorMocked(arch=architecture.ARCH_S390X, msgs=msgs)
+    monkeypatch.setattr(updategrubcore.api, 'current_actor', curr_actor_mocked)
+
+    updategrubcore.process()
+    assert not reporting.create_report.called
+    assert not updategrubcore.run.called
+
+
+def test_update_grub_nogrub_system(monkeypatch):
+    def raise_call_oserror(dummy):
+        # Note: grub2-probe is enough right now. If the implementation is changed,
+        # the test will most likely start to fail and better mocking will be needed.
+        raise OSError('File not found: grub2-probe')
+
+    monkeypatch.setattr(reporting, 'create_report', testutils.create_report_mocked())
+    monkeypatch.setattr(updategrubcore, 'run', run_mocked(raise_err=True, raise_callback=raise_call_oserror))
+
+    msgs = [FirmwareFacts(firmware='bios')]
+    curr_actor_mocked = testutils.CurrentActorMocked(arch=architecture.ARCH_X86_64, msgs=msgs)
+    monkeypatch.setattr(updategrubcore.api, 'current_actor', curr_actor_mocked)
+
+    with pytest.raises(StopActorExecution):
+        updategrubcore.process()
+    assert not reporting.create_report.called

--- a/repos/system_upgrade/common/libraries/grub.py
+++ b/repos/system_upgrade/common/libraries/grub.py
@@ -46,7 +46,7 @@ def blk_dev_from_partition(partition):
 
 def get_boot_partition():
     """
-    Get /boot partition name
+    Get /boot partition name.
     """
     try:
         # call grub2-probe to identify /boot partition
@@ -54,6 +54,13 @@ def get_boot_partition():
     except CalledProcessError:
         api.current_logger().warning(
             'Could not get name of underlying /boot partition'
+        )
+        raise StopActorExecution()
+    except OSError:
+        api.current_logger().warning(
+            'Could not get name of underlying /boot partition:'
+            ' grub2-probe is missing.'
+            ' Possibly called on system that does not use GRUB2?'
         )
         raise StopActorExecution()
     boot_partition = result['stdout'].strip()

--- a/repos/system_upgrade/common/libraries/tests/test_grub.py
+++ b/repos/system_upgrade/common/libraries/tests/test_grub.py
@@ -7,6 +7,7 @@ from leapp.libraries.common import grub, mdraid
 from leapp.libraries.common.testutils import logger_mocked
 from leapp.libraries.stdlib import api, CalledProcessError
 from leapp.models import DefaultGrub, DefaultGrubInfo
+from leapp.utils.deprecation import suppress_deprecation
 
 BOOT_PARTITION = '/dev/vda1'
 BOOT_DEVICE = '/dev/vda'
@@ -73,6 +74,7 @@ def close_mocked(f):
     f.close()
 
 
+@suppress_deprecation(grub.get_grub_device)
 def test_get_grub_device_library(monkeypatch):
     run_mocked = RunMocked()
     monkeypatch.setattr(grub, 'run', run_mocked)
@@ -87,7 +89,10 @@ def test_get_grub_device_library(monkeypatch):
     assert 'GRUB is installed on {}'.format(result) in api.current_logger.infomsg
 
 
+@suppress_deprecation(grub.get_grub_device)
 def test_get_grub_device_fail_library(monkeypatch):
+    # TODO(pstodulk): cover here also case with OSError (covered now in actors,
+    # so keeping for the future when we have a time)
     run_mocked = RunMocked(raise_err=True)
     monkeypatch.setattr(grub, 'run', run_mocked)
     monkeypatch.setattr(os, 'open', open_mocked)
@@ -101,6 +106,7 @@ def test_get_grub_device_fail_library(monkeypatch):
     assert err in api.current_logger.warnmsg
 
 
+@suppress_deprecation(grub.get_grub_device)
 def test_device_no_grub_library(monkeypatch):
     run_mocked = RunMocked()
     monkeypatch.setattr(grub, 'run', run_mocked)


### PR DESCRIPTION
As GRUB2 is not present on IBM Z, related commands cannot be used on this architecture as they just fail (as the executors are not present). In this particular case, logs contain a confusing traceback msg, which is not harmful, but it's not nice niether. Added check for s390x architecture.

Note that similar problem could possibly appear on baremetal POWER machines, where petitboot is used. After the fix of the leapp run functions from the stdlib, catch also OSError exception. In such a case, print info the grub2-core is not present with the hint that's most likely it should not be even called on the particular machine and the actor execution too.

Suppress deprecated warnings in unit tests for get_grub_device() tests.


# Additional info
Previous runs could provide errors like:
```
2023-08-17 13:02:25.757 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core: External command has started: ['grub2-probe', '--target=device', '/boot']
2023-08-17 13:02:25.769 DEBUG    PID: 12631 leapp.workflow.RPMUpgrade.update_grub_core: External command has finished: ['grub2-probe', '--target=device', '/boot']
2023-08-17 13:02:25.773 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core: Process Process-193:
2023-08-17 13:02:25.777 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core: Traceback (most recent call last):
2023-08-17 13:02:25.780 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/usr/lib64/python3.6/multiprocessing/process.py", line 258, in _bootstrap
2023-08-17 13:02:25.785 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/usr/lib64/python3.6/multiprocessing/process.py", line 93, in run 
2023-08-17 13:02:25.788 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/usr/lib/python3.6/site-packages/leapp/repository/actor_definition.py", line 74, in _do_run
2023-08-17 13:02:25.792 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:     actor_instance.run(*args, **kwargs)
2023-08-17 13:02:25.795 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/usr/lib/python3.6/site-packages/leapp/actors/__init__.py", line 289, in run
2023-08-17 13:02:25.797 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:     self.process(*args)
2023-08-17 13:02:25.800 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/etc/leapp/repos.d/system_upgrade/common/actors/updategrubcore/actor.py", line 24, in process
2023-08-17 13:02:25.803 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:     grub_devs = grub.get_grub_devices()
2023-08-17 13:02:25.806 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/etc/leapp/repos.d/system_upgrade/common/libraries/grub.py", line 73, in get_grub_devices
2023-08-17 13:02:25.809 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:     boot_device = get_boot_partition()
2023-08-17 13:02:25.812 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/etc/leapp/repos.d/system_upgrade/common/libraries/grub.py", line 53, in get_boot_partition
2023-08-17 13:02:25.814 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:     result = run(['grub2-probe', '--target=device', '/boot'])
2023-08-17 13:02:25.817 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/usr/lib/python3.6/site-packages/leapp/libraries/stdlib/__init__.py", line 181, in run
2023-08-17 13:02:25.820 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:     stdin=stdin, env=env, encoding=encoding)
2023-08-17 13:02:25.823 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/usr/lib/python3.6/site-packages/leapp/libraries/stdlib/call.py", line 217, in _call
2023-08-17 13:02:25.827 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:     os.execvpe(command[0], command, env=environ)
2023-08-17 13:02:25.830 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/usr/lib64/python3.6/os.py", line 568, in execvpe
2023-08-17 13:02:25.833 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/usr/lib64/python3.6/os.py", line 604, in _execvpe
2023-08-17 13:02:25.836 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core:   File "/usr/lib64/python3.6/os.py", line 594, in _execvpe
2023-08-17 13:02:25.839 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core: FileNotFoundError: [Errno 2] No such file or directory: b'/etc/leapp/repos.d/system_upgrade/el8toel9/tools/grub2-probe'
2023-08-17 13:02:25.842 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core: Command ['grub2-probe', '--target=device', '/boot'] failed with exit code 1.
2023-08-17 13:02:25.847 DEBUG    PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core: External command has finished: ['grub2-probe', '--target=device', '/boot'] 
2023-08-17 13:02:25.851 WARNING  PID: 12623 leapp.workflow.RPMUpgrade.update_grub_core: Could not get name of underlying /boot partition
```