### PR TITLE
load data files: update hints in error msgs and ignore the download by default

### DIFF
--- a/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/libraries/deviceanddriverdeprecationdataload.py
+++ b/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/libraries/deviceanddriverdeprecationdataload.py
@@ -13,6 +13,9 @@ def process():
     supported_device_types = set(DeviceDriverDeprecationEntry.device_type.serialize()['choices'])
 
     data_file_name = 'device_driver_deprecation_data.json'
+    # NOTE(pstodulk): load_data_assert raises StopActorExecutionError, see
+    # the code for more info. Keeping the handling on the framework in such
+    # a case as we have no work to do in such a case here.
     deprecation_data = fetch.load_data_asset(api.current_actor(),
                                              data_file_name,
                                              asset_fulltext_name='Device driver deprecation data',

--- a/repos/system_upgrade/common/libraries/fetch.py
+++ b/repos/system_upgrade/common/libraries/fetch.py
@@ -20,6 +20,7 @@ def _get_hint():
     rpmname = 'leapp-upgrade-el{}toel{}'.format(get_source_major_version(), get_target_major_version())
     hint = (
         'All official data files are nowadays part of the installed rpms.'
+        ' That is the only official resource of actual official data files for in-place upgrades.'
         ' This issue is usually encountered when the data files are incorrectly customized, replaced, or removed'
         ' (e.g. by custom scripts).'
         ' In case you want to recover the original file, remove it (if still exists)'
@@ -33,7 +34,9 @@ def _raise_error(local_path, details):
     """
     If the file acquisition fails in any way, throw an informative error to stop the actor.
     """
+    rpmname = 'leapp-upgrade-el{}toel{}'.format(get_source_major_version(), get_target_major_version())
     summary = 'Data file {lp} is missing or invalid.'.format(lp=local_path)
+
     raise StopActorExecutionError(summary, details={'details': details, 'hint': _get_hint()})
 
 
@@ -174,7 +177,7 @@ def load_data_asset(actor_requesting_asset,
 
     try:
         # The asset family ID has the form (major, minor), include only `major` in the URL
-        raw_asset_contents = read_or_fetch(asset_filename, data_stream=data_stream_major)
+        raw_asset_contents = read_or_fetch(asset_filename, data_stream=data_stream_major, allow_download=False)
         asset_contents = json.loads(raw_asset_contents)
     except ValueError:
         msg = 'The {0} file (at {1}) does not contain a valid JSON object.'.format(asset_fulltext_name, asset_filename)


### PR DESCRIPTION
As the leapp upgrade data files are nowadays part of the install rpm, there is no need to download them anymore. Also, we do not have any plans to provide the updated data files anywhere out of the rpm.

For that reason, update all texts and related error messages so people do not try to visit obsoleted article, trying to apply invalid (obsoleted) data files anymore.

I kept the original fetch functionality in case someone would like to use it for additional custom data files, but the load_data_asset function invoke the fetch without allowed downloads, so the fetch fails with the proper error msg if files are not stored locally.

@oamg/developers  postponed for the May release. Mostly covered by pr #1121 (changed err msgs). Another changes in this one PR are expected later after the release.

jira: RHEL-18298