### PR TITLE
load data files: update hints in error messages and prepare for the download drop

### DIFF
--- a/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/libraries/deviceanddriverdeprecationdataload.py
+++ b/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/libraries/deviceanddriverdeprecationdataload.py
@@ -16,9 +16,8 @@ def process():
     deprecation_data = fetch.load_data_asset(api.current_actor(),
                                              data_file_name,
                                              asset_fulltext_name='Device driver deprecation data',
-                                             docs_url='https://access.redhat.com/articles/3664871',
-                                             docs_title=('Leapp utility metadata in-place upgrades of RHEL '
-                                                         'for disconnected upgrades (including Satellite)'))
+                                             docs_url='',
+                                             docs_title='')
 
     api.produce(
         DeviceDriverDeprecationData(

--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_event_parsing.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_event_parsing.py
@@ -8,6 +8,7 @@ from leapp import reporting
 from leapp.exceptions import StopActorExecution
 from leapp.libraries.common import fetch
 from leapp.libraries.common.config import architecture
+from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
 from leapp.libraries.stdlib import api
 
 # NOTE(mhecko): The modulestream field contains a set of modulestreams until the very end when we generate a Package
@@ -69,9 +70,8 @@ def get_pes_events(pes_json_directory, pes_json_filename):
         events_data = fetch.load_data_asset(api.current_actor(),
                                             pes_json_filename,
                                             asset_fulltext_name='PES events file',
-                                            docs_url='https://access.redhat.com/articles/3664871',
-                                            docs_title=('Leapp utility metadata in-place upgrades of RHEL '
-                                                        'for disconnected upgrades (including Satellite)'))
+                                            docs_url='',
+                                            docs_title='')
         if not events_data:
             return None
 
@@ -83,9 +83,16 @@ def get_pes_events(pes_json_directory, pes_json_filename):
         events_matching_arch = [e for e in all_events if not e.architectures or arch in e.architectures]
         return events_matching_arch
     except (ValueError, KeyError):
+        rpmname = 'leapp-upgrade-el{}toel{}'.format(get_source_major_version(), get_target_major_version())
         title = 'Missing/Invalid PES data file ({}/{})'.format(pes_json_directory, pes_json_filename)
-        summary = ('Read documentation at: https://access.redhat.com/articles/3664871 for more information '
-                   'about how to retrieve the files')
+        summary = (
+            'All official data files are nowadays part of the installed rpms.'
+            ' This issue is usually encountered when the data files are incorrectly customized, replaced, or removed'
+            ' (e.g. by custom scripts).'
+            ' In case you want to recover the original file, remove it (if still exists)'
+            ' and reinstall the {} rpm.'
+            .format(rpmname)
+        )
         reporting.create_report([
             reporting.Title(title),
             reporting.Summary(summary),

--- a/repos/system_upgrade/common/actors/repositoriesmapping/libraries/repositoriesmapping.py
+++ b/repos/system_upgrade/common/actors/repositoriesmapping/libraries/repositoriesmapping.py
@@ -130,11 +130,16 @@ class RepoMapData(object):
 
 
 def _inhibit_upgrade(msg):
-    raise StopActorExecutionError(
-        msg,
-        details={'hint': ('Read documentation at the following link for more'
-                          ' information about how to retrieve the valid file:'
-                          ' https://access.redhat.com/articles/3664871')})
+    rpmname = 'leapp-upgrade-el{}toel{}'.format(get_source_major_version(), get_target_major_version())
+    hint = (
+        'All official data files are nowadays part of the installed rpms.'
+        ' This issue is usually encountered when the data files are incorrectly customized, replaced, or removed'
+        ' (e.g. by custom scripts).'
+        ' In case you want to recover the original file, remove it (if still exists)'
+        ' and reinstall the {} rpm.'
+        .format(rpmname)
+    )
+    raise StopActorExecutionError(msg, details={'hint': hint})
 
 
 def _read_repofile(repofile):
@@ -145,9 +150,8 @@ def _read_repofile(repofile):
     repofile_data = load_data_asset(api.current_actor(),
                                     repofile,
                                     asset_fulltext_name='Repositories mapping',
-                                    docs_url='https://access.redhat.com/articles/3664871',
-                                    docs_title=('Leapp utility metadata in-place upgrades of RHEL '
-                                                'for disconnected upgrades (including Satellite)'))
+                                    docs_url='',
+                                    docs_title='')
     return repofile_data  # If the file does not contain a valid json then load_asset will do a stop actor execution
 
 


### PR DESCRIPTION
As the leapp upgrade data files are nowadays part of the install rpm, there is no need to download them anymore. Also, we plan to drop the service providing the data files online in future.

For that reason, update all texts and related error messages so people are not instructed to visit obsoleted article and do not try to apply invalid (obsoleted) data files anymore.

Right now, we are keeping the functionality for the data files download, but the fetch functino is already updated and prepared to stop trying to download the files if not present. As we have the functionality already present, I think we should keep a possibility of the download for additional custom data files (not provided by us) in custom actors, but for the official data files we will require them in future to be present locally only.

NOTE: regarding another planned changes soon, skipping update of unit-tests