### PR TITLE
Remove TUV from supported target channels

### DIFF
--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -25,7 +25,7 @@ from leapp.utils.output import beautify_actor_exception, report_errors, report_i
              help='Enable specified repository. Can be used multiple times.')
 @command_opt('channel',
              help='Set preferred channel for the IPU target.',
-             choices=['ga', 'tuv', 'e4s', 'eus', 'aus'],
+             choices=['ga', 'e4s', 'eus', 'aus'],
              value_type=str.lower)  # This allows the choices to be case insensitive
 @command_opt('iso', help='Use provided target RHEL installation image to perform the in-place upgrade.')
 @command_opt('target', choices=command_utils.get_supported_target_versions(),

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -31,7 +31,7 @@ from leapp.utils.output import beautify_actor_exception, report_errors, report_i
              help='Enable specified repository. Can be used multiple times.')
 @command_opt('channel',
              help='Set preferred channel for the IPU target.',
-             choices=['ga', 'tuv', 'e4s', 'eus', 'aus'],
+             choices=['ga', 'e4s', 'eus', 'aus'],
              value_type=str.lower)  # This allows the choices to be case insensitive
 @command_opt('iso', help='Use provided target RHEL installation image to perform the in-place upgrade.')
 @command_opt('target', choices=command_utils.get_supported_target_versions(),

--- a/repos/system_upgrade/common/actors/setuptargetrepos/tests/test_repomapping.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/tests/test_repomapping.py
@@ -614,14 +614,14 @@ def test_get_expected_target_pesid_repos_with_priority_channel_set(monkeypatch):
             make_pesid_repo('pesid1', '7', 'pesid1-repoid-ga'),
             make_pesid_repo('pesid2', '8', 'pesid2-repoid-ga'),
             make_pesid_repo('pesid2', '8', 'pesid2-repoid-eus', channel='eus'),
-            make_pesid_repo('pesid2', '8', 'pesid2-repoid-tuv', channel='tuv'),
+            make_pesid_repo('pesid2', '8', 'pesid2-repoid-aus', channel='aus'),
             make_pesid_repo('pesid3', '8', 'pesid3-repoid-ga')
         ]
     )
 
     handler = RepoMapDataHandler(repositories_mapping)
     # Set defaults to verify that the priority channel is not overwritten by defaults
-    handler.set_default_channels(['tuv', 'ga'])
+    handler.set_default_channels(['aus', 'ga'])
     target_repoids = handler.get_expected_target_pesid_repos(['pesid1-repoid-ga'])
 
     fail_description = 'get_expected_target_peid_repos does not correctly respect preferred channel.'

--- a/repos/system_upgrade/common/libraries/config/__init__.py
+++ b/repos/system_upgrade/common/libraries/config/__init__.py
@@ -2,7 +2,7 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.stdlib import api
 
 # The devel variable for target product channel can also contain 'beta'
-SUPPORTED_TARGET_CHANNELS = {'ga', 'tuv', 'e4s', 'eus', 'aus'}
+SUPPORTED_TARGET_CHANNELS = {'ga', 'e4s', 'eus', 'aus'}
 CONSUMED_DATA_STREAM_ID = '2.0'
 
 

--- a/repos/system_upgrade/common/models/repositoriesmap.py
+++ b/repos/system_upgrade/common/models/repositoriesmap.py
@@ -61,7 +61,7 @@ class PESIDRepositoryEntry(Model):
     too.
     """
 
-    channel = fields.StringEnum(['ga', 'tuv', 'e4s', 'eus', 'aus', 'beta'])
+    channel = fields.StringEnum(['ga', 'e4s', 'eus', 'aus', 'beta'])
     """
     The 'channel' of the repository.
 


### PR DESCRIPTION
TUS (mispelled as TUV) is not suported channel for inplace upgrade, removed from the code.

Jira: OAMG-7288