### PR TITLE
call correct mkdir when trying to create /etc/rhsm/facts

### DIFF
--- a/commands/upgrade/breadcrumbs.py
+++ b/commands/upgrade/breadcrumbs.py
@@ -61,7 +61,12 @@ class _BreadCrumbs(object):
             if not os.path.exists('/etc/rhsm'):
                 # If there's no /etc/rhsm folder just skip it
                 return
-            os.path.mkdir('/etc/rhsm/facts')
+            try:
+                os.mkdir('/etc/rhsm/facts')
+            except OSError as e:
+                if e.errno == 17:
+                    # The directory already exists which is all we need.
+                    pass
         try:
             with open('/etc/rhsm/facts/leapp.facts', 'w') as f:
                 json.dump(_flattened({


### PR DESCRIPTION
os.path has no mkdir, but os does.

traceback without the patch:

    Traceback (most recent call last):
      File "/bin/leapp", line 11, in <module>
        load_entry_point('leapp==0.16.0', 'console_scripts', 'leapp')()
      File "/usr/lib/python3.6/site-packages/leapp/cli/__init__.py", line 45, in main
        cli.command.execute('leapp version {}'.format(VERSION))
      File "/usr/lib/python3.6/site-packages/leapp/utils/clicmd.py", line 111, in execute
        args.func(args)
      File "/usr/lib/python3.6/site-packages/leapp/utils/clicmd.py", line 133, in called
        self.target(args)
      File "/usr/lib/python3.6/site-packages/leapp/cli/commands/upgrade/breadcrumbs.py", line 170, in wrapper
        breadcrumbs.save()
      File "/usr/lib/python3.6/site-packages/leapp/cli/commands/upgrade/breadcrumbs.py", line 116, in save
        self._save_rhsm_facts(doc['activities'])
      File "/usr/lib/python3.6/site-packages/leapp/cli/commands/upgrade/breadcrumbs.py", line 64, in _save_rhsm_facts
        os.path.mkdir('/etc/rhsm/facts')
    AttributeError: module 'posixpath' has no attribute 'mkdir'

While at it, also catch OSError with errno 17, to safeguard against race
conditions if anything has created the directory between us checking for
it and us trying to create it.
