### PR TITLE
RHSM: Adjust the switch to container mode for new RHSM

### DIFF
--- a/repos/system_upgrade/common/libraries/rhsm.py
+++ b/repos/system_upgrade/common/libraries/rhsm.py
@@ -334,6 +334,7 @@ def set_container_mode(context):
         return
     try:
         context.call(['ln', '-s', '/etc/rhsm', '/etc/rhsm-host'])
+        context.call(['ln', '-s', '/etc/pki/entitlement', '/etc/pki/entitlement-host'])
     except CalledProcessError:
         raise StopActorExecutionError(
                 message='Cannot set the container mode for the subscription-manager.')


### PR DESCRIPTION
RHSM in RHEL 8.9+ & RHEL 9.3+ requires newly for the switch to the container mode existence and content under /etc/pki/entitlement-host, which in our case should by symlink to /etc/pki/entitlement.

So currently we need for the correct switch 2 symlinks:
  * /etc/pki/rhsm-host        -> /etc/pki/rhsm
  * /etc/pki/entitlement-host -> /etc/pki/entitlement

Technically we need that only for RHEL 8.9+ but discussing it with RHSM SST, we can do this change unconditionally for any RHEL system as older versions of RHSM do not check /etc/pki/entitlement-host.

jira: RHEL-14839