### PR TITLE
support rhel 8 upgrade to 9 on alibaba cloud

### DIFF
--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -481,6 +481,17 @@ RHUI_CLOUD_MAP = {
                 ('leapp-google-sap.repo', YUM_REPOS_PATH)
             ],
         },
+        'alibaba': {
+            'src_pkg': 'aliyun_rhui_rhel8',
+            'target_pkg': 'aliyun_rhui_rhel9',
+            'leapp_pkg': 'leapp-rhui-alibaba',
+            'leapp_pkg_repo': 'leapp-alibaba.repo',
+            'files_map': [
+                ('content.crt', RHUI_PKI_PRODUCT_DIR),
+                ('key.pem', RHUI_PKI_DIR),
+                ('leapp-alibaba.repo', YUM_REPOS_PATH)
+            ],
+        },
     },
 }
 


### PR DESCRIPTION
1 we add repomap in repomap.json including rhel 8 map to rhel 9 (x86 & arm).
2 we add alibaba rhui map in rhui.py.
3 rhel 8 repo rpm was signed with sha1,   there will have a check on checkdeprecatedrpmsignature.py for deprecated signature,  so we add a  whitelist for alibaba cloud,  repo rpm on rhel 9 have been updated  signed  with sha256， the new signature package will be installed in the new rhel 9  image in the future.