### PR TITLE
be less strict when figuring out major version in initrd

### DIFF
--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -9,7 +9,7 @@ type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
 get_rhel_major_release() {
     local os_version
-    os_version=$(grep -o '^VERSION="[0-9][0-9]*\.' /etc/initrd-release | grep -o '[0-9]*')
+    os_version=$(grep -o '^VERSION="[0-9][0-9]*' /etc/initrd-release | grep -o '[0-9]*')
     [ -z "$os_version" ] && {
         # This should not happen as /etc/initrd-release is supposed to have API
         # stability, but check is better than broken system.

--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/90sys-upgrade/initrd-system-upgrade-generator
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/90sys-upgrade/initrd-system-upgrade-generator
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 get_rhel_major_release() {
-    _os_version=$(cat /etc/initrd-release | grep -o '^VERSION="[0-9][0-9]*\.' | grep -o '[0-9]*')
+    _os_version=$(cat /etc/initrd-release | grep -o '^VERSION="[0-9][0-9]*' | grep -o '[0-9]*')
     [ -z "$_os_version" ] && {
         # This should not happen as /etc/initrd-release is supposed to have API
         # stability, but check is better than broken system.


### PR DESCRIPTION
We only care for the major part of the version, so it's sufficient to grep without the dot, which is not present on CentOS initrd.

CentOS Stream 8:

    VERSION="8 dracut-049-224.git20230330.el8"
    VERSION_ID=049-224.git20230330.el8

CentOS Stream 9:

    VERSION="9 dracut-057-38.git20230725.el9"
    VERSION_ID="9"

RHEL 8.8:

    VERSION="8.8 (Ootpa) dracut-049-223.git20230119.el8"
    VERSION_ID=049-223.git20230119.el8

RHEL 9.2:

    VERSION="9.2 (Plow) dracut-057-21.git20230214.el9"
    VERSION_ID="9.2"

Ideally, we would just use the major part of VERSION_ID, but this is set to the underlying OS'es VERSION_ID only since dracut 050 [1] and EL8 ships with 049.

[1] https://github.com/dracutdevs/dracut/commit/72ae1c4fe73c5637eb8f6843b9a127a6d69469d6