### PR TITLE
Add RHUI configuration

### DIFF
--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -62,6 +62,9 @@ def preupgrade(args, breadcrumbs):
     command_utils.set_resource_limits()
 
     workflow = repositories.lookup_workflow('IPUWorkflow')()
+
+    command_utils.load_actor_configs_and_store_it_in_db(context, repositories, cfg)
+
     util.warn_if_unsupported(configuration)
     util.process_whitelist_experimental(repositories, workflow, configuration, logger)
     with beautify_actor_exception():

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -93,6 +93,9 @@ def upgrade(args, breadcrumbs):
     command_utils.set_resource_limits()
 
     workflow = repositories.lookup_workflow('IPUWorkflow')(auto_reboot=args.reboot)
+
+    command_utils.load_actor_configs_and_store_it_in_db(context, repositories, cfg)
+
     util.process_whitelist_experimental(repositories, workflow, configuration, logger)
     util.warn_if_unsupported(configuration)
     with beautify_actor_exception():

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -250,6 +250,11 @@ install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/files/
 install -m 0644 etc/leapp/transaction/* %{buildroot}%{_sysconfdir}/leapp/transaction
 install -m 0644 etc/leapp/files/* %{buildroot}%{_sysconfdir}/leapp/files
 
+# Actor configuration dir
+install -m 0755 -d %{buildroot}%{_sysconfdir}/leapp/actor_conf.d/
+# uncomment to install existing configs
+#install -m 0644 etc/leapp/actor_conf.d/* %%{buildroot}%%{_sysconfdir}/leapp/actor_conf.d
+
 # install CLI commands for the leapp utility on the expected path
 install -m 0755 -d %{buildroot}%{leapp_python_sitelib}/leapp/cli/
 cp -r commands %{buildroot}%{leapp_python_sitelib}/leapp/cli/
@@ -295,6 +300,8 @@ done;
 %dir %{custom_repositorydir}
 %dir %{leapp_python_sitelib}/leapp/cli/commands
 %config %{_sysconfdir}/leapp/files/*
+# uncomment to package installed configs
+#%%config %%{_sysconfdir}/leapp/actor_conf.d/*
 %{_sysconfdir}/leapp/repos.d/*
 %{_sysconfdir}/leapp/transaction/*
 %{repositorydir}/*

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -120,7 +120,7 @@ Requires:       leapp-repository-dependencies = %{leapp_repo_deps}
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' instead of the real framework rpm version.
-Requires:       leapp-framework >= 5.0, leapp-framework < 6
+Requires:       leapp-framework >= 6.0, leapp-framework < 7
 
 # Since we provide sub-commands for the leapp utility, we expect the leapp
 # tool to be installed as well.

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -272,6 +272,9 @@ rm -rf %{buildroot}%{repositorydir}/common/actors/testactor
 find %{buildroot}%{repositorydir}/common -name "test.py" -delete
 rm -rf `find %{buildroot}%{repositorydir} -name "tests" -type d`
 find %{buildroot}%{repositorydir} -name "Makefile" -delete
+# .gitkeep file is used to have a directory in the repo. but we do not want these
+# files in the resulting RPM
+find %{buildroot} -name .gitkeep -delete
 
 for DIRECTORY in $(find  %{buildroot}%{repositorydir}/  -mindepth 1 -maxdepth 1 -type d);
 do

--- a/packaging/other_specs/leapp-el7toel8-deps.spec
+++ b/packaging/other_specs/leapp-el7toel8-deps.spec
@@ -14,7 +14,7 @@
 
 
 %define leapp_repo_deps  10
-%define leapp_framework_deps 5
+%define leapp_framework_deps 6
 
 # NOTE: the Version contains the %{rhel} macro just for the convenience to
 # have always upgrade path between newer and older deps packages. So for
@@ -112,6 +112,7 @@ Requires:   python3
 Requires:   python3-six
 Requires:   python3-setuptools
 Requires:   python3-requests
+Requires:   python3-PyYAML
 
 
 %description -n %{ldname}

--- a/repos/system_upgrade/common/actors/cloud/checkrhui/actor.py
+++ b/repos/system_upgrade/common/actors/cloud/checkrhui/actor.py
@@ -1,4 +1,5 @@
 from leapp.actors import Actor
+from leapp.configs.common.rhui import all_rhui_cfg
 from leapp.libraries.actor import checkrhui as checkrhui_lib
 from leapp.models import (
     CopyFile,
@@ -8,6 +9,7 @@ from leapp.models import (
     RequiredTargetUserspacePackages,
     RHUIInfo,
     RpmTransactionTasks,
+    TargetRepositories,
     TargetUserSpacePreupgradeTasks
 )
 from leapp.reporting import Report
@@ -21,6 +23,7 @@ class CheckRHUI(Actor):
     """
 
     name = 'checkrhui'
+    config_schemas = all_rhui_cfg
     consumes = (InstalledRPM,)
     produces = (
         KernelCmdlineArg,
@@ -28,6 +31,7 @@ class CheckRHUI(Actor):
         RequiredTargetUserspacePackages,
         Report, DNFPluginTask,
         RpmTransactionTasks,
+        TargetRepositories,
         TargetUserSpacePreupgradeTasks,
         CopyFile,
     )

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -1120,6 +1120,27 @@ def _get_target_userspace():
     return constants.TARGET_USERSPACE.format(get_target_major_version())
 
 
+def _remove_injected_repofiles_from_our_rhui_packages(target_userspace_ctx, rhui_setup_info):
+    target_userspace_path = _get_target_userspace()
+    for copy in rhui_setup_info.preinstall_tasks.files_to_copy_into_overlay:
+        dst_in_container = get_copy_location_from_copy_in_task(target_userspace_path, copy)
+        dst_in_container = dst_in_container.strip('/')
+        dst_in_host = os.path.join(target_userspace_path, dst_in_container)
+
+        if os.path.isfile(dst_in_host) and dst_in_host.endswith('.repo'):
+            # The repofile might have been replaced by a new one provided by the RHUI client if names collide
+            # Performance: Do the query here and not earlier, because we would be running rpm needlessly
+            try:
+                path_with_root = '/' + dst_in_container
+                target_userspace_ctx.call(['rpm', '-q', '--whatprovides', path_with_root])
+                api.current_logger().debug('Repofile {0} kept as it is owned by some RPM.'.format(dst_in_host))
+            except CalledProcessError:
+                # rpm exists with 1 if the file is not owned by any RPM. We might be catching all kinds of other
+                # problems here, but still better than always removing repofiles.
+                api.current_logger().debug('Removing repofile - not owned by any RPM: {0}'.format(dst_in_host))
+                os.remove(dst_in_host)
+
+
 def _create_target_userspace(context, indata, packages, files, target_repoids):
     """Create the target userspace."""
     target_path = _get_target_userspace()
@@ -1139,14 +1160,7 @@ def _create_target_userspace(context, indata, packages, files, target_repoids):
         )
         setup_info = indata.rhui_info.target_client_setup_info
         if not setup_info.bootstrap_target_client:
-            target_userspace_path = _get_target_userspace()
-            for copy in setup_info.preinstall_tasks.files_to_copy_into_overlay:
-                dst_in_container = get_copy_location_from_copy_in_task(target_userspace_path, copy)
-                dst_in_container = dst_in_container.strip('/')
-                dst_in_host = os.path.join(target_userspace_path, dst_in_container)
-                if os.path.isfile(dst_in_host) and dst_in_host.endswith('.repo'):
-                    api.current_logger().debug('Removing repofile: {0}'.format(dst_in_host))
-                    os.remove(dst_in_host)
+            _remove_injected_repofiles_from_our_rhui_packages(context, setup_info)
 
     # and do not forget to set the rhsm into the container mode again
     with mounting.NspawnActions(_get_target_userspace()) as target_context:

--- a/repos/system_upgrade/common/configs/rhui.py
+++ b/repos/system_upgrade/common/configs/rhui.py
@@ -1,0 +1,127 @@
+"""
+Configuration keys for RHUI.
+
+In case of RHUI in private regions it usual that publicly known RHUI data
+is not valid. In such cases it's possible to provide the correct expected
+RHUI data to correct the in-place upgrade process.
+"""
+
+from leapp.actors.config import Config
+from leapp.models import fields
+
+RHUI_CONFIG_SECTION = 'rhui'
+
+
+# @Note(mhecko): We use to distinguish config instantiated from default values that we should ignore
+# #              Maybe we could make all config values None and detect it that way, but then we cannot
+# #              give the user an example how the config should look like.
+class RhuiUseConfig(Config):
+    section = RHUI_CONFIG_SECTION
+    name = "use_config"
+    type_ = fields.Boolean()
+    default = False
+    description = """
+        Use values provided in the configuration file to override leapp's decisions.
+    """
+
+
+class RhuiSourcePkgs(Config):
+    section = RHUI_CONFIG_SECTION
+    name = "source_clients"
+    type_ = fields.List(fields.String())
+    default = []
+    description = """
+        The name of the source RHUI client RPMs (to be removed from the system).
+    """
+
+
+class RhuiTargetPkgs(Config):
+    section = RHUI_CONFIG_SECTION
+    name = "target_clients"
+    type_ = fields.List(fields.String())
+    default = []
+    description = """
+        The name of the target RHUI client RPM (to be installed on the system).
+    """
+
+
+class RhuiCloudProvider(Config):
+    section = RHUI_CONFIG_SECTION
+    name = "cloud_provider"
+    type_ = fields.String()
+    default = ""
+    description = """
+        Cloud provider name that should be used internally by leapp.
+
+        Leapp recognizes the following cloud providers:
+            - azure
+            - aws
+            - google
+
+        Cloud provider information is used for triggering some provider-specific modifications. The value also
+        influences how leapp determines target repositories to enable.
+    """
+
+
+# @Note(mhecko): We likely don't need this. We need the variant primarily to grab files from a correct directory
+# in leapp-rhui-<provider> folders.
+class RhuiCloudVariant(Config):
+    section = RHUI_CONFIG_SECTION
+    name = "image_variant"
+    type_ = fields.String()
+    default = "ordinary"
+    description = """
+        RHEL variant of the source system - is the source system SAP-specific image?
+
+        Leapp recognizes the following cloud providers:
+            - ordinary    # The source system has not been deployed from a RHEL with SAP image
+            - sap         # RHEL SAP images
+            - sap-apps    # RHEL SAP Apps images (Azure only)
+            - sap-ha      # RHEL HA Apps images (HA only)
+
+        Cloud provider information is used for triggering some provider-specific modifications. The value also
+        influences how leapp determines target repositories to enable.
+
+        Default:
+            "ordinary"
+    """
+
+
+class RhuiUpgradeFiles(Config):
+    section = RHUI_CONFIG_SECTION
+    name = "upgrade_files"
+    type_ = fields.StringMap(fields.String())
+    default = dict()
+    description = """
+        A mapping from source file paths to the destination where should they be
+        placed in the upgrade container.
+
+        Typically, these files should be provided by leapp-rhui-<PROVIDER> packages.
+
+        These files are needed to facilitate access to target repositories. Typical examples are: repofile(s),
+        certificates and keys.
+    """
+
+
+class RhuiTargetRepositoriesToUse(Config):
+    section = RHUI_CONFIG_SECTION
+    name = "rhui_target_repositories_to_use"
+    type_ = fields.List(fields.String())
+    description = """
+        List of target repositories enabled during the upgrade. Similar to executing leapp with --enablerepo.
+
+        The repositories to be enabled need to be either in the repofiles listed in the `upgrade_files` field,
+        or in repofiles present on the source system.
+    """
+    default = list()
+
+
+all_rhui_cfg = (
+    RhuiTargetPkgs,
+    RhuiUpgradeFiles,
+    RhuiTargetRepositoriesToUse,
+    RhuiCloudProvider,
+    RhuiCloudVariant,
+    RhuiSourcePkgs,
+    RhuiUseConfig
+)

--- a/repos/system_upgrade/common/libraries/testutils.py
+++ b/repos/system_upgrade/common/libraries/testutils.py
@@ -4,6 +4,7 @@ import os
 from collections import namedtuple
 
 from leapp import reporting
+from leapp.actors.config import _normalize_config, normalize_schemas
 from leapp.libraries.common.config import architecture
 from leapp.models import EnvVar
 from leapp.utils.deprecation import deprecated
@@ -67,9 +68,15 @@ class logger_mocked(object):
         return self
 
 
+def _make_default_config(actor_config_schema):
+    """ Make a config dict populated with default values. """
+    merged_schema = normalize_schemas((actor_config_schema, ))
+    return _normalize_config({}, merged_schema)  # Will fill default values during normalization
+
+
 class CurrentActorMocked(object):  # pylint:disable=R0904
     def __init__(self, arch=architecture.ARCH_X86_64, envars=None, kernel='3.10.0-957.43.1.el7.x86_64',
-                 release_id='rhel', src_ver='7.8', dst_ver='8.1', msgs=None, flavour='default'):
+                 release_id='rhel', src_ver='7.8', dst_ver='8.1', msgs=None, flavour='default', config=None):
         envarsList = [EnvVar(name=k, value=v) for k, v in envars.items()] if envars else []
         version = namedtuple('Version', ['source', 'target'])(src_ver, dst_ver)
         release = namedtuple('OS_release', ['release_id', 'version_id'])(release_id, src_ver)
@@ -82,6 +89,7 @@ class CurrentActorMocked(object):  # pylint:disable=R0904
             'configuration', ['architecture', 'kernel', 'leapp_env_vars', 'os_release', 'version', 'flavour']
         )(arch, kernel, envarsList, release, version, flavour)
         self._msgs = msgs or []
+        self.config = {} if config is None else config
 
     def __call__(self):
         return self


### PR DESCRIPTION
Add configuration options for leapp's RHUI handling and RPM transactions.

## RHUI Configuration
Example of RHUI configuration:
```yaml
rhui:
  use_config : True
  source_clients: [ rh-amazon-rhui-client ]
  target_clients: [ rh-amazon-rhui-client ]
  cloud_provider: aws
  upgrade_files:
    /usr/share/leapp-repository/repositories/system_upgrade/common/files/rhui/aws/leapp-aws.repo : /etc/yum.repos.d/
    /usr/share/leapp-repository/repositories/system_upgrade/common/files/rhui/aws/rhui-client-config-server-9.crt : /etc/pki/rhui/product/
    /usr/share/leapp-repository/repositories/system_upgrade/common/files/rhui/aws/rhui-client-config-server-9.key : /etc/pki/rhui/
    /usr/share/leapp-repository/repositories/system_upgrade/common/files/rhui/aws/content-rhel9.crt : /etc/pki/rhui/product/
    /usr/share/leapp-repository/repositories/system_upgrade/common/files/rhui/aws/content-rhel9.key : /etc/pki/rhui/
    /usr/share/leapp-repository/repositories/system_upgrade/common/files/rhui/aws/cdn.redhat.com-chain.crt : /etc/pki/rhui/product/
  rhui_target_repositories_to_use:
    - rhel-9-appstream-rhui-rpms
    - rhel-9-baseos-rhui-rpms

```
Leapp reads the configuration, checking the `use_config` field to know whether the values from config should be used, instead of leapp's decision routines. If `use_config=True`, leapp will not do *any* automatic decisions about RHUI whatsoever. Therefore, the configured values determine what leapp will do.

The following configuration options are added:
| Configuration field | Description |
| ----    | ---- |
| `source_clients` |  RHUI clients to uninstall during the upgrade | 
| `target_clients` |  RHUI clients to install during the upgrade  | 
| `cloud_provider` |  so that leapp knows it is running on cloud  | 
| `upgrade_files` |  mapping of paths of files on the source system to the corresponding destinations in the scratch container.  Once the target container is set up, the files provided by the target client are used and the files from `upgrade_files` are removed.
| `enabled_target_repositories` |  a list of repositories to enable. Functions the same way as using `leapp --enablerepo`  | 

#### Known limitations
Using a repofile withing `upgrade_files` that uses different repoids than the target client(s) in combination with `enable_target_repositories` causes DNF transaction check to fail.

Jira refs:
   - RHUI: https://issues.redhat.com/browse/RHEL-56251



Acceptance criteria for RHUI configuration:
- [x] It is possible to use config to upgrade unknown regions
- [x] Should make HA upgrades on AWS possible (achieved by a `leapp-rhui-aws-ha` that does not require)
- [x] Make `rhui_repositories` a required field (or rename to `target_repoids_to_enable`)
- [x] Make sure that repomapping does not error on unknown cloud providers.
  - Using `cloud_provider = 'some_random_provider` has been tried (with `enabled_target_repositories`), there were no problems - no code modifications are required.
- [x] Remove defaults - require user to supply everything