### PR TITLE
Extend leappdb with more execution information

### DIFF
--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -3,6 +3,7 @@ import itertools
 import json
 import os
 import shutil
+import sys
 import tarfile
 from datetime import datetime
 
@@ -235,6 +236,8 @@ def prepare_configuration(args):
         'debug': os.getenv('LEAPP_DEBUG', '0'),
         'verbose': os.getenv('LEAPP_VERBOSE', '0'),
         'whitelist_experimental': args.whitelist_experimental or (),
+        'environment': {env: os.getenv(env) for env in os.environ if env.startswith('LEAPP_')},
+        'cmd': sys.argv,
     }
     return configuration
 


### PR DESCRIPTION
Related to changes extending the information stored in the leapp db. After this comment, the command line arguments as well as the environment variables modifying the leapp execution (env vars starting with `LEAPP_`) will be stored in the database.

JIRA: [OAMG-8402](https://issues.redhat.com/browse/OAMG-8402)