### PR TITLE
pes_events_scanner: Ignore Leapp related PES events

### DIFF
--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
@@ -5,6 +5,7 @@ from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import peseventsscanner_repomap
 from leapp.libraries.actor.pes_event_parsing import Action, get_pes_events, Package
+from leapp.libraries.common import rpms
 from leapp.libraries.common.config import version
 from leapp.libraries.stdlib import api
 from leapp.libraries.stdlib.config import is_verbose
@@ -481,11 +482,9 @@ def apply_transaction_configuration(source_pkgs):
 
 
 def remove_leapp_related_events(events):
-    leapp_pkgs = [
-        'leapp', 'leapp-deps', 'leapp-upgrade-el7toel8', 'leapp-upgrade-el8toel9',
-        'leapp-upgrade-el7toel8-deps', 'leapp-upgrade-el8toel9-deps', 'python2-leapp',
-        'python3-leapp', 'snactor'
-    ]
+    # NOTE(ivasilev) Need to revisit this once rhel9->rhel10 upgrades become a thing
+    leapp_pkgs = rpms.get_leapp_dep_packages(
+            major_version=['7', '8']) + rpms.get_leapp_packages(major_version=['7', '8'])
     res = []
     for event in events:
         if not any(pkg.name in leapp_pkgs for pkg in event.in_pkgs):

--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
@@ -480,6 +480,21 @@ def apply_transaction_configuration(source_pkgs):
     return source_pkgs_with_conf_applied
 
 
+def remove_leapp_related_events(events):
+    leapp_pkgs = [
+        'leapp', 'leapp-deps', 'leapp-upgrade-el7toel8', 'leapp-upgrade-el8toel9',
+        'leapp-upgrade-el7toel8-deps', 'leapp-upgrade-el8toel9-deps', 'python2-leapp',
+        'python3-leapp', 'snactor'
+    ]
+    res = []
+    for event in events:
+        if not any(pkg.name in leapp_pkgs for pkg in event.in_pkgs):
+            res.append(event)
+        else:
+            api.current_logger().debug('Filtered out leapp related event, event id: {}'.format(event.id))
+    return res
+
+
 def process():
     # Retrieve data - installed_pkgs, transaction configuration, pes events
     events = get_pes_events('/etc/leapp/files', 'pes-events.json')
@@ -494,6 +509,7 @@ def process():
     # packages of the target system, so we can distinguish what needs to be repomapped
     repoids_of_source_pkgs = {pkg.repository for pkg in source_pkgs}
 
+    events = remove_leapp_related_events(events)
     events = remove_undesired_events(events, releases)
 
     # Apply events - compute what packages should the target system have

--- a/repos/system_upgrade/common/actors/peseventsscanner/tests/test_pes_event_scanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/tests/test_pes_event_scanner.py
@@ -404,7 +404,10 @@ def test_pkgs_are_demodularized_when_crossing_major_version(monkeypatch):
     assert target_pkgs == expected_target_pkgs
 
 
-def test_remove_leapp_related_events():
+def test_remove_leapp_related_events(monkeypatch):
+    # NOTE(ivasilev) That's required to use leapp library functions that rely on calls to
+    # get_source/target_system_version functions
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch='x86_64', src_ver='7.9', dst_ver='8.8'))
     # these are just hypothetical and not necessarily correct
     package_set_two_leapp = {Package('leapp-upgrade-el7toel8', 'repoid-rhel7', None),
                              Package('leapp-upgrade-el7toel8-deps', 'repoid-rhel7', None)}


### PR DESCRIPTION
When PES events are added for all the Leapp related packages, we need to make sure to ignore them in `pes_events_scanner` to make sure they are *not* taken into account during the RPM upgrade transaction as we don't want to upgrade them or want to handle their upgrade in a different way.

Jira: OAMG-5645