### PR TITLE
Update dependencies: require xfsprogs and e2fsprogs

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -2,7 +2,7 @@
 %global repositorydir %{leapp_datadir}/repositories
 %global custom_repositorydir %{leapp_datadir}/custom-repositories
 
-%define leapp_repo_deps  9
+%define leapp_repo_deps  10
 
 %if 0%{?rhel} == 7
     %define leapp_python_sitelib %{python2_sitelib}
@@ -149,6 +149,16 @@ Provides:  leapp-repository-dependencies = %{leapp_repo_deps}
 ##################################################
 Requires:   dnf >= 4
 Requires:   pciutils
+
+# required to be able to format disk images with XFS file systems (default)
+Requires:   xfsprogs
+
+# required to be able to format disk images with Ext4 file systems
+# NOTE: this is not happening by default, but we can expact that many customers
+# will want to / need to do this - especially on RHEL 7 now. Adding this deps
+# as the best trade-off to resolve this problem.
+Requires:   e2fsprogs
+
 %if 0%{?rhel} && 0%{?rhel} == 7
 # Required to gather system facts about SELinux
 Requires:   libselinux-python

--- a/packaging/other_specs/leapp-el7toel8-deps.spec
+++ b/packaging/other_specs/leapp-el7toel8-deps.spec
@@ -9,7 +9,7 @@
 %endif
 
 
-%define leapp_repo_deps  9
+%define leapp_repo_deps  10
 %define leapp_framework_deps 5
 
 # NOTE: the Version contains the %{rhel} macro just for the convenience to
@@ -67,6 +67,19 @@ Requires:   cpio
 
 # just to be sure that /etc/modprobe.d is present
 Requires:   kmod
+
+# required to be able to format disk images with XFS file systems (default)
+# NOTE: this is really needed on the source system, but keep it for the target
+# one too
+Requires:   xfsprogs
+
+# required to be able to format disk images with Ext4 file systems
+# NOTE: this is not happening by default, but we can expact that many customers
+# will want to / need to do this - especially on RHEL 7 now. Adding this deps
+# as the best trade-off to resolve this problem.
+# NOTE: this is really needed on the source system, but keep it for the target
+# one too
+Requires:   e2fsprogs
 
 
 %description -n %{lrdname}


### PR DESCRIPTION
To be able to format our OVL disk images with XFS or Ext4, we need the required tools present on the system. However, on systems with XFS file systems only, it's not needed to have tools for ext4, and vice versa. So on such systems, users can remove these packages manually. In that cases, we get into a problems, especially when XFS is the default FS in our case.

To resolve that, we add dependencies for xfsprogs and e2fsprogs rpms into the spec file, so we are sure these are always present on the system.

In case of Ext4 is a little bit "redundant" - as use of Ext4 is optional. However we expect actually that many people will do it (many == not a small amount of people -> not uncommon use..). So keeping this the least effort, let's add the requirement for both as the actual installation stack is not big.

Packaging:
    * Requires xfsprogs, e2fsprogs
    * Bump leapp-repository-dependencies to 10

jira: RHEL-10847

* Update: Note: we have agreement with QE on this.