### PR TITLE
Workaround tft issue with listing disabled plans

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -101,7 +101,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity'
+        plan_filter: 'tag:sanity & enabled:true'
     environments:
       - tmt:
           context:
@@ -129,7 +129,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:e2e'
+        plan_filter: 'tag:e2e & enabled:true'
     environments:
       - tmt:
           context:
@@ -184,7 +184,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:partitioning & tag:7to8'
+        plan_filter: 'tag:partitioning & tag:7to8 & enabled:true'
     environments:
       - tmt:
           context:
@@ -205,7 +205,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:kernel-rt & tag:7to8'
+        plan_filter: 'tag:kernel-rt & tag:7to8 & enabled:true'
     environments:
       - tmt:
           context:
@@ -326,7 +326,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity & tag:8to9'
+        plan_filter: 'tag:sanity & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -355,7 +355,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:partitioning & tag:8to9'
+        plan_filter: 'tag:partitioning & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -381,7 +381,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:kernel-rt & tag:8to9'
+        plan_filter: 'tag:kernel-rt & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -400,7 +400,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity & tag:8to9'
+        plan_filter: 'tag:sanity & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -430,7 +430,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:partitioning & tag:8to9'
+        plan_filter: 'tag:partitioning & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -457,7 +457,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:kernel-rt & tag:8to9'
+        plan_filter: 'tag:kernel-rt & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -476,7 +476,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity & tag:8to9'
+        plan_filter: 'tag:sanity & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -505,7 +505,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:partitioning & tag:8to9'
+        plan_filter: 'tag:partitioning & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -531,7 +531,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:kernel-rt & tag:8to9'
+        plan_filter: 'tag:kernel-rt & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -550,7 +550,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity & tag:8to9'
+        plan_filter: 'tag:sanity & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -579,7 +579,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:partitioning & tag:8to9'
+        plan_filter: 'tag:partitioning & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -604,7 +604,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:kernel-rt & tag:8to9'
+        plan_filter: 'tag:kernel-rt & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -623,7 +623,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:e2e'
+        plan_filter: 'tag:e2e & enabled:true'
     environments:
       - tmt:
           context:


### PR DESCRIPTION
Until TFT-2298 is resolved a mandatory enabled:true tests filtering won't hurt as we do have some tests that are disabled for particular distros.

OAMG-10177