### PR TITLE
dracut modules: add breakpoints with more consistent names

### DIFF
--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/do-upgrade.sh
@@ -227,6 +227,11 @@ do_upgrade() {
         getargbool 0 enforcing || echo 0 > /sys/fs/selinux/enforce
     fi
 
+    # NOTE: For debugging purposis. It's possible it will be changed in future.
+    getarg 'rd.upgrade.break=leapp-pre-upgrade' && {
+        emergency_shell -n upgrade "Break right before running leapp in initramfs"
+    }
+
     # and off we go...
     # NOTE: in case we would need to run leapp before pivot, we would need to
     #       specify where the root is, e.g. --root=/sysroot
@@ -237,9 +242,10 @@ do_upgrade() {
     # NOTE: flush the cached content to disk to ensure everything is written
     sync
 
-    #FIXME: for debugging purposes; this will be removed or redefined in future
-    getarg 'rd.upgrade.break=leapp-upgrade' 'rd.break=leapp-upgrade' && \
-        emergency_shell -n upgrade "Break after LEAPP upgrade stop"
+    # NOTE: For debugging purposes. It's possible it will be changed in future.
+    getarg 'rd.upgrade.break=leapp-post-upgrade' 'rd.upgrade.break=leapp-upgrade' 'rd.break=leapp-upgrade' && {
+        emergency_shell -n upgrade "Break right after LEAPP upgrade, before post-upgrade leapp run"
+    }
 
     if [ "$rv" -eq 0 ]; then
         # run leapp to proceed phases after the upgrade with Python3
@@ -370,8 +376,10 @@ result=$?
 ##### safe the data and remount $NEWROOT as it was previously mounted #####
 save_journal
 
-#FIXME: for debugging purposes; this will be removed or redefined in future
-getarg 'rd.break=leapp-logs' && emergency_shell -n upgrade "Break after LEAPP save_journal"
+# NOTE: For debugging purposis. It's possible it will be changed in future.
+getarg 'rd.break=leapp-logs' 'rd.upgrade.break=leapp-finish' && {
+    emergency_shell -n upgrade "Break after LEAPP save_journal (upgrade initramfs end)"
+}
 
 # NOTE: flush the cached content to disk to ensure everything is written
 sync

--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/90sys-upgrade/upgrade.sh
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/90sys-upgrade/upgrade.sh
@@ -11,8 +11,9 @@ type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
 source_conf /etc/conf.d
 
-getarg 'rd.upgrade.break=upgrade' 'rd.break=upgrade' && \
-    emergency_shell -n upgrade "Break before upgrade"
+# NOTE: For debugging purposis. It's possible it will be changed in future.
+getarg 'rd.upgrade.break=upgrade' 'rd.break=upgrade' 'rd.upgrade.break=leapp-initram' && \
+    emergency_shell -n upgrade "Break right after getting to leapp dracut modules"
 
 setstate() {
     export UPGRADE_STATE="$*"


### PR DESCRIPTION
I've already realized I missed couple of breakpoints over time inside the initramfs and cannot remember expected cmdline params for each of them. So let's try to make it more consistent. Keeping the original cmdline arguments as some people are used to them already, but introducing new ones.

New introduced breakpoints:
* rd.upgrade.break=leapp-initram
  * breaks right after getting to leapp dracut modules
  * orig
    * rd.break=upgrade
    * rd.upgrade.break=upgrade
* rd.upgrade.break=leapp-pre-upgrade
  * breaks just right before running leapp in initramfs
* rd.upgrade.break=leapp-post-upgrade
  * running just right after leapp upgrade (dnf transaction done), before the start of post-upgrade phases
  * orig:
    * rd.break=leapp-upgrade
    * rd.upgrade.break=leapp-upgrade
* rd.upgrade.break=leapp-finish
  * the last breakpoint, after logs are saved, before the upcoming reboot (leaving the upgrade environment)
  * orig:
    * rd.break=leapp-logs

Note: we could possibly drop old ones already, but as this is going to be one of last changes for IPU 7 -> 8, I decided to leave such a decision for future. Also, it's possible that we will need to redesign this part of the upgrade process, so that's another reason why to just add something, but do not drop anything.

## TODO
- [ ] Improve the messages - adding eg. hint what to do in particular breakpoints, so it's visible in the msg. e.g. run leapp using cmd: ....., etc
- [ ] part of the msg could/should be info about deprecated values (when deprecated argument is used, inform about the new value, etc). also we should cover it in upstream documentation