### PR TITLE
Switch test repo branch to main

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -88,7 +88,7 @@ jobs:
 - &sanity-79to86
   job: tests
   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "master"
+  fmf_ref: "main"
   use_internal_tf: True
   trigger: pull_request
   labels:


### PR DESCRIPTION
As default branch in tmt tests repo has been changed from master to main, we have to address this in
packit configuration.