### PR TITLE
Fix another cornercase with symlink handling

### DIFF
--- a/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
@@ -381,6 +381,70 @@ def temp_directory_layout(tmp_path, initial_structure):
         },
         id="Absolute_symlink_to_a_file_inside_via_a_symlink_to_the_rootdir"
     )),
+    # This should be fixed but not necessarily for this release.
+    # It makes sure that when we have two separate links to the
+    # same file outside of /etc/pki, one of the links is copied
+    # as a real file and the other is made a link to the copy.
+    # (Right now, the real file is copied in place of both links.)
+    # (pytest.param(
+    #     {
+    #         'dir': {
+    #             'fileA': '/outside/fileC',
+    #             'fileB': '/outside/fileC',
+    #         },
+    #         'outside': {
+    #             'fileC': None,
+    #         },
+    #     },
+    #     {
+    #         'dir': {
+    #             'fileA': None,
+    #             'fileB': '/dir/fileA',
+    #         },
+    #     },
+    #     id="Absolute_two_symlinks_to_the_same_copied_file"
+    # )),
+    (pytest.param(
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': '/dir/inside',
+                'inside': {
+                    'fileB': None,
+                },
+            },
+        },
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': '/dir/inside',
+                'inside': {
+                    'fileB': None,
+                },
+            },
+        },
+        id="Absolute_symlink_to_a_dir_inside"
+    )),
+    (pytest.param(
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': '/outside',
+            },
+            'outside': {
+                'fileB': None,
+            },
+        },
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': {
+                    'fileB': None,
+                },
+            },
+        },
+        id="Absolute_symlink_to_a_dir_outside"
+    )),
     (pytest.param(
         # This one is very tricky:
         # * The user has made /etc/pki a symlink to some other directory that
@@ -670,6 +734,70 @@ def temp_directory_layout(tmp_path, initial_structure):
             },
         },
         id="Relative_symlink_to_a_file_inside_via_a_symlink_to_the_rootdir"
+    )),
+    # This should be fixed but not necessarily for this release.
+    # It makes sure that when we have two separate links to the
+    # same file outside of /etc/pki, one of the links is copied
+    # as a real file and the other is made a link to the copy.
+    # (Right now, the real file is copied in place of both links.)
+    # (pytest.param(
+    #     {
+    #         'dir': {
+    #             'fileA': '../outside/fileC',
+    #             'fileB': '../outside/fileC',
+    #         },
+    #         'outside': {
+    #             'fileC': None,
+    #         },
+    #     },
+    #     {
+    #         'dir': {
+    #             'fileA': None,
+    #             'fileB': 'fileA',
+    #         },
+    #     },
+    #     id="Relative_two_symlinks_to_the_same_copied_file"
+    # )),
+    (pytest.param(
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': '../outside',
+            },
+            'outside': {
+                'fileB': None,
+            },
+        },
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': {
+                    'fileB': None,
+                },
+            },
+        },
+        id="Relative_symlink_to_a_dir_outside"
+    )),
+    (pytest.param(
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': 'inside',
+                'inside': {
+                    'fileB': None,
+                },
+            },
+        },
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': 'inside',
+                'inside': {
+                    'fileB': None,
+                },
+            },
+        },
+        id="Relative_symlink_to_a_dir_inside"
     )),
     (pytest.param(
         # This one is very tricky:


### PR DESCRIPTION
There are two commits in this PR.  We may want to defer the second one until after the release, though:
First change:
* Fixes symlinks to a directory inside of /etc/pki were being created as empty directories.

Second change:
* Fixes two links to the same file outside of /etc/pki should be created as a copy of the file and a link to that copy.
 
Another part of the fix for: https://issues.redhat.com/browse/RHEL-3284

Related PRs: #1135, #1160 