### PR TITLE
Fix symlink to same exterior location

### DIFF
--- a/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
@@ -381,6 +381,70 @@ def temp_directory_layout(tmp_path, initial_structure):
         },
         id="Absolute_symlink_to_a_file_inside_via_a_symlink_to_the_rootdir"
     )),
+    # This should be fixed but not necessarily for this release.
+    # It makes sure that when we have two separate links to the
+    # same file outside of /etc/pki, one of the links is copied
+    # as a real file and the other is made a link to the copy.
+    # (Right now, the real file is copied in place of both links.)
+    # (pytest.param(
+    #     {
+    #         'dir': {
+    #             'fileA': '/outside/fileC',
+    #             'fileB': '/outside/fileC',
+    #         },
+    #         'outside': {
+    #             'fileC': None,
+    #         },
+    #     },
+    #     {
+    #         'dir': {
+    #             'fileA': None,
+    #             'fileB': '/dir/fileA',
+    #         },
+    #     },
+    #     id="Absolute_two_symlinks_to_the_same_copied_file"
+    # )),
+    (pytest.param(
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': '/dir/inside',
+                'inside': {
+                    'fileB': None,
+                },
+            },
+        },
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': '/dir/inside',
+                'inside': {
+                    'fileB': None,
+                },
+            },
+        },
+        id="Absolute_symlink_to_a_dir_inside"
+    )),
+    (pytest.param(
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': '/outside',
+            },
+            'outside': {
+                'fileB': None,
+            },
+        },
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': {
+                    'fileB': None,
+                },
+            },
+        },
+        id="Absolute_symlink_to_a_dir_outside"
+    )),
     (pytest.param(
         # This one is very tricky:
         # * The user has made /etc/pki a symlink to some other directory that
@@ -670,6 +734,70 @@ def temp_directory_layout(tmp_path, initial_structure):
             },
         },
         id="Relative_symlink_to_a_file_inside_via_a_symlink_to_the_rootdir"
+    )),
+    # This should be fixed but not necessarily for this release.
+    # It makes sure that when we have two separate links to the
+    # same file outside of /etc/pki, one of the links is copied
+    # as a real file and the other is made a link to the copy.
+    # (Right now, the real file is copied in place of both links.)
+    # (pytest.param(
+    #     {
+    #         'dir': {
+    #             'fileA': '../outside/fileC',
+    #             'fileB': '../outside/fileC',
+    #         },
+    #         'outside': {
+    #             'fileC': None,
+    #         },
+    #     },
+    #     {
+    #         'dir': {
+    #             'fileA': None,
+    #             'fileB': 'fileA',
+    #         },
+    #     },
+    #     id="Relative_two_symlinks_to_the_same_copied_file"
+    # )),
+    (pytest.param(
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': '../outside',
+            },
+            'outside': {
+                'fileB': None,
+            },
+        },
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': {
+                    'fileB': None,
+                },
+            },
+        },
+        id="Relative_symlink_to_a_dir_outside"
+    )),
+    (pytest.param(
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': 'inside',
+                'inside': {
+                    'fileB': None,
+                },
+            },
+        },
+        {
+            'dir': {
+                'fileA': None,
+                'link_to_dir': 'inside',
+                'inside': {
+                    'fileB': None,
+                },
+            },
+        },
+        id="Relative_symlink_to_a_dir_inside"
     )),
     (pytest.param(
         # This one is very tricky:

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
@@ -381,29 +381,24 @@ def temp_directory_layout(tmp_path, initial_structure):
         },
         id="Absolute_symlink_to_a_file_inside_via_a_symlink_to_the_rootdir"
     )),
-    # This should be fixed but not necessarily for this release.
-    # It makes sure that when we have two separate links to the
-    # same file outside of /etc/pki, one of the links is copied
-    # as a real file and the other is made a link to the copy.
-    # (Right now, the real file is copied in place of both links.)
-    # (pytest.param(
-    #     {
-    #         'dir': {
-    #             'fileA': '/outside/fileC',
-    #             'fileB': '/outside/fileC',
-    #         },
-    #         'outside': {
-    #             'fileC': None,
-    #         },
-    #     },
-    #     {
-    #         'dir': {
-    #             'fileA': None,
-    #             'fileB': '/dir/fileA',
-    #         },
-    #     },
-    #     id="Absolute_two_symlinks_to_the_same_copied_file"
-    # )),
+    (pytest.param(
+        {
+            'dir': {
+                'fileA': '/outside/fileC',
+                'fileB': '/outside/fileC',
+            },
+            'outside': {
+                'fileC': None,
+            },
+        },
+        {
+            'dir': {
+                'fileA': None,
+                'fileB': '/dir/fileA',
+            },
+        },
+        id="Absolute_two_symlinks_to_the_same_copied_file"
+    )),
     (pytest.param(
         {
             'dir': {
@@ -735,29 +730,24 @@ def temp_directory_layout(tmp_path, initial_structure):
         },
         id="Relative_symlink_to_a_file_inside_via_a_symlink_to_the_rootdir"
     )),
-    # This should be fixed but not necessarily for this release.
-    # It makes sure that when we have two separate links to the
-    # same file outside of /etc/pki, one of the links is copied
-    # as a real file and the other is made a link to the copy.
-    # (Right now, the real file is copied in place of both links.)
-    # (pytest.param(
-    #     {
-    #         'dir': {
-    #             'fileA': '../outside/fileC',
-    #             'fileB': '../outside/fileC',
-    #         },
-    #         'outside': {
-    #             'fileC': None,
-    #         },
-    #     },
-    #     {
-    #         'dir': {
-    #             'fileA': None,
-    #             'fileB': 'fileA',
-    #         },
-    #     },
-    #     id="Relative_two_symlinks_to_the_same_copied_file"
-    # )),
+    (pytest.param(
+        {
+            'dir': {
+                'fileA': '../outside/fileC',
+                'fileB': '../outside/fileC',
+            },
+            'outside': {
+                'fileC': None,
+            },
+        },
+        {
+            'dir': {
+                'fileA': None,
+                'fileB': 'fileA',
+            },
+        },
+        id="Relative_two_symlinks_to_the_same_copied_file"
+    )),
     (pytest.param(
         {
             'dir': {


### PR DESCRIPTION
In the present code, when we have two separate links to the same file outside of /etc/pki, the real
file is copied to the location of both links.  The problem with this is when the user makes changes
to the file in the future, they will have to edit both files whereas before they would only have had
to edit one of the files (since they linked to the same underlying file). Example:

```
  Host:
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 fileA -> /etc/sourceFile
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 fileB -> /etc/sourceFile

  Becomes:

  -rw-r--r--.  1 badger badger  12 Jan 22 03:43 fileA
  -rw-r--r--.  1 badger badger  12 Jan 22 03:43 fileB
```

fileA and fileB are separate copies of /etc/sourceFile.

This change makes it so anytime two links eventually point to the same exterior file, the first link will be copied and the second link will becone a symlinks to that copy like this:

```
  -rw-r--r--.  1 badger badger  12 Jan 22 03:43 fileA
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 fileB -> /etc/pki/fileA
```

This is the behaviour even if the second link went through several other exterior links to reach the
same sourceFile (but not if there is another interior link in between).  Example:

```
  Host:
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 fileA -> /etc/sourceFile
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 fileB -> /etc/sourceFile
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 fileC -> /etc/external-to-same-file
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 fileD -> /etc/external-to-interior-link

  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 /etc/external-to-same-file -> /etc/sourceFile
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 /etc/external-to-interior-link -> pki/fileB

  Becomes:
  -rw-r--r--.  1 badger badger  12 Jan 22 03:43 fileA
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 fileB -> /etc/pki/fileA
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 fileC -> /etc/pki/fileA
  lrwxrwxrwx.  1 badger badger  13 Jan 22 03:42 fileD -> /etc/pki/fileB
```

The drawback to the end user is that, unless you trace all the way through the chain of symlinks, it
is confusing that fileA ends up being a real file and fileC ends up pointing to it.  It's not
immediately obvious how the two are related.

The advantage is if the end user makes any changes to either fileA or fileC, then the changes will
be visible in both files which is the behaviour that existed on the host system.