### PR TITLE
 Make the reboot required text more visible in the console output

### DIFF
--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -113,6 +113,11 @@ def upgrade(args, breadcrumbs):
 
     if workflow.failure:
         sys.exit(1)
+    elif not args.resume:
+        sys.stdout.write(
+            'Reboot the system to continue with the upgrade.'
+            ' This might take a while depending on the system configuration.\n'
+        )
 
 
 def register(base_command):


### PR DESCRIPTION
The "A reboot is required to continue. Please reboot your system." message is printed before the reports summary and thus is easily overlooked by users.

This patch adds a second such message after the report summary to improve this.

Example (slightly outdated, the extra comma is already removed):
![image](https://github.com/oamg/leapp-repository/assets/75834032/43f6d461-f8f6-4542-905a-e7927eea21c1)

Jira: RHEL-22736