### PR TITLE
Packit: Drop tests for obsoleted upgrade paths + restructuralisation

### DIFF
--- a/.github/workflows/pr-welcome-msg.yml
+++ b/.github/workflows/pr-welcome-msg.yml
@@ -24,18 +24,15 @@ jobs:
             - **review please @oamg/developers** to notify leapp developers of the review request
             - **/packit copr-build** to submit a public copr build using packit
 
-            Packit will automatically schedule regression tests for this PR's build and latest upstream leapp build. If you need a different version of leapp from PR#42, use `/packit test oamg/leapp#42`
+            Packit will automatically schedule regression tests for this PR's build and latest upstream leapp build. If you need a different version of leapp, e.g. from PR#42, use `/packit test oamg/leapp#42`
+            Note that first time contributors cannot run tests automatically - they will be started by a reviewer.
 
             It is possible to schedule specific on-demand tests as well. Currently 2 test sets are supported, `beaker-minimal` and `kernel-rt`, both can be used to be run on all upgrade paths or just a couple of specific ones.
             To launch on-demand tests with packit:
             - **/packit test --labels kernel-rt** to schedule `kernel-rt` tests set for all upgrade paths
-            - **/packit test --labels beaker-minimal-8.9to9.3,kernel-rt-8.9to9.3** to schedule `kernel-rt` and `beaker-minimal` test sets for 8.9->9.3 upgrade path
+            - **/packit test --labels beaker-minimal-8.10to9.4,kernel-rt-8.10to9.4** to schedule `kernel-rt` and `beaker-minimal` test sets for 8.10->9.4 upgrade path
 
-            [Deprecated] To launch on-demand regression testing public members of oamg organization can leave the following comment:
-            - **/rerun** to schedule basic regression tests using this pr build and latest upstream leapp build as artifacts
-            - **/rerun 42** to schedule basic regression tests using this pr build and leapp\*PR42\* as artifacts
-            - **/rerun-sst** to schedule sst tests using this pr build and latest upstream leapp build as artifacts
-            - **/rerun-sst 42** to schedule sst tests using this pr build and leapp\*PR42\* as artifacts
+            See other labels for particular jobs defined in the `.packit.yaml` file.
 
             Please [open ticket](https://url.corp.redhat.com/oamg-ci-issue) in case you experience technical problem with the CI. (RH internal only)
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -85,18 +85,31 @@ jobs:
     # builds from master branch should start with 100 release, to have high priority
     - bash -c "sed -i \"s/1%{?dist}/100%{?dist}/g\" packaging/leapp-repository.spec"
 
-- &sanity-79to86
+
+# NOTE: to see what envars, targets, .. can be set in tests, see
+# the configuration of tests here:
+#   https://gitlab.cee.redhat.com/oamg/leapp-tests/-/blob/main/config.yaml
+# Available only to RH Employees.
+
+# ###################################################################### #
+# ############################### 7 TO 8 ############################### #
+# ###################################################################### #
+
+# ###################################################################### #
+# ### Abstract job definitions to make individual tests/jobs smaller ### #
+# ###################################################################### #
+- &sanity-abstract-7to8
   job: tests
+  trigger: ignore
   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
   fmf_ref: "main"
   use_internal_tf: True
-  trigger: pull_request
   labels:
     - sanity
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-ZStream]
-  identifier: sanity-7.9to8.6
+  identifier: sanity-abstract-7to8
   tmt_plan: ""
   tf_extra_params:
     test:
@@ -110,20 +123,16 @@ jobs:
           provisioning:
             tags:
               BusinessUnit: sst_upgrades@leapp_upstream_test
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.6"
-    LEAPPDATA_BRANCH: "upstream"
 
-- &sanity-79to86-aws
-  <<: *sanity-79to86
+- &sanity-abstract-7to8-aws
+  <<: *sanity-abstract-7to8
   labels:
     - sanity
     - aws
   targets:
     epel-7-x86_64:
       distros: [RHEL-7.9-rhui]
-  identifier: sanity-7.9to8.6-aws
+  identifier: sanity-abstract-7to8-aws
   # NOTE(ivasilev) Unfortunately to use yaml templates we need to rewrite the whole tf_extra_params dict
   # to use plan_filter (can't just specify one section test.tmt.plan_filter, need to specify environments.* as well)
   tf_extra_params:
@@ -139,57 +148,14 @@ jobs:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
             tags:
               BusinessUnit: sst_upgrades@leapp_upstream_test
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.6"
-    RHUI: "aws"
-    LEAPPDATA_BRANCH: "upstream"
-    LEAPP_NO_RHSM: "1"
-    USE_CUSTOM_REPOS: rhui
-
-- &sanity-79to88-aws
-  <<: *sanity-79to86-aws
-  identifier: sanity-7.9to8.8-aws
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.8"
-    RHUI: "aws"
-    LEAPPDATA_BRANCH: "upstream"
-    LEAPP_NO_RHSM: "1"
-    USE_CUSTOM_REPOS: rhui
-
-- &sanity-79to89-aws
-  <<: *sanity-79to86-aws
-  identifier: sanity-7.9to8.9-aws
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.9"
-    RHUI: "aws"
-    LEAPPDATA_BRANCH: "upstream"
-    LEAPP_NO_RHSM: "1"
-    USE_CUSTOM_REPOS: rhui
-
-# NOTE(mkluson) RHEL 8.10 content is not publicly available (via RHUI)
-#- &sanity-79to810-aws
-#  <<: *sanity-79to86-aws
-#  identifier: sanity-7.9to8.10-aws
-#  env:
-#    SOURCE_RELEASE: "7.9"
-#    TARGET_RELEASE: "8.10"
-#    RHUI: "aws"
-#    LEAPPDATA_BRANCH: "upstream"
-#    LEAPP_NO_RHSM: "1"
-#    USE_CUSTOM_REPOS: rhui
 
 # On-demand minimal beaker tests
-- &beaker-minimal-79to86
-  <<: *sanity-79to86
+- &beaker-minimal-7to8-abstract-ondemand
+  <<: *sanity-abstract-7to8
   manual_trigger: True
   labels:
     - beaker-minimal
-    - beaker-minimal-7.9to8.6
-    - 7.9to8.6
-  identifier: sanity-7.9to8.6-beaker-minimal
+  identifier: beaker-minimal-7to8-abstract-ondemand
   tf_extra_params:
     test:
       tmt:
@@ -204,13 +170,11 @@ jobs:
               BusinessUnit: sst_upgrades@leapp_upstream_test
 
 # On-demand kernel-rt tests
-- &kernel-rt-79to86
-  <<: *beaker-minimal-79to86
+- &kernel-rt-abstract-7to8-ondemand
+  <<: *beaker-minimal-7to8-abstract-ondemand
   labels:
     - kernel-rt
-    - kernel-rt-7.9to8.6
-    - 7.9to8.6
-  identifier: sanity-7.9to8.6-kernel-rt
+  identifier: sanity-7to8-kernel-rt-abstract-ondemand
   tf_extra_params:
     test:
       tmt:
@@ -224,114 +188,133 @@ jobs:
             tags:
               BusinessUnit: sst_upgrades@leapp_upstream_test
 
+
+# ###################################################################### #
+# ######################### Individual tests ########################### #
+# ###################################################################### #
+
+# Tests: 7.9 -> 8.8
+- &sanity-79to88-aws
+  <<: *sanity-abstract-7to8-aws
+  trigger: pull_request
+  identifier: sanity-7.9to8.8-aws
+  env:
+    SOURCE_RELEASE: "7.9"
+    TARGET_RELEASE: "8.8"
+    RHUI: "aws"
+    LEAPPDATA_BRANCH: "upstream"
+    LEAPP_NO_RHSM: "1"
+    USE_CUSTOM_REPOS: rhui
+
 - &sanity-79to88
-  <<: *sanity-79to86
+  <<: *sanity-abstract-7to8
+  trigger: pull_request
   identifier: sanity-7.9to8.8
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.8"
     LEAPPDATA_BRANCH: "upstream"
 
-# On-demand minimal beaker tests
 - &beaker-minimal-79to88
-  <<: *beaker-minimal-79to86
+  <<: *beaker-minimal-7to8-abstract-ondemand
+  trigger: pull_request
   labels:
     - beaker-minimal
     - beaker-minimal-7.9to8.8
     - 7.9to8.8
-  identifier: sanity-7.9to8.8-beaker-minimal
+  identifier: sanity-7.9to8.8-beaker-minimal-ondemand
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.8"
     LEAPPDATA_BRANCH: "upstream"
 
-# On-demand kernel-rt tests
 - &kernel-rt-79to88
-  <<: *kernel-rt-79to86
+  <<: *kernel-rt-abstract-7to8-ondemand
+  trigger: pull_request
   labels:
     - kernel-rt
     - kernel-rt-7.9to8.8
     - 7.9to8.8
-  identifier: sanity-7.9to8.8-kernel-rt
+  identifier: sanity-7.9to8.8-kernel-rt-ondemand
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.8"
     LEAPPDATA_BRANCH: "upstream"
 
-- &sanity-79to89
-  <<: *sanity-79to86
-  identifier: sanity-7.9to8.9
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.9"
-    LEAPPDATA_BRANCH: "upstream"
-
-# On-demand minimal beaker tests
-- &beaker-minimal-79to89
-  <<: *beaker-minimal-79to86
-  labels:
-    - beaker-minimal
-    - beaker-minimal-7.9to8.9
-    - 7.9to8.9
-  identifier: sanity-7.9to8.9-beaker-minimal
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.9"
-    LEAPPDATA_BRANCH: "upstream"
-
-# On-demand kernel-rt tests
-- &kernel-rt-79to89
-  <<: *kernel-rt-79to88
-  labels:
-    - kernel-rt
-    - kernel-rt-7.9to8.9
-    - 7.9to8.9
-  identifier: sanity-7.9to8.9-kernel-rt
-  env:
-    SOURCE_RELEASE: "7.9"
-    TARGET_RELEASE: "8.9"
-    LEAPPDATA_BRANCH: "upstream"
-
+# Tests: 7.9 -> 8.10
 - &sanity-79to810
-  <<: *sanity-79to86
+  <<: *sanity-abstract-7to8
+  trigger: pull_request
   identifier: sanity-7.9to8.10
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.10"
     LEAPPDATA_BRANCH: "upstream"
 
-# On-demand minimal beaker tests
+# NOTE(mkluson) RHEL 8.10 content is not publicly available (via RHUI)
+#- &sanity-79to810-aws
+#  <<: *sanity-abstract-7to8-aws
+#  trigger: pull_request
+#  identifier: sanity-7.9to8.10-aws
+#  env:
+#    SOURCE_RELEASE: "7.9"
+#    TARGET_RELEASE: "8.10"
+#    RHUI: "aws"
+#    LEAPPDATA_BRANCH: "upstream"
+#    LEAPP_NO_RHSM: "1"
+#    USE_CUSTOM_REPOS: rhui
+
 - &beaker-minimal-79to810
-  <<: *beaker-minimal-79to86
+  <<: *beaker-minimal-7to8-abstract-ondemand
+  trigger: pull_request
   labels:
     - beaker-minimal
     - beaker-minimal-7.9to8.10
     - 7.9to8.10
-  identifier: sanity-7.9to8.10-beaker-minimal
+  identifier: sanity-7.9to8.10-beaker-minimal-ondemand
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.10"
     LEAPPDATA_BRANCH: "upstream"
 
-# On-demand kernel-rt tests
 - &kernel-rt-79to810
-  <<: *kernel-rt-79to88
+  <<: *kernel-rt-abstract-7to8-ondemand
+  trigger: pull_request
   labels:
     - kernel-rt
     - kernel-rt-7.9to8.10
     - 7.9to8.10
-  identifier: sanity-7.9to8.10-kernel-rt
+  identifier: sanity-7.9to8.10-kernel-rt-ondemand
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.10"
     LEAPPDATA_BRANCH: "upstream"
 
-- &sanity-86to90
-  <<: *sanity-79to86
+
+# ###################################################################### #
+# ############################## 8 TO 10 ############################### #
+# ###################################################################### #
+
+# ###################################################################### #
+# ### Abstract job definitions to make individual tests/jobs smaller ### #
+# ###################################################################### #
+
+#NOTE(pstodulk) putting default values in abstract jobs as from 8.10, as this
+# is the last RHEL 8 release and all new future tests will start from this
+# one release.
+
+- &sanity-abstract-8to9
+  job: tests
+  trigger: ignore
+  fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
+  fmf_ref: "main"
+  use_internal_tf: True
+  labels:
+    - sanity
   targets:
     epel-8-x86_64:
-      distros: [RHEL-8.6.0-Nightly]
-  identifier: sanity-8.6to9.0
+      distros: [RHEL-8.10.0-Nightly]
+  identifier: sanity-abstract-8to9
   tf_extra_params:
     test:
       tmt:
@@ -339,28 +322,44 @@ jobs:
     environments:
       - tmt:
           context:
-            distro: "rhel-8.6"
+            distro: "rhel-8.10"
         settings:
           provisioning:
             tags:
               BusinessUnit: sst_upgrades@leapp_upstream_test
-  env:
-    SOURCE_RELEASE: "8.6"
-    TARGET_RELEASE: "9.0"
-    RHSM_REPOS_EUS: "eus"
-    LEAPPDATA_BRANCH: "upstream"
 
-# On-demand minimal beaker tests
-- &beaker-minimal-86to90
-  <<: *beaker-minimal-79to86
+- &sanity-abstract-8to9-aws
+  <<: *sanity-abstract-8to9
   labels:
-    - beaker-minimal
-    - beaker-minimal-8.6to9.0
-    - 8.6to9.0
+    - sanity
+    - aws
   targets:
     epel-8-x86_64:
-      distros: [RHEL-8.6.0-Nightly]
-  identifier: sanity-8.6to9.0-beaker-minimal
+      distros: [RHEL-8.10-rhui]
+  identifier: sanity-abstract-8to9-aws
+  tf_extra_params:
+    test:
+      tmt:
+        plan_filter: 'tag:upgrade_happy_path & enabled:true'
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-8.10"
+        settings:
+          provisioning:
+            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
+            tags:
+              BusinessUnit: sst_upgrades@leapp_upstream_test
+
+- &beaker-minimal-8to9-abstract-ondemand
+  <<: *sanity-abstract-8to9
+  manual_trigger: True
+  labels:
+    - beaker-minimal
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.10.0-Nightly]
+  identifier: beaker-minimal-8to9-abstract-ondemand
   tf_extra_params:
     test:
       tmt:
@@ -368,25 +367,17 @@ jobs:
     environments:
       - tmt:
           context:
-            distro: "rhel-8.6"
+            distro: "rhel-8.10"
         settings:
           provisioning:
             tags:
               BusinessUnit: sst_upgrades@leapp_upstream_test
-  env:
-    SOURCE_RELEASE: "8.6"
-    TARGET_RELEASE: "9.0"
-    RHSM_REPOS_EUS: "eus"
-    LEAPPDATA_BRANCH: "upstream"
 
-# On-demand kernel-rt tests
-- &kernel-rt-86to90
-  <<: *beaker-minimal-86to90
+- &kernel-rt-abstract-8to9-ondemand
+  <<: *beaker-minimal-8to9-abstract-ondemand
   labels:
     - kernel-rt
-    - kernel-rt-8.6to9.0
-    - 8.6to9.0
-  identifier: sanity-8.6to9.0-kernel-rt
+  identifier: sanity-8to9-kernel-rt-abstract-ondemand
   tf_extra_params:
     test:
       tmt:
@@ -394,14 +385,21 @@ jobs:
     environments:
       - tmt:
           context:
-            distro: "rhel-8.6"
+            distro: "rhel-8.10"
         settings:
           provisioning:
             tags:
               BusinessUnit: sst_upgrades@leapp_upstream_test
 
+
+# ###################################################################### #
+# ######################### Individual tests ########################### #
+# ###################################################################### #
+
+# Tests: 8.8 -> 9.2
 - &sanity-88to92
-  <<: *sanity-86to90
+  <<: *sanity-abstract-8to9
+  trigger: pull_request
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.8.0-Nightly]
@@ -425,234 +423,9 @@ jobs:
     LEAPPDATA_BRANCH: "upstream"
     LEAPP_DEVEL_TARGET_RELEASE: "9.2"
 
-# On-demand minimal beaker tests
-- &beaker-minimal-88to92
-  <<: *beaker-minimal-86to90
-  labels:
-    - beaker-minimal
-    - beaker-minimal-8.8to9.2
-    - 8.6to9.2
-  targets:
-    epel-8-x86_64:
-      distros: [RHEL-8.8.0-Nightly]
-  identifier: sanity-8.8to9.2-beaker-minimal
-  tf_extra_params:
-    test:
-      tmt:
-        plan_filter: 'tag:partitioning & tag:8to9 & enabled:true'
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-8.8"
-        settings:
-          provisioning:
-            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-            tags:
-              BusinessUnit: sst_upgrades@leapp_upstream_test
-  env:
-    SOURCE_RELEASE: "8.8"
-    TARGET_RELEASE: "9.2"
-    LEAPPDATA_BRANCH: "upstream"
-    LEAPP_DEVEL_TARGET_RELEASE: "9.2"
-
-# On-demand kernel-rt tests
-- &kernel-rt-88to92
-  <<: *beaker-minimal-88to92
-  labels:
-    - kernel-rt
-    - kernel-rt-8.8to9.2
-    - 8.8to9.2
-  identifier: sanity-8.8to9.2-kernel-rt
-  tf_extra_params:
-    test:
-      tmt:
-        plan_filter: 'tag:kernel-rt & tag:8to9 & enabled:true'
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-8.8"
-        settings:
-          provisioning:
-            tags:
-              BusinessUnit: sst_upgrades@leapp_upstream_test
-
-- &sanity-89to93
-  <<: *sanity-88to92
-  targets:
-    epel-8-x86_64:
-      distros: [RHEL-8.9.0-Nightly]
-  identifier: sanity-8.9to9.3
-  tf_extra_params:
-    test:
-      tmt:
-        plan_filter: 'tag:sanity & tag:8to9 & enabled:true'
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-8.9"
-        settings:
-          provisioning:
-            tags:
-              BusinessUnit: sst_upgrades@leapp_upstream_test
-  env:
-    SOURCE_RELEASE: "8.9"
-    TARGET_RELEASE: "9.3"
-    LEAPPDATA_BRANCH: "upstream"
-    LEAPP_DEVEL_TARGET_RELEASE: "9.3"
-
-# On-demand minimal beaker tests
-- &beaker-minimal-89to93
-  <<: *beaker-minimal-88to92
-  labels:
-    - beaker-minimal
-    - beaker-minimal-8.9to9.3
-    - 8.9to9.3
-  targets:
-    epel-8-x86_64:
-      distros: [RHEL-8.9.0-Nightly]
-  identifier: sanity-8.9to9.3-beaker-minimal
-  tf_extra_params:
-    test:
-      tmt:
-        plan_filter: 'tag:partitioning & tag:8to9 & enabled:true'
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-8.9"
-        settings:
-          provisioning:
-            tags:
-              BusinessUnit: sst_upgrades@leapp_upstream_test
-  env:
-    SOURCE_RELEASE: "8.9"
-    TARGET_RELEASE: "9.3"
-    LEAPPDATA_BRANCH: "upstream"
-    LEAPP_DEVEL_TARGET_RELEASE: "9.3"
-
-# On-demand kernel-rt tests
-- &kernel-rt-89to93
-  <<: *beaker-minimal-89to93
-  labels:
-    - kernel-rt
-    - kernel-rt-8.9to9.3
-    - 8.9to9.3
-  identifier: sanity-8.9to9.3-kernel-rt
-  tf_extra_params:
-    test:
-      tmt:
-        plan_filter: 'tag:kernel-rt & tag:8to9 & enabled:true'
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-8.9"
-        settings:
-          provisioning:
-            tags:
-              BusinessUnit: sst_upgrades@leapp_upstream_test
-
-- &sanity-810to94
-  <<: *sanity-88to92
-  targets:
-    epel-8-x86_64:
-      distros: [RHEL-8.10.0-Nightly]
-  identifier: sanity-8.10to9.4
-  tf_extra_params:
-    test:
-      tmt:
-        plan_filter: 'tag:sanity & tag:8to9 & enabled:true'
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-8.10"
-        settings:
-          provisioning:
-            tags:
-              BusinessUnit: sst_upgrades@leapp_upstream_test
-  env:
-    SOURCE_RELEASE: "8.10"
-    TARGET_RELEASE: "9.4"
-    RHSM_REPOS: "rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-beta-rpms"
-    LEAPPDATA_BRANCH: "upstream"
-
-# On-demand minimal beaker tests
-- &beaker-minimal-810to94
-  <<: *beaker-minimal-88to92
-  labels:
-    - beaker-minimal
-    - beaker-minimal-8.10to9.4
-    - 8.10to9.4
-  targets:
-    epel-8-x86_64:
-      distros: [RHEL-8.10.0-Nightly]
-  identifier: sanity-8.10to9.4-beaker-minimal
-  tf_extra_params:
-    test:
-      tmt:
-        plan_filter: 'tag:partitioning & tag:8to9 & enabled:true'
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-8.10"
-        settings:
-          provisioning:
-            tags:
-              BusinessUnit: sst_upgrades@leapp_upstream_test
-  env:
-    SOURCE_RELEASE: "8.10"
-    TARGET_RELEASE: "9.4"
-    LEAPPDATA_BRANCH: "upstream"
-
-# On-demand kernel-rt tests
-- &kernel-rt-810to94
-  <<: *beaker-minimal-810to94
-  labels:
-    - kernel-rt
-    - kernel-rt-8.10to9.4
-    - 8.10to9.4
-  identifier: sanity-8.10to9.4-kernel-rt
-  tf_extra_params:
-    test:
-      tmt:
-        plan_filter: 'tag:kernel-rt & tag:8to9 & enabled:true'
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-8.10"
-        settings:
-          provisioning:
-            tags:
-              BusinessUnit: sst_upgrades@leapp_upstream_test
-
-- &sanity-86to90-aws
-  <<: *sanity-79to86-aws
-  targets:
-    epel-8-x86_64:
-      distros: [RHEL-8.6-rhui]
-  identifier: sanity-8.6to9.0-aws
-  tf_extra_params:
-    test:
-      tmt:
-        plan_filter: 'tag:upgrade_happy_path & enabled:true'
-    environments:
-      - tmt:
-          context:
-            distro: "rhel-8.6"
-        settings:
-          provisioning:
-            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
-            tags:
-              BusinessUnit: sst_upgrades@leapp_upstream_test
-  env:
-    SOURCE_RELEASE: "8.6"
-    TARGET_RELEASE: "9.0"
-    RHSM_REPOS: "rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-baseos-eus-rpms"
-    RHUI: "aws"
-    LEAPPDATA_BRANCH: "upstream"
-    LEAPP_NO_RHSM: "1"
-    USE_CUSTOM_REPOS: rhui
-
 - &sanity-88to92-aws
-  <<: *sanity-86to90-aws
+  <<: *sanity-abstract-8to9-aws
+  trigger: pull_request
   targets:
     epel-8-x86_64:
       distros: [RHEL-8.8-rhui]
@@ -680,31 +453,102 @@ jobs:
     LEAPP_NO_RHSM: "1"
     USE_CUSTOM_REPOS: rhui
 
-- &sanity-89to93-aws
-  <<: *sanity-86to90-aws
+- &beaker-minimal-88to92
+  <<: *beaker-minimal-8to9-abstract-ondemand
+  trigger: pull_request
+  labels:
+    - beaker-minimal
+    - beaker-minimal-8.8to9.2
+    - 8.8to9.2
   targets:
     epel-8-x86_64:
-      distros: [RHEL-8.9-rhui]
-  identifier: sanity-8.9to9.3-aws
-  # NOTE(mkluson) Unfortunately to use yaml templates we need to rewrite the whole tf_extra_params dict
+      distros: [RHEL-8.8.0-Nightly]
+  identifier: sanity-8.8to9.2-beaker-minimal-ondemand
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:upgrade_happy_path & enabled:true'
+        plan_filter: 'tag:partitioning & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
-            distro: "rhel-8.9"
+            distro: "rhel-8.8"
         settings:
           provisioning:
             post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
             tags:
               BusinessUnit: sst_upgrades@leapp_upstream_test
   env:
-    SOURCE_RELEASE: "8.9"
-    TARGET_RELEASE: "9.3"
-    RHSM_REPOS: "rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-baseos-rpms"
-    RHUI: "aws"
+    SOURCE_RELEASE: "8.8"
+    TARGET_RELEASE: "9.2"
     LEAPPDATA_BRANCH: "upstream"
-    LEAPP_NO_RHSM: "1"
-    USE_CUSTOM_REPOS: rhui
+    LEAPP_DEVEL_TARGET_RELEASE: "9.2"
+
+- &kernel-rt-88to92
+  <<: *kernel-rt-abstract-8to9-ondemand
+  trigger: pull_request
+  labels:
+    - kernel-rt
+    - kernel-rt-8.8to9.2
+    - 8.8to9.2
+  identifier: sanity-8.8to9.2-kernel-rt-ondemand
+  targets:
+    epel-8-x86_64:
+      distros: [RHEL-8.8.0-Nightly]
+  tf_extra_params:
+    test:
+      tmt:
+        plan_filter: 'tag:kernel-rt & tag:8to9 & enabled:true'
+    environments:
+      - tmt:
+          context:
+            distro: "rhel-8.8"
+        settings:
+          provisioning:
+            tags:
+              BusinessUnit: sst_upgrades@leapp_upstream_test
+  env:
+    SOURCE_RELEASE: "8.8"
+    TARGET_RELEASE: "9.2"
+    LEAPPDATA_BRANCH: "upstream"
+    LEAPP_DEVEL_TARGET_RELEASE: "9.2"
+
+
+# Tests: 8.10 -> 9.4
+- &sanity-810to94
+  <<: *sanity-abstract-8to9
+  trigger: pull_request
+  identifier: sanity-8.10to9.4
+  env:
+    SOURCE_RELEASE: "8.10"
+    TARGET_RELEASE: "9.4"
+    RHSM_REPOS: "rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-beta-rpms"
+    LEAPPDATA_BRANCH: "upstream"
+
+# On-demand minimal beaker tests
+- &beaker-minimal-810to94
+  <<: *beaker-minimal-8to9-abstract-ondemand
+  trigger: pull_request
+  labels:
+    - beaker-minimal
+    - beaker-minimal-8.10to9.4
+    - 8.10to9.4
+  identifier: sanity-8.10to9.4-beaker-minimal-ondemand
+  env:
+    SOURCE_RELEASE: "8.10"
+    TARGET_RELEASE: "9.4"
+    LEAPPDATA_BRANCH: "upstream"
+
+# On-demand kernel-rt tests
+- &kernel-rt-810to94
+  <<: *kernel-rt-abstract-8to9-ondemand
+  trigger: pull_request
+  labels:
+    - kernel-rt
+    - kernel-rt-8.10to9.4
+    - 8.10to9.4
+  identifier: sanity-8.10to9.4-kernel-rt-ondemand
+  env:
+    SOURCE_RELEASE: "8.10"
+    TARGET_RELEASE: "9.4"
+    RHSM_REPOS: "rhel-8-for-x86_64-appstream-beta-rpms,rhel-8-for-x86_64-baseos-beta-rpms"
+    LEAPPDATA_BRANCH: "upstream"


### PR DESCRIPTION
Dropping upgrade paths related to following releases: 8.6, 8.9, 9.0,
9.3. See the previous commit for more info.

During the drop of these release, I've realized the current structure
of tests is not suitable for such operations as current test/job
definitions has been chained. So e.g. tests for 8.10 -> 9.4 depended
on 8.9 -> 9.3, which depended on 8.8 -> 8.6, etc... Even going deeper,
IPU 8->9 definitions have been based on 7 -> 8 definitions.

So I updated the structure, separating tests for IPU 7 -> 8 and 8 -> 9
and also deps between all upgrade paths. Now, particular tests
can inherit one of *abstract* jobs definitions, so dropping or removing
tests for an upgrade path does not affect other tests.

Also fixed some incorrect definitions in tests, like a fixed label
for `beaker-minimal-88to92` (orig "8.6to9.2").

Update welcome-PR bot msg to reflect changes in upgrade paths.

Jira: OAMG-10451