### PR TITLE
Release 0.20.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -41,7 +41,7 @@ py2_byte_compile "%1" "%2"}
 # RHEL 8+ packages to be consistent with other leapp projects in future.
 
 Name:           leapp-repository
-Version:        0.19.0
+Version:        0.20.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Packaging
- Requires xfsprogs and e2fsprogs (#1154)
- Bump leapp-repository-dependencies to 10 (#1154)

## Upgrade handling
### Fixes
- Detect changes in openssl default configuration file and restore it to the default to the target default during the upgrade to reduce risk of potential issues (#1131)
- Do not try to download data files anymore when missing as the service is obsoleted since the data is part of installed packages (#1120)
- Drop the invalid `tuv` target channel (#1130)
- Fix handling of symlinks under /etc/pki when managing certificates (#1135, #1160, #1166)
- Fix semanage import issue (#1164)
- Fix the issue of going out of bounds in the isccfg parser (#1124)
- Fix traceback when saving the rhsm facts results and the /etc/rhsm/facts directory doesn’t exist yet (#1132)
- Handle the upgrade better when a proxy is configured in YUM/DNF configutations (#1143)
- Load all rpm repository substitutions that dnf knows about, not just releasever since repofiles may use the other substitutions too (#1134)
- Minor updates of generated reports (#1151)
- Print nice error msg when device and driver deprecation data is malformed (#1168)
- Report information about required manual steps after the upgrade when openssl-ibmca is installed (#1131)
- Update error messages and reports when installed upgrade data files are malformed or missing (#1120)
- [IPU 7 -> 8] Fix the upgrade of the RH Satellite server when tomcat is installed (#1150)
- [IPU 8 -> 9] Fix the upgrade from RHEL 8.9+ when the release is locked by subscription-manager (#1136, #1138)

### Enhancements
- Update upgrade paths: (#1146, #1147, #1175)
  - RHEL 7.9  -> 8.10, 8.8 (default: 8.10)
  - RHEL with SAPAHA 7.9  -> 8.10, 8.8 (default: 8.8)
  - RHEL w/o SAP HANA 8.8  -> 9.2
  - RHEL w/o SAP HANA 8.10 -> 9.4
- Added possibility to define DNF configuration for the target system (#1143)
- Code cleaning: drop redundant and invalid NFS checks (#1127)
- Default to NO_RHSM mode when subscription-manager is not found (#1133)
- Detect customized configuration of dynamic linker (#1118)
- Detect possible unexpected RPM GPG keys has been installed during RPM transaction (#1101)
- Drop obsoleted upgrade paths that relates to releases: 8.6, 8.9, 9.0, 9.3 (#1175)
- Ignore Leapp related PES events (#1153)
- Introduce generic transition of systemd services states during the IPU (#1060, #1174)
- Introduce possibility to upgrade with local repositories (#1099)
- Introduced some changes getting us closer to possibility of IPU for Centos (Stream) systems (#1140)
- Report the upgrade customisations and modifications of the upgrade tooling (#1148)
- Simplify handling of upgrades on systems using RHUI, reducing the maintenance burden for cloud providers (#1057)
- Update the leapp upgrade data files - bump data stream to "3.0" (#1163, #1165, #1170)
- Unify breakpoints inside the upgrade initramfs for the easier troubleshooting (#1157)
- [IPU 8 -> 9] Enable upgrades RHEL 8 -> 9 using RHUI on Alibaba cloud (#1137, #1165, #1172)

## Additional changes interesting for devels
- Introduced new functions returning a list of packages related to upgrade - see the rpms library (#1156)
- Make detection of installed signed packages distribution agnostic - covers RHEL & CentOS (#876)
- Model InstalledRedHatSignedRPM is deprecated, replaced by DistributionSignedRPM (#876)