### PR TITLE
rhui: do not bootstrap target client on aws

### DIFF
--- a/repos/system_upgrade/common/actors/cloud/checkrhui/libraries/checkrhui.py
+++ b/repos/system_upgrade/common/actors/cloud/checkrhui/libraries/checkrhui.py
@@ -142,7 +142,11 @@ def customize_rhui_setup_for_aws(rhui_family, setup_info):
 
     target_version = version.get_target_major_version()
     if target_version == '8':
-        return  # The rhel8 plugin is packed into leapp-rhui-aws as we need python2 compatible client
+        # RHEL8 rh-amazon-rhui-client depends on amazon-libdnf-plugin that depends
+        # essentially on the entire RHEL8 RPM stack, so we cannot just swap the clients
+        # The leapp-rhui-aws will provide all necessary files to access entire RHEL8 content
+        setup_info.bootstrap_target_client = False
+        return
 
     amazon_plugin_copy_task = CopyFile(src='/usr/lib/python3.9/site-packages/dnf-plugins/amazon-id.py',
                                        dst='/usr/lib/python3.6/site-packages/dnf-plugins/')

--- a/repos/system_upgrade/common/models/rhuiinfo.py
+++ b/repos/system_upgrade/common/models/rhuiinfo.py
@@ -36,6 +36,13 @@ class TargetRHUISetupInfo(Model):
     files_supporting_client_operation = fields.List(fields.String(), default=[])
     """A subset of files copied in preinstall tasks that should not be cleaned up."""
 
+    bootstrap_target_client = fields.Boolean(default=True)
+    """
+    Swap the current RHUI client for the target one to facilitate access to the target content.
+
+    When False, only files from the leapp-rhui-<provider> will be used to access target content.
+    """
+
 
 class RHUIInfo(Model):
     """


### PR DESCRIPTION
Bootstrapping target RHUI client on 7>8 AWS is not possible as the RHEL8 RHUI client now depends on virtually the entire RHEL8 RPM stack.

This patch turns the bootstrapping off. Leapp will rely only on the files bundled in the leapp-rhui-<provider> package.  