### PR TITLE
[wip] Correct scanning of non-PCI network devices

### DIFF
--- a/repos/system_upgrade/common/libraries/persistentnetnames.py
+++ b/repos/system_upgrade/common/libraries/persistentnetnames.py
@@ -42,9 +42,13 @@ def interfaces():
             attrs['name'] = dev.sys_name
             attrs['devpath'] = dev.device_path
             attrs['driver'] = dev['ID_NET_DRIVER']
-            attrs['vendor'] = dev['ID_VENDOR_ID']
-            attrs['pci_info'] = PCIAddress(**pci_info(dev['ID_PATH']))
             attrs['mac'] = dev.attributes.get('address')
+            attrs['vendor'] = dev.get('ID_VENDOR_ID', '')
+            if not attrs['vendor']:
+                attrs['pci_info'] = PCIAddress(**pci_info(dev['ID_PATH']))
+            else:
+                # non-PCI
+                attrs['pci_info'] = None
             if isinstance(attrs['mac'], bytes):
                 attrs['mac'] = attrs['mac'].decode()
         except Exception as e:  # pylint: disable=broad-except

--- a/repos/system_upgrade/common/models/persistentnetnamesfacts.py
+++ b/repos/system_upgrade/common/models/persistentnetnamesfacts.py
@@ -24,7 +24,7 @@ class Interface(Model):
     devpath = fields.String()
     driver = fields.String()
     vendor = fields.String()
-    pci_info = fields.Model(PCIAddress)
+    pci_info = fields.Nullable(fields.Model(PCIAddress))
     mac = fields.String()
 
 


### PR DESCRIPTION
Non-PCI network devices (present usually on IBM Z architecture) does not have ID_VENDOR_ID attribute and also there is nothing we could put into Interface.pci_info about them.

For such devices, set empty string for Interface.vendor field and None value for pci_info.

The Interface model has been updated, allowing None value for pci_info field.