### PR TITLE
cephvolumescan: Ceph container names change prevents upgrade due to inhibitwhenluks

### DIFF
--- a/repos/system_upgrade/common/actors/cephvolumescan/libraries/cephvolumescan.py
+++ b/repos/system_upgrade/common/actors/cephvolumescan/libraries/cephvolumescan.py
@@ -8,7 +8,7 @@ from leapp.libraries.stdlib import api, CalledProcessError, run
 from leapp.models import InstalledRPM
 
 CEPH_CONF = "/etc/ceph/ceph.conf"
-CONTAINER = "ceph-osd"
+CONTAINER = r"ceph-(\S*-)?osd-"
 
 
 def select_osd_container(engine):


### PR DESCRIPTION
Container names created by cephadm are now named ceph-{fsid}-osd-XX while in the past it was just
ceph-osd-XX. As the ceph-volume command cannot be run in an OSD container, it cannot detect if only
ceph OSDs are encrypted.

Fixes: https://issues.redhat.com/browse/RHEL-28647