### PR TITLE
pes_events_scanner: override repositories when applying an event

### DIFF
--- a/repos/system_upgrade/common/actors/peseventsscanner/tests/test_pes_event_scanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/tests/test_pes_event_scanner.py
@@ -123,6 +123,15 @@ def pkgs_into_tuples(pkgs):
             [(8, 0)],
             {Package('renamed-out', 'rhel8-repo', None)}
         ),
+        (
+            {Package('A', 'rhel7-repo', None), Package('B', 'rhel7-repo', None)},
+            [
+                Event(1, Action.SPLIT, {Package('A', 'rhel7-repo', None)},
+                      {Package('A', 'rhel8-repo', None), Package('B', 'rhel8-repo', None)}, (7, 6), (8, 0), [])
+            ],
+            [(8, 0)],
+            {Package('A', 'rhel8-repo', None), Package('B', 'rhel8-repo', None)}
+        ),
     )
 )
 def test_event_application_fundamentals(monkeypatch, installed_pkgs, events, releases, expected_target_pkgs):


### PR DESCRIPTION
The Package class has custom `__hash__` and `__eq__` methods in order to achieve a straightforward presentation via set manipulation. However, this causes problems, e.g., when applying split events. For example:
 Applying the event `Split event: in={(A, repo1)}, out={(A, repo2), (B, repo2)}` to the package state `{(A, repo1), (B, repo1)}` results in the following:
 ` {(A, repo1), (B, repo1)} --apply--> {(A, repo2), (B, repo1)}`
which is undesired as repo1 is a source system repository. Such a package will get reported to the user as potentially removed during the upgrade. This patch addresses this unwanted behavior.