### PR TITLE
Default channel to GA if not specified otherwise

### DIFF
--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -207,6 +207,8 @@ def prepare_configuration(args):
 
     if args.channel:
         os.environ['LEAPP_TARGET_PRODUCT_CHANNEL'] = args.channel
+    elif 'LEAPP_TARGET_PRODUCT_CHANNEL' not in os.environ:
+        os.environ['LEAPP_TARGET_PRODUCT_CHANNEL'] = 'ga'
 
     if args.iso:
         os.environ['LEAPP_TARGET_ISO'] = args.iso


### PR DESCRIPTION
Originally we tried to map by default repositories from particular channels on the source system  to their equivalents on the target system. IOW:
* eus -> eus
* aus -> aus
* e4s -> e4s
* "ga" -> "ga"
* ...

However, it has been revealed this logic should not apply on minor releases for which these non-ga (premium) repositories do not exist. So doing upgrade e.g. to `8.9`, `8.10` , `9.3` for which specific eus, etc.. repositories are not defined lead to 404 error.

Discussing this deeply between stakeholders, it has been decided to drop this logic and target always to "ga" repositories unless the leapp is executed with instructions to choose a different channel (using envars, `--channel ..` option). To prevent this issue.

It's still possible to require mistakenly e.g. "eus" channel for the target release for which the related repositories are not defined. e.g.:
```
# leapp upgrade --channel eus --target 8.10
``` 
In such a case, the previous errors (404 Not found) can be hit again. But it will not happen by default. In this case, we expect and request people to understand what they want.

(@pirat89: updated description)

jira: RHEL-24720