### PR TITLE
Fix incorrect lscpu command formulation

### DIFF
--- a/repos/system_upgrade/common/actors/scancpu/libraries/scancpu.py
+++ b/repos/system_upgrade/common/actors/scancpu/libraries/scancpu.py
@@ -12,7 +12,7 @@ PPC64LE_MODEL = re.compile(r'\d+\.\d+ \(pvr (?P<family>[0-9a-fA-F]+) 0*[0-9a-fA-
 
 def _get_lscpu_output(output_json=False):
     try:
-        result = run(['lscpu', '-J' if output_json else ''])
+        result = run(['lscpu'] + (['-J'] if output_json else []))
         return result.get('stdout', '')
     except (OSError, CalledProcessError):
         api.current_logger().debug('Executing `lscpu` failed', exc_info=True)


### PR DESCRIPTION
Mitigation of an error where instead of no argument an "empty argument" was passed to `lscpu`

	lscpu ''

vs.

	lscpu