### PR TITLE
Update packit config after tier redefinition

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -114,7 +114,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity & enabled:true'
+        plan_filter: 'tag:tier0 & enabled:true'
     environments:
       - tmt:
           context:
@@ -318,7 +318,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity & tag:8to9 & enabled:true'
+        plan_filter: 'tag:tier0 & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:
@@ -407,7 +407,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:sanity & tag:8to9 & enabled:true'
+        plan_filter: 'tag:tier0 & tag:8to9 & enabled:true'
     environments:
       - tmt:
           context:


### PR DESCRIPTION
Now for basic sanity test verification in upstream tests tagged by 'tier0' will be used instead of 'sanity'.

RHELMISC-3211