### PR TITLE
mention `Report` in produces of transitionsystemdservicesstates

### DIFF
--- a/repos/system_upgrade/common/actors/systemd/transitionsystemdservicesstates/actor.py
+++ b/repos/system_upgrade/common/actors/systemd/transitionsystemdservicesstates/actor.py
@@ -7,6 +7,7 @@ from leapp.models import (
     SystemdServicesPresetInfoTarget,
     SystemdServicesTasks
 )
+from leapp.reporting import Report
 from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
 
 
@@ -46,7 +47,7 @@ class TransitionSystemdServicesStates(Actor):
         SystemdServicesPresetInfoSource,
         SystemdServicesPresetInfoTarget
     )
-    produces = (SystemdServicesTasks,)
+    produces = (Report, SystemdServicesTasks)
     tags = (ApplicationsPhaseTag, IPUWorkflowTag)
 
     def process(self):


### PR DESCRIPTION
fixes upgrade warnings:

     leapp.workflow.Applications.transition_systemd_services_states: Actor is trying to produce a message of type "<class 'leapp.reporting.Report'>" without mentioning it explicitely in the actor's "produces" tuple. The message will be ignored