### PR TITLE
Improve set_systemd_services_states logging

### DIFF
--- a/repos/system_upgrade/common/actors/systemd/setsystemdservicesstates/libraries/setsystemdservicesstate.py
+++ b/repos/system_upgrade/common/actors/systemd/setsystemdservicesstates/libraries/setsystemdservicesstate.py
@@ -15,7 +15,7 @@ def process():
         msg = 'Attempted to both enable and disable systemd service "{}", service will be disabled.'.format(service)
         api.current_logger().warning(msg)
 
-    for service in services_to_enable:
+    for service in services_to_enable - intersection:
         try:
             systemd.enable_unit(service)
         except CalledProcessError:

--- a/repos/system_upgrade/common/actors/systemd/setsystemdservicesstates/libraries/setsystemdservicesstate.py
+++ b/repos/system_upgrade/common/actors/systemd/setsystemdservicesstates/libraries/setsystemdservicesstate.py
@@ -13,7 +13,7 @@ def process():
     intersection = services_to_enable.intersection(services_to_disable)
     for service in intersection:
         msg = 'Attempted to both enable and disable systemd service "{}", service will be disabled.'.format(service)
-        api.current_logger().error(msg)
+        api.current_logger().warning(msg)
 
     for service in services_to_enable:
         try:

--- a/repos/system_upgrade/common/actors/systemd/setsystemdservicesstates/tests/test_setsystemdservicesstate.py
+++ b/repos/system_upgrade/common/actors/systemd/setsystemdservicesstates/tests/test_setsystemdservicesstate.py
@@ -94,4 +94,4 @@ def test_enable_disable_conflict_logged(monkeypatch):
 
     expect_msg = ('Attempted to both enable and disable systemd service "hello.service",'
                   ' service will be disabled.')
-    assert expect_msg in api.current_logger.errmsg
+    assert expect_msg in api.current_logger.warnmsg


### PR DESCRIPTION
1. demotes the "both enable and disable" message to a warning, as it's not an error
2. doesn't try to enable services that will be disabled afterwards, limiting the amount of logged commands