### PR TITLE
Update reboot msg: Note the console access

### DIFF
--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -117,6 +117,7 @@ def upgrade(args, breadcrumbs):
         sys.stdout.write(
             'Reboot the system to continue with the upgrade.'
             ' This might take a while depending on the system configuration.\n'
+            'Make sure you have console access to view the actual upgrade process.\n'
         )
 
 


### PR DESCRIPTION
Some users hasn't read the upgrade documentation and are not aware that after the reboot the actual upgrade is processing. As they wait just for the ssh connection, they think that something is wrong and sometimes reboot the machine, interrupting the entire process, making the machine broken in some cases.

Adding info that they need a console access in case they want to watch the upgrade progress.

Jira: https://issues.redhat.com/browse/RHEL-27231

### TODO:
* [x] wait for reporter/CEE confirmation

### Output
```
============================================================
                      REPORT OVERVIEW                       
============================================================

HIGH and MEDIUM severity reports:
    1. Packages available in excluded repositories will not be installed
    2. Difference in Python versions and support in RHEL 8
    3. Upgrade is unsupported
    4. GRUB2 core will be automatically updated during the upgrade
    5. chrony using default configuration
    6. Module pam_pkcs11 will be removed from PAM configuration

Reports summary:
    Errors:                      0
    Inhibitors:                  0
    HIGH severity reports:       4
    MEDIUM severity reports:     2
    LOW severity reports:        5
    INFO severity reports:       4

Before continuing consult the full report:
    A report has been generated at /var/log/leapp/leapp-report.json
    A report has been generated at /var/log/leapp/leapp-report.txt

============================================================
                   END OF REPORT OVERVIEW                   
============================================================

Answerfile has been generated at /var/log/leapp/answerfile
Reboot the system to continue with the upgrade. This might take a while depending on the system configuration.
Make sure you have console access to view the actual upgrade process.
```