### PR TITLE
feature: add possibility to use net.naming-scheme

### DIFF
--- a/repos/system_upgrade/common/actors/addupgradebootentry/actor.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/actor.py
@@ -8,11 +8,13 @@ from leapp.models import (
     FirmwareFacts,
     GrubConfigError,
     KernelCmdline,
+    LateTargetKernelCmdlineArgTasks,
     LiveImagePreparationInfo,
     LiveModeArtifacts,
     LiveModeConfig,
     TargetKernelCmdlineArgTasks,
-    TransactionDryRun
+    TransactionDryRun,
+    UpgradeKernelCmdlineArgTasks
 )
 from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
 
@@ -33,9 +35,11 @@ class AddUpgradeBootEntry(Actor):
         LiveModeArtifacts,
         LiveModeConfig,
         KernelCmdline,
-        TransactionDryRun
+        TransactionDryRun,
+        TargetKernelCmdlineArgTasks,
+        UpgradeKernelCmdlineArgTasks
     )
-    produces = (TargetKernelCmdlineArgTasks,)
+    produces = (LateTargetKernelCmdlineArgTasks,)
     tags = (IPUWorkflowTag, InterimPreparationPhaseTag)
 
     def process(self):

--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/actor.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/actor.py
@@ -3,7 +3,13 @@ import os
 from leapp.actors import Actor
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import kernelcmdlineconfig
-from leapp.models import FirmwareFacts, InstalledTargetKernelInfo, KernelCmdlineArg, TargetKernelCmdlineArgTasks
+from leapp.models import (
+    FirmwareFacts,
+    InstalledTargetKernelInfo,
+    KernelCmdlineArg,
+    LateTargetKernelCmdlineArgTasks,
+    TargetKernelCmdlineArgTasks
+)
 from leapp.reporting import Report
 from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
 
@@ -14,7 +20,13 @@ class KernelCmdlineConfig(Actor):
     """
 
     name = 'kernelcmdlineconfig'
-    consumes = (KernelCmdlineArg, InstalledTargetKernelInfo, FirmwareFacts, TargetKernelCmdlineArgTasks)
+    consumes = (
+        KernelCmdlineArg,
+        InstalledTargetKernelInfo,
+        FirmwareFacts,
+        LateTargetKernelCmdlineArgTasks,
+        TargetKernelCmdlineArgTasks
+    )
     produces = (Report,)
     tags = (FinalizationPhaseTag, IPUWorkflowTag)
 

--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
@@ -1,3 +1,4 @@
+import itertools
 import re
 
 from leapp import reporting
@@ -5,7 +6,12 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries import stdlib
 from leapp.libraries.common.config import architecture, version
 from leapp.libraries.stdlib import api
-from leapp.models import InstalledTargetKernelInfo, KernelCmdlineArg, TargetKernelCmdlineArgTasks
+from leapp.models import (
+    InstalledTargetKernelInfo,
+    KernelCmdlineArg,
+    LateTargetKernelCmdlineArgTasks,
+    TargetKernelCmdlineArgTasks
+)
 
 KERNEL_CMDLINE_FILE = "/etc/kernel/cmdline"
 
@@ -71,7 +77,9 @@ def retrieve_arguments_to_modify():
     kernelargs_msgs_to_add = list(api.consume(KernelCmdlineArg))
     kernelargs_msgs_to_remove = []
 
-    for target_kernel_arg_task in api.consume(TargetKernelCmdlineArgTasks):
+    modification_msgs = itertools.chain(api.consume(TargetKernelCmdlineArgTasks),
+                                        api.consume(LateTargetKernelCmdlineArgTasks))
+    for target_kernel_arg_task in modification_msgs:
         kernelargs_msgs_to_add.extend(target_kernel_arg_task.to_add)
         kernelargs_msgs_to_remove.extend(target_kernel_arg_task.to_remove)
 

--- a/repos/system_upgrade/common/actors/persistentnetnamesconfig/libraries/persistentnetnamesconfig.py
+++ b/repos/system_upgrade/common/actors/persistentnetnamesconfig/libraries/persistentnetnamesconfig.py
@@ -2,7 +2,7 @@ import errno
 import os
 import re
 
-from leapp.libraries.common.config import get_env
+from leapp.libraries.common.config import get_env, version
 from leapp.libraries.stdlib import api
 from leapp.models import (
     InitrdIncludes,
@@ -39,6 +39,9 @@ def generate_link_file(interface):
 
 @suppress_deprecation(InitrdIncludes)
 def process():
+    if get_env('LEAPP_USE_NET_NAMING_SCHEMES', '0') == '1' and version.get_target_major_version() != '8':
+        api.current_logger().info('Skipping generation of .link files renaming NICs as LEAPP_USE_NET_NAMING_SCHEMES=1')
+        return
 
     if get_env('LEAPP_NO_NETWORK_RENAMING', '0') == '1':
         api.current_logger().info(

--- a/repos/system_upgrade/common/actors/persistentnetnamesconfig/libraries/persistentnetnamesconfig.py
+++ b/repos/system_upgrade/common/actors/persistentnetnamesconfig/libraries/persistentnetnamesconfig.py
@@ -39,7 +39,8 @@ def generate_link_file(interface):
 
 @suppress_deprecation(InitrdIncludes)
 def process():
-    if get_env('LEAPP_USE_NET_NAMING_SCHEMES', '0') == '1' and version.get_target_major_version() != '8':
+    if get_env('LEAPP_USE_NET_NAMING_SCHEMES', '0') == '1' and version.get_target_major_version() == '9':
+        # We can use this only for 8>9, for now
         api.current_logger().info('Skipping generation of .link files renaming NICs as LEAPP_USE_NET_NAMING_SCHEMES=1')
         return
 

--- a/repos/system_upgrade/common/models/kernelcmdlineargs.py
+++ b/repos/system_upgrade/common/models/kernelcmdlineargs.py
@@ -24,6 +24,27 @@ class TargetKernelCmdlineArgTasks(Model):
     to_remove = fields.List(fields.Model(KernelCmdlineArg), default=[])
 
 
+class LateTargetKernelCmdlineArgTasks(Model):
+    """
+    Desired modifications of the target kernel args produced later in the upgrade process.
+
+    Defined to prevent loops in the actor dependency graph.
+    """
+    topic = SystemInfoTopic
+
+    to_add = fields.List(fields.Model(KernelCmdlineArg), default=[])
+    to_remove = fields.List(fields.Model(KernelCmdlineArg), default=[])
+
+
+class UpgradeKernelCmdlineArgTasks(Model):
+    """
+    Modifications of the upgrade kernel cmdline.
+    """
+    topic = SystemInfoTopic
+
+    to_add = fields.List(fields.Model(KernelCmdlineArg), default=[])
+
+
 class KernelCmdline(Model):
     """
     Kernel command line parameters the system was booted with

--- a/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/actor.py
@@ -1,0 +1,28 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import emit_net_naming as emit_net_naming_lib
+from leapp.models import (
+    KernelCmdline,
+    RpmTransactionTasks,
+    TargetKernelCmdlineArgTasks,
+    TargetUserSpaceUpgradeTasks,
+    UpgradeKernelCmdlineArgTasks
+)
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class EmitNetNamingScheme(Actor):
+    """
+    Emit necessary modifications of the upgrade environment and target command line to use net.naming-scheme.
+    """
+    name = 'emit_net_naming_scheme'
+    consumes = (KernelCmdline,)
+    produces = (
+        RpmTransactionTasks,
+        TargetKernelCmdlineArgTasks,
+        TargetUserSpaceUpgradeTasks,
+        UpgradeKernelCmdlineArgTasks,
+    )
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        emit_net_naming_lib.emit_msgs_to_use_net_naming_schemes()

--- a/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/libraries/emit_net_naming.py
+++ b/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/libraries/emit_net_naming.py
@@ -1,0 +1,63 @@
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config import get_env, version
+from leapp.libraries.stdlib import api
+from leapp.models import (
+    KernelCmdline,
+    KernelCmdlineArg,
+    RpmTransactionTasks,
+    TargetKernelCmdlineArgTasks,
+    TargetUserSpaceUpgradeTasks,
+    UpgradeKernelCmdlineArgTasks
+)
+
+NET_NAMING_SYSATTRS_RPM_NAME = 'rhel-net-naming-sysattrs'
+
+
+def is_net_scheme_compatible_with_current_cmdline():
+    kernel_cmdline = next(api.consume(KernelCmdline), None)
+    if not kernel_cmdline:
+        # Super unlikely
+        raise StopActorExecutionError('Did not receive any KernelCmdline messages.')
+
+    allows_predictable_names = True
+    already_has_a_net_naming_scheme = False
+    for param in kernel_cmdline.parameters:
+        if param.key == 'net.ifnames':
+            if param.value == '0':
+                allows_predictable_names = False
+            elif param.value == '1':
+                allows_predictable_names = True
+        if param.key == 'net.naming-scheme':
+            # We assume that the kernel cmdline does not contain invalid entries, namely,
+            # that the net.naming-scheme refers to a valid scheme.
+            already_has_a_net_naming_scheme = True
+
+    is_compatible = allows_predictable_names and not already_has_a_net_naming_scheme
+
+    msg = ('Should net.naming-scheme be added to kernel cmdline: %s. '
+           'Reason: allows_predictable_names=%s, already_has_a_net_naming_scheme=%s')
+    api.current_logger().info(msg, 'yes' if is_compatible else 'no',
+                              allows_predictable_names,
+                              already_has_a_net_naming_scheme)
+
+    return is_compatible
+
+
+def emit_msgs_to_use_net_naming_schemes():
+    if get_env('LEAPP_USE_NET_NAMING_SCHEMES', '0') != '1' and version.get_target_major_version() != '8':
+        return
+
+    # The package should be installed regardless of whether we will modify the cmdline -
+    # if the cmdline already contains net.naming-scheme, then the package will be useful
+    # in both, the upgrade environment and on the target system.
+    pkgs_to_install = [NET_NAMING_SYSATTRS_RPM_NAME]
+    api.produce(TargetUserSpaceUpgradeTasks(install_rpms=pkgs_to_install))
+    api.produce(RpmTransactionTasks(to_install=pkgs_to_install))
+
+    if not is_net_scheme_compatible_with_current_cmdline():
+        return
+
+    naming_scheme = 'rhel-{0}.0'.format(version.get_source_major_version())
+    cmdline_args = [KernelCmdlineArg(key='net.naming-scheme', value=naming_scheme)]
+    api.produce(UpgradeKernelCmdlineArgTasks(to_add=cmdline_args))
+    api.produce(TargetKernelCmdlineArgTasks(to_add=cmdline_args))

--- a/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/libraries/emit_net_naming.py
+++ b/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/libraries/emit_net_naming.py
@@ -44,7 +44,10 @@ def is_net_scheme_compatible_with_current_cmdline():
 
 
 def emit_msgs_to_use_net_naming_schemes():
-    if get_env('LEAPP_USE_NET_NAMING_SCHEMES', '0') != '1' and version.get_target_major_version() != '8':
+    is_env_var_set = get_env('LEAPP_USE_NET_NAMING_SCHEMES', '0') == '1'
+    is_upgrade_8to9 = version.get_target_major_version() == '9'
+    is_net_naming_enabled_and_permitted = is_env_var_set and is_upgrade_8to9
+    if not is_net_naming_enabled_and_permitted:
         return
 
     # The package should be installed regardless of whether we will modify the cmdline -

--- a/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/tests/test_emit_net_naming_scheme.py
+++ b/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/tests/test_emit_net_naming_scheme.py
@@ -1,0 +1,95 @@
+import pytest
+
+from leapp.libraries.actor import emit_net_naming as emit_net_naming_lib
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import (
+    KernelCmdline,
+    KernelCmdlineArg,
+    RpmTransactionTasks,
+    TargetKernelCmdlineArgTasks,
+    TargetUserSpaceUpgradeTasks,
+    UpgradeKernelCmdlineArgTasks
+)
+
+
+@pytest.mark.parametrize(
+    ('kernel_args', 'should_be_compatible'),
+    [
+        ([KernelCmdlineArg(key='net.naming-scheme', value='rhel-8.10')], False),
+        ([KernelCmdlineArg(key='net.ifnames', value='1')], True),
+        ([KernelCmdlineArg(key='net.ifnames', value='0')], False),
+        (
+            [
+                KernelCmdlineArg(key='net.naming-scheme', value='rhel-8.10'),
+                KernelCmdlineArg(key='net.ifname', value='0'),
+                KernelCmdlineArg(key='root', value='/dev/vda1')
+            ],
+            False
+        ),
+        ([KernelCmdlineArg(key='root', value='/dev/vda1')], True),
+    ]
+)
+def test_is_net_scheme_compatible_with_current_cmdline(monkeypatch, kernel_args, should_be_compatible):
+    kernel_cmdline = KernelCmdline(parameters=kernel_args)
+
+    def mocked_consume(msg_type):
+        yield {KernelCmdline: kernel_cmdline}[msg_type]
+
+    monkeypatch.setattr(api, 'consume', mocked_consume)
+
+    assert emit_net_naming_lib.is_net_scheme_compatible_with_current_cmdline() == should_be_compatible, \
+        [(arg.key, arg.value) for arg in kernel_cmdline.parameters]
+
+
+@pytest.mark.parametrize(
+    ('is_net_scheme_enabled', 'is_current_cmdline_compatible'),
+    [
+        (True, True),
+        (True, False),
+        (False, True)
+    ]
+)
+def test_emit_msgs_to_use_net_naming_schemes(monkeypatch, is_net_scheme_enabled, is_current_cmdline_compatible):
+    envvar_value = '1' if is_net_scheme_enabled else '0'
+
+    mocked_actor = CurrentActorMocked(src_ver='8.10',
+                                      dst_ver='9.5',
+                                      envars={'LEAPP_USE_NET_NAMING_SCHEMES': envvar_value})
+    monkeypatch.setattr(api, 'current_actor', mocked_actor)
+
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(emit_net_naming_lib,
+                        'is_net_scheme_compatible_with_current_cmdline',
+                        lambda: is_current_cmdline_compatible)
+
+    emit_net_naming_lib.emit_msgs_to_use_net_naming_schemes()
+
+    def ensure_one_msg_of_type_produced(produced_messages, msg_type):
+        msgs = (msg for msg in produced_messages if isinstance(msg, msg_type))
+        msg = next(msgs)
+        assert not next(msgs, None), 'More than one message of type {type} produced'.format(type=type)
+        return msg
+
+    produced_messages = api.produce.model_instances
+    if is_net_scheme_enabled:
+        userspace_tasks = ensure_one_msg_of_type_produced(produced_messages, TargetUserSpaceUpgradeTasks)
+        assert userspace_tasks.install_rpms == [emit_net_naming_lib.NET_NAMING_SYSATTRS_RPM_NAME]
+
+        rpm_tasks = ensure_one_msg_of_type_produced(produced_messages, RpmTransactionTasks)
+        assert rpm_tasks.to_install == [emit_net_naming_lib.NET_NAMING_SYSATTRS_RPM_NAME]
+    else:
+        assert not api.produce.called
+        return
+
+    upgrade_cmdline_mods = (msg for msg in produced_messages if isinstance(msg, UpgradeKernelCmdlineArgTasks))
+    target_cmdline_mods = (msg for msg in produced_messages if isinstance(msg, TargetKernelCmdlineArgTasks))
+
+    if is_current_cmdline_compatible:
+        # We should emit cmdline modifications - both UpgradeKernelCmdlineArgTasks and TargetKernelCmdlineArgTasks
+        # should be produced
+        assert next(upgrade_cmdline_mods, None)
+        assert next(target_cmdline_mods, None)
+    else:
+        assert not next(upgrade_cmdline_mods, None)
+        assert not next(target_cmdline_mods, None)


### PR DESCRIPTION
Leapp writes .link files to prevent interfaces being renamed
after booting to post-upgrade system. This patch adds a less
error-prone approach that uses net.naming-scheme kernel param.
The naming-scheme tells udev what hardware properties to use
when composing a device name. Moreover, possible values of this
parameter are coarse-grained "profiles", that tell udev to
behave as if it did on RHEL8.0.

The functionality is enabled by setting LEAPP_USE_NET_NAMING_SCHEME
environmental variable to 1. If the feature is enabled, the .link
file generation is disabled. A kernel parameter `net.naming-scheme=`
is added to the upgrade boot entry and the post-upgrade entry.
The value of the parameter will be `rhel-<source_major>.0`. Note
that the minor source version is *not used*. Using also source major
version instead of 0 causes the device names to change slightly,
so we use 0. Moreover, an extra RPM named `rhel-net-naming-sysattrs`
is installed to the target system and target userspace container.
The RPM provides definitions of the "profiles" for net.naming-scheme.

The feature is available only for 8>9 and higher. Attempting to
upgrade 7>8 with LEAPP_USE_NET_NAMING_SCHEME=1 will ignore
the value of LEAPP_USE_NET_NAMING_SCHEME.

Add a possibility to use the net.naming-scheme cmdline argument
to make immutable network interface names during the upgrade.
The feature can be used only for 8>9 upgrades and higher.
To enable the feature, use LEAPP_USE_NET_NAMING_SCHEME=1.

Jira-ref: RHEL-23473