### PR TITLE
Add renovate to track github-actions deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+    "extends": [
+        "config:base"
+    ],
+    "enabledManagers": [
+        "github-actions"
+    ]
+}


### PR DESCRIPTION
The renovate bot will track and automatically update the github actions dependencies in the project.