### PR TITLE
grub2/efi: fix /boot/efi/EFI/redhat/grub.cfg

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/fixgrubefiwrapper/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/fixgrubefiwrapper/actor.py
@@ -1,0 +1,35 @@
+import os
+
+from leapp.actors import Actor
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import FirmwareFacts, TransactionCompleted
+from leapp.reporting import Report
+from leapp.tags import IPUWorkflowTag, RPMUpgradePhaseTag
+
+
+class FixGrubEFIWrapper(Actor):
+    """
+    Update /boot/efi/EFI/redhat/grub.cfg on UEFI systems.
+
+    See [RHEL-36186](https://issues.redhat.com/browse/RHEL-36186).
+    """
+
+    name = 'fix_grub_efi_wrapper'
+    consumes = (TransactionCompleted, FirmwareFacts)
+    produces = (Report,)
+    tags = (RPMUpgradePhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        ff = next(self.consume(FirmwareFacts), None)
+        if not ff:
+            api.current_logger().warning('Could not identify system firmware')
+            return
+
+        if ff.firmware == 'efi' and os.path.ismount('/boot/efi') and os.path.isfile('/boot/efi/EFI/redhat/grub.cfg'):
+            api.current_logger().info('Removing --root-dev-only if present.')
+            try:
+                run(['/usr/bin/sed', '-i', r's/--root-dev-only\s*//', '/boot/efi/EFI/redhat/grub.cfg'])
+            except (OSError, CalledProcessError):
+                api.current_logger().warning('Cannot apply the fix of /boot/efi/EFI/redhat/grub.cfg.')
+                return
+            api.current_logger().info('Removed --root-dev-only if present.')


### PR DESCRIPTION
When upgrading a UEFI system with /boot on Software Raid, the `/boot/efi/EFI/redhat/grub.cfg` wrapper is created with unexpected content, causing the system to land into `grub>` prompt upon upgrade completion.

jira: https://issues.redhat.com/browse/RHEL-36186 RHEL-36249