### PR TITLE
Make linter happy - fixing discovered potential problems

### DIFF
--- a/repos/system_upgrade/common/actors/checktargetrepos/libraries/checktargetrepos.py
+++ b/repos/system_upgrade/common/actors/checktargetrepos/libraries/checktargetrepos.py
@@ -33,6 +33,8 @@ def process():
         ipu_doc_url = 'https://red.ht/upgrading-rhel7-to-rhel8-main-official-doc'
     elif target_major_version == '9':
         ipu_doc_url = 'https://red.ht/upgrading-rhel8-to-rhel9-main-official-doc'
+    else:
+        ipu_doc_url = 'https://red.ht/upgrading-rhel9-to-rhel10-main-official-doc'
 
     rhui_info = next(api.consume(RHUIInfo), None)
 

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/tests/unit_test_upgradeinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/tests/unit_test_upgradeinitramfsgenerator.py
@@ -354,6 +354,7 @@ def test_copy_modules_fail(monkeypatch, kind):
 
     module_class = None
     copy_fn = None
+    dst_path = None
     if kind == 'dracut':
         module_class = DracutModule
         copy_fn = upgradeinitramfsgenerator.copy_dracut_modules

--- a/repos/system_upgrade/common/actors/scantargetiso/tests/test_scan_target_iso.py
+++ b/repos/system_upgrade/common/actors/scantargetiso/tests/test_scan_target_iso.py
@@ -201,6 +201,7 @@ def test_iso_repository_detection(monkeypatch, repodirs_in_iso, expected_repoids
 
     produced_custom_repo_msgs = []
     target_iso_msg = None
+    target_iso = None
     for produced_msg in produced_msgs:
         if isinstance(produced_msg, CustomTargetRepository):
             produced_custom_repo_msgs.append(produced_msg)

--- a/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/tests/unit_test_selinuxcontentscanner.py
+++ b/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/tests/unit_test_selinuxcontentscanner.py
@@ -33,6 +33,8 @@ class run_mocked(object):
                       "port -a -t http_port_t -p udp 81",
                       "fcontext -a -f a -t httpd_sys_content_t '/web(/.*)?'",
                       "fcontext -a -f a -t cgdcbxd_exec_t '/ganesha(/.*)?'"]
+        else:
+            assert False, 'run_mocked: Called unexpected cmd not covered by test: {}'.format(self.args)
 
         return {'stdout': stdout}
 

--- a/repos/system_upgrade/common/actors/selinux/selinuxprepare/tests/unit_test_selinuxprepare.py
+++ b/repos/system_upgrade/common/actors/selinux/selinuxprepare/tests/unit_test_selinuxprepare.py
@@ -24,6 +24,7 @@ class run_mocked(object):
                     self.removed_modules.add(self.args[idx + 1])
         else:
             self.non_semodule_calls += 1
+            stdout = []
 
         return {'stdout': stdout}
 

--- a/repos/system_upgrade/common/libraries/dnfplugin.py
+++ b/repos/system_upgrade/common/libraries/dnfplugin.py
@@ -460,6 +460,9 @@ def perform_transaction_install(target_userspace_info, storage_info, used_repos,
 
 @contextlib.contextmanager
 def _prepare_perform(used_repos, target_userspace_info, xfs_info, storage_info, target_iso=None):
+    # noqa: W0135; pylint: disable=contextmanager-generator-missing-cleanup
+    # NOTE(pstodulk): the pylint check is not valid in this case - finally is covered
+    # implicitly
     reserve_space = overlaygen.get_recommended_leapp_free_space(target_userspace_info.path)
     with _prepare_transaction(used_repos=used_repos,
                               target_userspace_info=target_userspace_info

--- a/repos/system_upgrade/common/libraries/overlaygen.py
+++ b/repos/system_upgrade/common/libraries/overlaygen.py
@@ -296,6 +296,9 @@ def _prepare_required_mounts(scratch_dir, mounts_dir, storage_info, scratch_rese
 
 @contextlib.contextmanager
 def _build_overlay_mount(root_mount, mounts):
+    # noqa: W0135; pylint: disable=contextmanager-generator-missing-cleanup
+    # NOTE(pstodulk): the pylint check is not valid in this case - finally is covered
+    # implicitly
     if not root_mount:
         raise StopActorExecutionError('Root mount point has not been prepared for overlayfs.')
     if not mounts:
@@ -519,6 +522,9 @@ def _mount_dnf_cache(overlay_target):
     """
     Convenience context manager to ensure bind mounted /var/cache/dnf and removal of the mount.
     """
+    # noqa: W0135; pylint: disable=contextmanager-generator-missing-cleanup
+    # NOTE(pstodulk): the pylint check is not valid in this case - finally is covered
+    # implicitly
     with mounting.BindMount(
             source='/var/cache/dnf',
             target=os.path.join(overlay_target, 'var', 'cache', 'dnf')) as cache_mount:
@@ -570,6 +576,9 @@ def create_source_overlay(mounts_dir, scratch_dir, xfs_info, storage_info, mount
     :type scratch_reserve: Optional[int]
     :rtype: mounting.BindMount or mounting.NullMount
     """
+    # noqa: W0135; pylint: disable=contextmanager-generator-missing-cleanup
+    # NOTE(pstodulk): the pylint check is not valid in this case - finally is covered
+    # implicitly
     api.current_logger().debug('Creating source overlay in {scratch_dir} with mounts in {mounts_dir}'.format(
         scratch_dir=scratch_dir, mounts_dir=mounts_dir))
     try:
@@ -589,11 +598,8 @@ def create_source_overlay(mounts_dir, scratch_dir, xfs_info, storage_info, mount
                     with _build_overlay_mount(root_overlay, mounts) as overlay:
                         with _mount_dnf_cache(overlay.target):
                             yield overlay
-    except Exception:
+    finally:
         cleanup_scratch(scratch_dir, mounts_dir)
-        raise
-    # cleanup always now
-    cleanup_scratch(scratch_dir, mounts_dir)
 
 
 # #############################################################################

--- a/repos/system_upgrade/common/libraries/tests/test_grub.py
+++ b/repos/system_upgrade/common/libraries/tests/test_grub.py
@@ -40,6 +40,7 @@ class RunMocked(object):
     def __call__(self, args, encoding=None):
         self.called += 1
         self.args = args
+        stdout = ''
         if self.raise_err:
             raise_call_error(args)
 
@@ -50,6 +51,8 @@ class RunMocked(object):
             stdout = BOOT_DEVICE
         elif self.args[:-1] == ['lsblk', '-spnlo', 'name']:
             stdout = self.args[-1][:-1]
+        else:
+            assert False, 'RunMockedError: Called unexpected cmd not covered by test: {}'.format(self.args)
 
         return {'stdout': stdout}
 

--- a/repos/system_upgrade/common/libraries/tests/test_mdraid.py
+++ b/repos/system_upgrade/common/libraries/tests/test_mdraid.py
@@ -42,6 +42,8 @@ class RunMocked(object):
             stdout = 'ARRAY /dev/md0 level=raid1 num-devices=2 metadata=1.2 name=localhost.localdomain:0 UUID=c4acea6e:d56e1598:91822e3f:fb26832c\n    devices=/dev/sda1,/dev/sdb1'  # noqa: E501; pylint: disable=line-too-long
         elif self.args == ['mdadm', '--detail', '--verbose', '--brief', NOT_MD_DEVICE]:
             stdout = 'mdadm: /dev/sda does not appear to be an md device'
+        else:
+            assert False, 'RunMockedError: Called unexpected cmd not covered by test: {}'.format(self.args)
 
         return {'stdout': stdout}
 


### PR DESCRIPTION
Issues:
* E0606 -> possibly-used-before-assignement
* W0135 -> contextmanager-generator-missing-cleanup

Note that in case of checktargetrepos actor we are introducing `https://red.ht/upgrading-rhel9-to-rhel10-main-official-doc` for IPU 9 -> 10. However, this shortened URL must be defined yet later. The doc does not exist yet, so no rush. I've added the URL to our list of used shortened URLs, marked as broken, so it's visible.

In case of `W0135`, linters expects try-finally right around `yield`. Checked reported context managers, usually it's FP as it doesn't take into acount:
* try-finally used aroud larger block of the code, it requires really try-finally around the `yield` (see `overlaygen.py:create_source_overlay()`)
* it does not take into account nested contextmanagers, like:
  ```python
  @contextlib.contextmanager
  def mycontectmgr():
    with another_context_mgr(...) as foo:
      yield foo
  ```
  which in such a case the try-final is handled by the nested `another_context_mgr`, which is the typical scenario in reported warnings.