### PR TITLE
drop unused packager field from distro metadata

### DIFF
--- a/repos/system_upgrade/common/actors/distributionsignedrpmscanner/libraries/distributionsignedrpmscanner.py
+++ b/repos/system_upgrade/common/actors/distributionsignedrpmscanner/libraries/distributionsignedrpmscanner.py
@@ -16,7 +16,6 @@ def get_distribution_data(distribution):
         with open(distribution_config) as distro_config_file:
             distro_config_json = json.load(distro_config_file)
             distro_keys = distro_config_json.get('keys', [])
-            # distro_packager = distro_config_json.get('packager', 'not-available')
     else:
         raise StopActorExecutionError(
             'Cannot find distribution signature configuration.',

--- a/repos/system_upgrade/common/files/distro/centos/gpg-signatures.json
+++ b/repos/system_upgrade/common/files/distro/centos/gpg-signatures.json
@@ -3,6 +3,5 @@
         "24c6a8a7f4a80eb5",
         "05b555b38483c65d",
         "4eb84e71f2ee9d55"
-    ],
-    "packager": "CentOS"
+    ]
 }

--- a/repos/system_upgrade/common/files/distro/rhel/gpg-signatures.json
+++ b/repos/system_upgrade/common/files/distro/rhel/gpg-signatures.json
@@ -5,6 +5,5 @@
         "938a80caf21541eb",
         "fd372689897da07a",
         "45689c882fa658e0"
-    ],
-    "packager": "Red Hat, Inc."
+    ]
 }


### PR DESCRIPTION
The actor was refactored to accept any `gpg-key` package, regardless of
the value in the packager field, but the data was never drop from the
JSON files.

Fixes: 4968bec73947fb83aeb2d89fe7e919fba2ca2776
