### PR TITLE
.packit.yaml: adjust `post_install_script` for RHEL 7.9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -145,7 +145,7 @@ jobs:
             distro: "rhel-7.9"
         settings:
           provisioning:
-            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys; yum-config-manager --enable rhel-7-server-rhui-optional-rpms"
+            post_install_script: "#!/bin/sh\nsudo sed -i s/.*ssh-rsa/ssh-rsa/ /root/.ssh/authorized_keys"
             tags:
               BusinessUnit: sst_upgrades@leapp_upstream_test
 


### PR DESCRIPTION
Remove enabling repos step from .packit.yaml, it was moved to TF, where it logically belongs to.