### PR TITLE
check_rhui: allow minor versions in the RHUI table

### DIFF
--- a/etc/leapp/files/repomap.json
+++ b/etc/leapp/files/repomap.json
@@ -1,5 +1,5 @@
 {
-    "datetime": "202404091246Z",
+    "datetime": "202405281033Z",
     "version_format": "1.2.1",
     "mapping": [
         {
@@ -416,6 +416,14 @@
                 },
                 {
                     "major_version": "7",
+                    "repoid": "rhui-rhel-7-server-els-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "els",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "7",
                     "repoid": "rhui-rhel-7-server-rhui-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
@@ -615,6 +623,14 @@
                     "repoid": "rhui-rhel-7-server-e4s-optional-rhui-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
+                    "repo_type": "rpm",
+                    "rhui": "google"
+                },
+                {
+                    "major_version": "7",
+                    "repoid": "rhui-rhel-7-server-els-optional-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "els",
                     "repo_type": "rpm",
                     "rhui": "google"
                 },

--- a/repos/system_upgrade/common/actors/cloud/checkhybridimage/libraries/checkhybridimage.py
+++ b/repos/system_upgrade/common/actors/cloud/checkhybridimage/libraries/checkhybridimage.py
@@ -28,7 +28,8 @@ def is_azure_agent_installed():
 
     agent_pkg = None
     for setup in azure_setups:
-        if setup.os_version == src_ver_major:
+        setup_major_ver = str(setup.os_version[0])
+        if setup_major_ver == src_ver_major:
             agent_pkg = setup.extra_info.get('agent_pkg')
             break
 

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -101,8 +101,15 @@ class RHUIFamily(object):
 
 
 def mk_rhui_setup(clients=None, leapp_pkg='', mandatory_files=None, optional_files=None,
-                  extra_info=None, os_version='7', arch=arch.ARCH_X86_64, content_channel=ContentChannel.GA,
+                  extra_info=None, os_version='7.0', arch=arch.ARCH_X86_64, content_channel=ContentChannel.GA,
                   files_supporting_client_operation=None):
+
+    os_version_fragments = os_version.split('.')
+    if len(os_version_fragments) == 1:
+        os_version_tuple = (int(os_version), 0)
+    else:
+        os_version_tuple = (int(os_version_fragments[0]), int(os_version_fragments[1]))
+
     clients = clients or set()
     mandatory_files = mandatory_files or []
     extra_info = extra_info or {}
@@ -115,7 +122,7 @@ def mk_rhui_setup(clients=None, leapp_pkg='', mandatory_files=None, optional_fil
 
     return RHUISetup(clients=clients, leapp_pkg=leapp_pkg, mandatory_files=mandatory_files, arch=arch,
                      content_channel=content_channel, optional_files=optional_files, extra_info=extra_info,
-                     os_version=os_version, files_supporting_client_operation=files_supporting_client_operation)
+                     os_version=os_version_tuple, files_supporting_client_operation=files_supporting_client_operation)
 
 
 # This will be the new "cloud map". Essentially a directed graph with edges defined implicitly by OS versions +
@@ -186,6 +193,8 @@ RHUI_SETUPS = {
                       mandatory_files=[
                         ('rhui-client-config-server-8-sap-bundle.crt', RHUI_PKI_PRODUCT_DIR),
                         ('rhui-client-config-server-8-sap-bundle.key', RHUI_PKI_DIR),
+                        ('content-rhel8-sap-bundle-e4s.crt', RHUI_PKI_PRODUCT_DIR),
+                        ('content-rhel8-sap-bundle-e4s.key', RHUI_PKI_DIR),
                         (AWS_DNF_PLUGIN_NAME, DNF_PLUGIN_PATH_PY2),
                         ('leapp-aws-sap-e4s.repo', YUM_REPOS_PATH)
                       ],
@@ -195,6 +204,21 @@ RHUI_SETUPS = {
                         ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
                         ('content-rhel8-sap.crt', RHUI_PKI_PRODUCT_DIR)
                       ], os_version='8', content_channel=ContentChannel.E4S),
+        mk_rhui_setup(clients={'rh-amazon-rhui-client-sap-bundle'}, leapp_pkg='leapp-rhui-aws-sap-e4s',
+                      mandatory_files=[
+                        ('rhui-client-config-server-8-sap-bundle.crt', RHUI_PKI_PRODUCT_DIR),
+                        ('rhui-client-config-server-8-sap-bundle.key', RHUI_PKI_DIR),
+                        ('content-rhel8-sap-bundle.crt', RHUI_PKI_PRODUCT_DIR),
+                        ('content-rhel8-sap-bundle.key', RHUI_PKI_DIR),
+                        (AWS_DNF_PLUGIN_NAME, DNF_PLUGIN_PATH_PY2),
+                        ('leapp-aws-sap.repo', YUM_REPOS_PATH)
+                      ],
+                      files_supporting_client_operation=[AWS_DNF_PLUGIN_NAME],
+                      optional_files=[
+                        ('content-rhel8-sap.key', RHUI_PKI_DIR),
+                        ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
+                        ('content-rhel8-sap.crt', RHUI_PKI_PRODUCT_DIR)
+                      ], os_version='8.10'),
         mk_rhui_setup(clients={'rh-amazon-rhui-client-sap-bundle-e4s'}, leapp_pkg='leapp-rhui-aws-sap-e4s',
                       mandatory_files=[
                         ('rhui-client-config-server-9-sap-bundle.crt', RHUI_PKI_PRODUCT_DIR),
@@ -237,6 +261,14 @@ RHUI_SETUPS = {
                       ],
                       extra_info={'agent_pkg': 'WALinuxAgent'},
                       os_version='8', content_channel=ContentChannel.EUS),
+        mk_rhui_setup(clients={'rhui-azure-rhel8-base-sap-apps'}, leapp_pkg='leapp-rhui-azure-sap',
+                      mandatory_files=[('leapp-azure-sap-apps.repo', YUM_REPOS_PATH)],
+                      optional_files=[
+                        ('key-sapapps.pem', RHUI_PKI_DIR),
+                        ('content-sapapps.crt', RHUI_PKI_PRODUCT_DIR)
+                      ],
+                      extra_info={'agent_pkg': 'WALinuxAgent'},
+                      os_version='8.10', content_channel=ContentChannel.GA),
         mk_rhui_setup(clients={'rhui-azure-rhel9-sapapps'}, leapp_pkg='leapp-rhui-azure-sap',
                       mandatory_files=[('leapp-azure-sap-apps.repo', YUM_REPOS_PATH)],
                       optional_files=[
@@ -256,6 +288,14 @@ RHUI_SETUPS = {
                       ],
                       extra_info={'agent_pkg': 'WALinuxAgent'},
                       os_version='8', content_channel=ContentChannel.E4S),
+        mk_rhui_setup(clients={'rhui-azure-rhel8-base-sap-ha'}, leapp_pkg='leapp-rhui-azure-sap',
+                      mandatory_files=[('leapp-azure-sap-ha.repo', YUM_REPOS_PATH)],
+                      optional_files=[
+                        ('key-sap-ha.pem', RHUI_PKI_DIR),
+                        ('content-sap-ha.crt', RHUI_PKI_PRODUCT_DIR)
+                      ],
+                      extra_info={'agent_pkg': 'WALinuxAgent'},
+                      os_version='8.10'),
         mk_rhui_setup(clients={'rhui-azure-rhel9-sap-ha'}, leapp_pkg='leapp-rhui-azure-sap',
                       mandatory_files=[('leapp-azure-sap-ha.repo', YUM_REPOS_PATH)],
                       optional_files=[

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -262,7 +262,7 @@ RHUI_SETUPS = {
                       extra_info={'agent_pkg': 'WALinuxAgent'},
                       os_version='8', content_channel=ContentChannel.EUS),
         mk_rhui_setup(clients={'rhui-azure-rhel8-base-sap-apps'}, leapp_pkg='leapp-rhui-azure-sap',
-                      mandatory_files=[('leapp-azure-sap-apps.repo', YUM_REPOS_PATH)],
+                      mandatory_files=[('leapp-azure-base-sap-apps.repo', YUM_REPOS_PATH)],
                       optional_files=[
                         ('key-sapapps.pem', RHUI_PKI_DIR),
                         ('content-sapapps.crt', RHUI_PKI_PRODUCT_DIR)
@@ -289,7 +289,7 @@ RHUI_SETUPS = {
                       extra_info={'agent_pkg': 'WALinuxAgent'},
                       os_version='8', content_channel=ContentChannel.E4S),
         mk_rhui_setup(clients={'rhui-azure-rhel8-base-sap-ha'}, leapp_pkg='leapp-rhui-azure-sap',
-                      mandatory_files=[('leapp-azure-sap-ha.repo', YUM_REPOS_PATH)],
+                      mandatory_files=[('leapp-azure-base-sap-ha.repo', YUM_REPOS_PATH)],
                       optional_files=[
                         ('key-sap-ha.pem', RHUI_PKI_DIR),
                         ('content-sap-ha.crt', RHUI_PKI_PRODUCT_DIR)

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -307,6 +307,7 @@ RHUI_SETUPS = {
     ],
     RHUIFamily(RHUIProvider.GOOGLE, client_files_folder='google'): [
         mk_rhui_setup(clients={'google-rhui-client-rhel7'}, os_version='7'),
+        mk_rhui_setup(clients={'google-rhui-client-rhel7-els'}, os_version='7'),
         mk_rhui_setup(clients={'google-rhui-client-rhel8'}, leapp_pkg='leapp-rhui-google',
                       mandatory_files=[('leapp-google.repo', YUM_REPOS_PATH)],
                       files_supporting_client_operation=['leapp-google.repo'],

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -161,7 +161,7 @@ RHUI_SETUPS = {
     ],
     RHUIFamily(RHUIProvider.AWS, arch=arch.ARCH_ARM64, client_files_folder='aws'): [
         mk_rhui_setup(clients={'rh-amazon-rhui-client-arm'}, optional_files=[], os_version='7', arch=arch.ARCH_ARM64),
-        mk_rhui_setup(clients={'rh-amazon-rhui-client-arm'}, leapp_pkg='leapp-rhui-aws',
+        mk_rhui_setup(clients={'rh-amazon-rhui-client'}, leapp_pkg='leapp-rhui-aws',
                       mandatory_files=[
                         ('rhui-client-config-server-8.crt', RHUI_PKI_PRODUCT_DIR),
                         ('rhui-client-config-server-8.key', RHUI_PKI_DIR),
@@ -174,7 +174,7 @@ RHUI_SETUPS = {
                         ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
                         ('content-rhel8.crt', RHUI_PKI_PRODUCT_DIR)
                       ], os_version='8', arch=arch.ARCH_ARM64),
-        mk_rhui_setup(clients={'rh-amazon-rhui-client-arm'}, leapp_pkg='leapp-rhui-aws',
+        mk_rhui_setup(clients={'rh-amazon-rhui-client'}, leapp_pkg='leapp-rhui-aws',
                       mandatory_files=[
                         ('rhui-client-config-server-9.crt', RHUI_PKI_PRODUCT_DIR),
                         ('rhui-client-config-server-9.key', RHUI_PKI_DIR),

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -582,7 +582,8 @@ def get_all_known_rhui_pkgs_for_current_upg():
     known_pkgs = set()
     for setup_family in RHUI_SETUPS.values():
         for setup in setup_family:
-            if setup.os_version not in upg_major_versions:
+            setup_major = str(setup.os_version[0])
+            if setup_major not in upg_major_versions:
                 continue
             known_pkgs.update(setup.clients)
             known_pkgs.add(setup.leapp_pkg)


### PR DESCRIPTION
check_rhui: allow minor versions in the RHUI table

With RHEL8.10, different target RHUI clients have to be installed,
depending on the target minor version. The RHUI_SETUPS structure
used for navigating upgrades on RHUI and associated infrastructure
did not allow to setups based on their minor version. RHUI_SETUPS
is used to both determine what RHUI variant are we running on and what
is the target setup. Therefore, any solution would have to:
- ensure that when we are on RHEL8.10, we will look for correct client
  (this point is fairly easy, and it would be sufficient to just declare
   another setup description in RHUI_SETUPS)
- determine what target client to install depending on whether we are
  targetting RHEL8.10 or, e.g., RHEL8.8
Introducing another setup to the map causes multiple target variants
to be eligible, and, thus, leapp would error due to not being able to
pick the target setup. Therefore, a solution has to include such
conflict resolution based on target minor version.

Given the above description of the solution space, this patch allows
specifying minor versions in the RHUI_SETUPS table used to resolve
conflicts when multiple target setups matching the major version are
eligable. Identification of the source and corresponding target RHUI
variant works by using the entry with the closest (younger) minor
version. For example, when 8.4 and 8.8 are suitable target setups (based
on the installed clients), 8.4 will be used when the upgrade taget is
8.6. The minor versions in the RHUI_SETUPS table, therefore, are
in a sense a "changelog" of leapp's RHUI knowledge. If the table
contains an entry A with version 8.0, and an entry B with version
8.8, this can be understood as:
  _Since 8.0, we know that the setups use this client and we need to do
  these things to access target content. Since 8.8 onwards, we know
  that we need to use a different client etc._
