### PR TITLE
Revert "Add RHEL 7 for SAP ELS to the RHUI config (#1254)"

### DIFF
--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -319,7 +319,6 @@ RHUI_SETUPS = {
     ],
     RHUIFamily(RHUIProvider.GOOGLE, variant=RHUIVariant.SAP, client_files_folder='google-sap'): [
         mk_rhui_setup(clients={'google-rhui-client-rhel79-sap'}, os_version='7', content_channel=ContentChannel.E4S),
-        mk_rhui_setup(clients={'google-rhui-client-rhel7-sap-els'}, os_version='7'),
         mk_rhui_setup(clients={'google-rhui-client-rhel8-sap'}, leapp_pkg='leapp-rhui-google-sap',
                       mandatory_files=[('leapp-google-sap.repo', YUM_REPOS_PATH)],
                       files_supporting_client_operation=['leapp-google-sap.repo'],


### PR DESCRIPTION
This reverts commit 4ba0ec3d51126cdff31b47f96312d7c6c0d138ad.

It turned out this change is not needed at the end.