### PR TITLE
Fix storage scanner parsing error

### DIFF
--- a/repos/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py
+++ b/repos/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py
@@ -206,7 +206,7 @@ def _get_lsblk_info():
 @aslist
 def _get_pvs_info():
     """ Collect storage info from pvs command """
-    for entry in _get_cmd_output(['pvs', '--noheadings', '--separator', r':'], ':', 6):
+    for entry in _get_cmd_output(['pvs', '--noheadings', '--separator', r'|'], '|', 6):
         pv, vg, fmt, attr, psize, pfree = entry
         yield PvsEntry(
             pv=pv,
@@ -220,7 +220,7 @@ def _get_pvs_info():
 @aslist
 def _get_vgs_info():
     """ Collect storage info from vgs command """
-    for entry in _get_cmd_output(['vgs', '--noheadings', '--separator', r':'], ':', 7):
+    for entry in _get_cmd_output(['vgs', '--noheadings', '--separator', r'|'], '|', 7):
         vg, pv, lv, sn, attr, vsize, vfree = entry
         yield VgsEntry(
             vg=vg,
@@ -235,7 +235,7 @@ def _get_vgs_info():
 @aslist
 def _get_lvdisplay_info():
     """ Collect storage info from lvdisplay command """
-    for entry in _get_cmd_output(['lvdisplay', '-C', '--noheadings', '--separator', r':'], ':', 12):
+    for entry in _get_cmd_output(['lvdisplay', '-C', '--noheadings', '--separator', r'|'], '|', 12):
         lv, vg, attr, lsize, pool, origin, data, meta, move, log, cpy_sync, convert = entry
         yield LvdisplayEntry(
             lv=lv,


### PR DESCRIPTION
The given error arises when storage scanner actor attempts to parse output from command `pvs` while output containts separator symbol within itself. Changed the format of physical volume as was suggested in the ticket so it contains separator `:`, and was given following error while preupgrade and upgrade.
(e.g: format of physical volume, contains the symbol `:`  `/dev/disk/by-path/pci-0000:00:03.0-part2)

```
  File "/etc/leapp/repos.d/system_upgrade/common/actors/storagescanner/libraries/storagescanner.py", line 195, in _get_pvs_info
    pv, vg, fmt, attr, psize, pfree = entry
ValueError: too many values to unpack (expected 6)
```

Therefore changing the separation symbol to `|`, and running preupgrade and upgrade from RHEL8 to RHEL9 didn't raise any errors.

Jira: RHEL-34570
