### PR TITLE
codespell: Use specific version instead of master

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@master
+      - uses: codespell-project/actions-codespell@v2
         with:
           ignore_words_list: ro,fo,couldn,repositor,zeor
           skip: "./repos/system_upgrade/common/actors/storagescanner/tests/files/mounts,\


### PR DESCRIPTION
Let's not blindly use the master ref, use a specific version instead.

This should fix the failing Codespell action. It's failing because only v2 is allowed to run in this repo (as set in repository settings).