### PR TITLE
GPG check: do not raise an error when TargetUserSpaceInfo is missing

### DIFF
--- a/repos/system_upgrade/common/actors/missinggpgkeysinhibitor/libraries/missinggpgkey.py
+++ b/repos/system_upgrade/common/actors/missinggpgkeysinhibitor/libraries/missinggpgkey.py
@@ -7,7 +7,7 @@ import tempfile
 from six.moves import urllib
 
 from leapp import reporting
-from leapp.exceptions import StopActorExecutionError
+from leapp.exceptions import StopActorExecution, StopActorExecutionError
 from leapp.libraries.common.config.version import get_target_major_version
 from leapp.libraries.common.gpg import get_gpg_fp_from_file, get_path_to_gpg_certs, is_nogpgcheck_set
 from leapp.libraries.stdlib import api
@@ -62,6 +62,15 @@ def _get_abs_file_path(target_userspace, file_url):
 
 def _consume_data():
     try:
+        target_userspace = next(api.consume(TargetUserSpaceInfo))
+    except StopIteration:
+        api.current_logger().warning(
+            'Missing TargetUserSpaceInfo data. The upgrade cannot continue'
+            'without this data, so skipping any other actions.'
+        )
+        raise StopActorExecution()
+
+    try:
         used_target_repos = next(api.consume(UsedTargetRepositories)).repos
     except StopIteration:
         raise StopActorExecutionError(
@@ -82,12 +91,6 @@ def _consume_data():
     except StopIteration:
         raise StopActorExecutionError(
             'Could not check for valid GPG keys', details={'details': 'No TrustedGpgKeys facts'}
-        )
-    try:
-        target_userspace = next(api.consume(TargetUserSpaceInfo))
-    except StopIteration:
-        raise StopActorExecutionError(
-            'Could not check for valid GPG keys', details={'details': 'No TargetUserSpaceInfo facts'}
         )
 
     return used_target_repos, target_repos, trusted_gpg_keys, target_userspace


### PR DESCRIPTION
Previously, if the upgrade has been inhibited during
    TargetTransactionFactsCollectionPhase
usually because we could not create (for whatever reason) the target userspace container, the actor checking rpm gpg keys failed with the `Could not check for valid GPG keys` error. This has confused many users as they couldn't know that this is impacted by the problem described in an inhibitor that is below this error.

As it's for sure that the upgrade cannot continue when the target user space container has not been created (the TargetUserSpaceInfo msg is missing), we consider it safe to stop the gpg check here silently just with a warning msg instead of raising the error - as this check is important only in case we could actually upgrade.

All other possible raised errors are presereved.

jira: https://issues.redhat.com/browse/RHEL-30573