### PR TITLE
Use frozen branch for rhel7 downstream testing

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -102,7 +102,7 @@ jobs:
   job: tests
   trigger: ignore
   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "main"
+  fmf_ref: "rhel7"
   use_internal_tf: True
   labels:
     - sanity

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -121,6 +121,11 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-rhui]
   identifier: sanity-abstract-7to8-aws
+  env:
+    RHUI: "aws"
+    LEAPPDATA_BRANCH: "upstream"
+    LEAPP_NO_RHSM: "1"
+    USE_CUSTOM_REPOS: rhui
 
 # On-demand minimal beaker tests
 - &beaker-minimal-7to8-abstract-ondemand
@@ -163,7 +168,6 @@ jobs:
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.8"
-    RHUI_HYPERSCALER: aws
 
 - &sanity-79to88
   <<: *sanity-abstract-7to8
@@ -279,7 +283,6 @@ jobs:
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.10"
-    RHUI_HYPERSCALER: aws
 
 - &beaker-minimal-79to810
   <<: *beaker-minimal-7to8-abstract-ondemand

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -121,11 +121,6 @@ jobs:
     epel-7-x86_64:
       distros: [RHEL-7.9-rhui]
   identifier: sanity-abstract-7to8-aws
-  env:
-    RHUI: "aws"
-    LEAPPDATA_BRANCH: "upstream"
-    LEAPP_NO_RHSM: "1"
-    USE_CUSTOM_REPOS: rhui
 
 # On-demand minimal beaker tests
 - &beaker-minimal-7to8-abstract-ondemand
@@ -168,6 +163,10 @@ jobs:
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.8"
+    RHUI: "aws"
+    LEAPPDATA_BRANCH: "upstream"
+    LEAPP_NO_RHSM: "1"
+    USE_CUSTOM_REPOS: rhui
 
 - &sanity-79to88
   <<: *sanity-abstract-7to8
@@ -283,6 +282,10 @@ jobs:
   env:
     SOURCE_RELEASE: "7.9"
     TARGET_RELEASE: "8.10"
+    RHUI: "aws"
+    LEAPPDATA_BRANCH: "upstream"
+    LEAPP_NO_RHSM: "1"
+    USE_CUSTOM_REPOS: rhui
 
 - &beaker-minimal-79to810
   <<: *beaker-minimal-7to8-abstract-ondemand

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -172,7 +172,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:7to8 & tag:tier0 & enabled:true'
+        plan_filter: 'tag:7to8 & tag:sanity & enabled:true'
     environments:
       - tmt:
           context:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -88,7 +88,8 @@ jobs:
 
 # NOTE: to see what envars, targets, .. can be set in tests, see
 # the configuration of tests here:
-#   https://gitlab.cee.redhat.com/oamg/leapp-tests/-/blob/main/config.yaml
+#  7toX path https://gitlab.cee.redhat.com/oamg/leapp-tests/-/blob/rhel7/config.yaml
+# >7tox path https://gitlab.cee.redhat.com/oamg/leapp-tests/-/blob/main/config.yaml
 # Available only to RH Employees.
 
 # ###################################################################### #

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -149,7 +149,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:7to8 & tag:rhui-tier[0] & enabled:true'
+        plan_filter: 'tag:7to8 & tag:upgrade_happy_path & enabled:true'
     environments:
       - tmt:
           context:
@@ -244,7 +244,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:7to8 & tag:tier0 & enabled:true'
+        plan_filter: 'tag:7to8 & tag:sanity & enabled:true'
     environments:
       - tmt:
           context:
@@ -265,7 +265,7 @@ jobs:
   tf_extra_params:
     test:
       tmt:
-        plan_filter: 'tag:7to8 & tag:rhui-tier[0] & enabled:true'
+        plan_filter: 'tag:7to8 & tag:upgrade_happy_path & enabled:true'
     environments:
       - tmt:
           context:


### PR DESCRIPTION
After discussion "RHEL Upgrades CI: maintenance time" we decide to use separate branch for rhel7 testing