### PR TITLE
Fix ModelViolationError while parsing repo files

### DIFF
--- a/repos/system_upgrade/common/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/common/actors/systemfacts/libraries/systemfacts.py
@@ -217,7 +217,18 @@ def get_sysctls_status():
 
 def get_repositories_status():
     """ Get a basic information about YUM repositories installed in the system """
-    return RepositoriesFacts(repositories=repofileutils.get_parsed_repofiles())
+    try:
+        return RepositoriesFacts(repositories=repofileutils.get_parsed_repofiles())
+    except repofileutils.InvalidRepoDefinition as e:
+        raise StopActorExecutionError(
+            message=str(e),
+            details={
+                'hint': 'For more directions on how to resolve the issue, see: {url}.'
+                        .format(
+                            url='https://access.redhat.com/solutions/6969001'
+                        )
+            }
+        )
 
 
 def get_selinux_status():


### PR DESCRIPTION
This error occurs when repo file has invalid definition, specifically the 'name' entry of the config file.

After this, we get rid of the traceback error, and the following errors are shown
```
2024-06-17 13:35:00.974356 [ERROR] Actor: system_facts
Message: Invalid repository definition: invalid-repo in: /etc/yum.repos.d/invalid.repo: The value of "name" field is None, but this is not allowed
Summary:
    Hint: For more directions on how to resolve the issue, see: https://access.redhat.com/solutions/6969001.
2024-06-17 13:35:01.545642 [ERROR] Actor: repositories_blacklist
Message: Actor didn't receive required messages: RepositoriesFact
```

Jira: RHEL-19249