### PR TITLE
Fix mocks that cause tests to fail outside of containers

### DIFF
--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -1266,6 +1266,7 @@ def perform():
             target_iso = next(api.consume(TargetOSInstallationImage), None)
             with mounting.mount_upgrade_iso_to_root_dir(overlay.target, target_iso):
 
+                # TODO: this is out of tests completely
                 setup_target_rhui_access_if_needed(context, indata)
 
                 target_repoids = _gather_target_repositories(context, indata, prod_cert_path)

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
@@ -1213,6 +1213,7 @@ def test_perform_ok(monkeypatch):
     monkeypatch.setattr(overlaygen, 'create_source_overlay', MockedMountingBase)
     monkeypatch.setattr(userspacegen, '_gather_target_repositories', lambda *x: repoids)
     monkeypatch.setattr(userspacegen, '_create_target_userspace', lambda *x: None)
+    monkeypatch.setattr(userspacegen, 'setup_target_rhui_access_if_needed', lambda *x: None)
     monkeypatch.setattr(userspacegen.api, 'current_actor', CurrentActorMocked())
     monkeypatch.setattr(userspacegen.api, 'produce', produce_mocked())
     monkeypatch.setattr(repofileutils, 'get_repodirs', lambda: ['/etc/yum.repos.d'])

--- a/repos/system_upgrade/common/libraries/grub.py
+++ b/repos/system_upgrade/common/libraries/grub.py
@@ -36,7 +36,7 @@ def blk_dev_from_partition(partition):
         api.current_logger().warning(
             'Could not get parent device of {} partition'.format(partition)
         )
-        raise StopActorExecution()
+        raise StopActorExecution()  # TODO: return some meaningful value/error
     # lsblk "-s" option prints dependencies in inverse order, so the parent device will always
     # be the last or the only device.
     # Command result example:
@@ -55,14 +55,14 @@ def get_boot_partition():
         api.current_logger().warning(
             'Could not get name of underlying /boot partition'
         )
-        raise StopActorExecution()
+        raise StopActorExecution()  # TODO: return some meaningful value/error
     except OSError:
         api.current_logger().warning(
             'Could not get name of underlying /boot partition:'
             ' grub2-probe is missing.'
             ' Possibly called on system that does not use GRUB2?'
         )
-        raise StopActorExecution()
+        raise StopActorExecution()  # TODO: return some meaningful value/error
     boot_partition = result['stdout'].strip()
     api.current_logger().info('/boot is on {}'.format(boot_partition))
     return boot_partition
@@ -77,6 +77,7 @@ def get_grub_devices():
     :return: Devices where GRUB is located
     :rtype: list
     """
+    # TODO: catch errors and return meaningful value/error instead of StopActorExecution
     boot_device = get_boot_partition()
     devices = []
     if mdraid.is_mdraid_dev(boot_device):


### PR DESCRIPTION
See commit messages for details.

To reproduce you can use, for example: `PYTHON_VENV=python3.6 REPOSITORIES='common,el8toel9' make install-deps-fedora test_no_lint`
