### PR TITLE
rhui setups support alibaba cloud for arm64

### DIFF
--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -348,6 +348,22 @@ RHUI_SETUPS = {
                         ('content.crt', RHUI_PKI_PRODUCT_DIR)
                       ],
                       os_version='9'),
+    ],
+    RHUIFamily(RHUIProvider.ALIBABA, arch=arch.ARCH_ARM64, client_files_folder='alibaba'): [
+        mk_rhui_setup(clients={'aliyun_rhui_rhel8'}, leapp_pkg='leapp-rhui-alibaba',
+                      mandatory_files=[('leapp-alibaba.repo', YUM_REPOS_PATH)],
+                      optional_files=[
+                        ('key.pem', RHUI_PKI_DIR),
+                        ('content.crt', RHUI_PKI_PRODUCT_DIR)
+                      ],
+                      os_version='8'),
+        mk_rhui_setup(clients={'aliyun_rhui_rhel9'}, leapp_pkg='leapp-rhui-alibaba',
+                      mandatory_files=[('leapp-alibaba.repo', YUM_REPOS_PATH)],
+                      optional_files=[
+                        ('key.pem', RHUI_PKI_DIR),
+                        ('content.crt', RHUI_PKI_PRODUCT_DIR)
+                      ],
+                      os_version='9'),
     ]
 }
 


### PR DESCRIPTION
rhui(alibaba): add ARM RHEL8 and RHEL9 setup entries

Since leapp's RHUI mechanism filters setups based on the architecture of the source system,
it was not possible to upgrade of ARM-based RHEL systems on Alibaba cloud as there
were no ARM entries in RHUI_SETUPS. This patch adds these entries, making it possible
for 8>9 upgrades of ARM systems on Alibaba cloud.

---
related jira: https://issues.redhat.com/browse/RHEL-53181