### PR TITLE
targetuserspacecreator: stop skipping `directory-hash`

### DIFF
--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -313,10 +313,6 @@ def _get_files_owned_by_rpms(context, dirpath, pkgs=None, recursive=False):
         for root, _, files in os.walk(searchdir):
             for filename in files:
                 relpath = os.path.relpath(os.path.join(root, filename), searchdir)
-                # "directory-hash" files are not owned by any package and can dynamically
-                # grow to a huge amount of files causing hitting open files limit
-                if 'directory-hash' in relpath:
-                    continue
                 file_list.append(relpath)
     else:
         file_list = os.listdir(searchdir)


### PR DESCRIPTION
If https://github.com/oamg/leapp/pull/880 was the only FD leak,
we should be able to remove this workaround.
