### PR TITLE
# Release 0.21.0

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -51,7 +51,7 @@ py2_byte_compile "%1" "%2"}
 # RHEL 8+ packages to be consistent with other leapp projects in future.
 
 Name:           leapp-repository
-Version:        0.20.0
+Version:        0.21.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Packaging
- Start building for EL 9 in the upstream repository on COPR (#1169)

## Upgrade handling
### Fixes
- Add missing RHUI GCP config info for RHEL for SAP (#1253)
- Fix creation of the post upgrade report about changes in states of systemd services (#1210)
- Fix detection of valid sshd config with internal-sftp subsystem in Leapp (#1212)
- Fix evaluation of PES data (#1194)
- Fix failing "update-ca-trust" command caused by missing util-linux package (#1169)
- Fix handling of versions in RHUI configuration for ELS and SAP upgrades (#1240)
- Fix the parsing of the lscpu output (#1184, #1208)
- Fix the upgrade of systems using RHUI on AWS after changes in RHUI client package (#1178)
- Fix upgrade on aarch64 via RHUI on AWS (#1240)
- Handle a false positive GPG check error when TargetUserSpaceInfo is missing  (#1269)
- Target by default always "GA" channel repositories unless a different channel is specified for the leapp execution (#1205)
- Update the default kernel cmdline (#1193, #1216)
- Update the device driver deprecation data, fixing invalid fields for some AMD CPUs (#1211)
- Wait for the storage initialization when /usr is on separate file system - covering SAN (#1218, #1219)
- [IPU 7 -> 8] Drop enforced tomcat removal for satellite when upgrading to RHEL 8.10 (#1243)
- [IPU 7 -> 8] Fix detection of bootable device on RAID (#1260)
- [IPU 8 -> 9] Inhibit the upgrade to RHEL 9.5 on ARM architecture due to incompatibility of the RHEL 8 bootloader and RHEL 9.5 kernel (#1270)

### Enhancements
- [IPU 8 -> 9] Introduce upgrade path 8.10 -> 9.5 (#1245, #1246)
- Update leapp data files (#1280)
- Apply solutions for leftover rpms for all major upgrade paths - including experimental actors (#1199)
- Do not terminate the upgrade dracut module execution anymore if /sysroot/root/tmp_leapp_py3/.leapp_upgrade_failed exists (#1197)
- Improve set_systemd_services_states logging (#1213)
- Include leapp command execution and defined leapp envars inside leapp.db - (#1152)
- Introduce experimental upgrades in 'live' mode for the testing (#1248)
- Load obsoleted GPG keys from gpg-signatures.json file instead of hardcoding them (#1241)
- Several minor improvements in messages printed in console output (#1173, #1214, #1274)
- Several minor improvements in report and error messages (#1207, #1217, #1234, #1235, #1242)
- Sort lists in dnf-plugin-data for easier overview (#1231)
- [IPU 7 -> 8] Allow upgrade of content from ELS repositories (#1198)
- [IPU 7 -> 8] Inhibit the upgrade when Legacy GRUB is detected (#1206)
- [IPU 7 -> 8] Inhibit the upgrade when embedding area is small to prevent failed bootloader update (#1195)
- [IPU 8 -> 9] Enable EL 8 > 9 upgrades on Alibaba cloud (#1249)
- [IPU 8 -> 9] Enable EL 8 to 9 upgrade of Satellite/Foreman server (#1181)
- [IPU 9 -> 10] Introduced number of changes to enable IPU 9 -> 10 for testing (#1169)
- [IPU 9 -> 10] Prevent upgrading if NetworkManager is configured with dhcp=dhclient (#1268)
- [IPU 9 -> 10] Update URLs in reports to reflect the next planned major upgrade path (#1169, #1273)

## Additional changes interesting for devels
- drop unused `packager` field from gpg-signatures.json (#1233)
- [IPU 9 -> 10] make system_upgrade/common leapp repo Python 3.12 compatible
- [IPU 9 -> 10] introduced system_upgrade/el9toel10 leapp repo