### PR TITLE
Cherry pick fix-check-of-config-files

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -106,7 +106,7 @@ jobs:
   job: tests
   trigger: ignore
   fmf_url: "https://gitlab.cee.redhat.com/oamg/leapp-tests"
-  fmf_ref: "rhel7"
+  fmf_ref: "fix-check-of-config-files"
   use_internal_tf: True
   labels:
     - sanity


### PR DESCRIPTION
DO NOT MERGE
PR to verify downstream tests are green