### PR TITLE
properly scope try/except when loading obsoleted keys

### DIFF
--- a/repos/system_upgrade/common/actors/removeobsoletegpgkeys/libraries/removeobsoleterpmgpgkeys.py
+++ b/repos/system_upgrade/common/actors/removeobsoletegpgkeys/libraries/removeobsoleterpmgpgkeys.py
@@ -12,14 +12,14 @@ def _get_obsolete_keys():
     distribution = api.current_actor().configuration.os_release.release_id
     obsoleted_keys_map = get_distribution_data(distribution).get('obsoleted-keys', {})
     keys = []
-    try:
-        for version in range(7, int(get_target_major_version()) + 1):
+    for version in range(7, int(get_target_major_version()) + 1):
+        try:
             for key in obsoleted_keys_map[str(version)]:
                 name, version, release = key.rsplit("-", 2)
                 if has_package(InstalledRPM, name, version=version, release=release):
                     keys.append(key)
-    except KeyError:
-        pass
+        except KeyError:
+            pass
 
     return keys
 


### PR DESCRIPTION
We want to load all possible keys, even *after* a KeyError happenend

Fixes: 7e0fb44bb673893d0409903f6a441d0eb2829d22
