### PR TITLE
Update references from master branch to main

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,10 +3,10 @@ name: Codespell
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   codespell:

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -4,7 +4,7 @@
 name: Differential ShellCheck
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read
@@ -17,7 +17,7 @@ jobs:
       security-events: write
       pull-requests: write
 
-    steps: 
+    steps:
       - name: Repository checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr-welcome-msg.yml
+++ b/.github/workflows/pr-welcome-msg.yml
@@ -28,7 +28,7 @@ jobs:
             However, here are additional useful commands for packit:
             - **`/packit test`** to re-run manually the default tests
             - **`/packit retest-failed`** to re-run failed tests manually
-            - **`/packit test oamg/leapp#42`** to run tests with leapp builds for the leapp PR#42 (default is latest upstream - master - build)
+            - **`/packit test oamg/leapp#42`** to run tests with leapp builds for the leapp PR#42 (default is latest upstream - main - build)
 
             Note that first time contributors cannot run tests automatically - they need to be started by a reviewer.
 

--- a/.github/workflows/tmt-tests.yml
+++ b/.github/workflows/tmt-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
   call_workflow_tests_79to88_integration:
     needs: call_workflow_copr_build
-    uses: oamg/leapp/.github/workflows/reuse-tests-7to8.yml@master
+    uses: oamg/leapp/.github/workflows/reuse-tests-7to8.yml@main
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
@@ -26,7 +26,7 @@ jobs:
 
   call_workflow_tests_79to86_integration:
     needs: call_workflow_copr_build
-    uses: oamg/leapp/.github/workflows/reuse-tests-7to8.yml@master
+    uses: oamg/leapp/.github/workflows/reuse-tests-7to8.yml@main
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
@@ -40,7 +40,7 @@ jobs:
 
   call_workflow_tests_79to88_sst:
     needs: call_workflow_copr_build
-    uses: oamg/leapp/.github/workflows/reuse-tests-7to8.yml@master
+    uses: oamg/leapp/.github/workflows/reuse-tests-7to8.yml@main
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
@@ -55,7 +55,7 @@ jobs:
 
   call_workflow_tests_7to8_aws:
     needs: call_workflow_copr_build
-    uses: oamg/leapp/.github/workflows/reuse-tests-7to8.yml@master
+    uses: oamg/leapp/.github/workflows/reuse-tests-7to8.yml@main
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
@@ -71,7 +71,7 @@ jobs:
 
   call_workflow_tests_86to90_integration:
     needs: call_workflow_copr_build
-    uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@master
+    uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@main
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
@@ -85,7 +85,7 @@ jobs:
 
   call_workflow_tests_88to92_integration:
     needs: call_workflow_copr_build
-    uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@master
+    uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@main
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
@@ -101,7 +101,7 @@ jobs:
 
   call_workflow_tests_86to90_sst:
     needs: call_workflow_copr_build
-    uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@master
+    uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@main
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}
@@ -116,7 +116,7 @@ jobs:
 
   call_workflow_tests_86to90_aws:
     needs: call_workflow_copr_build
-    uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@master
+    uses: oamg/leapp/.github/workflows/reuse-tests-8to9.yml@main
     secrets: inherit
     with:
       copr_artifacts: ${{ needs.call_workflow_copr_build.outputs.artifacts }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,10 +2,10 @@ name: Unit Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:
@@ -74,10 +74,10 @@ jobs:
           # NOTE(ivasilev) fetch-depth 0 is critical here as leapp deps discovery depends on specific substring in
           # commit message and default 1 option will get us just merge commit which has an unrelevant message.
           fetch-depth: '0'
-      # NOTE(ivasilev) master -> origin/master is used for leapp deps discovery in Makefile via git log master..HEAD
-      - name: Set master to origin/master
-        if: github.ref != 'refs/heads/master'
+      # NOTE(ivasilev) main -> origin/main is used for leapp deps discovery in Makefile via git log main..HEAD
+      - name: Set main to origin/main
+        if: github.ref != 'refs/heads/main'
         run: |
-          git branch -f master origin/master
+          git branch -f main origin/main
       - name: ${{matrix.scenarios.name}}
         run: script -e -c /bin/bash -c 'TERM=xterm podman build --security-opt=seccomp=unconfined -t leapp-tests -f utils/container-tests/Containerfile.${{matrix.scenarios.container}} utils/container-tests && PYTHON_VENV=${{matrix.scenarios.python}} REPOSITORIES=${{matrix.scenarios.repos}} podman run --security-opt=seccomp=unconfined --rm -ti -v ${PWD}:/payload --env=PYTHON_VENV --env=REPOSITORIES leapp-tests'

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,7 +22,7 @@ actions:
   fix-spec-file:
   - bash -c "sed -i -r \"0,/Release:/ s/Release:(\s*)\S*/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" packaging/leapp-repository.spec"
   post-upstream-clone:
-  # builds from PRs should have lower NVR than those from master branch
+  # builds from PRs should have lower NVR than those from main branch
   - bash -c "sed -i \"s/1%{?dist}/0%{?dist}/g\" packaging/leapp-repository.spec"
 
 jobs:
@@ -44,12 +44,12 @@ jobs:
     fix-spec-file:
     - bash -c "sed -i -r \"0,/Release:/ s/Release:(\s*)\S*/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" packaging/leapp-repository.spec"
     post-upstream-clone:
-    # builds from PRs should have lower NVR than those from master branch
+    # builds from PRs should have lower NVR than those from main branch
     - bash -c "sed -i \"s/1%{?dist}/0%{?dist}/g\" packaging/leapp-repository.spec"
 - job: copr_build
   trigger: commit
   metadata:
-    branch: master
+    branch: main
     owner: "@oamg"
     project: leapp
     targets:
@@ -65,7 +65,7 @@ jobs:
     fix-spec-file:
     - bash -c "sed -i -r \"0,/Release:/ s/Release:(\s*)\S*/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" packaging/leapp-repository.spec"
     post-upstream-clone:
-    # builds from master branch should start with 100 release, to have high priority
+    # builds from main branch should start with 100 release, to have high priority
     - bash -c "sed -i \"s/1%{?dist}/100%{?dist}/g\" packaging/leapp-repository.spec"
 - job: copr_build
   trigger: release
@@ -85,7 +85,7 @@ jobs:
     fix-spec-file:
     - bash -c "sed -i -r \"0,/Release:/ s/Release:(\s*)\S*/Release:\1${PACKIT_RPMSPEC_RELEASE}%{?dist}/\" packaging/leapp-repository.spec"
     post-upstream-clone:
-    # builds from master branch should start with 100 release, to have high priority
+    # builds from main branch should start with 100 release, to have high priority
     - bash -c "sed -i \"s/1%{?dist}/100%{?dist}/g\" packaging/leapp-repository.spec"
 
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ endif
 
 # just to reduce number of unwanted builds mark as the upstream one when
 # someone will call copr_build without additional parameters
-MASTER_BRANCH=master
+MASTER_BRANCH=main
 
 # In case the PR or MR is defined or in case build is not coming from the
 # MATER_BRANCH branch, N_REL=0; (so build is not update of the approved
@@ -76,10 +76,10 @@ SHORT_SHA=`git rev-parse --short HEAD`
 BRANCH=`git rev-parse --abbrev-ref HEAD | tr -- '-/' '_'`
 
 # The dependent framework PR connection will be taken from the top commit's depends-on message.
-REQ_LEAPP_PR=$(shell git log master..HEAD | grep -m1 -iE '^[[:space:]]*Depends-On:[[:space:]]*.*[[:digit:]]+[[:space:]]*$$' | grep -Eo '*[[:digit:]]*')
+REQ_LEAPP_PR=$(shell git log main..HEAD | grep -m1 -iE '^[[:space:]]*Depends-On:[[:space:]]*.*[[:digit:]]+[[:space:]]*$$' | grep -Eo '*[[:digit:]]*')
 # NOTE(ivasilev) In case of travis relying on top commit is a no go as a top commit will be a merge commit.
 ifdef CI
-	REQ_LEAPP_PR=$(shell git log master..HEAD | grep -m1 -iE '^[[:space:]]*Depends-On:[[:space:]]*.*[[:digit:]]+[[:space:]]*$$' | grep -Eo '[[:digit:]]*')
+	REQ_LEAPP_PR=$(shell git log main..HEAD | grep -m1 -iE '^[[:space:]]*Depends-On:[[:space:]]*.*[[:digit:]]+[[:space:]]*$$' | grep -Eo '[[:digit:]]*')
 endif
 
 # In case anyone would like to add any other suffix, just make it possible
@@ -92,8 +92,8 @@ REQUEST=`if test -n "$$PR"; then echo ".PR$${PR}"; elif test -n "$$MR"; then ech
 # Examples:
 #    0.201810080027Z.4078402.packaging.PR2
 #    0.201810080027Z.4078402.packaging
-#    0.201810080027Z.4078402.master.MR2
-#    1.201810080027Z.4078402.master
+#    0.201810080027Z.4078402.main.MR2
+#    1.201810080027Z.4078402.main
 RELEASE="$(N_REL).$(TIMESTAMP).$(SHORT_SHA).$(BRANCH)$(REQUEST)$(_SUFFIX)"
 
 all: help
@@ -302,7 +302,7 @@ install-deps:
 	pip install --upgrade setuptools; \
 	pip install --upgrade -r requirements.txt; \
 	./utils/install_commands.sh $(_PYTHON_VENV); \
-	# In case the top commit Depends-On some yet unmerged framework patch - override master leapp with the proper version
+	# In case the top commit Depends-On some yet unmerged framework patch - override main leapp with the proper version
 	if [[ ! -z "$(REQ_LEAPP_PR)" ]] ; then \
 		echo "Leapp-repository depends on the yet unmerged pr of the framework #$(REQ_LEAPP_PR), installing it.." && \
 		$(VENVNAME)/bin/pip install -I "git+https://github.com/oamg/leapp.git@refs/pull/$(REQ_LEAPP_PR)/head"; \
@@ -332,7 +332,7 @@ install-deps-fedora:
 	pip install --upgrade setuptools; \
 	pip install --upgrade -r requirements.txt; \
 	./utils/install_commands.sh $(_PYTHON_VENV); \
-	# In case the top commit Depends-On some yet unmerged framework patch - override master leapp with the proper version
+	# In case the top commit Depends-On some yet unmerged framework patch - override main leapp with the proper version
 	if [[ ! -z "$(REQ_LEAPP_PR)" ]] ; then \
 		echo "Leapp-repository depends on the yet unmerged pr of the framework #$(REQ_LEAPP_PR), installing it.." && \
 		$(VENVNAME)/bin/pip install -I "git+https://github.com/oamg/leapp.git@refs/pull/$(REQ_LEAPP_PR)/head"; \


### PR DESCRIPTION
Focus was on making the CI and GitHub actions work after the default
branch was switched from master to main.

See: OAMG-4907