### PR TITLE
Replace mirror.centos.org with vault.centos.org Centos 7 Containerfile

### DIFF
--- a/utils/container-builds/Containerfile.centos7
+++ b/utils/container-builds/Containerfile.centos7
@@ -2,6 +2,11 @@ FROM centos:7
 
 VOLUME /repo
 
+# mirror.centos.org is dead, comment out mirrorlist and set baseurl to vault.centos.org
+RUN sed -i s/mirror.centos.org/vault.centos.org/ /etc/yum.repos.d/CentOS-*.repo
+RUN sed -i s/^#\s*baseurl=http/baseurl=http/ /etc/yum.repos.d/CentOS-*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/ /etc/yum.repos.d/CentOS-*.repo
+
 RUN yum update -y && \
     yum install -y rpm-build python-devel make git
 


### PR DESCRIPTION
As mirror.centos.org is dead, replace mirrorlist with baseurl pointing to vault.centos.org in utils/container-builds/Containerfile.centos7.

To test, remove delete the `leapp-repo-build-el7` container image (`podman rmi leapp-repo-build-el7`) and run `BUILD_CONTAINER=el7 make build_container`. The image should be successfully created, whereas before it would fail.