### PR TITLE
Handle default kernel cmdline if multiple boot entries for the default kernel

### DIFF
--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/actor.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/actor.py
@@ -4,6 +4,7 @@ from leapp.actors import Actor
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import kernelcmdlineconfig
 from leapp.models import FirmwareFacts, InstalledTargetKernelInfo, KernelCmdlineArg, TargetKernelCmdlineArgTasks
+from leapp.reporting import Report
 from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
 
 
@@ -14,7 +15,7 @@ class KernelCmdlineConfig(Actor):
 
     name = 'kernelcmdlineconfig'
     consumes = (KernelCmdlineArg, InstalledTargetKernelInfo, FirmwareFacts, TargetKernelCmdlineArgTasks)
-    produces = ()
+    produces = (Report,)
     tags = (FinalizationPhaseTag, IPUWorkflowTag)
 
     def process(self):


### PR DESCRIPTION
Instead of erroring out when grubby lists multiple entries for the
default kernel, always use the `args=` and `root=` from the first one and create
a post-upgrade report. The report instruct user to ensure those are the
correct ones or to correct them.
This can happen, for example, if MAKEDEBUG=yes is set in
/etc/sysconfing/kernel.

Also the missing `leapp.reporting.Report` class is added to kernelcmdlineconfig actor `produces` tuple.

Jira: RHEL-46911