### PR TITLE
Add el9toel10 actor to handle symlink -> directory with ruby IRB.

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/registerrubyirbadjustment/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/registerrubyirbadjustment/actor.py
@@ -5,7 +5,16 @@ from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 class RegisterRubyIRBAdjustment(Actor):
     """
-    Registers a workaround which will adjust the Ruby IRB directories during the upgrade.
+    Register a workaround to allow rubygem-irb's directory -> symlink conversion.
+
+    The /usr/share/ruby/irb has been moved from a directory to a symlink
+    in RHEL 9 and this conversion was not handled on RPM level.
+    This leads to DNF reporting package file conflicts when a major upgrade
+    is attempted and rubygem-irb (or ruby-irb) is installed.
+
+    Register "handlerubyirbsymlink" script that removes the directory prior
+    to DNF upgrade and allows it to create the expected symlink in place of
+    the removed directory.
     """
 
     name = 'register_ruby_irb_adjustment'

--- a/repos/system_upgrade/el9toel10/actors/registerrubyirbadjustment/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/registerrubyirbadjustment/actor.py
@@ -1,0 +1,31 @@
+from leapp.actors import Actor
+from leapp.models import DNFWorkaround
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class RegisterRubyIRBAdjustment(Actor):
+    """
+    Register a workaround to allow rubygem-irb's symlink -> directory conversion.
+
+    The /usr/share/ruby/irb has been moved from a symlink to a directory
+    in RHEL 10 and this conversion was not handled on the RPM level.
+    This leads to DNF reporting package file conflicts when a major upgrade
+    is attempted and rubygem-irb is installed.
+
+    Register "handlerubyirbsymlink" script that removes the symlink prior
+    to DNF upgrade and allows it to create the expected directory in place of
+    the removed symlink.
+    """
+
+    name = 'register_ruby_irb_adjustment'
+    consumes = ()
+    produces = (DNFWorkaround,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        self.produce(
+            DNFWorkaround(
+                display_name='IRB directory fix',
+                script_path=self.get_tool_path('handlerubyirbsymlink'),
+            )
+        )

--- a/repos/system_upgrade/el9toel10/actors/registerrubyirbadjustment/tests/test_register_ruby_irb_adjustments.py
+++ b/repos/system_upgrade/el9toel10/actors/registerrubyirbadjustment/tests/test_register_ruby_irb_adjustments.py
@@ -1,0 +1,11 @@
+import os.path
+
+from leapp.models import DNFWorkaround
+
+
+def test_register_ruby_irb_adjustments(current_actor_context):
+    current_actor_context.run()
+    assert len(current_actor_context.consume(DNFWorkaround)) == 1
+    assert current_actor_context.consume(DNFWorkaround)[0].display_name == 'IRB directory fix'
+    assert os.path.basename(current_actor_context.consume(DNFWorkaround)[0].script_path) == 'handlerubyirbsymlink'
+    assert os.path.exists(current_actor_context.consume(DNFWorkaround)[0].script_path)

--- a/repos/system_upgrade/el9toel10/tools/handlerubyirbsymlink
+++ b/repos/system_upgrade/el9toel10/tools/handlerubyirbsymlink
@@ -1,0 +1,22 @@
+#!/usr/bin/bash -e
+
+# just in case of hidden files.. not sure why would someone do that, it's more
+# like forgotten cache file possibility, but rather do that..
+shopt -s dotglob
+
+handle_dir() {
+    # Check that $1 is a symlink then unlink it so that RPM
+    # can freely create the directory.
+    if [ ! -L "$1" ]; then
+        return
+    fi
+
+    # There is no configuration or anything that the user should ever customize
+    # and expect to retain.
+    unlink "$1"
+
+    return 0
+}
+
+
+handle_dir /usr/share/ruby/irb


### PR DESCRIPTION
The `/usr/share/ruby/irb` path is a symlink in RHEL 9, but a regular directory in RHEL 10.

Simply remove the symlink to then let the RPM mechanism create the correct directory on update.

Users should not expect to ever retain anything in this directory.

---

Fix for [OAMG-12187](https://issues.redhat.com/browse/OAMG-12187) .

instead of `readlink` present in el8->el9 actor, I just used `test -L` since here we only care if there is any symlink or not, contents or validity of where it is pointing is not important for the upgrade.

I left the rest as-is from a copy paste of the actor, I think naming and such still pretty much fits.