### PR TITLE
IPU 7 -> 8: scangrubdevpartitionlayout: Skip warning msgs

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/libraries/scan_layout.py
+++ b/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/libraries/scan_layout.py
@@ -68,6 +68,16 @@ def get_partition_layout(device):
 
     partitions = []
     for partition_line in table_iter:
+        if not partition_line.startswith('/'):
+            # the output can contain warning msg when a partition is not aligned
+            # on physical sector boundary, like:
+            # ~~~
+            # Partition 4 does not start on physical sector boundary.
+            # ~~~
+            # We know that in case of MBR the line we expect to parse always
+            # starts with canonical path. So let's use this condition.
+            # See https://issues.redhat.com/browse/RHEL-50947
+            continue
         # Fields:               Device     Boot   Start      End  Sectors Size Id Type
         # The line looks like: `/dev/vda1  *       2048  2099199  2097152   1G 83 Linux`
         part_info = split_on_space_segments(partition_line)

--- a/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/tests/test_scan_partition_layout.py
+++ b/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/tests/test_scan_partition_layout.py
@@ -49,6 +49,9 @@ def test_get_partition_layout(monkeypatch, devices, fs):
             part_line = '{0}   *     {1}     2099199     1048576   83  {2}'.format(part.name, part.start_offset, fs)
             fdisk_output.append(part_line)
 
+        # add a problematic warning msg to test:
+        # https://issues.redhat.com/browse/RHEL-50947
+        fdisk_output.append('Partition 3 does not start on physical sector boundary.')
         device_to_fdisk_output[device.name] = fdisk_output
 
     def mocked_run(cmd, *args, **kwargs):


### PR DESCRIPTION
The fdisk output can contain warning msgs when a partition is not alligned on physical sector boundary, like:
    Partition 4 does not start on physical sector boundary.
We know that in case of MBR the line we expect to parse always starts with canonical path. So let's skip all lines which does not start with '/'.

jira: https://issues.redhat.com/browse/RHEL-50947