### PR TITLE
feat(net-naming-scheme): enable by default

### DIFF
--- a/repos/system_upgrade/common/actors/persistentnetnamesconfig/libraries/persistentnetnamesconfig.py
+++ b/repos/system_upgrade/common/actors/persistentnetnamesconfig/libraries/persistentnetnamesconfig.py
@@ -39,9 +39,14 @@ def generate_link_file(interface):
 
 @suppress_deprecation(InitrdIncludes)
 def process():
-    if get_env('LEAPP_USE_NET_NAMING_SCHEMES', '0') == '1' and version.get_target_major_version() == '9':
-        # We can use this only for 8>9, for now
-        api.current_logger().info('Skipping generation of .link files renaming NICs as LEAPP_USE_NET_NAMING_SCHEMES=1')
+    are_net_schemes_enabled = get_env('LEAPP_DISABLE_NET_NAMING_SCHEMES', '0') != '1'
+    is_upgrade_8to9 = version.get_target_major_version() == '9'
+
+    if are_net_schemes_enabled and is_upgrade_8to9:
+        # For 8>9 we are using net.naming_scheme kernel arg by default - do not generate link files
+        msg = ('Skipping generation of .link files renaming NICs as net.naming-scheme '
+               '{LEAPP_DISABLE_NET_NAMING_SCHEMES != 1} is enabled and upgrade is 8>9')
+        api.current_logger().info(msg)
         return
 
     if get_env('LEAPP_NO_NETWORK_RENAMING', '0') == '1':

--- a/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/libraries/emit_net_naming.py
+++ b/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/libraries/emit_net_naming.py
@@ -44,9 +44,9 @@ def is_net_scheme_compatible_with_current_cmdline():
 
 
 def emit_msgs_to_use_net_naming_schemes():
-    is_env_var_set = get_env('LEAPP_USE_NET_NAMING_SCHEMES', '0') == '1'
+    is_feature_enabled = get_env('LEAPP_DISABLE_NET_NAMING_SCHEMES', '0') != '1'
     is_upgrade_8to9 = version.get_target_major_version() == '9'
-    is_net_naming_enabled_and_permitted = is_env_var_set and is_upgrade_8to9
+    is_net_naming_enabled_and_permitted = is_feature_enabled and is_upgrade_8to9
     if not is_net_naming_enabled_and_permitted:
         return
 

--- a/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/tests/test_emit_net_naming_scheme.py
+++ b/repos/system_upgrade/el8toel9/actors/emit_net_naming_scheme/tests/test_emit_net_naming_scheme.py
@@ -51,11 +51,11 @@ def test_is_net_scheme_compatible_with_current_cmdline(monkeypatch, kernel_args,
     ]
 )
 def test_emit_msgs_to_use_net_naming_schemes(monkeypatch, is_net_scheme_enabled, is_current_cmdline_compatible):
-    envvar_value = '1' if is_net_scheme_enabled else '0'
+    envvar_value = '0' if is_net_scheme_enabled else '1'
 
     mocked_actor = CurrentActorMocked(src_ver='8.10',
                                       dst_ver='9.5',
-                                      envars={'LEAPP_USE_NET_NAMING_SCHEMES': envvar_value})
+                                      envars={'LEAPP_DISABLE_NET_NAMING_SCHEMES': envvar_value})
     monkeypatch.setattr(api, 'current_actor', mocked_actor)
 
     monkeypatch.setattr(api, 'produce', produce_mocked())


### PR DESCRIPTION
This commit enables the use of net.naming-scheme for 8>9 upgrades by default. The previously used environmental variable `LEAPP_USE_NET_NAMING_SCHEMES` is replaced with `LEAPP_DISABLE_NET_NAMING_SCHEMES` with inverse semantics.
