### PR TITLE
fix(add_upgrade_boot_entry): convert arg list into a tuple

### DIFF
--- a/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
@@ -303,7 +303,7 @@ def _get_rdlvm_arg_values():
     api.current_logger().debug('Collected the following rd.lvm.lv args that are undesired for the squashfs: %s',
                                rd_lvm_values)
 
-    return rd_lvm_values
+    return tuple(rd_lvm_values)
 
 
 def construct_cmdline_args_for_livemode():

--- a/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
@@ -273,7 +273,7 @@ def test_get_rdlvm_arg_values(monkeypatch):
 
     args = addupgradebootentry._get_rdlvm_arg_values()
 
-    assert tuple(args) == ('A', 'B')
+    assert args == ('A', 'B')
 
 
 def test_get_device_uuid(monkeypatch):

--- a/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
@@ -273,7 +273,7 @@ def test_get_rdlvm_arg_values(monkeypatch):
 
     args = addupgradebootentry._get_rdlvm_arg_values()
 
-    assert args == ['A', 'B']
+    assert tuple(args) == ('A', 'B')
 
 
 def test_get_device_uuid(monkeypatch):


### PR DESCRIPTION
Convert collected rd.lvm args into a tuple before trying to make a set with one of the elements being the args. As list is not hashable, this causes the actor to crash.