### PR TITLE
feat(livemode, stratis): support stratis storage in live mode

### DIFF
--- a/repos/system_upgrade/common/actors/livemode/emit_livemode_userspace_requirements/libraries/emit_livemode_userspace_requirements.py
+++ b/repos/system_upgrade/common/actors/livemode/emit_livemode_userspace_requirements/libraries/emit_livemode_userspace_requirements.py
@@ -33,6 +33,9 @@ def emit_livemode_userspace_requirements():
     if livemode_config.setup_opensshd_with_auth_keys:
         packages += ['openssh-server', 'crypto-policies']
 
+    # TODO: Make this conditional depending on whether we detect stratis on the source system
+    packages += ['stratisd']
+
     packages = sorted(set(packages))
 
     api.produce(TargetUserSpaceUpgradeTasks(install_rpms=packages))


### PR DESCRIPTION
This is a draft PR that collects results of my investigations of what would be needed to support `stratis` filesystems during the upgrade. It is far from being done.

Add support for mounting stratis storage which requires the stratisd.service to be running in order to mount the filesystems. It is sufficient to make sure that the stratisd daemon is available in the squashfs image - fstab entries will request its start.