### PR TITLE
Reload EFI info, boot order has changed as Leapp upgrade efi entry was removed

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/removeupgradeefientry/libraries/removeupgradeefientry.py
+++ b/repos/system_upgrade/el8toel9/actors/removeupgradeefientry/libraries/removeupgradeefientry.py
@@ -54,6 +54,8 @@ def remove_upgrade_efi_entry():
     except CalledProcessError:
         api.current_logger().warning('Unable to remove Leapp upgrade efi files.')
 
+    # Reload EFI info, boot order has changed as Leapp upgrade efi entry was removed
+    bootloader_info = get_workaround_efi_info()
     original_boot_number = bootloader_info.original_entry.boot_number
     run(['/usr/sbin/efibootmgr', '--bootnext', original_boot_number])
 


### PR DESCRIPTION
Removing Leapp upgrade efi entry changes boot order. Because of that, BootNext fails:

```
Dec 02 13:47:00 localhost upgrade[654]: leapp.libraries.stdlib.CalledProcessError: Command ['/usr/sbin/efibootmgr', '--bootnext', '0004'] failed with exit code 12.
Dec 02 13:47:01 localhost upgrade[654]: =========================================================================================================
Dec 02 13:47:01 localhost upgrade[654]: Actor remove_upgrade_efi_entry unexpectedly terminated with exit code: 1 - Please check the above details
```

It is required to reload EFI info prior running `efibootmgr --bootnext`