### PR TITLE
Fix unreadable output in upgrade log

### DIFF
--- a/repos/system_upgrade/common/libraries/mounting.py
+++ b/repos/system_upgrade/common/libraries/mounting.py
@@ -5,7 +5,7 @@ import shutil
 from collections import namedtuple
 
 from leapp.libraries.common.config import get_all_envs
-from leapp.libraries.common.config.version import get_source_major_version
+from leapp.libraries.common.config.version import get_source_major_version, matches_source_version
 from leapp.libraries.stdlib import api, CalledProcessError, run
 
 # Using ALWAYS_BIND will crash the upgrade process if the file does not exist.
@@ -88,6 +88,9 @@ class IsolationType(object):
                 # in such a case, just add line into the previous solution..
                 # TODO: the same about --capability=all
                 final_cmd += ['--keep-unit', '--capability=all']
+            if matches_source_version('>= 9.0'):
+                # Disable pseudo-TTY in container
+                final_cmd += ['--pipe']
             return final_cmd + ['-D', self.target] + binds + setenvs + cmd
 
     class CHROOT(_Implementation):


### PR DESCRIPTION
This commit resolves an issue where unwanted escape sequences (e.g., ANSI codes) appear in the output of certain commands like `dnf` during upgrades.

The issue seems to arise because, starting with version 242, `systemd-nspawn` introduced new pseudo-TTY capabilities (see the `Input/Output Options` section in `systemd-nspawn(1)`). As a result, commands run within container may include these escape sequences.

To address this, pseudo-TTY support is explicitly disabled in `systemd-nspawn` for upgrades on RHEL9 and later.

JIRA: [RHEL-69829](https://issues.redhat.com/browse/RHEL-69829)