### PR TITLE
IPU 9 -> 10: obsolete GPG key with SHA1 signature

### DIFF
--- a/repos/system_upgrade/common/files/distro/rhel/gpg-signatures.json
+++ b/repos/system_upgrade/common/files/distro/rhel/gpg-signatures.json
@@ -14,6 +14,6 @@
             "gpg-pubkey-db42a60e-37ea5438"
           ],
         "9": ["gpg-pubkey-d4082792-5b32db75"],
-        "10": []
+        "10": ["gpg-pubkey-fd431d51-4ae0493b"]
     }
 }


### PR DESCRIPTION
When upgrading to RHEL 10, we have analogical problem as we had for IPU 8 -> 9 due to GPG keys with SHA1 signatures. The SHA1 algorithm is considered unsecure since RHEL 9 and all RPMs are required to be signed by keys with SHA2 signatures. The RHEL 9 GPG (auxiliary) key is unfortunately still signed with SHA1 and RHEL 10 tooling refuse to use it for any operations.

To resolve this apply the same solution as we did in the past:
* obsolete original key
* install the target RHEL 10 GPG keys during the upgrade

jira: [RHEL-71517](https://issues.redhat.com/browse/RHEL-71517)

### TODO
- [x] add RHEL 10 GPG key to the trusted dir
  - checked, that present keys are already really the correct ones
- [x] test this manually to see whether it's complete or not :)