### PR TITLE
redhatsignedrpmcheck: Add remediation hint and URL

### DIFF
--- a/repos/system_upgrade/common/actors/redhatsignedrpmcheck/libraries/redhatsignedrpmcheck.py
+++ b/repos/system_upgrade/common/actors/redhatsignedrpmcheck/libraries/redhatsignedrpmcheck.py
@@ -3,8 +3,6 @@ from leapp.libraries.stdlib import api
 from leapp.libraries.stdlib.config import is_verbose
 from leapp.models import InstalledUnsignedRPM
 
-COMMON_REPORT_TAGS = [reporting.Groups.SANITY]
-
 
 def generate_report(packages):
     """ Generate a report if there are unsigned packages installed on the system """
@@ -16,11 +14,30 @@ def generate_report(packages):
                ' and may be removed during the upgrade process in case Red Hat-signed'
                ' packages to be removed during the upgrade depend on them:\n{}'
                .format(unsigned_packages_new_line))
+    hint = (
+        'The most simple solution that does not require additional knowledge'
+        ' about the upgrade process'
+        ' is the uninstallation of such packages before the upgrade and'
+        ' installing these (or their newer versions compatible with the target'
+        ' system) back after the upgrade. Also you can just try to upgrade the'
+        ' system on a testing machine (or after the full system backup) to see'
+        ' the result.\n'
+        'However, it is common use case to migrate or upgrade installed third'
+        ' party packages together with the system during the in-place upgrade'
+        ' process. To examine how to customize the process to deal with such'
+        ' packages, follow the documentation in the attached link'
+        ' for more details.'
+    )
     reporting.create_report([
         reporting.Title(title),
         reporting.Summary(summary),
         reporting.Severity(reporting.Severity.HIGH),
-        reporting.Groups(COMMON_REPORT_TAGS)
+        reporting.Groups([reporting.Groups.SANITY]),
+        reporting.Remediation(hint=hint),
+        reporting.ExternalLink(
+            url='https://red.ht/customize-rhel-upgrade-actors',
+            title='Handling the migration of your custom and third-party applications'
+        )
     ])
 
     if is_verbose():


### PR DESCRIPTION
Users do not have an idea what they should do about the third party packages - and quite often they do not understand the report itself. Adding the remediation hint with a link to related KB solution to help them to understand what they can do about this.

Note the actor needs significant changes to cover also other non-RHEL distributions. I decided to keep the change simple and resolve that in a follow up when we enable upgrades on other distributions as well.

jira: RHEL-44596