### PR TITLE
Use --sysinit when calling vgchange from mount_usr.sh

### DIFF
--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/mount_usr.sh
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/files/dracut/85sys-upgrade-redhat/mount_usr.sh
@@ -107,7 +107,7 @@ try_to_mount_usr() {
 
   # In case we have the LVM command available try make it activate all partitions
   if command -v lvm 2>/dev/null 1>/dev/null; then
-      lvm vgchange -a y || {
+      lvm vgchange --sysinit -a y || {
           warn "Detected problem when tried to activate LVM VG."
           if [ "$_last_attempt" != "true" ]; then
               # this is not last execution, retry


### PR DESCRIPTION
Since:

* da5ce33f storage initialisation: apply sleep always
* 64e2c58a mount /usr: Implement try-sleep loop - add time for storage initialisation

I see a long delay booting the upgrade initramfs and log messages about retrying LVM activation when LVM2 CoW snapshots are present:

```
Detected problem when tried to activate LVM VG.
Storage initialisation: Attempt 0 of 11. Wait 15 seconds.
...
```

The `mount_usr.sh` script runs `lvm vgchange`: if there are logical volumes present that require monitoring (snapshots, thin pools, RAID, etc.) the command will attempt to launch `dmeventd`.

Since `dmeventd` is not installed in the dracut initramfs this produces a warning and causes the lvm command to exit with non-zero exit status even though the volume group has been activated and LV block devices are available.

This in turn triggers the retry logic in `mount_usr.sh`: once the retries are exhausted the script carries on and successfully initiates the upgrade process.

The `--sysinit` switch is used by the LVM dracut modules for this reason. From vgchange(8):

```
       --sysinit
        Indicates  that  vgchange/lvchange  is being invoked from early
        system initialisation scripts (e.g. rc.sysinit or an initrd),
        before writable filesystems are available. As such, some
        functionality needs to be disabled and this option acts as a
        shortcut which selects an appropriate set of options. Currently,
        this is equivalent to using  --ignorelockingfailure,
        --ignoremonitoring,  --poll  n, and setting env var
        LVM_SUPPRESS_LOCKING_FAILURE_MESSAGES.  vgchange/lvchange skip
        autoactivation, and defer to pvscan autoactivation.
```

Testing with this change I no longer see the delay booting the upgrade initramfs when snapshot LVs are present.