### PR TITLE
Inhibit upgrades with non-SCA registration 

### DIFF
--- a/repos/system_upgrade/common/models/rhsminfo.py
+++ b/repos/system_upgrade/common/models/rhsminfo.py
@@ -20,3 +20,10 @@ class RHSMInfo(Model):
     """ Product certificates that are currently installed on the system. """
     sca_detected = fields.Boolean(default=False)
     """ Info about whether SCA manifest was used or not. """
+    is_registered = fields.Boolean(default=False)
+    """
+    Whether the system is registered through subscription-manager
+
+    Note that this doesn't differentiate between a registration to an SKU or
+    SCA organization.
+    """

--- a/repos/system_upgrade/el9toel10/actors/nonscarhsm/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/nonscarhsm/actor.py
@@ -1,0 +1,26 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import nonscarhsm
+from leapp.models import Report, RHSMInfo
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckRedHatSubscriptionManagerSCA(Actor):
+    """
+    Ensure that a registered system is in SCA (Simple Content Access)
+
+    This actor verifies that in case the system is subscribed to the Red Hat
+    Subscription Manager it is registered to an SCA organization. The actor
+    will inhibit the upgrade if the system is registered to an entitlements
+    organization.
+
+    This actor will run regardless of whether the --skip-rhsm command line
+    parameter is specified.
+    """
+
+    name = 'check_rhsmsca'
+    consumes = (RHSMInfo,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        nonscarhsm.process()

--- a/repos/system_upgrade/el9toel10/actors/nonscarhsm/libraries/nonscarhsm.py
+++ b/repos/system_upgrade/el9toel10/actors/nonscarhsm/libraries/nonscarhsm.py
@@ -1,0 +1,38 @@
+from leapp import reporting
+from leapp.libraries.stdlib import api
+from leapp.models import RHSMInfo
+from leapp.reporting import create_report
+
+
+def process():
+    for info in api.consume(RHSMInfo):
+        if info.is_registered and not info.sca_detected:
+            create_report(
+                [
+                    reporting.Title(
+                        "The system is not registered to an SCA organization"
+                    ),
+                    reporting.Summary(
+                        "Leapp detected that the system is registered to an account based on"
+                        " entitlements, and not on Simple Content Access (SCA). Starting from"
+                        " RHEL 10, Red Hat Subscription Manager supports only SCA accounts, and"
+                        " does not function with entitlement-based accounts."
+                    ),
+                    reporting.Severity(reporting.Severity.HIGH),
+                    reporting.Groups([reporting.Groups.SANITY]),
+                    reporting.Groups([reporting.Groups.INHIBITOR]),
+                    reporting.Remediation(
+                        hint="The account on which this system is registered to must be set in SCA"
+                        " mode. Please note that switching the account mode applies to all the"
+                        " systems already registered to it, and to the systems that will be"
+                        " registered in the future. Please consult the linked documentation"
+                        " for a more detailed explanation."
+                    ),
+                    reporting.RelatedResource("package", "subscription-manager"),
+                    reporting.ExternalLink(
+                        url="https://access.redhat.com/articles/transition_of_subscription_services_to_the_hybrid_cloud_console",  # noqa: E501; pylint: disable=line-too-long
+                        title="Transition of Red Hat's subscription services to the Red Hat Hybrid"
+                        "Cloud Console (console.redhat.com)",
+                    ),
+                ]
+            )


### PR DESCRIPTION
In RHEL 10, only systems registered with an SCA organization are supported. This patch adds a check and subsequent inhibitor if that's not the case.

NOTE: when leapp is invoked with --no-rhsm, the check nor inhibitor are currently performed.

Jira: RHEL-68309