### PR TITLE
el9to10: actors: mysql

### DIFF
--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/actor.py
@@ -1,0 +1,26 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkmysql
+from leapp.models import MySQLConfiguration, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class MySQLCheck(Actor):
+    """
+    Actor checking for output produced by scanmysql actor.
+
+    If no deprecated options/arguments are in use, we warn user that MySQL
+    server is installed and that more steps might be needed after upgrade with
+    link to article.
+
+    If there are deprecated options/arguments found we warn user that MySQL
+    server is installed and more steps ARE needed. They can be done either
+    before or after upgrading, but if done after MySQL server won't be
+    operational until config is fixed.
+    """
+    name = 'mysql_check'
+    consumes = (MySQLConfiguration,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self) -> None:
+        checkmysql.process()

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
@@ -1,0 +1,167 @@
+from leapp import reporting
+from leapp.libraries.stdlib import api
+from leapp.models import MySQLConfiguration
+from leapp.exceptions import StopActorExecutionError
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from repos.system_upgrade.el9toel10.models.mysql import MySQLConfiguration
+else:
+    from leapp.models import MySQLConfiguration
+
+FMT_LIST_SEPARATOR = '\n    - '
+
+# https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html
+# https://dev.mysql.com/doc/refman/8.0/en/server-options.html
+# https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html
+REMOVED_ARGS = [
+    '--avoid-temporal-upgrade',
+    'avoid_temporal_upgrade',
+    '--show-old-temporals',
+    'show_old_temporals',
+    '--old',
+    '--new',
+    '--default-authentication-plugin',
+    'default_authentication_plugin',
+    '--no-dd-upgrade',
+    '--language',
+    '--ssl',
+    '--admin-ssl',
+    '--character-set-client-handshake',
+    '--old-style-user-limits',
+]
+
+# Link URL for mysql-server report
+REPORT_SERVER_INST_LINK_URL = 'https://access.redhat.com/articles/7099234'
+
+
+def _generate_mysql_present_report() -> None:
+    """
+    Create report on mysql-server package installation detection.
+
+    Should remind user about present MySQL server package
+    installation, warn them about necessary additional steps, and
+    redirect them to online documentation for the upgrade process.
+
+    This report is used in case MySQL package is detected, but no
+    immediate action is needed.
+    """
+    reporting.create_report([
+        reporting.Title('Further action to upgrade MySQL might be needed'),
+        reporting.Summary((
+            'MySQL server component will be upgraded. '
+            'Since RHEL-10 includes MySQL server 8.4 by default, '
+            'it might be necessary to proceed with additional steps after '
+            'RHEL upgrade is completed. In simple setups MySQL server should '
+            'automatically upgrade all data on first start, but in more '
+            'complicated setups manual intervention might be needed.'
+        )),
+        reporting.Severity(reporting.Severity.MEDIUM),
+        reporting.Groups([reporting.Groups.SERVICES]),
+        reporting.ExternalLink(title='Migrating MySQL databases from RHEL 9 to RHEL 10',
+                               url=REPORT_SERVER_INST_LINK_URL),
+        reporting.RelatedResource('package', 'mysql-server'),
+        reporting.Remediation(hint=(
+            'Dump or backup your data before proceeding with the upgrade '
+            'and consult attached article '
+            '\'Migrating MySQL databases from RHEL 9 to RHEL 10\' '
+            'with up to date recommended steps before and after the upgrade.'
+        )),
+        ])
+
+
+def _generate_deprecated_config_report(found_options: set | list,
+                                       found_arguments: set | list) -> None:
+    """
+    Create report on mysql-server deprecated configuration.
+
+    Apart from showing user the article for upgrade process, we inform the
+    user that there are deprecated configuration options being used and
+    proceeding with upgrade will result in MySQL server failing to start.
+    """
+
+    generated_list = ''
+    if found_options:
+        generated_list += (
+            'Following configuration options won\'t work on a new version '
+            'of MySQL after upgrading and have to be removed from configuration files:'
+            )
+
+        for arg in found_options:
+            generated_list += FMT_LIST_SEPARATOR + arg
+
+        generated_list += (
+            '\nDefault configuration file is present at `/etc/my.cnf`\n'
+        )
+
+    if found_arguments:
+        generated_list += (
+            'Following startup arguments won\'t work on a new version '
+            'of MySQL after upgrading and have to be removed from '
+            'systemd service files:'
+            )
+
+        for arg in found_arguments:
+            generated_list += FMT_LIST_SEPARATOR + arg
+
+        generated_list += (
+            '\nDefault service override file is present at '
+            '`/etc/systemd/system/mysqld.service.d/override.conf`\n'
+        )
+
+    reporting.create_report([
+        reporting.Title('MySQL is using configuration that will be invalid after upgrade'),
+        reporting.Summary((
+            'MySQL server component will be upgraded. '
+            'Since RHEL-10 includes MySQL server 8.4 by default, '
+            'it is necessary to proceed with additional steps. '
+            'Some options that are currently used in MySQL configuration are '
+            'deprecated and will result in MySQL server failing to start '
+            'after upgrading. '
+            'After RHEL upgrade is completed MySQL server should automatically upgrade all '
+            'data on first start in simple setups. In more '
+            'complicated setups manual intervention might be needed.'
+        )),
+        reporting.Severity(reporting.Severity.MEDIUM),
+        reporting.Groups([reporting.Groups.SERVICES]),
+        reporting.ExternalLink(title='Migrating MySQL databases from RHEL 9 to RHEL 10',
+                               url=REPORT_SERVER_INST_LINK_URL),
+        reporting.RelatedResource('package', 'mysql-server'),
+        reporting.Remediation(hint=(
+            'To ensure smooth upgrade process it is strongly recommended to '
+            'remove deprecated config options \n' +
+            generated_list +
+            'Dump or backup your data before proceeding with the upgrade '
+            'and consult attached article '
+            '\'Migrating MySQL databases from RHEL 9 to RHEL 10\' '
+            'with up to date recommended steps before and after the upgrade.'
+        )),
+        ])
+
+
+def _generate_report(found_options: set | list, found_arguments: set | list) -> None:
+    """
+    Create report on mysql-server package installation detection.
+
+    Should remind user about present MySQL server package
+    installation, warn them about necessary additional steps, and
+    redirect them to online documentation for the upgrade process.
+    """
+
+    if found_arguments or found_options:
+        _generate_deprecated_config_report(found_options, found_arguments)
+    else:
+        _generate_mysql_present_report()
+
+
+def process() -> None:
+    msg: MySQLConfiguration = next(api.consume(MySQLConfiguration), None)
+    if not msg:
+        raise StopActorExecutionError('Expected MySQLConfiguration, but got None')
+
+    if msg.mysql_present:
+        _generate_report(msg.removed_options, msg.removed_arguments)
+    else:
+        api.current_logger().debug(
+            'mysql-server package not found, no report generated'
+        )

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
@@ -10,28 +10,12 @@ else:
 
 FMT_LIST_SEPARATOR = '\n    - '
 
-# https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html
-# https://dev.mysql.com/doc/refman/8.0/en/server-options.html
-# https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html
-REMOVED_ARGS = [
-    '--avoid-temporal-upgrade',
-    'avoid_temporal_upgrade',
-    '--show-old-temporals',
-    'show_old_temporals',
-    '--old',
-    '--new',
-    '--default-authentication-plugin',
-    'default_authentication_plugin',
-    '--no-dd-upgrade',
-    '--language',
-    '--ssl',
-    '--admin-ssl',
-    '--character-set-client-handshake',
-    '--old-style-user-limits',
-]
-
 # Link URL for mysql-server report
 REPORT_SERVER_INST_LINK_URL = 'https://access.redhat.com/articles/7099234'
+
+
+def _formatted_list_output(input_list, sep=FMT_LIST_SEPARATOR):
+    return ['{}{}'.format(sep, item) for item in input_list]
 
 
 def _generate_mysql_present_report() -> None:
@@ -46,7 +30,7 @@ def _generate_mysql_present_report() -> None:
     immediate action is needed.
     """
     reporting.create_report([
-        reporting.Title('Further action to upgrade MySQL might be needed'),
+        reporting.Title('Manual migration of data from MySQL database might be needed'),
         reporting.Summary((
             'MySQL server component will be upgraded. '
             'Since RHEL-10 includes MySQL server 8.4 by default, '
@@ -63,14 +47,14 @@ def _generate_mysql_present_report() -> None:
         reporting.Remediation(hint=(
             'Dump or backup your data before proceeding with the upgrade '
             'and consult attached article '
-            '\'Migrating MySQL databases from RHEL 9 to RHEL 10\' '
+            '"Migrating MySQL databases from RHEL 9 to RHEL 10" '
             'with up to date recommended steps before and after the upgrade.'
         )),
         ])
 
 
-def _generate_deprecated_config_report(found_options: set | list,
-                                       found_arguments: set | list) -> None:
+def _generate_deprecated_config_report(found_options: list,
+                                       found_arguments: list) -> None:
     """
     Create report on mysql-server deprecated configuration.
 
@@ -79,66 +63,53 @@ def _generate_deprecated_config_report(found_options: set | list,
     proceeding with upgrade will result in MySQL server failing to start.
     """
 
-    generated_list = ''
+    summary_list = []
+    remedy_list = []
     if found_options:
-        generated_list += (
-            'Following configuration options won\'t work on a new version '
-            'of MySQL after upgrading and have to be removed from configuration files:'
-            )
-
-        for arg in found_options:
-            generated_list += FMT_LIST_SEPARATOR + arg
-
-        generated_list += (
-            '\nDefault configuration file is present at `/etc/my.cnf`\n'
+        summary_list.append(
+            'Following incompatible configuration options have been detected:{}'
+            '\nDefault configuration file is present at `/etc/my.cnf`'
+            .format(''.join(_formatted_list_output(found_options)))
         )
+        remedy_list.append('Drop all deprecated configuration options before the upgrade.')
 
     if found_arguments:
-        generated_list += (
-            'Following startup arguments won\'t work on a new version '
-            'of MySQL after upgrading and have to be removed from '
-            'systemd service files:'
-            )
-
-        for arg in found_arguments:
-            generated_list += FMT_LIST_SEPARATOR + arg
-
-        generated_list += (
-            '\nDefault service override file is present at '
-            '`/etc/systemd/system/mysqld.service.d/override.conf`\n'
+        summary_list.append(
+            'Following detected startup arguments in systemd service files'
+            'will not work with the new MySQL after upgrading:{}\n'
+            'Default service override file is present at '
+            '`/etc/systemd/system/mysqld.service.d/override.conf`'
+            .format(''.join(_formatted_list_output(found_arguments)))
+        )
+        remedy_list.append(
+            'Drop all detected problematic startup arguments from '
+            'the customized systemd service file.'
         )
 
     reporting.create_report([
-        reporting.Title('MySQL is using configuration that will be invalid after upgrade'),
+        reporting.Title('Detected incompatible MySQL configuration'),
         reporting.Summary((
-            'MySQL server component will be upgraded. '
-            'Since RHEL-10 includes MySQL server 8.4 by default, '
-            'it is necessary to proceed with additional steps. '
-            'Some options that are currently used in MySQL configuration are '
-            'deprecated and will result in MySQL server failing to start '
-            'after upgrading. '
-            'After RHEL upgrade is completed MySQL server should automatically upgrade all '
-            'data on first start in simple setups. In more '
-            'complicated setups manual intervention might be needed.'
+            'Current MySQL configuration is not compatible with the new MySQL '
+            'version on the target system and '
+            'will result in MySQL server failing to start after upgrading.'
+            '\n\n{}'
+            .format('\n\n'.join(summary_list))
         )),
         reporting.Severity(reporting.Severity.MEDIUM),
         reporting.Groups([reporting.Groups.SERVICES]),
         reporting.ExternalLink(title='Migrating MySQL databases from RHEL 9 to RHEL 10',
                                url=REPORT_SERVER_INST_LINK_URL),
         reporting.RelatedResource('package', 'mysql-server'),
+        reporting.RelatedResource('file', '/etc/my.cnf'),
+        reporting.RelatedResource('file', '/etc/systemd/system/mysqld.service.d/override.conf'),
         reporting.Remediation(hint=(
-            'To ensure smooth upgrade process it is strongly recommended to '
-            'remove deprecated config options \n' +
-            generated_list +
-            'Dump or backup your data before proceeding with the upgrade '
-            'and consult attached article '
-            '\'Migrating MySQL databases from RHEL 9 to RHEL 10\' '
-            'with up to date recommended steps before and after the upgrade.'
+            'To ensure smooth upgrade process it is strongly recommended to:{}'
+            .format(''.join(''._formatted_list_output(remedy_list)))
         )),
         ])
 
 
-def _generate_report(found_options: set | list, found_arguments: set | list) -> None:
+def _generate_report(found_options: list, found_arguments: list) -> None:
     """
     Create report on mysql-server package installation detection.
 

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
@@ -75,7 +75,7 @@ def _generate_deprecated_config_report(found_options: list,
 
     if found_arguments:
         summary_list.append(
-            'Following detected startup arguments in systemd service files'
+            'Following detected startup arguments in systemd service files '
             'will not work with the new MySQL after upgrading:{}\n'
             'Default service override file is present at '
             '`/etc/systemd/system/mysqld.service.d/override.conf`'

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
@@ -1,7 +1,6 @@
 from leapp import reporting
-from leapp.libraries.stdlib import api
-from leapp.models import MySQLConfiguration
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
@@ -1,8 +1,9 @@
+from typing import TYPE_CHECKING
+
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.stdlib import api
 
-from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from repos.system_upgrade.el9toel10.models.mysql import MySQLConfiguration
 else:

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
@@ -104,7 +104,7 @@ def _generate_deprecated_config_report(found_options: list,
         reporting.RelatedResource('file', '/etc/systemd/system/mysqld.service.d/override.conf'),
         reporting.Remediation(hint=(
             'To ensure smooth upgrade process it is strongly recommended to:{}'
-            .format(''.join(''._formatted_list_output(remedy_list)))
+            .format(''.join(_formatted_list_output(remedy_list)))
         )),
         ])
 
@@ -120,8 +120,8 @@ def _generate_report(found_options: list, found_arguments: list) -> None:
 
     if found_arguments or found_options:
         _generate_deprecated_config_report(found_options, found_arguments)
-    else:
-        _generate_mysql_present_report()
+
+    _generate_mysql_present_report()
 
 
 def process() -> None:

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
@@ -1,0 +1,94 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import checkmysql
+from leapp.libraries.common.testutils import create_report_mocked, logger_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import MySQLConfiguration, Report
+from leapp.exceptions import StopActorExecutionError
+
+
+def _find_hint(report: dict) -> str | None:
+    r = None
+    for remedy in report['detail']['remediations']:
+        if remedy['type'] == 'hint':
+            r = remedy['context']
+            break
+    return r
+
+
+def test_process_no_msg(monkeypatch):
+    def consume_mocked(*args, **kwargs):
+        yield None
+
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+
+    with pytest.raises(StopActorExecutionError):
+        checkmysql.process()
+
+
+def test_process_no_mysql(monkeypatch):
+    def consume_mocked(*args, **kwargs):
+        yield MySQLConfiguration(mysql_present=False,
+                                 removed_options=[],
+                                 removed_arguments=[])
+
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+
+    checkmysql.process()
+    assert (
+        'mysql-server package not found, no report generated'
+        in api.current_logger.dbgmsg
+    )
+    assert len(reporting.create_report.reports) == 0
+
+
+def test_process_no_deprecated(monkeypatch):
+    def consume_mocked(*args, **kwargs):
+        yield MySQLConfiguration(mysql_present=True,
+                                 removed_options=[],
+                                 removed_arguments=[])
+
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+
+    checkmysql.process()
+
+    # Check that we have made a report
+    assert len(reporting.create_report.reports) == 1
+
+    r = _find_hint(reporting.create_report.reports[0])
+
+    # Check that Hint was in the report
+    assert r is not None
+
+    assert ('Following configuration options won\'t work on a new version'
+            not in r)
+
+
+def test_process_deprecated(monkeypatch):
+    def consume_mocked(*args, **kwargs):
+        yield MySQLConfiguration(mysql_present=True,
+                                 removed_options=['avoid_temporal_upgrade', '--old'],
+                                 removed_arguments=['--language'])
+
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+
+    checkmysql.process()
+
+    # Check that we have made a report
+    assert len(reporting.create_report.reports) == 1
+
+    # Find first hint message in remediations
+    r = _find_hint(reporting.create_report.reports[0])
+
+    # Check that Hint was in the report
+    assert r is not None
+
+    # Check that we informed user about all the deprecated options
+    assert 'avoid_temporal_upgrade' in r
+    assert '--old' in r
+    assert '--language' in r

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
@@ -64,7 +64,7 @@ def test_process_no_deprecated(monkeypatch):
     # Check that Hint was in the report
     assert r is not None
 
-    assert ('Following configuration options won\'t work on a new version'
+    assert ('Following incompatible configuration options'
             not in r)
 
 

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
@@ -1,11 +1,11 @@
 import pytest
 
 from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import checkmysql
 from leapp.libraries.common.testutils import create_report_mocked, logger_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import MySQLConfiguration, Report
-from leapp.exceptions import StopActorExecutionError
 
 
 def _find_hint(report: dict) -> str | None:

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
@@ -59,14 +59,6 @@ def test_process_no_deprecated(monkeypatch):
     # Check that we have made a report
     assert len(reporting.create_report.reports) == 1
 
-    r = _find_hint(reporting.create_report.reports[0])
-
-    # Check that Hint was in the report
-    assert r is not None
-
-    assert ('Following incompatible configuration options'
-            not in r)
-
 
 def test_process_deprecated(monkeypatch):
     def consume_mocked(*args, **kwargs):
@@ -80,10 +72,18 @@ def test_process_deprecated(monkeypatch):
     checkmysql.process()
 
     # Check that we have made a report
-    assert len(reporting.create_report.reports) == 1
+    assert len(reporting.create_report.reports) == 2
 
-    # Find first hint message in remediations
-    r = _find_hint(reporting.create_report.reports[0])
+    # Find deprecation report
+    found = None
+    for rep in reporting.create_report.reports:
+        if rep['title'] == 'Detected incompatible MySQL configuration':
+            found = rep
+            break
+
+    assert found is not None
+
+    r = found['summary']
 
     # Check that Hint was in the report
     assert r is not None

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
@@ -5,16 +5,7 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import checkmysql
 from leapp.libraries.common.testutils import create_report_mocked, logger_mocked
 from leapp.libraries.stdlib import api
-from leapp.models import MySQLConfiguration, Report
-
-
-def _find_hint(report: dict) -> str | None:
-    r = None
-    for remedy in report['detail']['remediations']:
-        if remedy['type'] == 'hint':
-            r = remedy['context']
-            break
-    return r
+from leapp.models import MySQLConfiguration
 
 
 def test_process_no_msg(monkeypatch):

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/actor.py
@@ -1,0 +1,30 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scanmysql
+from leapp.models import DistributionSignedRPM, MySQLConfiguration
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanMySQL(Actor):
+    """
+    Actor checking for presence of MySQL installation.
+
+    If MySQL server is found it will check whether current configuration is not
+    deprecated and produce all options and arguments that are in use and are
+    deprecated. These are removed in newer version of MySQL that is present in
+    RHEL10.
+
+    List of options:
+        https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html
+    List of arguments: (usable only as an argument for mysqld - systemd service)
+        https://dev.mysql.com/doc/refman/8.0/en/server-options.html
+    Complete documentation of changes in newer MySQL - including removed
+    options:
+        https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html
+    """
+    name = 'scan_mysql'
+    consumes = (DistributionSignedRPM,)
+    produces = (MySQLConfiguration,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self) -> None:
+        self.produce(scanmysql.check_status())

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/libraries/scanmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/libraries/scanmysql.py
@@ -36,7 +36,7 @@ def _check_incompatible_config() -> set[str]:
     """
     Get incompatible configuration options. Since MySQL can have basically
     unlimited number of config files that can link to one another, most
-    convenient way is running `mysqld` command with `--validate-config 
+    convenient way is running `mysqld` command with `--validate-config
     --log-error-verbosity=2` arguments. Validate config only validates the
     config, without starting the MySQL server. Verbosity=2 is required to show
     deprecated options - which are removed after upgrade.

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/libraries/scanmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/libraries/scanmysql.py
@@ -1,8 +1,9 @@
-from leapp.models import DistributionSignedRPM
+from typing import TYPE_CHECKING
+
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api, run
+from leapp.models import DistributionSignedRPM
 
-from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from repos.system_upgrade.el9toel10.models.mysql import MySQLConfiguration
 else:

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/libraries/scanmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/libraries/scanmysql.py
@@ -1,0 +1,104 @@
+from leapp.models import DistributionSignedRPM
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api, run
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from repos.system_upgrade.el9toel10.models.mysql import MySQLConfiguration
+else:
+    from leapp.models import MySQLConfiguration
+
+# https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html
+# https://dev.mysql.com/doc/refman/8.0/en/server-options.html
+# https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html
+REMOVED_ARGS = [
+    '--avoid-temporal-upgrade',
+    'avoid_temporal_upgrade',
+    '--show-old-temporals',
+    'show_old_temporals',
+    '--old',
+    '--new',
+    '--default-authentication-plugin',
+    'default_authentication_plugin',
+    '--no-dd-upgrade',
+    '--language',
+    '--ssl',
+    '--admin-ssl',
+    '--character-set-client-handshake',
+    '--old-style-user-limits',
+]
+
+SERVICE_OVERRIDE_PATH = '/etc/systemd/system/mysqld.service.d/override.conf'
+
+
+def _check_incompatible_config() -> set[str]:
+    """
+    Get incompatible configuration options. Since MySQL can have basically
+    unlimited number of config files that can link to one another, most
+    convenient way is running `mysqld` command with `--validate-config 
+    --log-error-verbosity=2` arguments. Validate config only validates the
+    config, without starting the MySQL server. Verbosity=2 is required to show
+    deprecated options - which are removed after upgrade.
+
+    Example output:
+    2024-12-18T11:40:04.725073Z 0 [Warning] [MY-011069] [Server]
+    The syntax '--old' is deprecated and will be removed in a future release.
+
+    Returns:
+        set[str]: Config options found that will be removed
+    """
+
+    found_options = set()
+    stderr = run(['mysqld', '--validate-config', '--log-error-verbosity=2'],
+                 checked=False)['stderr']
+
+    if 'deprecated' in stderr:
+        found_options = {arg for arg
+                         in REMOVED_ARGS
+                         if arg in stderr}
+    return found_options
+
+
+def _check_incompatible_launch_param() -> set[str]:
+    """
+    Get incompatible launch parameters from systemd service override file
+    located at /etc/systemd/system/mysqld.service.d/override.conf
+
+    Returns:
+        set[str]: Launch parameters found that will be removed
+    """
+
+    found_arguments = set()
+    try:
+        with open(SERVICE_OVERRIDE_PATH) as f:
+            file_content = f.read()
+            found_arguments = {arg for arg
+                               in REMOVED_ARGS
+                               if arg in file_content}
+    except OSError:
+        # File probably doesn't exist, ignore it and pass
+        pass
+
+    return found_arguments
+
+
+def check_status(_context=api) -> MySQLConfiguration:
+    """
+    Check whether MySQL is installed and if so whether config is compatible with
+    newer version.
+
+    Returns:
+        MySQLConfiguration: Current status of MySQL on the system
+    """
+
+    mysql_present = has_package(DistributionSignedRPM, 'mysql-server', context=_context)
+
+    found_options = []
+    found_arguments = []
+    if mysql_present:
+        found_options = list(_check_incompatible_config())
+        found_arguments = list(_check_incompatible_launch_param())
+
+    return MySQLConfiguration(mysql_present=mysql_present,
+                              removed_options=found_options,
+                              removed_arguments=found_arguments)

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/config_invalid.txt
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/config_invalid.txt
@@ -1,0 +1,19 @@
+#
+# This group are read by MySQL server.
+# Use it for options that only the server (but not clients) should see
+#
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/en/server-configuration-defaults.html
+
+# Settings user and group are ignored when systemd is used.
+# If you need to run mysqld under a different user or group,
+# customize your systemd unit file for mysqld according to the
+# instructions in http://fedoraproject.org/wiki/Systemd
+
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+log-error=/var/log/mysql/mysqld.log
+pid-file=/run/mysqld/mysqld.pid
+old=true
+avoid_temporal_upgrade=true

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/config_valid.txt
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/config_valid.txt
@@ -1,0 +1,17 @@
+#
+# This group are read by MySQL server.
+# Use it for options that only the server (but not clients) should see
+#
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/en/server-configuration-defaults.html
+
+# Settings user and group are ignored when systemd is used.
+# If you need to run mysqld under a different user or group,
+# customize your systemd unit file for mysqld according to the
+# instructions in http://fedoraproject.org/wiki/Systemd
+
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+log-error=/var/log/mysql/mysqld.log
+pid-file=/run/mysqld/mysqld.pid

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/service_invalid.txt
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/service_invalid.txt
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/libexec/mysqld --language=/usr/local/mysql/share/mysql/english/ --basedir=/usr

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/sterr_invalid.txt
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/sterr_invalid.txt
@@ -1,0 +1,2 @@
+2025-01-23T15:28:05.352420Z 0 [Warning] [MY-011069] [Server] The syntax '--old' is deprecated and will be removed in a future release.
+2025-01-23T15:28:05.352425Z 0 [Warning] [MY-011069] [Server] The syntax 'avoid_temporal_upgrade' is deprecated and will be removed in a future release.

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/test_mysqlcheck.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/test_mysqlcheck.py
@@ -1,5 +1,6 @@
-import pytest
+from typing import TYPE_CHECKING
 import os
+import pytest
 
 from leapp import reporting
 from leapp.libraries.common.testutils import produce_mocked, CurrentActorMocked
@@ -7,7 +8,6 @@ from leapp.libraries.stdlib import api
 from leapp.libraries import stdlib
 from leapp.models import DistributionSignedRPM, RPM
 
-from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from repos.system_upgrade.el9toel10.models.mysql import MySQLConfiguration
     from repos.system_upgrade.el9toel10.actors.mysql.scanmysql.libraries import scanmysql

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/test_mysqlcheck.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/test_mysqlcheck.py
@@ -1,19 +1,18 @@
-from typing import TYPE_CHECKING
 import os
+from typing import TYPE_CHECKING
+
 import pytest
 
-from leapp import reporting
-from leapp.libraries.common.testutils import produce_mocked, CurrentActorMocked
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
 from leapp.libraries.stdlib import api
-from leapp.libraries import stdlib
 from leapp.models import DistributionSignedRPM, RPM
 
 if TYPE_CHECKING:
-    from repos.system_upgrade.el9toel10.models.mysql import MySQLConfiguration
     from repos.system_upgrade.el9toel10.actors.mysql.scanmysql.libraries import scanmysql
+    from repos.system_upgrade.el9toel10.models.mysql import MySQLConfiguration
 else:
-    from leapp.models import MySQLConfiguration
     from leapp.libraries.actor import scanmysql
+    from leapp.models import MySQLConfiguration
 
 
 def _generate_rpm_with_name(name):

--- a/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/test_mysqlcheck.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/scanmysql/tests/test_mysqlcheck.py
@@ -1,0 +1,130 @@
+import pytest
+import os
+
+from leapp import reporting
+from leapp.libraries.common.testutils import produce_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.libraries import stdlib
+from leapp.models import DistributionSignedRPM, RPM
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from repos.system_upgrade.el9toel10.models.mysql import MySQLConfiguration
+    from repos.system_upgrade.el9toel10.actors.mysql.scanmysql.libraries import scanmysql
+else:
+    from leapp.models import MySQLConfiguration
+    from leapp.libraries.actor import scanmysql
+
+
+def _generate_rpm_with_name(name):
+    """
+    Generate new RPM model item with given name.
+
+    Parameters:
+        name (str): rpm name
+
+    Returns:
+        rpm  (RPM): new RPM object with name parameter set
+    """
+    return RPM(name=name,
+               version='0.1',
+               release='1.sm01',
+               epoch='1',
+               pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51',
+               packager='Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>',
+               arch='noarch')
+
+
+def _run_mocked_valid(args=None, split=None, callback_raw=None,
+                      callback_linebuffered=None, env=None, checked=None,
+                      stdin=None, encoding=None):
+    return {'stderr': ''}
+
+
+def _run_mocked_invalid(args=None, split=None, callback_raw=None,
+                        callback_linebuffered=None, env=None, checked=None,
+                        stdin=None, encoding=None):
+    return {'stderr':  '2025-01-23T15:28:05.352420Z 0 [Warning] [MY-011069] [Server] The \
+                        syntax \'--old\' is deprecated and will be removed in a future release.\n \
+                        2025-01-23T15:28:05.352425Z 0 [Warning] [MY-011069] [Server] The \
+                        syntax \'avoid_temporal_upgrade\' is deprecated and will be removed \
+                        in a future release.'}
+
+
+@pytest.mark.parametrize('has_server', [
+    (True),  # with server
+    (False),  # without server
+])
+def test_server_detection(monkeypatch, has_server):
+    """
+    Parametrized helper function for test_actor_* functions.
+
+    First generate list of RPM models based on set arguments. Then, run
+    the actor fed with our RPM list. Finally, assert Reports
+    according to set arguments.
+
+    Parameters:
+        has_server  (bool): mysql-server installed
+    """
+
+    # Couple of random packages
+    rpms = [_generate_rpm_with_name('sed'),
+            _generate_rpm_with_name('htop')]
+
+    if has_server:
+        # Add mysql-server
+        rpms += [_generate_rpm_with_name('mysql-server')]
+
+    curr_actor_mocked = CurrentActorMocked(msgs=[DistributionSignedRPM(items=rpms)])
+    monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
+    monkeypatch.setattr(api, 'produce', produce_mocked)
+    monkeypatch.setattr(scanmysql, 'run', _run_mocked_valid)
+
+    result: MySQLConfiguration = scanmysql.check_status()
+
+    assert result.mysql_present == has_server
+
+
+@pytest.mark.parametrize('valid_conf', [True, False])
+@pytest.mark.parametrize('valid_args', [True, False])
+def test_configuration_check(monkeypatch, valid_conf, valid_args):
+    """
+    Parametrized helper function for test_actor_* functions.
+
+    First generate list of RPM models based on set arguments. Then, run
+    the actor fed with our RPM list. Finally, assert Reports
+    according to set arguments.
+
+    Parameters:
+        has_server  (bool): mysql-server installed
+    """
+
+    # Couple of random packages
+    rpms = [_generate_rpm_with_name('sed'),
+            _generate_rpm_with_name('htop'),
+            _generate_rpm_with_name('mysql-server')]
+
+    curr_actor_mocked = CurrentActorMocked(msgs=[DistributionSignedRPM(items=rpms)])
+    monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
+    monkeypatch.setattr(api, 'produce', produce_mocked)
+
+    if valid_conf:
+        monkeypatch.setattr(scanmysql, 'run', _run_mocked_valid)
+    else:
+        monkeypatch.setattr(scanmysql, 'run', _run_mocked_invalid)
+
+    if not valid_args:
+        monkeypatch.setattr(scanmysql, 'SERVICE_OVERRIDE_PATH',
+                            os.path.dirname(os.path.realpath(__file__))+'/service_invalid.txt')
+
+    result: MySQLConfiguration = scanmysql.check_status()
+
+    if valid_conf:
+        assert len(result.removed_options) == 0
+    else:
+        assert len(result.removed_options) == 2
+
+    if valid_args:
+        assert len(result.removed_arguments) == 0
+    else:
+        assert len(result.removed_arguments) == 1

--- a/repos/system_upgrade/el9toel10/models/mysql.py
+++ b/repos/system_upgrade/el9toel10/models/mysql.py
@@ -1,0 +1,17 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class MySQLConfiguration(Model):
+    """
+    Model describing current state of MySQL server including configuration compatibility
+    """
+
+    topic = SystemInfoTopic
+
+    # True in case mysql-server package was found on the system
+    mysql_present = fields.Boolean(default=False)
+
+    # Configured options which are removed in RHEL 10 MySQL
+    removed_options = fields.List(fields.String(), default=[])
+    removed_arguments = fields.List(fields.String(), default=[])


### PR DESCRIPTION
RHEL 9 and RHEL 10 have different MySQL versions and user should be
informed about differences and required steps to migrate their data
and configuration safely. In case of MySQL configuration, number of
deprecated options have been removed in MySQL on RHEL 10 which would
prevent run of the mysql server if present. In such a case users
need to drop all deprecated options. Also the mysqld service could
be executed with deprecated arguments which are no longer valid
on RHEL 10, so possible customized service should be detected also.

jira: RHEL-62689