### PR TITLE
pytest: update conftest to load leapp.snactor.fixture explicitly

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ from leapp.repository.manager import RepositoryManager
 from leapp.repository.scan import find_and_scan_repositories
 from leapp.utils.repository import find_repository_basedir, get_repository_id
 
+pytest_plugins = ('leapp.snactor.fixture',)
 logger = logging.getLogger(__name__)
 logging.getLogger("asyncio").setLevel(logging.INFO)
 logging.getLogger("parso").setLevel(logging.INFO)


### PR DESCRIPTION
The snactor plugin has been originally specified between entrypoints in the leapp python package. However, this has been breaking pytest on systems where snactor has not been installed (as pytest as very interesting design...). So the pytest plugin hook had to be removed. As it has no other value than for running unit-tests using pytest, let's just specify it in the conftest.py file explicitly for running the tests as it should actually be all the time.