### PR TITLE
# Release 0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-**Before doing anything, please read
-[Leapp framework documentation](https://leapp.readthedocs.io/).**
+**Before doing anything, please read the upstream [documentation](https://leapp-repository.readthedocs.io/).**
+
+Also, you could find useufl to read [Leapp framework documentation](https://leapp.readthedocs.io/).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,0 @@
-# Leapp repository documentation
-
-The Leapp repository documentation has been moved to [Read the Docs](https://leapp.readthedocs.io/).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,9 +9,9 @@
 import sphinx_rtd_theme
 
 project = 'leapp-repository'
-copyright = '2024, Leapp team'
+copyright = '2025, Leapp team'
 author = 'Leapp team'
-release = '0.21.0'
+release = '0.22.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/libraries-and-api/deprecations-list.md
+++ b/docs/source/libraries-and-api/deprecations-list.md
@@ -12,7 +12,11 @@ framework, see {ref}`deprecation:list of the deprecated functionality in leapp`.
 
 Only the versions in which a deprecation has been made are listed.
 
-## v0.20.0 <span style="font-size:0.5em; font-weight:normal">(till TODO date)</span>
+## Next release <span style="font-size:0.5em; font-weight:normal">(till TODO date)</span>
+
+- No new deprecation yet
+
+## v0.20.0 <span style="font-size:0.5em; font-weight:normal">(till September 2024)</span>
 - Models
   - **`InstalledRedHatSignedRPM`** - Replaced by the distribution agnostic `DistributionSignedRPM`.
 

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -51,7 +51,7 @@ py2_byte_compile "%1" "%2"}
 # RHEL 8+ packages to be consistent with other leapp projects in future.
 
 Name:           leapp-repository
-Version:        0.21.0
+Version:        0.22.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 


### PR DESCRIPTION
## Announce
This is the last upstream release covering IPU 7 -> 8. The system_upgrade_el7toel8 repository is going to be removed from further releases. Other artifacts related to IPU 7 -> 8 are going to be removed too.

In the same time it's the last release compatible with Python 2.7. Since now we are going to develope and test the code only for Python 3.6 and newer.

## Packaging
- [IPU 9 -> 10] Require libdb-utils on RHEL 9 (#1289)
- Require leapp-framework 6.0+ (#1142)
- Update leapp-deps package to satisfy leapp_framework_deps 6 (#1142)

## Upgrade handling
### Fixes
- Activate LVM VGs with `--sysinit` option to correct the use in the upgrade initramfs (#1329)
- Cap max size of the sparse files to 1TiB when storage with large amount of space (#1294)
- Fix IPU being blocked by resource limitations (#1256)
- Fix pes events scanner crashing when there are duplicate packages in the received instructions (#1296)
- Fix pes events scanner not respecting user’s transaction configuration (#1296)
- Fix storage scanner crashing when command outputs contain colon character (#1258)
- Fix the report when handling broken parsing of kernel cmdline (#1290)
- Generate proper error message instead ModelViolationError when parsing invalid repository definition (#1266)
- Handle default kernel cmdline when multiple boot entries for the default kernel are defined (#1302)
- Load all available obsoleted keys (#1286)
- Prevent a possible crash with LiveMode when adding the upgrade boot entry on LVM systems (#1313)
- Prevent failure for upgrade paths when obsoleted keys are not defined (#1285)
- [IPU 7 -> 8] Ignore invalid firewalld configuration (#1341)
- [IPU 7 -> 8] scangrubdevpartitionlayout: Skip warning msgs from fdisk (#1306)
- [IPU 8 -> 9] Fix problems with the bootloader when upgrading to RHEL 9.6 on ARM (#1275, #1331, #1339)
- [IPU 9 -> 10] Fix output of commands executed inside systemd-nspawn containers (#1323)
- [IPU 9 -> 10] Fix remediation instructions for deprecated NM configuration (#1330)
- [IPU 9 -> 10] Obsolete RHEL9 GPG key signed with SHA1 (#1325)

### Enhancements
- Add RHEL 9.6 and 10.0 product certificates (#1287, #1309)
- Introduce new IPU paths 8.10 -> 9.6 and 9.6 -> 10.0 (#1309)
- Add possibility to use net.naming-scheme (for IPU 8 -> 9 only for now) (#1215, #1312)
- Drop upgrade paths related to RHEL 8.8, 9.2, and 9.5 (#1309, #1344)
- Enable upgrade for EL8+ systems with LUKS bound to Clevis with TPM 2.0 token (#1200)
- Enable upgrade with RHUI on Alibaba cloud for ARM machines (#1277)
- Introduce a possibility to configure leapp actors covering RHUI on clouds (#1142)
- Minor improvements in preupgrade reports (#1315, #1326, #1342)
- Raise an inhibitor if unsupported target version supplied instead of error (#1328)
- Skip checking of (PKI) `directory-hash` dir to speedup the upgrade process and clean logs (#1297)
- Update leapp upgrade data files (#1307, #1349)
- [IPU 9 -> 10] Cover upgrades for MySQL and PostgreSQL databases (#1316, #1343)
- [IPU 9 -> 10] Detect OpenSSL engines configured in /etc/pki/tls/openssl.cnf (#1338)
- [IPU 9 -> 10] Detect XFS file systems with problematic parameters (#1318)
- [IPU 9 -> 10] Detect deprecated network-scripts (ifcfg) files (#1332, #1347)
- [IPU 9 -> 10] Detect whether subscribed systems are using SCA (#1333)
- [IPU 9 -> 10] Handle correctly switch of symlink to directory when upgrading Ruby IRB (#1304)
- [IPU 9 -> 10] Inform user about Libdb removal if present (#1319)
- [IPU 9 -> 10] Inhibit the upgrade for Intel CPUs with microarchitecture x86_64-v2 (#1196)
- [IPU 9 -> 10] Move crypto-policies related actors to the system_upgrade_common repository to apply it for IPU 9 -> 10 as well
- [IPU 9 -> 10] Update checks for SAP HANA (#1346)
- [IPU 9 -> 10] Update pam_userdb database backend for RHEL10 (#1289)

## Additional changes interesting for devels
- Introducing new upstream documentation focused on the leapp-repository project at https://leapp-repository.readthedocs.io/introduce-docs/. The documentation is still under reconstruction at this time, however we consider it a big step. All PRs impacting stuff that should be documented will be required to do so before they could be merged.