### PR TITLE
Livemode: various improvements to make the feature more accessible to users

### DIFF
--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -14,6 +14,10 @@ from leapp.utils.output import beautify_actor_exception, report_errors, report_i
 
 @command('preupgrade', help='Generate preupgrade report')
 @command_opt('whitelist-experimental', action='append', metavar='ActorName', help='Enables experimental actors')
+@command_opt('enable-experimental-feature', action='append', metavar='Feature',
+             help=('Enable experimental feature. '
+                   'Available experimental features: {}').format(util.get_help_str_with_avail_experimental_features()),
+             choices=list(util.EXPERIMENTAL_FEATURES), default=[])
 @command_opt('debug', is_flag=True, help='Enable debug mode', inherit=False)
 @command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
 @command_opt('no-rhsm', is_flag=True, help='Use only custom repositories and skip actions'

--- a/commands/rerun/__init__.py
+++ b/commands/rerun/__init__.py
@@ -71,6 +71,7 @@ def rerun(args):
         nogpgcheck=False,
         channel=None,
         report_schema='1.1.0',
+        enable_experimental_feature=[],
         whitelist_experimental=[],
         enablerepo=[]))
 

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -20,6 +20,10 @@ from leapp.utils.output import beautify_actor_exception, report_errors, report_i
 @command_opt('resume', is_flag=True, help='Continue the last execution after it was stopped (e.g. after reboot)')
 @command_opt('reboot', is_flag=True, help='Automatically performs reboot when requested.')
 @command_opt('whitelist-experimental', action='append', metavar='ActorName', help='Enable experimental actors')
+@command_opt('enable-experimental-feature', action='append', metavar='Feature',
+             help=('Enable experimental feature. '
+                   'Available experimental features: {}').format(util.get_help_str_with_avail_experimental_features()),
+             choices=list(util.EXPERIMENTAL_FEATURES), default=[])
 @command_opt('debug', is_flag=True, help='Enable debug mode', inherit=False)
 @command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
 @command_opt('no-rhsm', is_flag=True, help='Use only custom repositories and skip actions'

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -16,7 +16,6 @@ from leapp.utils.audit import get_checkpoints, get_connection, get_messages
 from leapp.utils.output import report_unsupported
 from leapp.utils.report import fetch_upgrade_report_messages, generate_report_file
 
-
 EXPERIMENTAL_FEATURES = {
     'livemode': [
         'live_image_generator',

--- a/docs/source/configuring-ipu.md
+++ b/docs/source/configuring-ipu.md
@@ -52,9 +52,6 @@ The alternative to the --channel leapp option. As a parameter accepts a channel 
 To use development variables, the LEAPP_UNSUPPORTED variable has to be set.
 ```
 
-#### LEAPP_DEVEL_ENABLE_LIVE_MODE
-If set to `1`, enable the use of the experimental live mode
-
 #### LEAPP_DEVEL_DM_DISABLE_UDEV
 Setting the environment variable provides a more convenient way of disabling udev support in libdevmapper, dmsetup and LVM2 tools globally without a need to modify any existing configuration settings. This is mostly useful if the system environment does not use udev.
 

--- a/etc/leapp/files/devel-livemode.ini
+++ b/etc/leapp/files/devel-livemode.ini
@@ -1,9 +1,0 @@
-# Configuration for the *experimental* livemode feature
-# It is likely that this entire configuration file will be replaced by some
-# other mechanism/file in the future. For the full list of configuration options,
-# see models/livemode.py
-[livemode]
-squashfs_fullpath=/var/lib/leapp/live-upgrade.img
-setup_network_manager=no
-autostart_upgrade_after_reboot=yes
-setup_passwordless_root=no

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -120,7 +120,7 @@ Requires:       leapp-repository-dependencies = %{leapp_repo_deps}
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' instead of the real framework rpm version.
-Requires:       leapp-framework >= 6.0, leapp-framework < 7
+Requires:       leapp-framework >= 6.1, leapp-framework < 7
 
 # Since we provide sub-commands for the leapp utility, we expect the leapp
 # tool to be installed as well.

--- a/repos/system_upgrade/common/actors/livemode/liveimagegenerator/tests/test_image_generation.py
+++ b/repos/system_upgrade/common/actors/livemode/liveimagegenerator/tests/test_image_generation.py
@@ -78,10 +78,12 @@ def test_generate_live_image_if_enabled(monkeypatch, livemode_config, should_pro
         def __exit__(self, *args, **kwargs):
             pass
 
+    def build_squashfs_image_mock(livemode_config, userspace_info, *args, **kwargs):
+        return '/squashfs'
+
     monkeypatch.setattr(mounting, 'NspawnActions', NspawnMock)
     monkeypatch.setattr(live_image_generator_lib, 'lighten_target_userpace', lambda context: None)
-    monkeypatch.setattr(live_image_generator_lib, 'build_squashfs',
-                        lambda livemode_config, userspace_info: '/squashfs')
+    monkeypatch.setattr(live_image_generator_lib, 'build_squashfs', build_squashfs_image_mock)
     monkeypatch.setattr(api, 'produce', produce_mocked())
 
     live_image_generator_lib.generate_live_image_if_enabled()

--- a/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/actor.py
+++ b/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/actor.py
@@ -1,4 +1,5 @@
 from leapp.actors import Actor
+from leapp.configs.actor import livemode as livemode_config_lib
 from leapp.libraries.actor import scan_livemode_config as scan_livemode_config_lib
 from leapp.models import InstalledRPM, LiveModeConfig
 from leapp.tags import ExperimentalTag, FactsPhaseTag, IPUWorkflowTag
@@ -10,6 +11,7 @@ class LiveModeConfigScanner(Actor):
     """
 
     name = 'live_mode_config_scanner'
+    config_schemas = livemode_config_lib.livemode_cfg_fields
     consumes = (InstalledRPM,)
     produces = (LiveModeConfig,)
     tags = (ExperimentalTag, FactsPhaseTag, IPUWorkflowTag,)

--- a/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/configs/livemode.py
+++ b/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/configs/livemode.py
@@ -1,0 +1,127 @@
+"""
+Configuration keys for the 'livemode' feature.
+"""
+
+from leapp.actors.config import Config
+from leapp.models import fields
+
+LIVEMODE_CONFIG_SECTION = 'livemode'
+
+
+class SquashfsImagePath(Config):
+    section = LIVEMODE_CONFIG_SECTION
+    name = "squashfs_image_path"
+    type_ = fields.String()
+    default = '/var/lib/leapp/live-upgrade.img'
+    description = """
+        Location where the squashfs image of the minimal target system will be placed.
+    """
+
+
+class AdditionalPackages(Config):
+    section = LIVEMODE_CONFIG_SECTION
+    name = "additional_packages"
+    type_ = fields.List(fields.String())
+    default = []
+    description = """
+        Additional packages to be installed into the squashfs image.
+
+        Can be used to install various debugging utilities when connecting to the upgrade environment.
+    """
+
+
+class AutostartUpgradeAfterReboot(Config):
+    section = LIVEMODE_CONFIG_SECTION
+    name = "autostart_upgrade_after_reboot"
+    type_ = fields.Boolean()
+    default = True
+    description = """
+        If set to True, the upgrade will start automatically after the reboot. Otherwise a manual trigger is required.
+    """
+
+
+class SetupNetworkManager(Config):
+    section = LIVEMODE_CONFIG_SECTION
+    name = "setup_network_manager"
+    type_ = fields.Boolean()
+    default = False
+    description = """
+        Try enabling Network Manager in the squashfs image.
+
+        If set to True, leapp will copy source system's Network Manager profiles into the squashfs image and
+        enable the Network Manager service.
+    """
+
+
+class DracutNetwork(Config):
+    section = LIVEMODE_CONFIG_SECTION
+    name = "dracut_network"
+    type_ = fields.String()
+    default = ''
+    description = """
+        Dracut network arguments, required if the `url_to_load_squashfs_from` option is set.
+
+        Example:
+            ip=192.168.122.146::192.168.122.1:255.255.255.0:foo::none
+    """
+
+
+class URLToLoadSquashfsImageFrom(Config):
+    section = LIVEMODE_CONFIG_SECTION
+    name = "url_to_load_squashfs_image_from"
+    type_ = fields.String()
+    default = ''
+    description = """
+        Url pointing to the squashfs image that should be used for the upgrade environment.
+
+        Example:
+            http://192.168.122.1/live-upgrade.img
+    """
+
+
+class SetupPasswordlessRoot(Config):
+    section = LIVEMODE_CONFIG_SECTION
+    name = "setup_passwordless_root"
+    type_ = fields.Boolean()
+    default = False
+    description = """
+        If set to True, the root account of the squashfs image will have empty password. Use with caution.
+    """
+
+
+class SetupOpenSSHDUsingAuthKeys(Config):
+    section = LIVEMODE_CONFIG_SECTION
+    name = "setup_opensshd_using_auth_keys"
+    type_ = fields.String()
+    default = ''
+    description = """
+        If set to a non-empty string, openssh daemon will be setup within the squashfs image using the provided
+        authorized keys.
+
+        Example:
+            /root/.ssh/authorized_keys
+    """
+
+
+class CaptureSTraceInfoInto(Config):
+    section = LIVEMODE_CONFIG_SECTION
+    name = "capture_strace_info_into"
+    type_ = fields.String()
+    default = ''
+    description = """
+        If set to a non-empty string, leapp will be executed under strace and results will be stored within
+        the provided file path.
+    """
+
+
+livemode_cfg_fields = (
+    AdditionalPackages,
+    AutostartUpgradeAfterReboot,
+    CaptureSTraceInfoInto,
+    DracutNetwork,
+    SetupNetworkManager,
+    SetupOpenSSHDUsingAuthKeys,
+    SetupPasswordlessRoot,
+    SquashfsImagePath,
+    URLToLoadSquashfsImageFrom,
+)

--- a/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/libraries/scan_livemode_config.py
+++ b/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/libraries/scan_livemode_config.py
@@ -11,14 +11,9 @@ DEFAULT_SQUASHFS_PATH = '/var/lib/leapp/live-upgrade.img'
 
 def should_scan_config():
     is_unsupported = get_env('LEAPP_UNSUPPORTED', '0') == '1'
-    is_livemode_enabled = get_env('LEAPP_DEVEL_ENABLE_LIVE_MODE', '0') == '1'
 
     if not is_unsupported:
         api.current_logger().debug('Will not scan livemode config - the upgrade is not unsupported.')
-        return False
-
-    if not is_livemode_enabled:
-        api.current_logger().debug('Will not scan livemode config - the live mode is not enabled.')
         return False
 
     if not architecture.matches_architecture(architecture.ARCH_X86_64):

--- a/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/libraries/scan_livemode_config.py
+++ b/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/libraries/scan_livemode_config.py
@@ -1,14 +1,9 @@
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
-
+from leapp.configs.actor import livemode as livemode_config_lib
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.config import architecture, get_env
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import InstalledRPM, LiveModeConfig
-from leapp.models.fields import ModelViolationError
 
 LIVEMODE_CONFIG_LOCATION = '/etc/leapp/files/devel-livemode.ini'
 DEFAULT_SQUASHFS_PATH = '/var/lib/leapp/live-upgrade.img'
@@ -50,76 +45,32 @@ def scan_config_and_emit_message():
         return
 
     api.current_logger().info('Loading livemode config from %s', LIVEMODE_CONFIG_LOCATION)
-    parser = configparser.ConfigParser()
 
-    try:
-        parser.read((LIVEMODE_CONFIG_LOCATION, ))
-    except configparser.ParsingError as error:
-        api.current_logger().error('Failed to parse live mode configuration due to the following error: %s', error)
+    config = api.current_actor().config[livemode_config_lib.LIVEMODE_CONFIG_SECTION]
 
-        details = 'Failed to read livemode configuration due to the following error: {0}.'
-        raise StopActorExecutionError(
-            'Failed to read livemode configuration',
-            details={'Problem': details.format(error)}
-        )
-
-    livemode_section = 'livemode'
-    if not parser.has_section(livemode_section):
-        details = 'The configuration is missing the \'[{0}]\' section'.format(livemode_section)
-        raise StopActorExecutionError(
-            'Live mode configuration does not have the required structure',
-            details={'Problem': details}
-        )
-
-    config_kwargs = {
-        'is_enabled': True,
-        'url_to_load_squashfs_from': None,
-        'squashfs_fullpath': DEFAULT_SQUASHFS_PATH,
-        'dracut_network': None,
-        'setup_network_manager': False,
-        'additional_packages': [],
-        'autostart_upgrade_after_reboot': True,
-        'setup_opensshd_with_auth_keys': None,
-        'setup_passwordless_root': False,
-        'capture_upgrade_strace_into': None
+    # Mapping from model field names to configuration fields - because we might have
+    # changed some configuration field names for configuration to be more
+    # comprehensible for our users.
+    model_fields_to_config_options_map = {
+        'url_to_load_squashfs_from': livemode_config_lib.URLToLoadSquashfsImageFrom,
+        'squashfs_fullpath': livemode_config_lib.SquashfsImagePath,
+        'dracut_network': livemode_config_lib.DracutNetwork,
+        'setup_network_manager': livemode_config_lib.SetupNetworkManager,
+        'additional_packages': livemode_config_lib.AdditionalPackages,
+        'autostart_upgrade_after_reboot': livemode_config_lib.AutostartUpgradeAfterReboot,
+        'setup_opensshd_with_auth_keys': livemode_config_lib.SetupOpenSSHDUsingAuthKeys,
+        'setup_passwordless_root': livemode_config_lib.SetupPasswordlessRoot,
+        'capture_upgrade_strace_into': livemode_config_lib.CaptureSTraceInfoInto
     }
 
-    config_str_options = (
-        'url_to_load_squashfs_from',
-        'squashfs_fullpath',
-        'dracut_network',
-        'setup_opensshd_with_auth_keys',
-        'capture_upgrade_strace_into'
-    )
+    # Read values of model fields from user-supplied configuration according to the above mapping
+    config_msg_init_kwargs = {}
+    for model_field_name, config_field in model_fields_to_config_options_map.items():
+        config_msg_init_kwargs[model_field_name] = config[config_field.name]
 
-    config_list_options = (
-        'additional_packages',
-    )
+    # Some fields of the LiveModeConfig are historical and can no longer be changed by the user
+    # in the config. Therefore, we just hard-code them here.
+    config_msg_init_kwargs['is_enabled'] = True
 
-    config_bool_options = (
-        'setup_network_manager',
-        'setup_passwordless_root',
-        'autostart_upgrade_after_reboot',
-    )
-
-    for config_option in config_str_options:
-        if parser.has_option(livemode_section, config_option):
-            config_kwargs[config_option] = parser.get(livemode_section, config_option)
-
-    for config_option in config_bool_options:
-        if parser.has_option(livemode_section, config_option):
-            config_kwargs[config_option] = parser.getboolean(livemode_section, config_option)
-
-    for config_option in config_list_options:
-        if parser.has_option(livemode_section, config_option):
-            option_val = parser.get(livemode_section, config_option)
-            option_list = (opt_val.strip() for opt_val in option_val.split(','))
-            option_list = [opt for opt in option_list if opt]
-            config_kwargs[config_option] = option_list
-
-    try:
-        config = LiveModeConfig(**config_kwargs)
-    except ModelViolationError as error:
-        raise StopActorExecutionError('Failed to parse livemode configuration.', details={'Problem': str(error)})
-
-    api.produce(config)
+    config_msg = LiveModeConfig(**config_msg_init_kwargs)
+    api.produce(config_msg)

--- a/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/tests/test_config_scanner.py
+++ b/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/tests/test_config_scanner.py
@@ -29,19 +29,16 @@ EnablementTestCase = namedtuple('EnablementTestCase', ('env_vars', 'arch', 'pkgs
 @pytest.mark.parametrize(
     'case_descr',
     (
-        EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '1', 'LEAPP_DEVEL_ENABLE_LIVE_MODE': '1'},
+        EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '1'},
                            arch=architecture.ARCH_X86_64, pkgs=('squashfs-tools', ),
                            result=EnablementResult.SCAN_CONFIG),
-        EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '0', 'LEAPP_DEVEL_ENABLE_LIVE_MODE': '1'},
+        EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '0'},
                            arch=architecture.ARCH_X86_64, pkgs=('squashfs-tools', ),
                            result=EnablementResult.DO_NOTHING),
-        EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '1', 'LEAPP_DEVEL_ENABLE_LIVE_MODE': '0'},
-                           arch=architecture.ARCH_X86_64, pkgs=('squashfs-tools', ),
-                           result=EnablementResult.DO_NOTHING),
-        EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '1', 'LEAPP_DEVEL_ENABLE_LIVE_MODE': '1'},
+        EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '1'},
                            arch=architecture.ARCH_ARM64, pkgs=('squashfs-tools', ),
                            result=EnablementResult.RAISE),
-        EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '1', 'LEAPP_DEVEL_ENABLE_LIVE_MODE': '1'},
+        EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '1'},
                            arch=architecture.ARCH_ARM64, pkgs=tuple(),
                            result=EnablementResult.RAISE),
     )
@@ -52,7 +49,6 @@ def test_enablement_conditions(monkeypatch, case_descr):
 
     Enablement conditions:
     - LEAPP_UNSUPPORTED=1
-    - LEAPP_DEVEL_ENABLE_LIVE_MODE=1
 
     Not meeting enablement conditions should prevent config message from being produced.
 


### PR DESCRIPTION
## Livemode improvements
This is a first part of the work necessary to make the  `livemode` feature more accessible, hoping to make it the default -in the future. There are multiple quality-of-live implemented as part of this PR (kept as separate commits):
- CLI: introduce `--enable-experimental-feature` that allows users to simply enable entire group of actors
- exclude DNF cache from squashfs to reduce the size of the created image. The DNF cache that contains packages to be installed during the upgrade is always read from `/sysroot/var/lib/leapp`, and therefore, it would not be read from squashfs'ed `/var/lib/leapp`
- configuration: use configuration capabilities provided by the framework instead of ad-hoc INI file
- bugfix: do not crash with an unhandled exception when trying to enable a systemd service inside the squashfs image that already appears to be enabled

## Why are we introducing a new command line option `--enable-experimental-feature`?
1) `--whitelist-experimental` is a quite bad user experience. Why should a user know actor names? The user is more interested in functionality, not in leapp-repository's internals.
2) Some features like `livemode` use a bunch of actors to facilitate the feature, therefore, the user would need to list all of these actors explicitly and he/she better not forget any of them.

Why don't we just use a single experimental actor that produces a message which will "enable" (if the message is received) all of the remaining actors? The problem is that anyone can produce such a message. We could write the remaining experimental actors such that they check for a combination of receiving a special message + checking that `LEAPP_EXPERIMENTAL` is set, but this solution is cumbersome and far from perfect (user can enable a different experimental actor, and, unintentionally enable livemode if some actor is producing the special message). Finally, there is no way for actors to check whether a specific experimental actor has been enabled, if I am not wrong -- `LEAPP_EXPERIMENTAL` is binary information (yes/no). 

## Example of livemode configuration
```
livemode:
  additional_packages : [ vim ]
  autostart_upgrade_after_reboot : false
  setup_network_manager : true
  setup_passwordless_root : true
  setup_opensshd_using_auth_keys : /root/.ssh/authorized_keys
```

jira-ref: RHELMISC-10648