### PR TITLE
selinux: do not run "semodule" when no modules are selected

### DIFF
--- a/repos/system_upgrade/common/actors/selinux/selinuxapplycustom/actor.py
+++ b/repos/system_upgrade/common/actors/selinux/selinuxapplycustom/actor.py
@@ -92,6 +92,10 @@ class SELinuxApplyCustom(Actor):
 
                 command.extend(['-X', str(module.priority), '-i', cil_filename])
 
+            if command == ['semodule']:
+                # no modules selected for installation
+                continue
+
             try:
                 run(command)
             except CalledProcessError as e:


### PR DESCRIPTION
Fixes:
2025-03-04 11:21:31.550 DEBUG    PID: 679 leapp.workflow.Applications.selinuxapplycustom: External command has finished: ['semodule', '-lfull']
2025-03-04 11:21:31.551 INFO     PID: 679 leapp.workflow.Applications.selinuxapplycustom: Processing custom SELinux policy modules. Count: 1.
2025-03-04 11:21:31.551 INFO     PID: 679 leapp.workflow.Applications.selinuxapplycustom: Skipping module permissive_rhcd_t on priority 400 because it is already installed.
2025-03-04 11:21:31.551 DEBUG    PID: 679 leapp.workflow.Applications.selinuxapplycustom: External command has started: ['semodule']
2025-03-04 11:21:31.555 DEBUG    PID: 679 leapp.workflow.Applications.selinuxapplycustom: At least one mode must be specified.
2025-03-04 11:21:31.555 DEBUG    PID: 679 leapp.workflow.Applications.selinuxapplycustom: usage:  semodule [option]... MODE...
2025-03-04 11:21:31.555 DEBUG    PID: 679 leapp.workflow.Applications.selinuxapplycustom: Manage SELinux policy modules.
2025-03-04 11:21:31.556 DEBUG    PID: 679 leapp.workflow.Applications.selinuxapplycustom: MODES:
2025-03-04 11:21:31.556 DEBUG    PID: 679 leapp.workflow.Applications.selinuxapplycustom:   -R, --reload                    reload policy
...
2025-03-04 11:21:31.564 WARNING  PID: 679 leapp.workflow.Applications.selinuxapplycustom: Error installing modules in a single transaction:At least one mode must be specified.