### PR TITLE
Add handling of shorten PCI ID and lowercases

### DIFF
--- a/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/libraries/deviceanddriverdeprecationdataload.py
+++ b/repos/system_upgrade/common/actors/loaddevicedriverdeprecationdata/libraries/deviceanddriverdeprecationdataload.py
@@ -25,6 +25,15 @@ def process():
                                              docs_url='',
                                              docs_title='')
 
+    # Unify all device ids to lowercase
+    try:
+        for entry in deprecation_data['data']:
+            if "device_id" in entry.keys():
+                entry["device_id"] = entry.get("device_id").lower()
+    except (KeyError, AttributeError, TypeError):
+        # this may happen if receiving invalid data
+        pass
+
     try:
         api.produce(
             DeviceDriverDeprecationData(


### PR DESCRIPTION
HW data file is inconsistent and sometimes contains both upper/lower cases so this patch is unifying it. Also PCI ID can be passed as full ID: Vendor:Device:SVendor:SDevice, but also in shorten version: Vendor:Device. This patch introduce handling of both cases.

JIRA: RHEL-72544