### PR TITLE
repomap: Process repositories based on distro

### DIFF
--- a/etc/leapp/files/device_driver_deprecation_data.json
+++ b/etc/leapp/files/device_driver_deprecation_data.json
@@ -1,6 +1,6 @@
 {
   "provided_data_streams": [
-    "3.3"
+    "4.0"
   ],
   "data": [
     {

--- a/etc/leapp/files/repomap.json
+++ b/etc/leapp/files/repomap.json
@@ -1,8 +1,8 @@
 {
-    "datetime": "202505021842Z",
-    "version_format": "1.2.1",
+    "datetime": "202505201636Z",
+    "version_format": "1.3.0",
     "provided_data_streams": [
-        "3.3"
+        "4.0"
     ],
     "mapping": [
         {
@@ -304,10 +304,43 @@
             "entries": [
                 {
                     "major_version": "10",
+                    "repoid": "baseos",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "baseos",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "baseos",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "baseos",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
                     "repoid": "rhel-10-baseos-rhui-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -316,6 +349,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -323,112 +357,128 @@
                     "repoid": "rhel-10-for-aarch64-baseos-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-baseos-e4s-rpms",
                     "arch": "aarch64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-baseos-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-baseos-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-baseos-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-baseos-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-baseos-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-baseos-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-baseos-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-baseos-e4s-rpms",
                     "arch": "s390x",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-baseos-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-baseos-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-baseos-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-baseos-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-baseos-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-baseos-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -437,10 +487,43 @@
             "entries": [
                 {
                     "major_version": "10",
+                    "repoid": "appstream",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "appstream",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "appstream",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "appstream",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
                     "repoid": "rhel-10-appstream-rhui-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -449,6 +532,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -456,112 +540,128 @@
                     "repoid": "rhel-10-for-aarch64-appstream-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-appstream-e4s-rpms",
                     "arch": "aarch64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-appstream-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-appstream-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-appstream-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-appstream-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-appstream-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-appstream-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-appstream-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-appstream-e4s-rpms",
                     "arch": "s390x",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-appstream-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-appstream-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-appstream-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-appstream-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-appstream-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-appstream-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -573,56 +673,64 @@
                     "repoid": "codeready-builder-beta-for-rhel-10-aarch64-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-beta-for-rhel-10-ppc64le-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-beta-for-rhel-10-s390x-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-beta-for-rhel-10-x86_64-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-for-rhel-10-aarch64-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-for-rhel-10-aarch64-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-for-rhel-10-ppc64le-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-for-rhel-10-ppc64le-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
@@ -630,6 +738,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -638,6 +747,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -645,28 +755,64 @@
                     "repoid": "codeready-builder-for-rhel-10-s390x-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-for-rhel-10-s390x-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-for-rhel-10-x86_64-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-for-rhel-10-x86_64-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "crb",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "crb",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "crb",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "crb",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
                 }
             ]
         },
@@ -678,84 +824,96 @@
                     "repoid": "rhel-10-for-aarch64-supplementary-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-supplementary-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-supplementary-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-supplementary-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-supplementary-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-supplementary-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-supplementary-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-supplementary-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-supplementary-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-supplementary-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-supplementary-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-supplementary-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
@@ -763,6 +921,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 }
             ]
@@ -775,42 +934,56 @@
                     "repoid": "rhel-10-for-aarch64-rt-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-rt-e4s-rpms",
                     "arch": "aarch64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-rt-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-rt-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-rt-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-rt-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rt",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
                 }
             ]
         },
@@ -819,38 +992,51 @@
             "entries": [
                 {
                     "major_version": "10",
+                    "repoid": "nfv",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-nfv-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-nfv-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-nfv-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-nfv-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-nfv-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -862,84 +1048,96 @@
                     "repoid": "rhel-10-for-ppc64le-sap-netweaver-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-sap-netweaver-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-sap-netweaver-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-sap-netweaver-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-sap-netweaver-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-sap-netweaver-e4s-rpms",
                     "arch": "s390x",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-sap-netweaver-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-sap-netweaver-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-sap-netweaver-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-sap-netweaver-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-sap-netweaver-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-sap-netweaver-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -951,28 +1149,32 @@
                     "repoid": "rhel-10-for-ppc64le-sap-solutions-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-sap-solutions-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-sap-solutions-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-sap-solutions-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -981,115 +1183,163 @@
             "entries": [
                 {
                     "major_version": "10",
+                    "repoid": "highavailability",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "highavailability",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "highavailability",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "highavailability",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-highavailability-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-highavailability-e4s-rpms",
                     "arch": "aarch64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-highavailability-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-aarch64-highavailability-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-highavailability-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-highavailability-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-highavailability-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-ppc64le-highavailability-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-highavailability-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-highavailability-e4s-rpms",
                     "arch": "s390x",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-highavailability-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-s390x-highavailability-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-highavailability-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-highavailability-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-highavailability-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-highavailability-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -1102,6 +1352,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1109,98 +1360,112 @@
                     "repoid": "rhel-7-for-arm-64-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-9-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-els-rpms",
                     "arch": "ppc64le",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-a-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-els-rpms",
                     "arch": "s390x",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-aus-rpms",
                     "arch": "x86_64",
                     "channel": "aus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1208,6 +1473,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1215,21 +1481,24 @@
                     "repoid": "rhel-7-server-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-els-rpms",
                     "arch": "x86_64",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1237,6 +1506,7 @@
                     "arch": "x86_64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1245,6 +1515,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1253,6 +1524,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1261,6 +1533,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -1268,7 +1541,8 @@
                     "repoid": "rhel-7-server-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1276,6 +1550,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -1284,6 +1559,7 @@
                     "arch": "x86_64",
                     "channel": "els",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -1292,6 +1568,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -1300,6 +1577,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -1308,6 +1586,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -1320,7 +1599,8 @@
                     "repoid": "rhel-7-for-arm-64-optional-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1328,6 +1608,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1335,84 +1616,96 @@
                     "repoid": "rhel-7-for-power-9-optional-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-e4s-optional-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-els-optional-rpms",
                     "arch": "ppc64le",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-eus-optional-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-optional-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-optional-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-a-optional-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-els-optional-rpms",
                     "arch": "s390x",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-eus-optional-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-optional-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-optional-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-aus-optional-rpms",
                     "arch": "x86_64",
                     "channel": "aus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1420,6 +1713,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1427,35 +1721,40 @@
                     "repoid": "rhel-7-server-e4s-optional-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-els-optional-rpms",
                     "arch": "x86_64",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-eus-optional-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-optional-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-optional-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1463,6 +1762,7 @@
                     "arch": "x86_64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1471,6 +1771,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1479,6 +1780,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1487,6 +1789,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -1495,6 +1798,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -1503,6 +1807,7 @@
                     "arch": "x86_64",
                     "channel": "els",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -1511,6 +1816,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -1519,6 +1825,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -1531,42 +1838,48 @@
                     "repoid": "rhel-7-for-power-9-supplementary-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-eus-supplementary-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-supplementary-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-eus-supplementary-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-supplementary-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-eus-supplementary-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1574,6 +1887,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1582,6 +1896,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1590,6 +1905,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -1597,7 +1913,8 @@
                     "repoid": "rhel-7-server-supplementary-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1605,6 +1922,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -1617,7 +1935,8 @@
                     "repoid": "rhel-7-for-arm-64-extras-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1625,6 +1944,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1632,77 +1952,88 @@
                     "repoid": "rhel-7-for-arm-64-extras-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-9-extras-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-9-extras-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-extras-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-power-le-extras-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-a-extras-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-a-extras-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-extras-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-for-system-z-extras-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-extras-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-extras-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1710,6 +2041,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1718,6 +2050,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -1726,6 +2059,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -1734,6 +2068,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -1746,28 +2081,32 @@
                     "repoid": "rhel-7-server-eus-rt-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-rt-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-rt-els-rpms",
                     "arch": "x86_64",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-7-server-rt-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -1779,7 +2118,8 @@
                     "repoid": "rhel-7-server-nfv-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -1791,77 +2131,88 @@
                     "repoid": "rhel-sap-for-rhel-7-for-power-le-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-for-rhel-7-for-power-le-els-rpms",
                     "arch": "ppc64le",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-for-rhel-7-for-power-le-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-for-rhel-7-for-power-le-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-for-rhel-7-for-system-z-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-for-rhel-7-for-system-z-els-rpms",
                     "arch": "s390x",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-for-rhel-7-for-system-z-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-for-rhel-7-for-system-z-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-for-rhel-7-server-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-for-rhel-7-server-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-for-rhel-7-server-els-rpms",
                     "arch": "x86_64",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1869,6 +2220,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1876,7 +2228,8 @@
                     "repoid": "rhel-sap-for-rhel-7-server-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1884,6 +2237,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1892,6 +2246,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1900,6 +2255,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -1907,7 +2263,8 @@
                     "repoid": "rhel-sap-for-rhel-7-server-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1915,6 +2272,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -1923,6 +2281,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -1935,49 +2294,56 @@
                     "repoid": "rhel-sap-hana-for-rhel-7-for-power-le-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-hana-for-rhel-7-for-power-le-els-rpms",
                     "arch": "ppc64le",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-hana-for-rhel-7-for-power-le-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-hana-for-rhel-7-for-power-le-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-hana-for-rhel-7-server-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-hana-for-rhel-7-server-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-sap-hana-for-rhel-7-server-els-rpms",
                     "arch": "x86_64",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -1985,6 +2351,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -1992,7 +2359,8 @@
                     "repoid": "rhel-sap-hana-for-rhel-7-server-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -2000,6 +2368,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2008,6 +2377,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2016,6 +2386,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2023,7 +2394,8 @@
                     "repoid": "rhel-sap-hana-for-rhel-7-server-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -2031,6 +2403,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -2039,6 +2412,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -2051,21 +2425,24 @@
                     "repoid": "rhel-ha-for-rhel-7-for-system-z-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-ha-for-rhel-7-for-system-z-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-ha-for-rhel-7-server-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -2073,6 +2450,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2080,14 +2458,16 @@
                     "repoid": "rhel-ha-for-rhel-7-server-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
                     "repoid": "rhel-ha-for-rhel-7-server-els-rpms",
                     "arch": "x86_64",
                     "channel": "els",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -2095,6 +2475,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2102,7 +2483,8 @@
                     "repoid": "rhel-ha-for-rhel-7-server-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -2110,6 +2492,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2118,6 +2501,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2125,7 +2509,8 @@
                     "repoid": "rhel-ha-for-rhel-7-server-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "7",
@@ -2133,6 +2518,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -2146,6 +2532,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -2159,6 +2546,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2167,6 +2555,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 }
             ]
@@ -2180,6 +2569,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 }
             ]
@@ -2193,6 +2583,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2201,6 +2592,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -2214,6 +2606,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -2227,6 +2620,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -2240,6 +2634,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -2253,6 +2648,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -2266,6 +2662,7 @@
                     "arch": "aarch64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2274,6 +2671,7 @@
                     "arch": "x86_64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2282,6 +2680,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2290,6 +2689,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2297,98 +2697,112 @@
                     "repoid": "rhel-8-for-aarch64-baseos-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-aarch64-baseos-e4s-rpms",
                     "arch": "aarch64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-aarch64-baseos-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-aarch64-baseos-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-baseos-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-baseos-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-baseos-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-baseos-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-baseos-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-baseos-e4s-rpms",
                     "arch": "s390x",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-baseos-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-baseos-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-baseos-aus-rpms",
                     "arch": "x86_64",
                     "channel": "aus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-baseos-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2396,6 +2810,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2404,6 +2819,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2411,7 +2827,8 @@
                     "repoid": "rhel-8-for-x86_64-baseos-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2419,6 +2836,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2427,6 +2845,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2434,7 +2853,8 @@
                     "repoid": "rhel-8-for-x86_64-baseos-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2442,6 +2862,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2449,7 +2870,8 @@
                     "repoid": "rhel-8-for-x86_64-baseos-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2457,6 +2879,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 },
                 {
@@ -2465,6 +2888,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -2473,6 +2897,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2481,6 +2906,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -2489,6 +2915,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -2502,6 +2929,7 @@
                     "arch": "aarch64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2510,6 +2938,7 @@
                     "arch": "x86_64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2518,6 +2947,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2526,6 +2956,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2533,98 +2964,112 @@
                     "repoid": "rhel-8-for-aarch64-appstream-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-aarch64-appstream-e4s-rpms",
                     "arch": "aarch64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-aarch64-appstream-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-aarch64-appstream-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-appstream-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-appstream-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-appstream-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-appstream-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-appstream-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-appstream-e4s-rpms",
                     "arch": "s390x",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-appstream-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-appstream-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-appstream-aus-rpms",
                     "arch": "x86_64",
                     "channel": "aus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-appstream-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2632,6 +3077,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2640,6 +3086,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2647,7 +3094,8 @@
                     "repoid": "rhel-8-for-x86_64-appstream-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2655,6 +3103,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2663,6 +3112,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2670,7 +3120,8 @@
                     "repoid": "rhel-8-for-x86_64-appstream-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2678,6 +3129,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2685,7 +3137,8 @@
                     "repoid": "rhel-8-for-x86_64-appstream-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2693,6 +3146,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 },
                 {
@@ -2701,6 +3155,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -2709,6 +3164,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2717,6 +3173,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -2725,6 +3182,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -2737,56 +3195,64 @@
                     "repoid": "codeready-builder-beta-for-rhel-8-aarch64-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "codeready-builder-beta-for-rhel-8-ppc64le-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "codeready-builder-beta-for-rhel-8-s390x-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "codeready-builder-beta-for-rhel-8-x86_64-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "codeready-builder-for-rhel-8-aarch64-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "codeready-builder-for-rhel-8-aarch64-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "codeready-builder-for-rhel-8-ppc64le-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "codeready-builder-for-rhel-8-ppc64le-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2794,6 +3260,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2802,6 +3269,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2809,14 +3277,16 @@
                     "repoid": "codeready-builder-for-rhel-8-s390x-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "codeready-builder-for-rhel-8-s390x-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2824,6 +3294,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2831,7 +3302,8 @@
                     "repoid": "codeready-builder-for-rhel-8-x86_64-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2839,6 +3311,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2846,7 +3319,8 @@
                     "repoid": "codeready-builder-for-rhel-8-x86_64-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2854,6 +3328,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 },
                 {
@@ -2862,6 +3337,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -2870,6 +3346,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -2882,77 +3359,88 @@
                     "repoid": "rhel-8-for-aarch64-supplementary-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-aarch64-supplementary-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-aarch64-supplementary-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-supplementary-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-supplementary-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-supplementary-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-supplementary-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-supplementary-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-supplementary-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-supplementary-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-supplementary-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2960,6 +3448,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -2967,7 +3456,8 @@
                     "repoid": "rhel-8-for-x86_64-supplementary-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -2975,6 +3465,7 @@
                     "arch": "x86_64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2983,6 +3474,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -2991,6 +3483,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 },
                 {
@@ -2999,6 +3492,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3007,6 +3501,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -3015,6 +3510,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -3027,14 +3523,16 @@
                     "repoid": "rhel-8-for-x86_64-rt-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-rt-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -3046,21 +3544,24 @@
                     "repoid": "rhel-8-for-x86_64-nfv-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-nfv-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-nfv-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -3072,56 +3573,64 @@
                     "repoid": "rhel-8-for-ppc64le-sap-netweaver-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-sap-netweaver-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-sap-netweaver-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-sap-netweaver-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-sap-netweaver-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-sap-netweaver-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-sap-netweaver-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-sap-netweaver-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -3129,6 +3638,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3137,6 +3647,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -3144,7 +3655,8 @@
                     "repoid": "rhel-8-for-x86_64-sap-netweaver-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -3152,6 +3664,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3160,6 +3673,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -3167,14 +3681,16 @@
                     "repoid": "rhel-8-for-x86_64-sap-netweaver-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-sap-netweaver-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -3182,6 +3698,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -3194,35 +3711,40 @@
                     "repoid": "rhel-8-for-ppc64le-sap-solutions-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-sap-solutions-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-sap-solutions-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-sap-solutions-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-sap-solutions-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -3230,6 +3752,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3238,6 +3761,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -3245,7 +3769,8 @@
                     "repoid": "rhel-8-for-x86_64-sap-solutions-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -3253,6 +3778,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3260,14 +3786,16 @@
                     "repoid": "rhel-8-for-x86_64-sap-solutions-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-sap-solutions-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -3275,6 +3803,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -3287,77 +3816,88 @@
                     "repoid": "rhel-8-for-aarch64-highavailability-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-aarch64-highavailability-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-aarch64-highavailability-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-highavailability-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-highavailability-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-highavailability-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-ppc64le-highavailability-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-highavailability-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-highavailability-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-s390x-highavailability-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "rhel-8-for-x86_64-highavailability-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -3365,6 +3905,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3373,6 +3914,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -3380,7 +3922,8 @@
                     "repoid": "rhel-8-for-x86_64-highavailability-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -3388,6 +3931,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3395,7 +3939,8 @@
                     "repoid": "rhel-8-for-x86_64-highavailability-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -3403,6 +3948,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3410,7 +3956,8 @@
                     "repoid": "rhel-8-for-x86_64-highavailability-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
@@ -3418,6 +3965,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -3426,6 +3974,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -3434,6 +3983,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -3447,6 +3997,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -3460,6 +4011,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3468,6 +4020,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 }
             ]
@@ -3481,6 +4034,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 }
             ]
@@ -3494,6 +4048,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -3502,6 +4057,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -3515,6 +4071,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -3528,6 +4085,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -3541,6 +4099,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 }
             ]
@@ -3554,6 +4113,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -3567,6 +4127,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -3579,49 +4140,56 @@
                     "repoid": "advanced-virt-for-rhel-8-aarch64-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "advanced-virt-for-rhel-8-ppc64le-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "advanced-virt-for-rhel-8-ppc64le-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "advanced-virt-for-rhel-8-s390x-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "advanced-virt-for-rhel-8-s390x-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "advanced-virt-for-rhel-8-x86_64-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "advanced-virt-for-rhel-8-x86_64-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -3633,28 +4201,32 @@
                     "repoid": "advanced-virt-crb-for-rhel-8-aarch64-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "advanced-virt-crb-for-rhel-8-ppc64le-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "advanced-virt-crb-for-rhel-8-s390x-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "8",
                     "repoid": "advanced-virt-crb-for-rhel-8-x86_64-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -3667,6 +4239,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 },
                 {
@@ -3675,6 +4248,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -3684,10 +4258,43 @@
             "entries": [
                 {
                     "major_version": "9",
+                    "repoid": "baseos",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "baseos",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "baseos",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "baseos",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
                     "repoid": "rhel-9-baseos-beta-rhui-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3696,6 +4303,7 @@
                     "arch": "x86_64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3704,6 +4312,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3712,6 +4321,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3719,98 +4329,112 @@
                     "repoid": "rhel-9-for-aarch64-baseos-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-baseos-e4s-rpms",
                     "arch": "aarch64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-baseos-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-baseos-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-baseos-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-baseos-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-baseos-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-baseos-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-baseos-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-baseos-e4s-rpms",
                     "arch": "s390x",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-baseos-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-baseos-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-baseos-aus-rpms",
                     "arch": "x86_64",
                     "channel": "aus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-baseos-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -3818,6 +4442,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3826,6 +4451,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -3833,7 +4459,8 @@
                     "repoid": "rhel-9-for-x86_64-baseos-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -3841,6 +4468,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -3848,7 +4476,8 @@
                     "repoid": "rhel-9-for-x86_64-baseos-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -3856,6 +4485,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -3863,7 +4493,8 @@
                     "repoid": "rhel-9-for-x86_64-baseos-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -3871,6 +4502,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 },
                 {
@@ -3879,6 +4511,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -3887,6 +4520,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -3895,6 +4529,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -3904,10 +4539,43 @@
             "entries": [
                 {
                     "major_version": "9",
+                    "repoid": "appstream",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "appstream",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "appstream",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "appstream",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
                     "repoid": "rhel-9-appstream-beta-rhui-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3916,6 +4584,7 @@
                     "arch": "x86_64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3924,6 +4593,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3932,6 +4602,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -3939,98 +4610,112 @@
                     "repoid": "rhel-9-for-aarch64-appstream-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-appstream-e4s-rpms",
                     "arch": "aarch64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-appstream-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-appstream-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-appstream-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-appstream-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-appstream-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-appstream-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-appstream-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-appstream-e4s-rpms",
                     "arch": "s390x",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-appstream-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-appstream-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-appstream-aus-rpms",
                     "arch": "x86_64",
                     "channel": "aus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-appstream-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4038,6 +4723,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -4046,6 +4732,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -4053,7 +4740,8 @@
                     "repoid": "rhel-9-for-x86_64-appstream-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4061,6 +4749,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -4068,7 +4757,8 @@
                     "repoid": "rhel-9-for-x86_64-appstream-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4076,6 +4766,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -4083,7 +4774,8 @@
                     "repoid": "rhel-9-for-x86_64-appstream-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4091,6 +4783,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 },
                 {
@@ -4099,6 +4792,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -4107,6 +4801,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -4115,6 +4810,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -4127,56 +4823,64 @@
                     "repoid": "codeready-builder-beta-for-rhel-9-aarch64-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "codeready-builder-beta-for-rhel-9-ppc64le-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "codeready-builder-beta-for-rhel-9-s390x-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "codeready-builder-beta-for-rhel-9-x86_64-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "codeready-builder-for-rhel-9-aarch64-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "codeready-builder-for-rhel-9-aarch64-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "codeready-builder-for-rhel-9-ppc64le-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "codeready-builder-for-rhel-9-ppc64le-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4184,6 +4888,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -4192,6 +4897,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -4199,21 +4905,24 @@
                     "repoid": "codeready-builder-for-rhel-9-s390x-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "codeready-builder-for-rhel-9-s390x-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "codeready-builder-for-rhel-9-x86_64-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4221,6 +4930,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -4228,7 +4938,40 @@
                     "repoid": "codeready-builder-for-rhel-9-x86_64-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "crb",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "crb",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "crb",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "crb",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
                 },
                 {
                     "major_version": "9",
@@ -4236,6 +4979,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 },
                 {
@@ -4244,6 +4988,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -4252,6 +4997,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -4264,84 +5010,96 @@
                     "repoid": "rhel-9-for-aarch64-supplementary-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-supplementary-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-supplementary-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-supplementary-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-supplementary-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-supplementary-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-supplementary-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-supplementary-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-supplementary-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-supplementary-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-supplementary-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-supplementary-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4349,6 +5107,7 @@
                     "arch": "x86_64",
                     "channel": "beta",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -4357,6 +5116,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -4365,6 +5125,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 },
                 {
@@ -4373,6 +5134,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -4381,6 +5143,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -4393,42 +5156,56 @@
                     "repoid": "rhel-9-for-aarch64-rt-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-rt-e4s-rpms",
                     "arch": "aarch64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-rt-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-rt-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-rt-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-rt-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rt",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
                 }
             ]
         },
@@ -4437,38 +5214,51 @@
             "entries": [
                 {
                     "major_version": "9",
+                    "repoid": "nfv",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-nfv-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-nfv-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-nfv-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-nfv-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-nfv-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 }
             ]
         },
@@ -4480,63 +5270,72 @@
                     "repoid": "rhel-9-for-ppc64le-sap-netweaver-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-sap-netweaver-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-sap-netweaver-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-sap-netweaver-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-sap-netweaver-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-sap-netweaver-e4s-rpms",
                     "arch": "s390x",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-sap-netweaver-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-sap-netweaver-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-sap-netweaver-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4544,6 +5343,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -4552,6 +5352,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -4559,7 +5360,8 @@
                     "repoid": "rhel-9-for-x86_64-sap-netweaver-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4567,6 +5369,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -4574,14 +5377,16 @@
                     "repoid": "rhel-9-for-x86_64-sap-netweaver-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-sap-netweaver-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4589,6 +5394,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -4601,14 +5407,16 @@
                     "repoid": "rhel-9-for-ppc64le-sap-solutions-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-sap-solutions-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4616,6 +5424,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -4624,6 +5433,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -4631,14 +5441,16 @@
                     "repoid": "rhel-9-for-x86_64-sap-solutions-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-sap-solutions-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4646,6 +5458,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -4655,94 +5468,139 @@
             "entries": [
                 {
                     "major_version": "9",
+                    "repoid": "highavailability",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "highavailability",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "highavailability",
+                    "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "highavailability",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "centos"
+                },
+                {
+                    "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-highavailability-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-highavailability-e4s-rpms",
                     "arch": "aarch64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-highavailability-eus-rpms",
                     "arch": "aarch64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-highavailability-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-highavailability-beta-rpms",
                     "arch": "ppc64le",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-highavailability-e4s-rpms",
                     "arch": "ppc64le",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-highavailability-eus-rpms",
                     "arch": "ppc64le",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-ppc64le-highavailability-rpms",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-highavailability-beta-rpms",
                     "arch": "s390x",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-highavailability-e4s-rpms",
                     "arch": "s390x",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-highavailability-eus-rpms",
                     "arch": "s390x",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-s390x-highavailability-rpms",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-highavailability-beta-rpms",
                     "arch": "x86_64",
                     "channel": "beta",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4750,6 +5608,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -4758,6 +5617,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 },
                 {
@@ -4765,21 +5625,24 @@
                     "repoid": "rhel-9-for-x86_64-highavailability-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-highavailability-eus-rpms",
                     "arch": "x86_64",
                     "channel": "eus",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
                     "repoid": "rhel-9-for-x86_64-highavailability-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "rhel"
                 },
                 {
                     "major_version": "9",
@@ -4787,6 +5650,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -4795,6 +5659,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 },
                 {
@@ -4803,6 +5668,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]
@@ -4816,6 +5682,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 },
                 {
@@ -4824,6 +5691,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 }
             ]
@@ -4837,6 +5705,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "aws"
                 }
             ]
@@ -4850,6 +5719,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -4863,6 +5733,7 @@
                     "arch": "x86_64",
                     "channel": "eus",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -4876,6 +5747,7 @@
                     "arch": "x86_64",
                     "channel": "e4s",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "azure"
                 }
             ]
@@ -4889,6 +5761,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -4902,6 +5775,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "google"
                 }
             ]
@@ -4915,6 +5789,7 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 },
                 {
@@ -4923,6 +5798,7 @@
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
+                    "distro": "rhel",
                     "rhui": "alibaba"
                 }
             ]

--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
@@ -400,6 +400,7 @@ def get_pesid_to_repoid_map(target_pesids):
             repo_type='rpm',
             channel='ga',
             rhui='',
+            distro=api.current_actor().configuration.os_release.release_id,
         )
 
     for pesid in target_pesids:

--- a/repos/system_upgrade/common/actors/peseventsscanner/tests/test_pes_event_scanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/tests/test_pes_event_scanner.py
@@ -246,9 +246,9 @@ def test_actor_performs(monkeypatch):
         ],
         repositories=[
             PESIDRepositoryEntry(pesid='rhel7-base', major_version='7', repoid='rhel7-repo', arch='x86_64',
-                                 repo_type='rpm', channel='ga', rhui=''),
+                                 repo_type='rpm', channel='ga', rhui='', distro='rhel'),
             PESIDRepositoryEntry(pesid='rhel8-BaseOS', major_version='8', repoid='rhel8-repo', arch='x86_64',
-                                 repo_type='rpm', channel='ga', rhui='')]
+                                 repo_type='rpm', channel='ga', rhui='', distro='rhel')]
     )
 
     enabled_modules = EnabledModules(modules=[])

--- a/repos/system_upgrade/common/actors/repositoriesblacklist/tests/test_repositoriesblacklist.py
+++ b/repos/system_upgrade/common/actors/repositoriesblacklist/tests/test_repositoriesblacklist.py
@@ -6,7 +6,6 @@ from leapp.libraries.common.testutils import create_report_mocked, CurrentActorM
 from leapp.libraries.stdlib import api
 from leapp.models import (
     CustomTargetRepository,
-    EnvVar,
     PESIDRepositoryEntry,
     RepoMapEntry,
     RepositoriesBlacklisted,
@@ -42,6 +41,7 @@ def rhel7_optional_pesidrepo():
         arch='x86_64',
         channel='ga',
         repo_type='rpm',
+        distro='rhel',
     )
 
 
@@ -54,7 +54,9 @@ def rhel8_crb_pesidrepo():
         rhui='',
         arch='x86_64',
         channel='ga',
-        repo_type='rpm')
+        repo_type='rpm',
+        distro='rhel',
+    )
 
 
 @pytest.fixture

--- a/repos/system_upgrade/common/actors/repositoriesmapping/libraries/repositoriesmapping.py
+++ b/repos/system_upgrade/common/actors/repositoriesmapping/libraries/repositoriesmapping.py
@@ -17,7 +17,7 @@ REPOMAP_FILE = 'repomap.json'
 
 
 class RepoMapData(object):
-    VERSION_FORMAT = '1.2.1'
+    VERSION_FORMAT = '1.3.0'
 
     def __init__(self):
         self.repositories = []
@@ -40,7 +40,8 @@ class RepoMapData(object):
             repo_type=data['repo_type'],
             arch=data['arch'],
             major_version=data['major_version'],
-            pesid=pesid
+            pesid=pesid,
+            distro=data['distro'],
         ))
 
     def get_repositories(self, valid_major_versions):

--- a/repos/system_upgrade/common/actors/repositoriesmapping/tests/files/repomap_example.json
+++ b/repos/system_upgrade/common/actors/repositoriesmapping/tests/files/repomap_example.json
@@ -1,6 +1,6 @@
 {
   "datetime": "202107141655Z",
-  "version_format": "1.2.1",
+  "version_format": "1.3.0",
   "mapping": [
     {
       "source_major_version": "7",
@@ -38,7 +38,8 @@
           "repoid": "some-rhel-7-repoid",
           "arch": "x86_64",
           "repo_type": "rpm",
-          "channel": "eus"
+          "channel": "eus",
+          "distro": "rhel"
         }
       ]
     },
@@ -50,7 +51,8 @@
           "repoid": "some-rhel-8-repoid1",
           "arch": "x86_64",
           "repo_type": "rpm",
-          "channel": "eus"
+          "channel": "eus",
+          "distro": "rhel"
         }
       ]
     },
@@ -62,7 +64,8 @@
           "repoid": "some-rhel-8-repoid2",
           "arch": "x86_64",
           "repo_type": "rpm",
-          "channel": "eus"
+          "channel": "eus",
+          "distro": "rhel"
         }
       ]
     },
@@ -74,7 +77,8 @@
           "repoid": "some-rhel-9-repo1",
           "arch": "x86_64",
           "repo_type": "rpm",
-          "channel": "eus"
+          "channel": "eus",
+          "distro": "rhel"
         }
       ]
     },
@@ -86,7 +90,34 @@
           "repoid": "some-rhel-9-repo2",
           "arch": "x86_64",
           "repo_type": "rpm",
-          "channel": "eus"
+          "channel": "eus",
+          "distro": "rhel"
+        }
+      ]
+    },
+    {
+      "pesid": "pesid6",
+      "entries": [
+        {
+          "major_version": "7",
+          "repoid": "some-centos-9-repoid1",
+          "arch": "x86_64",
+          "repo_type": "rpm",
+          "channel": "ga",
+          "distro": "centos"
+        }
+      ]
+    },
+    {
+      "pesid": "pesid7",
+      "entries": [
+        {
+          "major_version": "8",
+          "repoid": "some-centos-10-repoid1",
+          "arch": "x86_64",
+          "repo_type": "rpm",
+          "channel": "ga",
+          "distro": "centos"
         }
       ]
     }

--- a/repos/system_upgrade/common/actors/repositoriesmapping/tests/unit_test_repositoriesmapping.py
+++ b/repos/system_upgrade/common/actors/repositoriesmapping/tests/unit_test_repositoriesmapping.py
@@ -7,10 +7,9 @@ import requests
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import repositoriesmapping
 from leapp.libraries.common import fetch
-from leapp.libraries.common.config import architecture, version
 from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
 from leapp.libraries.stdlib import api
-from leapp.models import ConsumedDataAsset, PESIDRepositoryEntry, RPM
+from leapp.models import ConsumedDataAsset, PESIDRepositoryEntry
 
 CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -53,7 +52,7 @@ def test_scan_existing_valid_data(monkeypatch, adjust_cwd):
     # 2. Verify that only repositories valid for the current IPU are produced
     pesid_repos = repo_mapping.repositories
     fail_description = 'Actor produced incorrect number of IPU-relevant pesid repos.'
-    assert len(pesid_repos) == 3, fail_description
+    assert len(pesid_repos) == 5, fail_description
 
     expected_pesid_repos = [
         PESIDRepositoryEntry(
@@ -63,7 +62,8 @@ def test_scan_existing_valid_data(monkeypatch, adjust_cwd):
             arch='x86_64',
             repo_type='rpm',
             channel='eus',
-            rhui=''
+            rhui='',
+            distro='rhel',
         ),
         PESIDRepositoryEntry(
             pesid='pesid2',
@@ -72,7 +72,8 @@ def test_scan_existing_valid_data(monkeypatch, adjust_cwd):
             arch='x86_64',
             repo_type='rpm',
             channel='eus',
-            rhui=''
+            rhui='',
+            distro='rhel',
         ),
         PESIDRepositoryEntry(
             pesid='pesid3',
@@ -81,7 +82,28 @@ def test_scan_existing_valid_data(monkeypatch, adjust_cwd):
             arch='x86_64',
             repo_type='rpm',
             channel='eus',
-            rhui=''
+            rhui='',
+            distro='rhel',
+        ),
+        PESIDRepositoryEntry(
+            pesid='pesid6',
+            major_version='7',
+            repoid='some-centos-9-repoid1',
+            arch='x86_64',
+            repo_type='rpm',
+            channel='ga',
+            rhui='',
+            distro='centos',
+        ),
+        PESIDRepositoryEntry(
+            pesid='pesid7',
+            major_version='8',
+            repoid='some-centos-10-repoid1',
+            arch='x86_64',
+            repo_type='rpm',
+            channel='ga',
+            rhui='',
+            distro='centos',
         ),
     ]
 
@@ -177,7 +199,8 @@ def test_scan_repositories_with_mapping_to_pesid_without_repos(monkeypatch):
                         'repoid': 'some-rhel-7-repo',
                         'arch': 'x86_64',
                         'repo_type': 'rpm',
-                        'channel': 'eus'
+                        'channel': 'eus',
+                        'distro': 'rhel',
                     }
                 ]
             }

--- a/repos/system_upgrade/common/actors/setuptargetrepos/actor.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/actor.py
@@ -17,11 +17,16 @@ from leapp.tags import FactsPhaseTag, IPUWorkflowTag
 
 class SetupTargetRepos(Actor):
     """
-    Produces list of repositories that should be available to be used by Upgrade process.
+    Produces list of repositories that should be available to be used during IPU process.
 
-    Based on current set of Red Hat Enterprise Linux repositories, produces the list of target
-    repositories. Additionally process request to use custom repositories during the upgrade
-    transaction.
+    The list of expected target repositories is produced based on:
+      * required custom target repositories,
+      * discovered enabled repositories,
+      * repositories from which originates the installed content,
+      * and the system distribution.
+
+    The list of repositories can be additionally affected in case of RHEL by
+    required channel (e.g. eus) or by detected use of RHUI.
     """
 
     name = 'setuptargetrepos'

--- a/repos/system_upgrade/common/actors/setuptargetrepos/tests/test_setuptargetrepos.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/tests/test_setuptargetrepos.py
@@ -127,7 +127,8 @@ def test_repos_mapping(monkeypatch):
                 arch='x86_64',
                 repo_type='rpm',
                 channel='ga',
-                rhui=''
+                rhui='',
+                distro='rhel',
             ),
             PESIDRepositoryEntry(
                 pesid='rhel8-baseos',
@@ -136,7 +137,8 @@ def test_repos_mapping(monkeypatch):
                 arch='x86_64',
                 repo_type='rpm',
                 channel='ga',
-                rhui=''
+                rhui='',
+                distro='rhel',
             ),
             PESIDRepositoryEntry(
                 pesid='rhel8-appstream',
@@ -145,7 +147,8 @@ def test_repos_mapping(monkeypatch):
                 arch='x86_64',
                 repo_type='rpm',
                 channel='ga',
-                rhui=''
+                rhui='',
+                distro='rhel',
             ),
             PESIDRepositoryEntry(
                 pesid='rhel8-blacklist',
@@ -154,7 +157,8 @@ def test_repos_mapping(monkeypatch):
                 arch='x86_64',
                 repo_type='rpm',
                 channel='ga',
-                rhui=''
+                rhui='',
+                distro='rhel',
             ),
             PESIDRepositoryEntry(
                 pesid='rhel7-satellite-extras',
@@ -163,7 +167,8 @@ def test_repos_mapping(monkeypatch):
                 arch='x86_64',
                 repo_type='rpm',
                 channel='ga',
-                rhui=''
+                rhui='',
+                distro='rhel',
             ),
             PESIDRepositoryEntry(
                 pesid='rhel8-satellite-extras',
@@ -172,7 +177,8 @@ def test_repos_mapping(monkeypatch):
                 arch='x86_64',
                 repo_type='rpm',
                 channel='ga',
-                rhui=''
+                rhui='',
+                distro='rhel',
             ),
         ]
     )

--- a/repos/system_upgrade/common/libraries/config/__init__.py
+++ b/repos/system_upgrade/common/libraries/config/__init__.py
@@ -3,7 +3,7 @@ from leapp.libraries.stdlib import api
 
 # The devel variable for target product channel can also contain 'beta'
 SUPPORTED_TARGET_CHANNELS = {'ga', 'e4s', 'eus', 'aus'}
-CONSUMED_DATA_STREAM_ID = '3.0'
+CONSUMED_DATA_STREAM_ID = '4.0'
 
 
 def get_env(name, default=None):

--- a/repos/system_upgrade/common/libraries/config/tests/test_version.py
+++ b/repos/system_upgrade/common/libraries/config/tests/test_version.py
@@ -108,6 +108,7 @@ def test_matches_target_version(monkeypatch, result, version_list):
     (False, '4.14.0-100.8.2.el8.x86_64', 'rhel', '8.1'),
     (False, '4.14.0-100.8.2.el9.x86_64', 'rhel', '9.1'),
 ])
+@suppress_deprecation(version.is_rhel_alt)
 def test_is_rhel_alt(monkeypatch, result, kernel, release_id, src_ver):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver=src_ver, kernel=kernel,
                                                                  release_id=release_id))

--- a/repos/system_upgrade/common/models/repositoriesmap.py
+++ b/repos/system_upgrade/common/models/repositoriesmap.py
@@ -71,11 +71,16 @@ class PESIDRepositoryEntry(Model):
     purposes. The other channels indicate premium repositories.
     """
 
-    rhui = fields.StringEnum(['', 'aws', 'azure', 'google', 'alibaba'])
+    rhui = fields.String(default='')
     """
     Specifies what cloud provider (RHUI) is the repository specific to.
 
     Empty string denotes that the repository is not specific to any cloud provider.
+    """
+
+    distro = fields.String()
+    """
+    Specifies what distribution is the repository specific to.
     """
 
 


### PR DESCRIPTION
The original solution expect just IPU of RHEL systems and so only source RHEL DNF repositories have been mapped to the target RHEL repositories. Making this more distro agnostic for CentOS-like systems, the mapping needs to be updated to respect distro specific repositories.

Hence a 'distro' field has been added in the 1.3.0 version of the repomap.json format. The field is required for all the `repositories` entries. RepomapDataHandler now takes in distro as a constructor parameter and only consider entries with the matching distro value.
    
Reflects also changes in the repomap json schema for version 1.3.0, which drops enumeration for the `rhui` field and replace it by simple String type to make the solution more scalable. This also means that vendor of the repomap data file must validate this field "manually".
    
All related unit-tests have been updated. As the commit is already large, keeping the update of data files on a separate commit.

Update the PESIDRepositoryEntry model:
     * add the distro field represented by String
     * change rhui type from StringEnum to String

Jira: RHEL-80336