### PR TITLE
Prevent device list from containing incorrent content

### DIFF
--- a/repos/system_upgrade/common/actors/pcidevicesscanner/libraries/pcidevicesscanner.py
+++ b/repos/system_upgrade/common/actors/pcidevicesscanner/libraries/pcidevicesscanner.py
@@ -80,6 +80,7 @@ def produce_detected_devices(devices):
     entry_lookup = {
         prefix_re.sub('', entry.device_id.lower()): entry
         for message in api.consume(DeviceDriverDeprecationData) for entry in message.entries
+        if entry.device_id
     }
 
     device_list = []


### PR DESCRIPTION
```
Some PCI devices got from lspci output do not have to neccessarily
provide SVendor and SDevice fields. PCI ID of such devices is
composed in the pci_device_scanner actor just from:
    Vendor:Device
instead of the full id:
    Vendor:Device:SVendor:SDevice

The recent change comparing such devices with bundled DDDD
data drops last two fragments from the composed PCI ID,
which led to the situation when the `shortened_pci_id`
resulted in an empty string and it has been incorrectly
matched with one of (consider random) drivers and possibly
inhibited the in-place upgrade.

So let's ensure that we do not match any PCI device with
any entry from DDDD undefined PCI ID.
```

Related PR: #1362

Thanks to @yuravk for the reported problem.  

JIRA: RHEL-72544