### PR TITLE
Deprecate is_rhel_alt from share libraries

### DIFF
--- a/docs/source/libraries-and-api/deprecations-list.md
+++ b/docs/source/libraries-and-api/deprecations-list.md
@@ -16,6 +16,8 @@ Only the versions in which a deprecation has been made are listed.
 
 - Shared libraries
   - **`leapp.libraries.common.config.version.SUPPORTED_VERSIONS`** - The `SUPPORTED_VERSIONS` dict has been deprecated as it is problematic with the new design. Use `leapp.libraries.common.config.version.is_supported_version()` or `IPUConfig.supported_upgrade_paths` instead.
+  - **`leapp.libraries.common.config.version.is_rhel_alt()`** - The function can return only `False` nowadays as RHEL-ALT 7 is EOL for years and future version of leapp-repository will not support RHEL 7 anymore.
+
 
 ## v0.20.0 <span style="font-size:0.5em; font-weight:normal">(till September 2024)</span>
 - Models

--- a/repos/system_upgrade/common/libraries/config/version.py
+++ b/repos/system_upgrade/common/libraries/config/version.py
@@ -278,6 +278,11 @@ def is_sap_hana_flavour():
     return api.current_actor().configuration.flavour == 'saphana'
 
 
+@deprecated(since='2025-05-31', message=(
+    'RHEL-ALT reached EOL years ago and it is connected just to RHEL 7 systems.'
+    'As such the function is useless nowadays and will return always False.'
+    'The function is going to be removed in the next leapp-repository release.'
+))
 def is_rhel_alt():
     """
     Check if the current system is RHEL-ALT or not (only for RHEL 7)


### PR DESCRIPTION
The function has no value anymore as RHEL-ALT 7 is EOL for years and RHEL 7 is not longer maintained in this project neither. I have considered the direct removal as this function is really old (it's not even used anywhere in the project anymore).

But as it is just one small function without additional impact and another rhel-alt artifacts became deprecated this month, I consider it better to fulfill our promise and add it on the deprecation list for 6months instead.