### PR TITLE
libs(rhui): add rhel10 targets for upgrades

### DIFF
--- a/etc/leapp/files/repomap.json
+++ b/etc/leapp/files/repomap.json
@@ -1,5 +1,5 @@
 {
-    "datetime": "202505201636Z",
+    "datetime": "202507171303Z",
     "version_format": "1.3.0",
     "provided_data_streams": [
         "4.0"
@@ -294,6 +294,24 @@
                     "target": [
                         "rhel10-HighAvailability"
                     ]
+                },
+                {
+                    "source": "rhel9-rhui-client-config-server-9",
+                    "target": [
+                        "rhel10-rhui-client-config-server-10"
+                    ]
+                },
+                {
+                    "source": "rhel9-rhui-microsoft-azure-rhel9",
+                    "target": [
+                        "rhel10-rhui-microsoft-azure-rhel10"
+                    ]
+                },
+                {
+                    "source": "rhel9-rhui-custom-client-at-alibaba",
+                    "target": [
+                        "rhel10-rhui-custom-client-at-alibaba"
+                    ]
                 }
             ]
         }
@@ -346,11 +364,29 @@
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-baseos-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhel-10-baseos-rhui-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "rhel",
                     "rhui": "aws"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhel-10-baseos-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "azure"
                 },
                 {
                     "major_version": "10",
@@ -458,6 +494,15 @@
                 },
                 {
                     "major_version": "10",
+                    "repoid": "rhel-10-for-x86_64-baseos-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-baseos-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
@@ -479,6 +524,24 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "rhel"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-rhel-10-for-aarch64-baseos-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-rhel-10-for-x86_64-baseos-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
                 }
             ]
         },
@@ -529,11 +592,29 @@
                 {
                     "major_version": "10",
                     "repoid": "rhel-10-appstream-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhel-10-appstream-rhui-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "rhel",
                     "rhui": "aws"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhel-10-appstream-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "azure"
                 },
                 {
                     "major_version": "10",
@@ -641,6 +722,15 @@
                 },
                 {
                     "major_version": "10",
+                    "repoid": "rhel-10-for-x86_64-appstream-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-appstream-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
@@ -662,6 +752,24 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "rhel"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-rhel-10-for-aarch64-appstream-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-rhel-10-for-x86_64-appstream-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
                 }
             ]
         },
@@ -744,11 +852,29 @@
                 {
                     "major_version": "10",
                     "repoid": "codeready-builder-for-rhel-10-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "codeready-builder-for-rhel-10-rhui-rpms",
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "rhel",
                     "rhui": "aws"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "codeready-builder-for-rhel-10-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "azure"
                 },
                 {
                     "major_version": "10",
@@ -813,6 +939,24 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "centos"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-codeready-builder-for-rhel-10-aarch64-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-codeready-builder-for-rhel-10-x86_64-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
                 }
             ]
         },
@@ -923,6 +1067,33 @@
                     "repo_type": "rpm",
                     "distro": "rhel",
                     "rhui": "aws"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhel-10-supplementary-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "azure"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-rhel-10-for-aarch64-supplementary-rhui-rpms",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-rhel-10-for-x86_64-supplementary-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
                 }
             ]
         },
@@ -1003,6 +1174,14 @@
                     "repoid": "rhel-10-for-aarch64-nfv-beta-rpms",
                     "arch": "aarch64",
                     "channel": "beta",
+                    "repo_type": "rpm",
+                    "distro": "rhel"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhel-10-for-aarch64-nfv-e4s-rpms",
+                    "arch": "aarch64",
+                    "channel": "e4s",
                     "repo_type": "rpm",
                     "distro": "rhel"
                 },
@@ -1117,6 +1296,15 @@
                 },
                 {
                     "major_version": "10",
+                    "repoid": "rhel-10-for-x86_64-sap-netweaver-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-sap-netweaver-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
@@ -1159,6 +1347,15 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "rhel"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhel-10-for-x86_64-sap-solutions-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "aws"
                 },
                 {
                     "major_version": "10",
@@ -1319,6 +1516,15 @@
                 },
                 {
                     "major_version": "10",
+                    "repoid": "rhel-10-for-x86_64-highavailability-e4s-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "10",
                     "repoid": "rhel-10-for-x86_64-highavailability-e4s-rpms",
                     "arch": "x86_64",
                     "channel": "e4s",
@@ -1340,6 +1546,75 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "rhel"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-rhel-10-for-x86_64-highavailability-rhui-rpms",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel10-rhui-microsoft-azure-rhel10",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-microsoft-azure-rhel10",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "azure"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel10-rhui-client-config-server-10",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-client-config-server-10",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "aws"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-client-config-server-10",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "aws"
+                }
+            ]
+        },
+        {
+            "pesid": "rhel10-rhui-custom-client-at-alibaba",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-custom-rhui_client_at_alibaba-rhel-10",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "rhui-custom-rhui_client_at_alibaba-rhel-10",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel",
+                    "rhui": "alibaba"
                 }
             ]
         },
@@ -5230,6 +5505,14 @@
                 },
                 {
                     "major_version": "9",
+                    "repoid": "rhel-9-for-aarch64-nfv-e4s-rpms",
+                    "arch": "aarch64",
+                    "channel": "e4s",
+                    "repo_type": "rpm",
+                    "distro": "rhel"
+                },
+                {
+                    "major_version": "9",
                     "repoid": "rhel-9-for-aarch64-nfv-rpms",
                     "arch": "aarch64",
                     "channel": "ga",
@@ -5591,6 +5874,14 @@
                     "repoid": "rhel-9-for-s390x-highavailability-rpms",
                     "arch": "s390x",
                     "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "rhel"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "rhel-9-for-x86_64-highavailability-aus-rpms",
+                    "arch": "x86_64",
+                    "channel": "aus",
                     "repo_type": "rpm",
                     "distro": "rhel"
                 },

--- a/repos/system_upgrade/common/actors/cloud/checkrhui/libraries/checkrhui.py
+++ b/repos/system_upgrade/common/actors/cloud/checkrhui/libraries/checkrhui.py
@@ -254,10 +254,16 @@ def customize_rhui_setup_for_aws(rhui_family, setup_info):
         # The leapp-rhui-aws will provide all necessary files to access entire RHEL8 content
         setup_info.bootstrap_target_client = False
         return
+    if target_version == '9':
+        amazon_plugin_copy_task = CopyFile(src='/usr/lib/python3.9/site-packages/dnf-plugins/amazon-id.py',
+                                           dst='/usr/lib/python3.6/site-packages/dnf-plugins/')
+        setup_info.postinstall_tasks.files_to_copy.append(amazon_plugin_copy_task)
+        return
 
-    amazon_plugin_copy_task = CopyFile(src='/usr/lib/python3.9/site-packages/dnf-plugins/amazon-id.py',
-                                       dst='/usr/lib/python3.6/site-packages/dnf-plugins/')
-    setup_info.postinstall_tasks.files_to_copy.append(amazon_plugin_copy_task)
+    # For 9>10 and higher we give up trying to do client swapping since the client has too many dependencies
+    # from target system's repositories. Our leapp-rhui-aws package will carry all of the repos provided
+    # by the client.
+    setup_info.bootstrap_target_client = False
 
 
 def produce_rhui_info_to_setup_target(rhui_family, source_setup_desc, target_setup_desc):

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -927,7 +927,13 @@ def _get_rh_available_repoids(context, indata):
             os.rename(foreign_repofile, '{0}.back'.format(foreign_repofile))
 
         try:
-            dnf_cmd = ['dnf', 'repolist', '--releasever', target_ver, '-v', '--enablerepo', '*']
+            dnf_cmd = [
+                'dnf', 'repolist',
+                '--releasever', target_ver, '-v',
+                '--enablerepo', '*',
+                '--disablerepo', '*-source-*',
+                '--disablerepo', '*-debug-*',
+            ]
             repolist_result = context.call(dnf_cmd)['stdout']
             repoid_lines = [line for line in repolist_result.split('\n') if line.startswith('Repo-id')]
             rhui_repoids = {extract_repoid_from_line(line) for line in repoid_lines}

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -273,7 +273,12 @@ RHUI_SETUPS = {
                       extra_info={'agent_pkg': 'WALinuxAgent'},
                       os_version='9'),
         mk_rhui_setup(clients={'rhui-azure-rhel10'}, leapp_pkg='leapp-rhui-azure',
-                      mandatory_files=[('leapp-azure.repo', YUM_REPOS_PATH)],
+                      mandatory_files=[
+                          ('leapp-azure.repo', YUM_REPOS_PATH),
+                          # We need to have the new GPG key ready when we will be bootstrapping
+                          # target rhui client.
+                          ('RPM-GPG-KEY-microsoft-azure-release-new', '/etc/pki/rpm-gpg/')
+                      ],
                       optional_files=[
                         ('key.pem', RHUI_PKI_DIR),
                         ('content.crt', RHUI_PKI_PRODUCT_DIR)

--- a/repos/system_upgrade/common/libraries/rhui.py
+++ b/repos/system_upgrade/common/libraries/rhui.py
@@ -158,6 +158,17 @@ RHUI_SETUPS = {
                         ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
                         ('content-rhel9.crt', RHUI_PKI_PRODUCT_DIR)
                       ], os_version='9'),
+        mk_rhui_setup(clients={'rh-amazon-rhui-client'}, leapp_pkg='leapp-rhui-aws',
+                      mandatory_files=[
+                        ('rhui-client-config-server-10.crt', RHUI_PKI_PRODUCT_DIR),
+                        ('rhui-client-config-server-10.key', RHUI_PKI_DIR),
+                        ('leapp-aws.repo', YUM_REPOS_PATH)
+                      ],
+                      optional_files=[
+                        ('content-rhel10.key', RHUI_PKI_DIR),
+                        ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
+                        ('content-rhel10.crt', RHUI_PKI_PRODUCT_DIR)
+                      ], os_version='10'),
     ],
     RHUIFamily(RHUIProvider.AWS, arch=arch.ARCH_ARM64, client_files_folder='aws'): [
         mk_rhui_setup(clients={'rh-amazon-rhui-client-arm'}, optional_files=[], os_version='7', arch=arch.ARCH_ARM64),
@@ -185,6 +196,17 @@ RHUI_SETUPS = {
                         ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
                         ('content-rhel9.crt', RHUI_PKI_PRODUCT_DIR)
                       ], os_version='9', arch=arch.ARCH_ARM64),
+        mk_rhui_setup(clients={'rh-amazon-rhui-client'}, leapp_pkg='leapp-rhui-aws',
+                      mandatory_files=[
+                        ('rhui-client-config-server-10.crt', RHUI_PKI_PRODUCT_DIR),
+                        ('rhui-client-config-server-10.key', RHUI_PKI_DIR),
+                        ('leapp-aws.repo', YUM_REPOS_PATH)
+                      ],
+                      optional_files=[
+                        ('content-rhel10.key', RHUI_PKI_DIR),
+                        ('cdn.redhat.com-chain.crt', RHUI_PKI_DIR),
+                        ('content-rhel10.crt', RHUI_PKI_PRODUCT_DIR)
+                      ], os_version='10'),
     ],
     RHUIFamily(RHUIProvider.AWS, variant=RHUIVariant.SAP, client_files_folder='aws-sap-e4s'): [
         mk_rhui_setup(clients={'rh-amazon-rhui-client-sap-bundle'}, optional_files=[], os_version='7',
@@ -250,6 +272,14 @@ RHUI_SETUPS = {
                       ],
                       extra_info={'agent_pkg': 'WALinuxAgent'},
                       os_version='9'),
+        mk_rhui_setup(clients={'rhui-azure-rhel10'}, leapp_pkg='leapp-rhui-azure',
+                      mandatory_files=[('leapp-azure.repo', YUM_REPOS_PATH)],
+                      optional_files=[
+                        ('key.pem', RHUI_PKI_DIR),
+                        ('content.crt', RHUI_PKI_PRODUCT_DIR)
+                      ],
+                      extra_info={'agent_pkg': 'WALinuxAgent'},
+                      os_version='10'),
     ],
     RHUIFamily(RHUIProvider.AZURE, variant=RHUIVariant.SAP_APPS, client_files_folder='azure-sap-apps'): [
         mk_rhui_setup(clients={'rhui-azure-rhel7-base-sap-apps'}, os_version='7', content_channel=ContentChannel.EUS),


### PR DESCRIPTION
Adds RHEL 10 system definitions to leapp's internal database so that upgrades are possible. Naturally, a necessary dependence is having RHEL 9 `leapp-rhui-{cloud_provider}` packages prepared. 

Also implements a quality-of-life improvement that prevents leapp from "scanning" source/debug repositories as they will not be used during the upgrade. This prevents silly crashes when the cloud provider forgot to sync debug/source repositories (`dnf repolist` which we are running would cause `CalledProcessError` and ultimately crash the entire upgrade).

Jira-ref: RHEL-64911, RHEL-64910