### PR TITLE
Inhibit upgrade on systems with cgroupsv1 on 9to10

### DIFF
--- a/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/actor.py
@@ -14,7 +14,7 @@ class InhibitCgroupsv1(Actor):
     hierarchy (cgroups-v2) is supported.
     """
 
-    name = 'inhibit_cgroupsv1'
+    name = "inhibit_cgroupsv1"
     consumes = (KernelCmdline,)
     produces = (Report,)
     tags = (ChecksPhaseTag, IPUWorkflowTag)

--- a/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import inhibitcgroupsv1
+from leapp.models import KernelCmdline
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class InhibitCgroupsv1(Actor):
+    """
+    Inhibit upgrade if cgroups-v1 are enabled
+
+    Support for cgroups-v1 was deprecated in RHEL 9 and removed in RHEL 10.
+    Both legacy and hybrid modes are unsupported, only the unified cgroup
+    hierarchy (cgroups-v2) is supported.
+    """
+
+    name = 'inhibit_cgroupsv1'
+    consumes = (KernelCmdline,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        inhibitcgroupsv1.process()

--- a/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/libraries/inhibitcgroupsv1.py
+++ b/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/libraries/inhibitcgroupsv1.py
@@ -1,0 +1,47 @@
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp.models import KernelCmdline
+
+
+def process():
+    kernel_cmdline = next(api.consume(KernelCmdline), None)
+    if not kernel_cmdline:
+        # really unlikely
+        raise StopActorExecutionError("Did not receive any KernelCmdline messages.")
+
+    unified_hierarchy = True  # default since RHEL 9
+    for param in kernel_cmdline.parameters:
+        if param.key == "systemd.unified_cgroup_hierarchy":
+            if param.value is not None and param.value.lower() in ("0", "false", "no"):
+                unified_hierarchy = False
+
+    if unified_hierarchy:
+        api.current_logger().debug("cgroups-v2 already in use, nothing to do, skipping.")
+        return
+
+    summary = (
+        "Leapp detected cgroups-v1 is enabled on the system."
+        " cgroups-v1 support was deprecated in RHEL 9 and is removed in RHEL 10."
+        " Software requiring cgroups-v1 might not work correctly or at all on RHEL 10. "
+    )
+    reporting.create_report(
+        [
+            reporting.Title("cgroups-v1 enabled on the system"),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.KERNEL]),
+            reporting.Remediation(
+                hint="Make sure no third party software requires cgroups-v1 and switch to cgroups-v2.",
+                commands=[
+                    [
+                        "grubby",
+                        "--update-kernel=ALL",
+                        # dont really have to remove the systemd.legacy_systemd_cgroup_controller,
+                        # it has no effect when unified hierarchy is enabled
+                        '--remove-args="systemd.unified_cgroup_hierarchy,systemd.legacy_systemd_cgroup_controller"',
+                    ],
+                ],
+            ),
+        ]
+    )

--- a/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/libraries/inhibitcgroupsv1.py
+++ b/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/libraries/inhibitcgroupsv1.py
@@ -11,19 +11,28 @@ def process():
         raise StopActorExecutionError("Did not receive any KernelCmdline messages.")
 
     unified_hierarchy = True  # default since RHEL 9
+    legacy_controller_present = False
     for param in kernel_cmdline.parameters:
         if param.key == "systemd.unified_cgroup_hierarchy":
             if param.value is not None and param.value.lower() in ("0", "false", "no"):
                 unified_hierarchy = False
+        if param.key == "systemd.legacy_systemd_cgroup_controller":
+            # no matter the value, it should be removed
+            # it has no effect when unified hierarchy is enabled
+            legacy_controller_present = True
 
     if unified_hierarchy:
         api.current_logger().debug("cgroups-v2 already in use, nothing to do, skipping.")
         return
 
+    remediation_cmd_args = ["systemd.unified_cgroup_hierarchy"]
+    if legacy_controller_present:
+        remediation_cmd_args.append('systemd.legacy_systemd_cgroup_controller')
+
     summary = (
         "Leapp detected cgroups-v1 is enabled on the system."
-        " cgroups-v1 support was deprecated in RHEL 9 and is removed in RHEL 10."
-        " Software requiring cgroups-v1 might not work correctly or at all on RHEL 10. "
+        " The support of cgroups-v1 was deprecated in RHEL 9 and is removed in RHEL 10."
+        " Software requiring cgroups-v1 might not work correctly or at all on RHEL 10."
     )
     reporting.create_report(
         [
@@ -31,15 +40,15 @@ def process():
             reporting.Summary(summary),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.KERNEL]),
+            reporting.RelatedResource("package", "systemd"),
             reporting.Remediation(
                 hint="Make sure no third party software requires cgroups-v1 and switch to cgroups-v2.",
+                # remove the args from commandline, the defaults are the desired values
                 commands=[
                     [
                         "grubby",
                         "--update-kernel=ALL",
-                        # dont really have to remove the systemd.legacy_systemd_cgroup_controller,
-                        # it has no effect when unified hierarchy is enabled
-                        '--remove-args="systemd.unified_cgroup_hierarchy,systemd.legacy_systemd_cgroup_controller"',
+                        '--remove-args="{}"'.format(",".join(remediation_cmd_args)),
                     ],
                 ],
             ),

--- a/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/tests/test_inhibitcgroupsv1.py
+++ b/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/tests/test_inhibitcgroupsv1.py
@@ -1,0 +1,57 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import inhibitcgroupsv1
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import KernelCmdline, KernelCmdlineArg
+
+
+@pytest.mark.parametrize(
+    "cmdline_params,should_inhibit", (
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="0")], True),
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="1")], False),
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="false")], True,),
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="true")], False,),
+        (
+            [
+                KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="0"),
+                KernelCmdlineArg(key="systemd.legacy_systemd_cgroup_controller", value="0"),
+            ],
+            True,
+        ), (
+            [
+                KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="0"),
+                KernelCmdlineArg(key="systemd.legacy_systemd_cgroup_controller", value="1"),
+            ],
+            True,
+        ), (
+            [
+                KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="1"),
+                KernelCmdlineArg(key="systemd.legacy_systemd_cgroup_controller", value="1"),
+            ],
+            False,
+        ), (
+            [
+                KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="1"),
+                KernelCmdlineArg(key="systemd.legacy_systemd_cgroup_controller", value="1"),
+            ],
+            False,
+        ),
+    )
+)
+def test_inhibit_v1(monkeypatch, cmdline_params, should_inhibit):
+    curr_actor_mocked = CurrentActorMocked(msgs=[KernelCmdline(parameters=cmdline_params)])
+    monkeypatch.setattr(api, "current_actor", curr_actor_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    inhibitcgroupsv1.process()
+
+    if should_inhibit:
+        assert reporting.create_report.called == 1
+        assert "cgroups-v1" in reporting.create_report.reports[0]["title"]
+        assert (
+            reporting.Groups.INHIBITOR in reporting.create_report.reports[0]["groups"]
+        )
+    else:
+        assert not reporting.create_report.called

--- a/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/tests/test_inhibitcgroupsv1.py
+++ b/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/tests/test_inhibitcgroupsv1.py
@@ -8,50 +8,67 @@ from leapp.models import KernelCmdline, KernelCmdlineArg
 
 
 @pytest.mark.parametrize(
-    "cmdline_params,should_inhibit", (
-        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="0")], True),
-        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="1")], False),
-        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="false")], True,),
-        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="true")], False,),
+    "cmdline_params", (
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="0")]),
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="false")]),
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="False")]),
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="no")]),
         (
             [
                 KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="0"),
                 KernelCmdlineArg(key="systemd.legacy_systemd_cgroup_controller", value="0"),
-            ],
-            True,
+            ]
         ), (
             [
                 KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="0"),
                 KernelCmdlineArg(key="systemd.legacy_systemd_cgroup_controller", value="1"),
-            ],
-            True,
-        ), (
-            [
-                KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="1"),
-                KernelCmdlineArg(key="systemd.legacy_systemd_cgroup_controller", value="1"),
-            ],
-            False,
-        ), (
-            [
-                KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="1"),
-                KernelCmdlineArg(key="systemd.legacy_systemd_cgroup_controller", value="1"),
-            ],
-            False,
-        ),
+            ]
+        )
     )
 )
-def test_inhibit_v1(monkeypatch, cmdline_params, should_inhibit):
+def test_inhibit_should_inhibit(monkeypatch, cmdline_params):
     curr_actor_mocked = CurrentActorMocked(msgs=[KernelCmdline(parameters=cmdline_params)])
     monkeypatch.setattr(api, "current_actor", curr_actor_mocked)
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
 
     inhibitcgroupsv1.process()
 
-    if should_inhibit:
-        assert reporting.create_report.called == 1
-        assert "cgroups-v1" in reporting.create_report.reports[0]["title"]
-        assert (
-            reporting.Groups.INHIBITOR in reporting.create_report.reports[0]["groups"]
-        )
-    else:
-        assert not reporting.create_report.called
+    assert reporting.create_report.called == 1
+    report = reporting.create_report.reports[0]
+    assert "cgroups-v1" in report["title"]
+    assert reporting.Groups.INHIBITOR in report["groups"]
+
+    command = [r for r in report["detail"]["remediations"] if r["type"] == "command"][0]
+    assert "systemd.unified_cgroup_hierarchy" in command['context'][2]
+    if len(cmdline_params) == 2:
+        assert "systemd.legacy_systemd_cgroup_controller" in command['context'][2]
+
+
+@pytest.mark.parametrize(
+    "cmdline_params", (
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="1")]),
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="true")]),
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="True")]),
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="yes")]),
+        ([KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value=None)]),
+        (
+            [
+                KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="1"),
+                KernelCmdlineArg(key="systemd.legacy_systemd_cgroup_controller", value="1"),
+            ]
+        ), (
+            [
+                KernelCmdlineArg(key="systemd.unified_cgroup_hierarchy", value="1"),
+                KernelCmdlineArg(key="systemd.legacy_systemd_cgroup_controller", value="0"),
+            ]
+        ),
+    )
+)
+def test_inhibit_should_not_inhibit(monkeypatch, cmdline_params):
+    curr_actor_mocked = CurrentActorMocked(msgs=[KernelCmdline(parameters=cmdline_params)])
+    monkeypatch.setattr(api, "current_actor", curr_actor_mocked)
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+
+    inhibitcgroupsv1.process()
+
+    assert not reporting.create_report.called


### PR DESCRIPTION
cgroups-v1 were deprecated in RHEL 9 and are unsupported in RHEL 10. The kernel cmdline options to switch to cgroups-v1 are ignored. Users have to migrate to cgroups-v2 in order to upgrade.

Both legacy and hybrid modes are unsupported. Only unified hierarchy (cgroups-v2) is supported. More info on how the modes are switched is at: https://www.freedesktop.org/software/systemd/man/247/systemd.html#systemd.unified_cgroup_hierarchy and https://www.freedesktop.org/software/systemd/man/247/systemd.html#systemd.legacy_systemd_cgroup_controller.

Jira: RHEL-81212