### PR TITLE
Add Sat 6.16/6.17 repomap for el8toel9/el9toel10

### DIFF
--- a/etc/leapp/files/repomap.json
+++ b/etc/leapp/files/repomap.json
@@ -234,6 +234,30 @@
                     "target": [
                         "rhel9-rhui-custom-client-at-alibaba"
                     ]
+                },
+                {
+                    "source": "satellite-6.16-for-rhel-8-x86_64-rpms",
+                    "target": [
+                        "satellite-6.16-for-rhel-9-x86_64-rpms"
+                    ]
+                },
+                {
+                    "source": "satellite-maintenance-6.16-for-rhel-8-x86_64-rpms",
+                    "target": [
+                        "satellite-maintenance-6.16-for-rhel-9-x86_64-rpms"
+                    ]
+                },
+                {
+                    "source": "satellite-capsule-6.16-for-rhel-8-x86_64-rpms",
+                    "target": [
+                        "satellite-capsule-6.16-for-rhel-9-x86_64-rpms"
+                    ]
+                },
+                {
+                    "source": "satellite-utils-6.16-for-rhel-8-x86_64-rpms",
+                    "target": [
+                        "satellite-utils-6.16-for-rhel-9-x86_64-rpms"
+                    ]
                 }
             ]
         },
@@ -293,6 +317,30 @@
                     "source": "rhel9-HighAvailability",
                     "target": [
                         "rhel10-HighAvailability"
+                    ]
+                },
+                {
+                    "source": "satellite-6.16-for-rhel-9-x86_64-rpms",
+                    "target": [
+                        "satellite-6.16-for-rhel-10-x86_64-rpms"
+                    ]
+                },
+                {
+                    "source": "satellite-maintenance-6.16-for-rhel-9-x86_64-rpms",
+                    "target": [
+                        "satellite-maintenance-6.16-for-rhel-10-x86_64-rpms"
+                    ]
+                },
+                {
+                    "source": "satellite-capsule-6.16-for-rhel-9-x86_64-rpms",
+                    "target": [
+                        "satellite-capsule-6.16-for-rhel-10-x86_64-rpms"
+                    ]
+                },
+                {
+                    "source": "satellite-utils-6.16-for-rhel-9-x86_64-rpms",
+                    "target": [
+                        "satellite-utils-6.16-for-rhel-10-x86_64-rpms"
                     ]
                 }
             ]


### PR DESCRIPTION
When upgrading RHEL 8 to RHEL 9 with Satellite 6.16 installed, leapp complains with a low risk message that it does not know the Satellite repositories and thus there's a risk that Satellite packages won't be upgraded. This message causes an unnecessary confusion because in fact the correct RHEL 9 Satellite 6.16 repos are enabled thanks to [repos/system_upgrade/el8toel9/actors/satellite_upgrade_facts/actor.py](https://github.com/oamg/leapp-repository/tree/main/repos/system_upgrade/el8toel9/actors/satellite_upgrade_facts/actor.py) added under https://github.com/oamg/leapp-repository/pull/1181.

To avoid emitting this confusing report message, this commit adds the Satellite 6.16 repositories to the repomapping file.

We don't need to deal with Satellite 6.15 as it's already out of support.

There's already Satellite 6.17 available but it's currently available just for RHEL 9. The predictable repo naming schema allows us to get to know what the Satellite 6.17 repositories will be named for RHEL 10.

Assisted-by: Cursor AI with Claude Sonnet 4

Jira: [RHEL-100961](https://issues.redhat.com/browse/RHEL-100961)