### PR TITLE
Point to leapp-repository contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See the [Contribution guidelines](https://leapp.readthedocs.io/en/latest/contributing.html)
+See the [contribution guidelines](https://leapp-repository.readthedocs.io/latest/contrib-and-devel-guidelines.html).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-**Before doing anything, please read the upstream [documentation](https://leapp-repository.readthedocs.io/).**
+**Before doing anything, please read the [leapp-repository documentation](https://leapp-repository.readthedocs.io/).**
 
-Also, you could find useufl to read [Leapp framework documentation](https://leapp.readthedocs.io/).
+Also, you could find the [Leapp framework documentation](https://leapp.readthedocs.io/) useful to read.
 
 ---
 
@@ -17,7 +17,7 @@ Also, you could find useufl to read [Leapp framework documentation](https://leap
   - *All files in /var/log/leapp*
   - */var/lib/leapp/leapp.db*
   - *journalctl*
-  - If you want, you can optionally send anything else would you like to provide (e.g. storage info)
+  - If you want, you can optionally send any other relevant information (e.g. storage, network)
 
 **For your convenience you can pack all logs with this command:**
 

--- a/docs/source/contrib-and-devel-guidelines.md
+++ b/docs/source/contrib-and-devel-guidelines.md
@@ -1,7 +1,7 @@
 # Contribution and development guidelines
 ## Code guidelines
 
-Your code should follow the [Python Coding Guidelines](https://leapp.readthedocs.io/en/latest/python-coding-guidelines.html) used for the leapp project. On top of these rules follow instructions
+Your code should follow the [Python Coding Guidelines](https://leapp.readthedocs.io/en/latest/contributing.html#follow-python-coding-guidelines) used for the leapp project. On top of these rules follow instructions
 below.
 
 ### Retrieving information about the source system should be separated from its use


### PR DESCRIPTION
Instead of the leapp framework contribution guidelines.