### PR TITLE
Fix target version format checks

### DIFF
--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -253,8 +253,8 @@ def prepare_configuration(args):
     if args.nogpgcheck:
         os.environ['LEAPP_NOGPGCHECK'] = '1'
 
-    # Check upgrade path and fail early if it's unsupported
-    target_version, flavor = command_utils.vet_upgrade_path(args)
+    # Check upgrade path and fail early if it's invalid
+    target_version, flavor = command_utils.get_target_release(args)
     os.environ['LEAPP_UPGRADE_PATH_TARGET_RELEASE'] = target_version
     os.environ['LEAPP_UPGRADE_PATH_FLAVOUR'] = flavor
 


### PR DESCRIPTION
Currently only the format of a version specified by
LEAPP_DEVEL_TARGET_RELEASE is checked, when specified via --target
cmdline argument it isn't, which is a bug.

This patch fixes the bug, ~~and also disables the check for
LEAPP_DEVEL_TARGET_RELEASE. This is a development variable and the user
is expected to set a correct one.~~

NOTE: these are only format checks, the state of support is already
checked later in the upgrade process by the checktargetversion actor.

Jira: RHEL-96238