### PR TITLE
Add SSSD actors for sss_ssh_knownhosts

### DIFF
--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.models import SSSDConfig
+from leapp.libraries.actor import sssdchecks
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class SSSDCheck(Actor):
+    """
+    Check SSSD configuration for changes in RHEL10 and report them in model.
+    """
+
+    name = 'sssd_check'
+    consumes = (SSSDConfig,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        for cfg in self.consume(SSSDConfig):
+            sssdchecks.check_config(cfg)

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/libraries/sssdchecks.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/libraries/sssdchecks.py
@@ -1,0 +1,39 @@
+import os
+
+from leapp import reporting
+
+
+def check_config(model):
+    if not model:
+        return
+
+    # If sss_ssh_knownhostsproxy was not configured, there is nothing to do
+    if len(model.ssh_config_files) == 0:
+        return
+
+    unwritable = []
+    for file in model.sssd_config_files + model.ssh_config_files:
+        if not os.access(file, os.W_OK, effective_ids=True):
+            unwritable.append(file)
+
+    summary = 'SSSD\'s sss_ssh_knownhostsproxy tool is replaced by the more ' \
+    'reliable sss_ssh_knownhosts tool. SSH\'s configuration will be updated ' \
+    'to reflect this.\n' \
+    'SSSD\'s ssh service needs to be enabled.'
+    if len(unwritable) > 0:
+        summary += '\nThe following files are not writable: ' + ', '.join(unwritable)
+
+    report = [
+        reporting.Title('sss_ssh_knownhosts replaces sss_ssh_knownhostsproxy.'),
+        reporting.Summary(summary),
+        reporting.Groups([reporting.Groups.AUTHENTICATION, reporting.Groups.SECURITY]),
+        reporting.Severity(reporting.Severity.INFO),
+    ]
+
+    if len(unwritable) > 0:
+        report.append(reporting.Remediation(hint='Correct the unwritable files permissions.'))
+
+    for file in model.sssd_config_files + model.ssh_config_files:
+        report.append(reporting.RelatedResource('file', file))
+
+    reporting.create_report(report)

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/tests/component_test_sssdchecks.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/tests/component_test_sssdchecks.py
@@ -1,0 +1,71 @@
+import os
+import stat
+
+from tempfile import NamedTemporaryFile
+
+from leapp.models import SSSDConfig, Report
+
+def make_tmp_file() -> str:
+    file = NamedTemporaryFile(mode='w+t', prefix='test.sssdfchecks.', delete=False)
+    # The file will be deleted on closure, so keep it open.
+    return file.name
+
+def make_files(count: int) -> list[str]:
+    files = []
+    for i in range(count):
+        files.append(make_tmp_file())
+
+    return files
+
+def test_sssdchecks__no_files(current_actor_context):
+    config = SSSDConfig()
+    current_actor_context.feed(config)
+    current_actor_context.run()
+    reports = current_actor_context.consume(Report)
+    assert len(reports) == 0
+
+def test_sssdchecks__files(current_actor_context):
+    sssd_files = make_files(2)
+    ssh_files = make_files(2)
+    all_files = sssd_files + ssh_files
+
+    config = SSSDConfig(sssd_config_files = sssd_files, ssh_config_files = ssh_files)
+    current_actor_context.feed(config)
+    current_actor_context.run()
+    reports = current_actor_context.consume(Report)
+
+    for file in all_files:
+        os.unlink(file)
+
+    assert len(reports) == 1
+
+    report = reports[0].report
+    assert report['title'] == 'sss_ssh_knownhosts replaces sss_ssh_knownhostsproxy.'
+    assert 'sss_ssh_knownhosts tool' in report['summary']
+    assert 'not writable: ' not in report['summary']
+
+    resources = report['detail']['related_resources']
+    assert len(resources) == len(all_files)
+    for res in resources:
+        assert res['scheme'] == 'file'
+        assert res['title'] in all_files
+
+def test_sssdchecks__file_error(current_actor_context):
+    ssh_files = make_files(1)
+    os.chmod(ssh_files[0], 0o444)
+
+    config = SSSDConfig(ssh_config_files = ssh_files)
+    current_actor_context.feed(config)
+    current_actor_context.run()
+    reports = current_actor_context.consume(Report)
+
+    fstat = os.stat(ssh_files[0])
+    assert stat.filemode(fstat.st_mode & stat.ST_MODE) == stat.filemode(0o444 & stat.ST_MODE)
+
+    os.unlink(ssh_files[0])
+
+    assert len(reports) == 1
+
+    report = reports[0].report
+    assert report['title'] == 'sss_ssh_knownhosts replaces sss_ssh_knownhostsproxy.'
+    assert 'not writable: ' + ssh_files[0] in report['summary']

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdfacts/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdfacts/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import sssdfacts
+from leapp.models import SSSDConfig
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class SSSDFacts(Actor):
+    """
+    Check SSSD configuration for changes in RHEL10 and report them in model.
+
+    We want to know if the 'ssh' service is enabled and whether ssh was
+    configured to use the sss_ssh_knownhosts tool.
+    """
+
+    name = 'sssd_facts'
+    consumes = ()
+    produces = (SSSDConfig,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        self.produce(sssdfacts.get_facts(['/etc/sssd/sssd.conf', '/etc/sssd/conf.d/'],
+                                         ['/etc/ssh/ssh_config', '/etc/ssh/ssh_config.d/']))

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdfacts/libraries/sssdfacts.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdfacts/libraries/sssdfacts.py
@@ -1,0 +1,38 @@
+import os
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.models import SSSDConfig
+
+
+def _look_for_files(expression: str, files: list[str]) -> list[str]:
+    found = []
+
+    for file in files:
+        if os.path.isdir(file):
+            found += _look_for_files(expression, [file + '/' + x for x in os.listdir(file)])
+        else:
+            try:
+                with open(file, 'r') as f:
+                    if expression in f.read():
+                        found.append(file)
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                raise StopActorExecutionError('Could not open file ' + file, details={'details': str(e)})
+
+    return found
+
+
+def get_facts(sssd_config: list[str], ssh_config: str) ->SSSDConfig:
+    """
+    Check SSSD and SSH configuration related to the sss_ssh_knownhostsproxy tool.
+
+    Checks:
+        - Which files in the SSSD configuration include the `service` keyword,
+        - Which files in the SSH configuration mention the tool.
+    """
+
+    sssd_files = _look_for_files('services', sssd_config)
+    ssh_files = _look_for_files('sss_ssh_knownhostsproxy', ssh_config)
+
+    return SSSDConfig(sssd_config_files = sssd_files, ssh_config_files = ssh_files)

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdfacts/tests/unit_test_sssdfacts.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdfacts/tests/unit_test_sssdfacts.py
@@ -1,0 +1,118 @@
+import pytest
+import os
+
+from tempfile import NamedTemporaryFile
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import sssdfacts
+
+
+def make_tmp_file(contents: str, *, dir: str| None = None) -> NamedTemporaryFile:
+    file = NamedTemporaryFile(mode='w+t', prefix='test.sssdfacts.', dir=dir)
+    file.write(contents)
+    file.seek(0)
+    # The file will be deleted on closure, so keep it open.
+    return file
+
+def make_sssd_config_file(configured: bool, enabled: bool) -> NamedTemporaryFile:
+    contents = f"""
+    [sssd]
+    {'#' if not configured else ''}services = pam
+    """
+
+    contents = '[sssd]\n'
+    if configured:
+        if not enabled:
+            contents += "# "
+        contents += 'services = pam\n'
+    contents += '# last line\n'
+
+    return make_tmp_file(contents)
+
+def make_ssh_config_file(configured: bool, enabled: bool, *, dir: str| None = None) -> NamedTemporaryFile:
+    contents = '# 1st line\n'
+    if configured:
+        if not enabled:
+            contents += "# "
+        contents += 'ProxyCommand /usr/bin/sss_ssh_knownhostsproxy -p %p %h\n'
+    contents += '# last line\n'
+    return make_tmp_file(contents, dir=dir)
+
+def test_sssdfacts__missing_config():
+    facts = sssdfacts.get_facts(sssd_config=['/etc/missing-file'],
+                                ssh_config=['/etc/missing-file'])
+
+    assert len(facts.sssd_config_files) == 0
+    assert len(facts.ssh_config_files) == 0
+
+def test_sssdfacts__empty_config():
+    facts = sssdfacts.get_facts(sssd_config=['/dev/null'],
+                                ssh_config=['/dev/null'])
+    assert len(facts.sssd_config_files) == 0
+    assert len(facts.ssh_config_files) == 0
+
+@pytest.mark.parametrize('svc_configured', [(True), (False)])
+@pytest.mark.parametrize('svc_enabled', [(True), (False)])
+def test_sssdfacts__ssh_service(svc_configured, svc_enabled):
+    sssd_config = make_sssd_config_file(svc_configured, svc_enabled)
+
+    facts = sssdfacts.get_facts(sssd_config=[sssd_config.name],
+                                ssh_config=['/dev/null'])
+
+    sssd_config.close()
+
+    if svc_configured:
+        assert len(facts.sssd_config_files) == 1
+        assert sssd_config.name in facts.sssd_config_files
+    else:
+        assert len(facts.sssd_config_files) == 0
+
+@pytest.mark.parametrize('proxy_configured', [(True), (False)])
+@pytest.mark.parametrize('proxy_enabled', [(True), (False)])
+def test_sssdfacts__knownhostsproxy(proxy_configured, proxy_enabled):
+    ssh_config = make_ssh_config_file(proxy_configured, proxy_enabled)
+
+    facts = sssdfacts.get_facts(sssd_config=['/dev/null'],
+                                ssh_config=[ssh_config.name])
+
+    ssh_config.close()
+
+    if proxy_configured:
+        assert len(facts.ssh_config_files) == 1
+        assert ssh_config.name in facts.ssh_config_files
+    else:
+        assert len(facts.ssh_config_files) == 0
+
+def test_sssdfacts__directory():
+    dir = '/tmp/test.sssdfacts'
+    os.mkdir(dir)
+    ssh_config = make_ssh_config_file(True, True, dir=dir)
+
+    facts = sssdfacts.get_facts(sssd_config=['/dev/null'],
+                                ssh_config=[dir])
+
+    ssh_config.close()
+    os.rmdir(dir)
+
+    assert len(facts.ssh_config_files) == 1
+    assert ssh_config.name in facts.ssh_config_files
+
+def test_sssdfacts__file_error():
+    ssh_config = make_ssh_config_file(True, True)
+    os.chmod(ssh_config.name, 0)
+
+    exception = None
+    try:
+        sssdfacts.get_facts(sssd_config=['/dev/null'],
+                            ssh_config=[ssh_config.name])
+    except StopActorExecutionError as e:
+        exception = e
+
+    ssh_config.close()
+
+    assert exception is not None
+    assert isinstance(exception, StopActorExecutionError)
+    assert str(exception) == 'Could not open file ' + ssh_config.name
+    assert exception.details is not None
+    assert 'Permission denied' in exception.details['details']
+    assert ssh_config.name in exception.details['details']

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdupdate/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdupdate/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.models import SSSDConfig
+from leapp.libraries.actor import sssdupdate
+from leapp.tags import PreparationPhaseTag, IPUWorkflowTag
+
+
+class SSSDUpdate(Actor):
+    """
+    Update SSSD's and SSH's configuration to use sss_ssh_knownhosts instead
+    of sss_ssh_knownhosts proxy.
+    """
+
+    name = 'sssd_update'
+    consumes = (SSSDConfig,)
+    produces = ()
+    tags = (IPUWorkflowTag, PreparationPhaseTag)
+
+    def process(self):
+        for cfg in self.consume(SSSDConfig):
+            sssdupdate.update_config(cfg)

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdupdate/libraries/sssdupdate.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdupdate/libraries/sssdupdate.py
@@ -1,0 +1,74 @@
+import os
+
+from leapp.exceptions import StopActorExecutionError
+
+def _process_knownhosts(line:str) -> str:
+    if 'sss_ssh_knownhostsproxy' in line:
+        # Update the line, leaving intact any # and any --domain/-d parameter
+        line = line.replace('ProxyCommand', 'KnownHostsCommand')
+        line = line.replace('sss_ssh_knownhostsproxy', 'sss_ssh_knownhosts')
+        line = line.replace('--port=', '')
+        line = line.replace('--port', '')
+        line = line.replace('-p=', '')
+        line = line.replace('-p', '')
+        line = line.replace('%p', '')
+        line = line.replace('%h', '%H')
+
+    return line
+
+def _process_enable_svc(line:str) -> str:
+    if 'services' in line:
+        line = line.rstrip()
+        line += (',' if line[-1] != '=' else '') + 'ssh\n'
+
+    return line
+
+def _update_file(filename, process_function):
+    newname = filename + '.new'
+    oldname = filename + '.old'
+    try:
+        with open(filename, 'r') as input:
+            istat = os.fstat(input.fileno())
+            with open(newname, 'x', ) as output:
+                os.fchmod(output.fileno(), istat.st_mode)
+                for line in input:
+                    try:
+                        output.write(process_function(line))
+                    except SyntaxError as e:
+                        raise StopActorExecutionError(filename + ': ' + e)
+
+    except FileExistsError:
+        raise StopActorExecutionError('Temporary file ' + newname + ' already exists')
+    except OSError as e:
+        try:
+            os.unlink(newname)
+        except FileNotFoundError:
+            pass
+        raise StopActorExecutionError(str(e))
+
+    # Let's make sure the old configuration is preserverd if something goes wrong
+    os.replace(filename, oldname)
+    os.replace(newname, filename)
+    os.unlink(oldname)
+
+def _update_ssh_config(filename: str):
+    _update_file(filename, _process_knownhosts)
+
+
+def _enable_svc(filename):
+    _update_file(filename, _process_enable_svc)
+
+
+def update_config(model):
+    if not model:
+        return
+
+    # If sss_ssh_knownhostsproxy was not configured, there is nothing to do
+    if len(model.ssh_config_files) == 0:
+        return
+
+    for file in model.ssh_config_files:
+        _update_ssh_config(file)
+
+    for file in model.sssd_config_files:
+        _enable_svc(file)

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdupdate/tests/component_test_sssdupdate.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdupdate/tests/component_test_sssdupdate.py
@@ -1,0 +1,139 @@
+import os
+import pytest
+
+from tempfile import NamedTemporaryFile
+
+from leapp.models import SSSDConfig
+
+def make_tmp_file(contents: str) -> NamedTemporaryFile:
+    file = NamedTemporaryFile(mode='w+t', prefix='test.sssdupdate.', delete=False)
+    file.write(contents)
+    file.close()
+    return file.name
+
+def make_files(contents: list[str]) -> list[str]:
+    files = []
+    for conts in contents:
+        files.append(make_tmp_file(conts))
+
+    return files
+
+def check_file(name:str, expected: str):
+    with open(name, 'r') as f:
+        assert f.read() == expected
+
+@pytest.mark.parametrize('sssd', [(True), (False)])
+def test_sssdupdate__no_change(current_actor_context, sssd: bool):
+    contents = [
+        """
+        The time has come, the Walrus said,
+        To talk of many things:
+        Of shoes — and ships — and sealing-wax —
+        Of cabbages — and kings —
+        And why the sea is boiling hot —
+        And whether pigs have wings.
+        """,
+        """
+        Der Hölle Rache kocht in meinem Herzen,
+        Tod und Verzweiflung flammet um mich her!
+        Fühlt nicht durch dich Sarastro
+        Todesschmerzen,
+        So bist du meine Tochter nimmermehr.
+        """
+    ]
+
+    files = make_files(contents)
+    if sssd:
+        config = SSSDConfig(sssd_config_files=files)
+    else:
+        config = SSSDConfig(ssh_config_files=files)
+
+    current_actor_context.feed(config)
+    current_actor_context.run()
+
+    i = 0
+    for file in files:
+        check_file(file, contents[i])
+        os.unlink(file)
+        i += 1
+
+def test_sssdupdate__sssd_change(current_actor_context):
+    contents = [
+        """
+        [sssd]
+        services = pam, nss
+        domains = test
+        """,
+        """
+        [sssd]
+        # services = pam,nss
+        domains = test
+        """
+    ]
+    expected = [
+        """
+        [sssd]
+        services = pam, nss,ssh
+        domains = test
+        """,
+        """
+        [sssd]
+        # services = pam,nss,ssh
+        domains = test
+        """
+    ]
+    # A failure here indicates an error in the test
+    assert len(contents) == len(expected)
+
+    sssd_files = make_files(contents)
+    ssh_files = []
+    ssh_files.append(make_tmp_file(''))
+    config = SSSDConfig(sssd_config_files=sssd_files, ssh_config_files = ssh_files)
+
+    current_actor_context.feed(config)
+    current_actor_context.run()
+
+    os.unlink(ssh_files[0])
+    i = 0
+    for file in sssd_files:
+        check_file(file, expected[i])
+        os.unlink(file)
+        i += 1
+
+def test_sssdupdate__ssh_change(current_actor_context):
+    contents = [
+        """
+        First line
+        ProxyCommand  /usr/bin/sss_ssh_knownhostsproxy -p %p -d domain %h
+        3rd line
+        """,
+        """
+        #\tProxyCommand /usr/bin/sss_ssh_knownhostsproxy --port=%p  %h
+        # Another comment
+        """
+    ]
+    expected = [
+        """
+        First line
+        KnownHostsCommand  /usr/bin/sss_ssh_knownhosts   -d domain %H
+        3rd line
+        """,
+        """
+        #\tKnownHostsCommand /usr/bin/sss_ssh_knownhosts   %H
+        # Another comment
+        """
+    ]
+    # A failure here indicates an error in the test
+    assert len(contents) == len(expected)
+
+    files = make_files(contents)
+    config = SSSDConfig(ssh_config_files=files)
+
+    current_actor_context.feed(config)
+    current_actor_context.run()
+
+    i = 0
+    for file in files:
+        check_file(file, expected[i])
+        os.unlink(file)
+        i += 1

--- a/repos/system_upgrade/el9toel10/models/sssd.py
+++ b/repos/system_upgrade/el9toel10/models/sssd.py
@@ -1,0 +1,24 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class SSSDConfig(Model):
+    """
+    SSSD configuration that is related to the upgrade process.
+
+    The configuration might belong to some other service, such as SSH,
+    but because it is related to SSSD we report it.
+    """
+    topic = SystemInfoTopic
+
+    sssd_config_files = fields.List(fields.String(), default = [])
+    """
+    List of files in the sssd configuration that include `service`
+    and that may need to be updated.
+    """
+
+    ssh_config_files = fields.List(fields.String(), default = [])
+    """
+    List of files in the ssh configuration that include `sss_ssh_knownhostsproxy`
+    and that need to be updated.
+    """


### PR DESCRIPTION
The old tool `sss_ssh_knownhostsproxy` was replaced by `sss_ssh_knonwhosts` in RHEL 10. SSH's configuration has to be updated from things like:

`ProxyCommand  /usr/bin/sss_ssh_knownhostsproxy -p %p %h`

to:

`KnownHostsCommand  /usr/bin/sss_ssh_knownhosts %H`

Three actors are added:

* `SSSDFacts` retrieves facts about SSSD and SSH configuration related to the sss_ssh_knownhostsproxy tool. It dentifies files in the SSSD configuration including the `service` keyword, and files in the SSH configuration mentioning the tool.

* `SSSDCheck` checks if there is something to do and, in that case, creates a report. File access is also checked and reported if they cannot be written to.

* `SSSDUpdate` updates the SSSD and SSH configuration to use the new tool and meet its requirements.

Each actor includes its test.