### PR TITLE
Read the DNF config by module.py library

### DIFF
--- a/repos/system_upgrade/common/actors/rpmscanner/libraries/rpmscanner.py
+++ b/repos/system_upgrade/common/actors/rpmscanner/libraries/rpmscanner.py
@@ -25,6 +25,8 @@ except ImportError:
 
 def _get_package_repository_data_yum():
     yum_base = yum.YumBase()
+    # DNF configuration is not loaded here, since no impact for operations
+    # done by the actor is observed here
     pkg_repos = {}
 
     try:

--- a/repos/system_upgrade/common/libraries/module.py
+++ b/repos/system_upgrade/common/libraries/module.py
@@ -38,6 +38,7 @@ def _create_or_get_dnf_base(base=None):
         conf.substitutions.update_from_etc('/')
 
         base = dnf.Base(conf=conf)
+        base.conf.read()
         base.init_plugins()
         base.read_all_repos()
         # configure plugins after the repositories are loaded


### PR DESCRIPTION
The DNF configuration has not been loaded when trying to get
information about available module streams (library module.py).
This causes a traceback e.g. on systems which must access DNF
repositories via a proxy.
This patch introduces loading the DNF configuration before trying
to access remote resources.

Jira: RHEL-39095