### PR TITLE
Disable localpkg_gpgcheck parameter from plugin data

### DIFF
--- a/repos/system_upgrade/common/files/rhel_upgrade.py
+++ b/repos/system_upgrade/common/files/rhel_upgrade.py
@@ -116,6 +116,7 @@ class RhelUpgradeCommand(dnf.cli.Command):
         self.base.conf.best = self.plugin_data['dnf_conf']['best']
         self.base.conf.assumeyes = True
         self.base.conf.gpgcheck = self.plugin_data['dnf_conf']['gpgcheck']
+        self.base.conf.localpkg_gpgcheck = False
         self.base.conf.debug_solver = self.plugin_data['dnf_conf']['debugsolver']
         self.base.conf.module_platform_id = self.plugin_data['dnf_conf']['platform_id']
         installroot = self.plugin_data['dnf_conf'].get('installroot')


### PR DESCRIPTION
This commit is setting the localpkg_gpgcheck DNF option within the
rhel-upgrade plugin to 0 (disabled).
The upgrade process has been blocked with "Error: GPG check FAILED"
when dnf has been configured to apply gpg check also on local packages
(localpkg_gpgcheck=1). That's because the bundled leapp*-deps meta
packages, which are managing Leapp and leapp-repository dependencies
during the transition to the new system, are not signed by the Red
Hat key. Therefore, this option needs to be disabled.

Jira: RHEL-47472