### PR TITLE
Fix: skip checking ownership of files in .../directory-hash/ dir

### DIFF
--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -294,6 +294,8 @@ def _get_files_owned_by_rpms(context, dirpath, pkgs=None, recursive=False):
     """
     Return the list of file names inside dirpath owned by RPMs.
 
+    The returned paths are relative to the dirpath.
+
     This is important e.g. in case of RHUI which installs specific repo files
     in the yum.repos.d directory.
 
@@ -334,7 +336,7 @@ def _get_files_owned_by_rpms(context, dirpath, pkgs=None, recursive=False):
             api.current_logger().debug('SKIP the {} file: not owned by any rpm'.format(fname))
             continue
         if pkgs and not [pkg for pkg in pkgs if pkg in result['stdout']]:
-            api.current_logger().debug('SKIP the {} file: not owned by any searched rpm:'.format(fname))
+            api.current_logger().debug('SKIP the {} file: not owned by any searched rpm'.format(fname))
             continue
         api.current_logger().debug('Found the file owned by an rpm: {}.'.format(fname))
         files_owned_by_rpms.append(fname)

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -311,7 +311,7 @@ def _get_files_owned_by_rpms(context, dirpath, pkgs=None, recursive=False):
     searchdir = context.full_path(dirpath)
     if recursive:
         for root, _, files in os.walk(searchdir):
-            if '/directory-hash/' in root:
+            if '/directory-hash' in root:
                 # tl;dr; for the performance improvement
                 # The directory has been relatively recently added to ca-certificates
                 # rpm on EL 9+ systems and the content does not seem to be important

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
@@ -1229,7 +1229,7 @@ def test_perform_ok(monkeypatch):
 
 
 def test__get_files_owned_by_rpms(monkeypatch):
-    # this is not necessarily accurate, but close enoguh
+    # this is not necessarily accurate, but close enough
     fake_walk = [
         ("/base/dir/etc/pki", ["ca-trust", "tls", "rpm-gpg"], []),
         ("/base/dir/etc/pki/ca-trust", ["extracted", "source"], []),


### PR DESCRIPTION
This check has been reintroduced in 87013d25b5aa3 in #1297, however the "root" directory during traversal is:
`/var/lib/leapp/el10userspace/etc/pki/ca-trust/extracted/pem/directory-hash`. 
The skip condition looks for '/directory-hash/' which is false and the files are still checked.

I also added a test, which is not nice, but is only designed to ensure the existing behaviour keeps working. It also doesn't cover all paths.

From pdb:
```
> /etc/leapp/repos.d/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py(315)_get_files_owned_by_rpms()
-> if '/directory-hash/' in root:
display root: '/var/lib/leapp/el10userspace/etc/pki/ca-trust/extracted/pem/directory-hash'
display files: ['5931b5bc.0', 'ACCVRAIZ1.pem', 'a94d09e5.0', '3c9a4d3b.0', '228f89db.0', 'AC_RAIZ_FNMT-RCM.pem', 'cd8c0d63.0', 'b936d1c6.0', ... ]
```

On a minimal install this saves around 450 rpm ownership checks:
Before the change:
```
# grep directory-hash /var/log/leapp/leapp-preupgrade.log | grep owned | wc -l
445
```
after:
```
# grep directory-hash /var/log/leapp/leapp-preupgrade.log | grep owned | wc -l
0
```
and:
```
# grep directory-hash /var/log/leapp/leapp-upgrade.log | grep SKIP
2025-07-11 13:22:08.879 DEBUG    PID: 243344 leapp.workflow.TargetTransactionFactsCollection.target_userspace_creator: SKIP files in the /var/lib/leapp/el10userspace/etc/pki/ca-trust/extracted/pem/directory-hash directory: Not important for the IPU.
```