### PR TITLE
Skip RHSM related actions on non-RHEL systems

### DIFF
--- a/commands/command_utils.py
+++ b/commands/command_utils.py
@@ -136,6 +136,16 @@ def get_os_release_version_id(filepath):
     return _retrieve_os_release_contents(_os_release_path=filepath).get('VERSION_ID', '')
 
 
+def get_distro_id():
+    """
+    Retrieve the OS release ID from /etc/os-release.
+
+    :return: The OS release ID from /etc/os-release
+    :rtype: str
+    """
+    return _retrieve_os_release_contents('/etc/os-release').get('VERSION_ID', '')
+
+
 def get_upgrade_paths_config():
     # NOTE(ivasilev) Importing here not to have circular dependencies
     from leapp.cli.commands.upgrade import util  # noqa: C415; pylint: disable=import-outside-toplevel
@@ -205,8 +215,7 @@ def get_target_release(args):
 
     target_ver = env_version_override or args.target
     if target_ver:
-        os_release_contents = _retrieve_os_release_contents()
-        distro_id = os_release_contents.get('ID', '')
+        distro_id = get_distro_id()
         expected_version_format = _DISTRO_VERSION_FORMATS.get(distro_id, VersionFormats.MAJOR_MINOR).value
         assert_version_format(target_ver, expected_version_format, _VersionKind.TARGET)
         return (target_ver, flavor)

--- a/commands/preupgrade/__init__.py
+++ b/commands/preupgrade/__init__.py
@@ -20,8 +20,12 @@ from leapp.utils.output import beautify_actor_exception, report_errors, report_i
              choices=list(util.EXPERIMENTAL_FEATURES), default=[])
 @command_opt('debug', is_flag=True, help='Enable debug mode', inherit=False)
 @command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
-@command_opt('no-rhsm', is_flag=True, help='Use only custom repositories and skip actions'
-                                           ' with Red Hat Subscription Manager')
+@command_opt(
+    'no-rhsm',
+    is_flag=True,
+    help='Use only custom repositories and skip actions with Red Hat Subscription Manager.'
+         ' This only has effect on Red Hat Enterprise Linux systems.'
+)
 @command_opt('no-insights-register', is_flag=True, help='Do not register into Red Hat Insights')
 @command_opt('no-rhsm-facts', is_flag=True, help='Do not store migration information using Red Hat '
                                                  'Subscription Manager. Automatically implied by --no-rhsm.')

--- a/commands/upgrade/__init__.py
+++ b/commands/upgrade/__init__.py
@@ -26,8 +26,12 @@ from leapp.utils.output import beautify_actor_exception, report_errors, report_i
              choices=list(util.EXPERIMENTAL_FEATURES), default=[])
 @command_opt('debug', is_flag=True, help='Enable debug mode', inherit=False)
 @command_opt('verbose', is_flag=True, help='Enable verbose logging', inherit=False)
-@command_opt('no-rhsm', is_flag=True, help='Use only custom repositories and skip actions'
-                                           ' with Red Hat Subscription Manager')
+@command_opt(
+    'no-rhsm',
+    is_flag=True,
+    help='Use only custom repositories and skip actions with Red Hat Subscription Manager.'
+         ' This only has effect on Red Hat Enterprise Linux systems.'
+)
 @command_opt('no-insights-register', is_flag=True, help='Do not register into Red Hat Insights')
 @command_opt('no-rhsm-facts', is_flag=True, help='Do not store migration information using Red Hat '
                                                  'Subscription Manager. Automatically implied by --no-rhsm.')

--- a/commands/upgrade/util.py
+++ b/commands/upgrade/util.py
@@ -222,7 +222,8 @@ def prepare_configuration(args):
         os.environ['LEAPP_EXPERIMENTAL'] = '1'
 
     os.environ['LEAPP_UNSUPPORTED'] = '0' if os.getenv('LEAPP_UNSUPPORTED', '0') == '0' else '1'
-    if args.no_rhsm:
+    # force no rhsm on non-rhel systems, regardless of whether the binary is there
+    if args.no_rhsm or command_utils.get_distro_id() != 'rhel':
         os.environ['LEAPP_NO_RHSM'] = '1'
     elif not os.path.exists('/usr/sbin/subscription-manager'):
         os.environ['LEAPP_NO_RHSM'] = '1'

--- a/repos/system_upgrade/common/actors/reportsettargetrelease/libraries/reportsettargetrelease.py
+++ b/repos/system_upgrade/common/actors/reportsettargetrelease/libraries/reportsettargetrelease.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.libraries.common import rhsm
+from leapp.libraries.common.config import get_distro_id
 from leapp.libraries.stdlib import api
 
 
@@ -49,6 +50,7 @@ def _report_unhandled_release():
 
 def process():
     if rhsm.skip_rhsm():
-        _report_unhandled_release()
+        if get_distro_id() == 'rhel':
+            _report_unhandled_release()
     else:
         _report_set_release()

--- a/repos/system_upgrade/common/actors/reportsettargetrelease/tests/test_targetreleasereport_reportsettargetrelease.py
+++ b/repos/system_upgrade/common/actors/reportsettargetrelease/tests/test_targetreleasereport_reportsettargetrelease.py
@@ -26,3 +26,13 @@ def test_report_unhandled_release(monkeypatch):
     reportsettargetrelease.process()
     assert reporting.create_report.called == 1
     assert 'is going to be kept' in reporting.create_report.report_fields['title']
+
+
+def test_no_report_on_non_rhel(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(release_id='centos'))
+    monkeypatch.setattr(rhsm, 'skip_rhsm', lambda: True)  # this is always the case on nonrhel
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+
+    reportsettargetrelease.process()
+
+    assert reporting.create_report.called == 0

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -7,7 +7,7 @@ from leapp import reporting
 from leapp.exceptions import StopActorExecution, StopActorExecutionError
 from leapp.libraries.actor import constants
 from leapp.libraries.common import dnfplugin, mounting, overlaygen, repofileutils, rhsm, utils
-from leapp.libraries.common.config import get_env, get_product_type
+from leapp.libraries.common.config import get_distro_id, get_env, get_product_type
 from leapp.libraries.common.config.version import get_target_major_version
 from leapp.libraries.common.gpg import get_path_to_gpg_certs, is_nogpgcheck_set
 from leapp.libraries.stdlib import api, CalledProcessError, config, run
@@ -673,7 +673,15 @@ def _prep_repository_access(context, target_userspace):
 def _get_product_certificate_path():
     """
     Retrieve the required / used product certificate for RHSM.
+
+    Product certificates are only used on RHEL, on non-RHEL systems the function returns None.
+
+    :return: The path to the product certificate or None on non-RHEL systems
+    :raises: StopActorExecution if a certificate cannot be found
     """
+    if get_distro_id() != 'rhel':
+        return None
+
     architecture = api.current_actor().configuration.architecture
     target_version = api.current_actor().configuration.version.target
     target_product_type = get_product_type('target')

--- a/repos/system_upgrade/common/libraries/config/__init__.py
+++ b/repos/system_upgrade/common/libraries/config/__init__.py
@@ -97,3 +97,16 @@ def get_target_product_channel(default='ga'):
 def get_consumed_data_stream_id():
     """Get the identifier of the asset family used by leapp."""
     return CONSUMED_DATA_STREAM_ID
+
+
+def get_distro_id():
+    """
+    Retrieve the distro ID.
+
+    This is the ID string from /etc/os_release.
+    E.g. "rhel" for Red Hat Enterprise Linux
+
+    :return: The ID string from /etc/os_release
+    :rtype: str
+    """
+    return api.current_actor().configuration.os_release.release_id

--- a/repos/system_upgrade/common/libraries/rhsm.py
+++ b/repos/system_upgrade/common/libraries/rhsm.py
@@ -7,7 +7,7 @@ import time
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import repofileutils
-from leapp.libraries.common.config import get_env
+from leapp.libraries.common.config import get_distro_id, get_env
 from leapp.libraries.stdlib import api, CalledProcessError
 from leapp.models import RHSMInfo
 
@@ -331,10 +331,19 @@ def set_container_mode(context):
     /etc/pki/entitlement directories exists, even when leapp is executed with
     --no-rhsm option. If any of these directories are missing, skip other
     actions - most likely RHSM is not installed in such a case.
+    Note that this only true on RHEL systems, on non-RHEL (which don't use RHSM)
+    this function does nothing.
 
     :param context: An instance of a mounting.IsolatedActions class
     :type context: mounting.IsolatedActions class
     """
+    # this has to happen even with skip_rhsm, but only on RHEL
+    if get_distro_id() != 'rhel':
+        api.current_logger().info(
+            'Skipping setting RHSM into container mode on non-RHEL systems.'
+        )
+        return
+
     if not context.is_isolated():
         api.current_logger().error('Trying to set RHSM into the container mode'
                                    'on host. Skipping the action.')


### PR DESCRIPTION
Non-RHEL systems do not use Red Hat Subscription Manager (RHSM),
therefore all RHSM related actions should be skipped on such systems.

Changes:
- The --no-rhsm option is implied on non-RHEL systems and LEAPP_NO_RHSM is
forcefully set to 1.
- On non-RHEL distros skip rhsm actions which are not skipped on RHEL even with --no-rhsm.
- Do not report unhandled RHSM release on non-RHEL systems

There are still reports that need to be adjusted, this is just "functional" changes.

Jira: RHEL-95975

