### PR TITLE
feat: Check for use of dracut modules that are known to be missing on the target system

### DIFF
--- a/repos/system_upgrade/common/actors/scan_default_initramfs/actor.py
+++ b/repos/system_upgrade/common/actors/scan_default_initramfs/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scan_default_initramfs as scan_default_initramfs_lib
+from leapp.models import DefaultInitramfsInfo, DefaultSourceBootEntry
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanDefaultInitramfs(Actor):
+    """
+    Scan details of the default boot entry's initramfs image.
+
+    Information such as used dracut modules are collected.
+    """
+
+    name = 'scan_default_initramfs'
+    consumes = (DefaultSourceBootEntry,)
+    produces = (DefaultInitramfsInfo,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        scan_default_initramfs_lib.scan_default_initramfs()

--- a/repos/system_upgrade/common/actors/scan_default_initramfs/libraries/scan_default_initramfs.py
+++ b/repos/system_upgrade/common/actors/scan_default_initramfs/libraries/scan_default_initramfs.py
@@ -1,0 +1,41 @@
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import DefaultInitramfsInfo, DefaultSourceBootEntry
+
+
+def scan_default_initramfs():
+    default_boot_entry = next(api.consume(DefaultSourceBootEntry), None)
+    if not default_boot_entry:
+        raise StopActorExecutionError('Actor did not receive default boot entry info.')
+
+    target_initramfs_path = default_boot_entry.initramfs_path
+    try:
+        initramfs_info = run(['lsinitrd', '-m', target_initramfs_path], split=True)['stdout']
+
+    except CalledProcessError as err:
+        details = {'details': str(err)}
+        msg = 'Failed to list details (lsinitrd) of the default boot entry\'s initramfs.'
+        raise StopActorExecutionError(msg, details=details)
+
+    dracut_modules_lines = iter(initramfs_info)
+
+    for line in dracut_modules_lines:  # Consume everything until `dracut-modules:` is seen
+        line = line.strip()
+        if line == 'dracut modules:':
+            break
+
+    dracut_modules = []
+    for module_line in dracut_modules_lines:
+        module_line = module_line.strip()
+        if module_line.startswith('========'):
+            break
+
+        dracut_modules.append(module_line)
+
+    api.current_logger().debug(('Default boot entry\'s initramfs ({}) has '
+                                'the following dracut modules: {}').format(default_boot_entry.initramfs_path,
+                                                                           dracut_modules))
+
+    default_initramfs_info_msg = DefaultInitramfsInfo(path=default_boot_entry.initramfs_path,
+                                                      used_dracut_modules=dracut_modules)
+    api.produce(default_initramfs_info_msg)

--- a/repos/system_upgrade/common/actors/scan_default_initramfs/tests/test_scan_default_initramfs.py
+++ b/repos/system_upgrade/common/actors/scan_default_initramfs/tests/test_scan_default_initramfs.py
@@ -1,0 +1,82 @@
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import scan_default_initramfs
+from leapp.libraries.common import testutils
+from leapp.libraries.stdlib import CalledProcessError
+from leapp.models import DefaultInitramfsInfo, DefaultSourceBootEntry
+
+
+def test_scan_default_initramfs(monkeypatch):
+    lsinitrd_output = [
+        'Image: /boot/initramfs-5.14.0-570.12.1.el9_6.x86_64.img: 38M',
+        '========================================================================',
+        'Early CPIO image',
+        '========================================================================',
+        'drwxr-xr-x   3 root     root            0 Mar 11 04:02 .',
+        '-rw-r--r--   1 root     root            2 Mar 11 04:02 early_cpio',
+        'drwxr-xr-x   3 root     root            0 Mar 11 04:02 kernel',
+        'drwxr-xr-x   3 root     root            0 Mar 11 04:02 kernel/x86',
+        'drwxr-xr-x   2 root     root            0 Mar 11 04:02 kernel/x86/microcode',
+        '-rw-r--r--   1 root     root       220160 Mar 11 04:02 kernel/x86/microcode/GenuineIntel.bin',
+        '========================================================================',
+        'Version: dracut-057-87.git20250311.el9_6',
+        '',
+        'dracut modules:',
+        'bash',
+        'systemd',
+        '========================================',
+    ]
+
+    def run_mock(command, split=False):
+        if command == ['lsinitrd', '-m', '/boot/initramfs-upgrade.x86_64.img']:
+            return {'stdout': lsinitrd_output}
+        assert False, f'Unexpected command: {command}'
+
+    default_source_entry_msg = DefaultSourceBootEntry(
+        kernel_path='/boot/vmlinuz-upgrade.x86_64',
+        initramfs_path='/boot/initramfs-upgrade.x86_64.img'
+    )
+
+    actor_mock = testutils.CurrentActorMocked(msgs=[default_source_entry_msg])
+    produce_mock = testutils.produce_mocked()
+
+    monkeypatch.setattr(scan_default_initramfs.api, 'current_actor', actor_mock)
+    monkeypatch.setattr(scan_default_initramfs.api, 'produce', produce_mock)
+    monkeypatch.setattr(scan_default_initramfs, 'run', run_mock)
+
+    scan_default_initramfs.scan_default_initramfs()
+
+    assert produce_mock.called
+    assert len(produce_mock.model_instances) == 1
+    assert isinstance(produce_mock.model_instances[0], DefaultInitramfsInfo)
+
+    initramfs_info = produce_mock.model_instances[0]
+    assert initramfs_info.used_dracut_modules == ['bash', 'systemd']
+
+
+def test_no_default_boot_entry(monkeypatch):
+    monkeypatch.setattr(scan_default_initramfs.api, 'current_actor', testutils.CurrentActorMocked(msgs=[]))
+
+    with pytest.raises(StopActorExecutionError):
+        scan_default_initramfs.scan_default_initramfs()
+
+
+def test_lsinitrd_error(monkeypatch):
+    default_boot_entry = DefaultSourceBootEntry(
+        kernel_path='/boot/vmlinuz-upgrade.x86_64',
+        initramfs_path='/boot/initramfs-upgrade.x86_64.img'
+    )
+
+    def run_mock(command, split=False):
+        if command == ['lsinitrd', '-m', '/boot/initramfs-upgrade.x86_64.img']:
+            raise CalledProcessError('Simulated lsinitrd call error (in tests)', command, 1)
+        assert False, f'Unexpected command: {command}'
+
+    actor_mock = testutils.CurrentActorMocked(msgs=[default_boot_entry])
+    monkeypatch.setattr(scan_default_initramfs.api, 'current_actor', actor_mock)
+    monkeypatch.setattr(scan_default_initramfs.api, 'produce', testutils.produce_mocked())
+    monkeypatch.setattr(scan_default_initramfs, 'run', run_mock)
+
+    with pytest.raises(StopActorExecutionError):
+        scan_default_initramfs.scan_default_initramfs()

--- a/repos/system_upgrade/common/actors/scan_source_boot_loader/actor.py
+++ b/repos/system_upgrade/common/actors/scan_source_boot_loader/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scan_source_boot_entry as scan_source_boot_entry_lib
+from leapp.models import DefaultSourceBootEntry
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanSourceBootEntry(Actor):
+    """
+    Scan the default boot entry of the source system.
+    """
+
+    name = 'scan_source_boot_entry'
+    consumes = ()
+    produces = (DefaultSourceBootEntry,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        scan_source_boot_entry_lib.scan_default_source_boot_entry()

--- a/repos/system_upgrade/common/actors/scan_source_boot_loader/libraries/scan_source_boot_entry.py
+++ b/repos/system_upgrade/common/actors/scan_source_boot_loader/libraries/scan_source_boot_entry.py
@@ -1,0 +1,55 @@
+import os
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import DefaultSourceBootEntry
+
+
+def extract_path_with_img_extension(initramfs_path):
+    try:
+        img_extension_start = initramfs_path.rindex('.img')  # .index() returns the starting position
+        initramfs_path = initramfs_path[:img_extension_start + len('.img')]
+
+        if not os.path.exists(initramfs_path):
+            msg = 'Failed to extract the path to the default\'s boot entry initramfs.'
+            details = {'details': f'The current initramfs path {initramfs_path}'}
+            raise StopActorExecutionError(msg, details=details)
+
+    except ValueError:
+        details = {'details': f'The current initramfs path {initramfs_path}'}
+        # The system is using some non-traditional naming scheme, no point in trying to extract image path
+        # Better safe, than sorry, we stop the upgrade here rather than crashing because of a weird path
+        msg = ('The initrd path of the default kernel does not contain the `.img` extension, '
+               'thus the upgrade cannot safely continue.')
+        raise StopActorExecutionError(msg, details=details)
+    return initramfs_path
+
+
+def scan_default_source_boot_entry():
+    try:
+        default_kernel = run(['grubby', '--default-kernel'])['stdout'].strip()
+        default_kernel_info_lines = run(['grubby', '--info', default_kernel], split=True)['stdout']
+
+    except CalledProcessError as err:
+        details = {'details': str(err)}
+        raise StopActorExecutionError('Failed to determine default boot entry.', details=details)
+
+    # Note that there can be multiple entries listed sharing the same default kernel.
+    # The parsing is done in a way that it should not fail in such a case. For the current use
+    # it does not matter -- at the moment we care primarily about the initramfs path, and these
+    # entries should typically share the initramfs.
+
+    default_kernel_info = {}
+    for line in default_kernel_info_lines:
+        key, value = line.split('=', 1)
+        default_kernel_info[key] = value.strip('"')
+
+    initramfs_path = default_kernel_info['initrd']
+    initramfs_path = extract_path_with_img_extension(initramfs_path)
+
+    default_boot_entry_message = DefaultSourceBootEntry(
+        initramfs_path=initramfs_path,
+        kernel_path=default_kernel_info['kernel'],
+    )
+
+    api.produce(default_boot_entry_message)

--- a/repos/system_upgrade/common/actors/scan_source_boot_loader/tests/test_scan_source_boot_entry.py
+++ b/repos/system_upgrade/common/actors/scan_source_boot_loader/tests/test_scan_source_boot_entry.py
@@ -1,0 +1,61 @@
+import os
+
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import scan_source_boot_entry
+from leapp.libraries.common import testutils
+from leapp.libraries.stdlib import CalledProcessError
+from leapp.models import DefaultSourceBootEntry
+
+
+def test_scan_default_source_boot_entry(monkeypatch):
+    grubby_default_kernel_output = '/boot/vmlinuz-upgrade.x86_64\n'
+    grubby_default_kernel_info_lines = [
+        'index=3',
+        'kernel="/boot/vmlinuz-upgrade.x86_64"',
+        'args="ro console=tty0 console=ttyS0,115200 rd_NO_PLYMOUTH"',
+        'root="/dev/mapper/rhel_ibm--p8--kvm--03--guest--02-root"',
+        'initrd="/boot/initramfs-upgrade.x86_64.img $tuned_initrd"',
+        'title="RHEL-Upgrade-Initramfs"',
+        'id="f6f57ac447784f60ba924dfbd5776a1b-upgrade.x86_64"',
+    ]
+
+    def run_mock(command, split=False):
+        if command == ['grubby', '--default-kernel']:
+            return {'stdout': grubby_default_kernel_output}
+        if command == ['grubby', '--info', grubby_default_kernel_output.strip()]:
+            return {'stdout': grubby_default_kernel_info_lines}
+        assert False, f'Unexpected command: {command}'
+
+    def exists_mock(path):
+        if path == '/boot/initramfs-upgrade.x86_64.img':
+            return True
+        return os.path.exists(path)
+
+    produce_mock = testutils.produce_mocked()
+    monkeypatch.setattr(scan_source_boot_entry, 'run', run_mock)
+    monkeypatch.setattr(scan_source_boot_entry.api, 'produce', produce_mock)
+    monkeypatch.setattr(scan_source_boot_entry.os.path, 'exists', exists_mock)
+
+    scan_source_boot_entry.scan_default_source_boot_entry()
+
+    assert produce_mock.called
+    assert len(produce_mock.model_instances) == 1
+    assert isinstance(produce_mock.model_instances[0], DefaultSourceBootEntry)
+
+    boot_entry_info = produce_mock.model_instances[0]
+    assert boot_entry_info.initramfs_path == '/boot/initramfs-upgrade.x86_64.img'
+    assert boot_entry_info.kernel_path == '/boot/vmlinuz-upgrade.x86_64'
+
+
+def test_error_during_grubby_call(monkeypatch):
+    def run_mock(command, split=False):
+        if command == ['grubby', '--default-kernel']:
+            raise CalledProcessError('Simulated grubby call error (in tests)', command, 1)
+        assert False, f'Unexpected command: {command}'
+
+    monkeypatch.setattr(scan_source_boot_entry, 'run', run_mock)
+
+    with pytest.raises(StopActorExecutionError):
+        scan_source_boot_entry.scan_default_source_boot_entry()

--- a/repos/system_upgrade/common/models/initramfs.py
+++ b/repos/system_upgrade/common/models/initramfs.py
@@ -3,6 +3,15 @@ from leapp.topics import BootPrepTopic, SystemInfoTopic
 from leapp.utils.deprecation import deprecated
 
 
+# Note that this is the only model about the source (rather than upgrade) initramfs
+class DefaultInitramfsInfo(Model):
+    """ Information about the initramfs image that corresponds to the default source boot entry """
+    topic = SystemInfoTopic
+
+    path = fields.String()
+    used_dracut_modules = fields.List(fields.String(), default=[])
+
+
 class DracutModule(Model):
     """
     Specify a dracut module that should be included into the initramfs

--- a/repos/system_upgrade/common/models/source_boot_entry.py
+++ b/repos/system_upgrade/common/models/source_boot_entry.py
@@ -1,0 +1,10 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class DefaultSourceBootEntry(Model):
+    """ Default boot entry of the source system. """
+    topic = SystemInfoTopic
+
+    initramfs_path = fields.String()
+    kernel_path = fields.String()

--- a/repos/system_upgrade/el9toel10/actors/check_default_initramfs/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/check_default_initramfs/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import check_default_initramfs as check_default_initramfs_lib
+from leapp.models import DefaultInitramfsInfo
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckDefaultInitramfs(Actor):
+    """
+    Checks whether the default initramfs uses problematic dracut modules.
+
+    Checks whether dracut modules that are missing on the target system are used.
+    If yes, the upgrade is inhibited.
+    """
+
+    name = 'check_default_initramfs'
+    consumes = (DefaultInitramfsInfo,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        check_default_initramfs_lib.check_default_initramfs()

--- a/repos/system_upgrade/el9toel10/actors/check_default_initramfs/libraries/check_default_initramfs.py
+++ b/repos/system_upgrade/el9toel10/actors/check_default_initramfs/libraries/check_default_initramfs.py
@@ -1,0 +1,47 @@
+import os
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp.models import DefaultInitramfsInfo
+
+
+def check_default_initramfs():
+    default_initramfs_info = next(api.consume(DefaultInitramfsInfo), None)
+    if not default_initramfs_info:
+        msg = 'Actor did not receive information about default boot entry\'s initramfs.'
+        raise StopActorExecutionError(msg)
+
+    if 'network-legacy' in default_initramfs_info.used_dracut_modules:
+        summary = (
+            f'Initramfs ({default_initramfs_info.path}) of the default boot entry uses dracut '
+            'modules that are missing on the target system. This could cause a fatal '
+            'failure during the upgrade, resulting in unbootable system as '
+            'the missing dracut module could prevent creation of the required target '
+            'initramfs.\n\n'
+            'Namely, the legacy-network dracut module is used on this system, which '
+            'could originate from older system installations. The problem is typical '
+            'for RHEL 7 and early RHEL 8 systems that were in-place-upgraded to RHEL 9.'
+        )
+        remediation_hint = (
+            'Remove the dracut config file which adds the `network-legacy` dracut module. '
+            'Then rebuild existing initramfs images to remove the dracut module from them.'
+        )
+        report_fields = [
+            reporting.Title('Use of dracut modules that are missing on the target system detected'),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.BOOT]),
+            reporting.Remediation(hint=remediation_hint),
+            reporting.Groups([reporting.Groups.INHIBITOR]),
+            reporting.ExternalLink(
+                url='https://access.redhat.com/solutions/7127576',
+                title='leapp upgrade fails to boot after upgrading to RHEL 10.0'
+            )
+        ]
+
+        usual_definition_file = '/etc/dracut.conf.d/50-network-legacy.conf'
+        if os.path.exists(usual_definition_file):
+            report_fields.append(reporting.RelatedResource('file', usual_definition_file))
+
+        reporting.create_report(report_fields)

--- a/repos/system_upgrade/el9toel10/actors/check_default_initramfs/tests/test_check_default_initramfs.py
+++ b/repos/system_upgrade/el9toel10/actors/check_default_initramfs/tests/test_check_default_initramfs.py
@@ -1,0 +1,105 @@
+import os
+
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import check_default_initramfs
+from leapp.libraries.common import testutils
+from leapp.models import DefaultInitramfsInfo
+from leapp.utils.report import is_inhibitor
+
+
+def test_no_default_initramfs_info(monkeypatch):
+    """Test that StopActorExecutionError is raised when no DefaultInitramfsInfo is provided."""
+    # Mock api.consume to return empty iterator
+    actor_mock = testutils.CurrentActorMocked(msgs=[])
+    monkeypatch.setattr(check_default_initramfs.api, 'current_actor', actor_mock)
+
+    with pytest.raises(StopActorExecutionError):
+        check_default_initramfs.check_default_initramfs()
+
+
+def test_initramfs_without_network_legacy(monkeypatch):
+    """Test that no report is created when network-legacy module is not present."""
+    # Create a DefaultInitramfsInfo without the problematic module
+    initramfs_info = DefaultInitramfsInfo(
+        path='/boot/initramfs-upgrade.x86_64.img',
+        used_dracut_modules=['bash', 'systemd', 'kernel-modules', 'resume']
+    )
+
+    actor_mock = testutils.CurrentActorMocked(msgs=[initramfs_info])
+    create_report_mock = testutils.create_report_mocked()
+
+    monkeypatch.setattr(check_default_initramfs.api, 'current_actor', actor_mock)
+    monkeypatch.setattr(check_default_initramfs.reporting, 'create_report', create_report_mock)
+
+    check_default_initramfs.check_default_initramfs()
+
+    # No report should be created
+    assert not create_report_mock.called
+
+
+def test_initramfs_with_network_legacy_without_config_file(monkeypatch):
+    """
+    Test that a report is created when network-legacy module is present but config file doesn't exist.
+
+    The typical location of the config file (/etc/dracut.conf.d/50-network-legacy.conf) that
+    adds the 'network-legacy' module is not present.
+    """
+    # Create a DefaultInitramfsInfo with the problematic module
+    initramfs_info = DefaultInitramfsInfo(
+        path='/boot/initramfs-upgrade.x86_64.img',
+        used_dracut_modules=['bash', 'systemd', 'network-legacy', 'kernel-modules']
+    )
+
+    actor_mock = testutils.CurrentActorMocked(msgs=[initramfs_info])
+    create_report_mock = testutils.create_report_mocked()
+
+    monkeypatch.setattr(check_default_initramfs.api, 'current_actor', actor_mock)
+    monkeypatch.setattr(check_default_initramfs.reporting, 'create_report', create_report_mock)
+    # Mock os.path.exists to return False for the config file
+    monkeypatch.setattr(check_default_initramfs.os.path, 'exists', lambda path: False)
+
+    check_default_initramfs.check_default_initramfs()
+
+    assert create_report_mock.called
+    assert len(create_report_mock.reports) == 1
+
+    report = create_report_mock.reports[0]
+
+    assert is_inhibitor(report)
+
+    report_resources = report['detail'].get('related_resources', [])
+    assert not report_resources
+
+
+def test_initramfs_with_network_legacy_with_config_file(monkeypatch):
+    """Test that a report with related resource is created when network-legacy module and config file are present."""
+    initramfs_info = DefaultInitramfsInfo(
+        path='/boot/initramfs-upgrade.x86_64.img',
+        used_dracut_modules=['bash', 'systemd', 'network-legacy', 'kernel-modules']
+    )
+
+    actor_mock = testutils.CurrentActorMocked(msgs=[initramfs_info])
+    create_report_mock = testutils.create_report_mocked()
+
+    monkeypatch.setattr(check_default_initramfs.api, 'current_actor', actor_mock)
+    monkeypatch.setattr(check_default_initramfs.reporting, 'create_report', create_report_mock)
+
+    def mock_exists(path):
+        if path == '/etc/dracut.conf.d/50-network-legacy.conf':
+            return True
+        return os.path.exists(path)  # Fall back to original implementation since it is used in pytest internally
+
+    monkeypatch.setattr(check_default_initramfs.os.path, 'exists', mock_exists)
+
+    check_default_initramfs.check_default_initramfs()
+
+    assert create_report_mock.called
+    assert len(create_report_mock.reports) == 1
+
+    report = create_report_mock.reports[0]
+    assert is_inhibitor(report)
+
+    report_resources = report['detail'].get('related_resources', [])
+    assert report_resources


### PR DESCRIPTION
## Add detection of use of dracut modules known to be missing on target system

This PR introduces a new feature to detect and inhibit upgrades caused by using dracut modules that are known to be missing on the target system. The implementation consists of three main components working together to ensure upgrade safety:

### Changes Overview:
**1. Boot Entry Scanning**
- Added `scan_source_boot_loader` actor to extract default boot entry information using `grubby`
- Introduced `DefaultSourceBootEntry` model to capture kernel and initramfs paths

**2. Default Initramfs Analysis**  
- Added `scan_default_initramfs` actor that analyzes initramfs contents using `lsinitrd`
- Introduced `DefaultInitramfsInfo` model to store detected dracut modules
- Enables identification of dracut modules used in the source system's initramfs

**3. Detection of missing dracut modules**
- Added upgrade inhibition logic for missing dracut modules on the target system
- Currently detects and inhibits upgrades when `network-legacy` dracut module is missing


Jira-ref: RHEL-102591

Assisted by: Cursor