### PR TITLE
fix: get_distro_id returns version instead of distro name

### DIFF
--- a/commands/command_utils.py
+++ b/commands/command_utils.py
@@ -143,7 +143,7 @@ def get_distro_id():
     :return: The OS release ID from /etc/os-release
     :rtype: str
     """
-    return _retrieve_os_release_contents('/etc/os-release').get('VERSION_ID', '')
+    return _retrieve_os_release_contents('/etc/os-release').get('ID', '')
 
 
 def get_upgrade_paths_config():


### PR DESCRIPTION
The get_distro_id function from command_utils seeks wrong key in /etc/os-release. Instead of using 'ID', the function uses 'VERSION_ID', returning OS version (e.g. 9.6) instead of distro identifier such as RHEL.

Jira: RHELMISC-15777