### PR TITLE
Enable EUS channels on the 810to94 upgrade tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -168,6 +168,7 @@ jobs:
   env:
     SOURCE_RELEASE: "8.10"
     TARGET_RELEASE: "9.4"
+    LEAPP_TARGET_PRODUCT_CHANNEL: "EUS"
 
 # On-demand minimal beaker tests
 - &beaker-minimal-810to94
@@ -194,6 +195,7 @@ jobs:
   env:
     SOURCE_RELEASE: "8.10"
     TARGET_RELEASE: "9.4"
+    LEAPP_TARGET_PRODUCT_CHANNEL: "EUS"
 
 # On-demand kernel-rt tests
 - &kernel-rt-810to94
@@ -220,6 +222,7 @@ jobs:
   env:
     SOURCE_RELEASE: "8.10"
     TARGET_RELEASE: "9.4"
+    LEAPP_TARGET_PRODUCT_CHANNEL: "EUS"
 
 # Tests: 8.10 -> 9.6
 - &sanity-810to96


### PR DESCRIPTION
The linux-firmware RPM has been rebased in RHEL 8.10.z, 9.6.z, 10.0.z, and updated in 9.4.z-eus. As the new rebased package contains dir <-> symlink change, it creates conflicts with old (not-updated) linux-firmware packages. To be able to test IPU 8.10.z -> 9.4, EUS repositories must be used for the target rhel 9.4 system as standard repositories do not receive updates anymore.