### PR TITLE
Release 0.23.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@ import sphinx_rtd_theme
 project = 'leapp-repository'
 copyright = '2025, Leapp team'
 author = 'Leapp team'
-release = '0.22.0'
+release = '0.23.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/libraries-and-api/deprecations-list.md
+++ b/docs/source/libraries-and-api/deprecations-list.md
@@ -14,6 +14,10 @@ Only the versions in which a deprecation has been made are listed.
 
 ## Next release <span style="font-size:0.5em; font-weight:normal">(till TODO date)</span>
 
+- Note: nothing new deprecated yet
+
+## v0.23.0 <span style="font-size:0.5em; font-weight:normal">(till March 2026)</span>
+
 - Shared libraries
   - **`leapp.libraries.common.config.version.SUPPORTED_VERSIONS`** - The `SUPPORTED_VERSIONS` dict has been deprecated as it is problematic with the new design. Use `leapp.libraries.common.config.version.is_supported_version()` or `IPUConfig.supported_upgrade_paths` instead.
   - **`leapp.libraries.common.config.version.is_rhel_alt()`** - The function can return only `False` nowadays as RHEL-ALT 7 is EOL for years and future version of leapp-repository will not support RHEL 7 anymore.

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -51,7 +51,7 @@ py2_byte_compile "%1" "%2"}
 # RHEL 8+ packages to be consistent with other leapp projects in future.
 
 Name:           leapp-repository
-Version:        0.22.0
+Version:        0.23.0
 Release:        1%{?dist}
 Summary:        Repositories for leapp
 
@@ -85,7 +85,7 @@ Obsoletes:      leapp-repository-data <= 0.6.1
 Provides:       leapp-repository-data <= 0.6.1
 
 # Former leapp subpackage that is part of the sos package since RHEL 7.8
-Obsoletes:      leapp-repository-sos-plugin <= 0.9.0
+Obsoletes:      leapp-repository-sos-plugin <= 0.10.0
 
 # Set the conflict to be sure this RPM is not upgraded automatically to
 # the one from the target (upgraded) RHEL. The RPM has to stay untouched
@@ -287,6 +287,7 @@ rm -rf %{buildroot}%{repositorydir}/common/actors/testactor
 find %{buildroot}%{repositorydir}/common -name "test.py" -delete
 rm -rf `find %{buildroot}%{repositorydir} -name "tests" -type d`
 find %{buildroot}%{repositorydir} -name "Makefile" -delete
+find %{buildroot} -name "*.py.orig" -delete
 # .gitkeep file is used to have a directory in the repo. but we do not want these
 # files in the resulting RPM
 find %{buildroot} -name .gitkeep -delete

--- a/repos/system_upgrade/common/libraries/config/version.py
+++ b/repos/system_upgrade/common/libraries/config/version.py
@@ -314,7 +314,7 @@ def is_sap_hana_flavour():
     return api.current_actor().configuration.flavour == 'saphana'
 
 
-@deprecated(since='2025-05-31', message=(
+@deprecated(since='2025-08-14', message=(
     'RHEL-ALT reached EOL years ago and it is connected just to RHEL 7 systems.'
     'As such the function is useless nowadays and will return always False.'
     'The function is going to be removed in the next leapp-repository release.'

--- a/repos/system_upgrade/common/models/installedrpm.py
+++ b/repos/system_upgrade/common/models/installedrpm.py
@@ -47,6 +47,6 @@ class ThirdPartyRPM(InstalledRPM):
     pass
 
 
-@deprecated(since='2025-07-09', message='Replaced by ThirdPartyRPM')
+@deprecated(since='2025-08-14', message='Replaced by ThirdPartyRPM')
 class InstalledUnsignedRPM(InstalledRPM):
     pass


### PR DESCRIPTION
## Packaging
- Require leapp-framework > 6.1 (#1350)
- Introduced leapp-upgrade-*-fapolicyd subpackage with config file for fapolicyd (#1410)

## Upgrade handling
### Fixes
- Disable localpkg_gpgcheck during the upgrade if set to allow installation of bundled leapp and leapp-repository deps packages (#1401)
- Fix in-place upgrades on systems using fapolicyd (#1410)
- Fix parsing of the kernel cmdline  (#1372)
- Load DNF configuration in the `module.py` shared library to prevent errors when downloading remote content and proxy is required (#1398)
- Minor fixes in reports (#1355, #1371, #1370, #1402)
- Prevent a crash during the Application phase when no custom SELinux modules needs to be handled post-upgrade (#1352)
- Sanitize the device driver deprecation data and the scan of deprecated PCI devices (#1362, #1376)
- Skip checking ownership of files in the /etc/pki/ca-trust/extracted/pem/directory-hash directory (#1405)
- [IPU 8 -> 9] Fix broken bootloader on Azure hybrid images for systems previously upgraded from RHEL 7 (#1284)
- [IPU 9 -> 10] Create proper error message when the swap of RHUI clients fails (#1353)
- [IPU 9 -> 10] Exclude the leapp-upgrade-el9toel10 RPM from the upgrade transaction (#1351)
- [IPU 9 -> 10] Inhibit the upgrade on systems using deprecated network-legacy dracut module to prevent kernel panic (#1412)

### Enhancements
- Add IPU paths 8.10 -> 9.7 and 9.7 -> 10 (#1411, #1415)
- Add RHEL 9.7 and 10.1 product certificates (#1374)
- Requires data with provided_data_streams 4.0+ (#1375)
- Generalize the solution to make it more distribution agnostic
  - Skip RHSM-related actions on non-RHEL distros (#1407, #1414)
  - Manage RPM GPG keys during the upgrade respecting used linux distributions (#1378)
  - Respect the release_id of the OS when processing DNF repositories (#1375)
- Enable upgrades of CentOS Stream
  - Adjust the DNF `stream` variable during CentOS upgrades (#1406)
  - Gracefully handle CentOS OS versions that do not provide a minor version number (#1363, #1396)
  - [IPU 9 -> 10] Remove obsoleted RPM GPG key when upgrading to CentOS 10 (#1408)
- Enable upgrades of AlmaLinux (#1391)
- Introduced the --enable-experimental-feature to simplify use of experimental features (#1350)
- Simplified use of the LiveMode experimental feature with additional enhancements (#1350)
- Unify definition and processing of defined upgrade paths (#1359)
- Update leapp upgrade data files, start to provide data stream 4.0 (#1358, #1380, #1375, #1388, #1409, #1418)
- [IPU 8 -> 9] Add actor with recommendations for upgrade of MySQL (#1335)
- [IPU 9 -> 10] Add actors to migrate SSSD configuration (#1397)
- [IPU 9 -> 10] Enable upgrades on systems using RHUI on AWS, Azure, and Alibaba (#1387, #1383, #1420)
- [IPU 9 -> 10] Inhibit the upgrade if cgroups v1 are enabled on the system (#1392)

## Additional changes interesting for devels
- Documented more technical details about the LiveMode (#1357, #1366)
- Makefile: Return non-zero exit code on failed tests in container (#1382)
- New deprecations introduced:
  - The `HybridImage` model has been replaced by `ConvertGrubenvTask`. (#1284)
  - The `InstalledUnsignedRPM` model has been deprecated and replaced by `ThirdPartyRPM` (#1402)
  - The `leapp.libraries.common.config.version.SUPPORTED_VERSIONS` variable is deprecated (#1359)
  - the is_rhel_alt function from shared libraries has been deprecated (#1377)
- The rhui field in PESIDRepositoryEntry model is now plain string type instead of enumeration (#1375)
- Cleaning:
  - The el7toel8 repository has been removed (#1385)
  - Removal of some deprecated models: InstalledRedHatSignedRPM, IPUPaths (#1359, #1402)
- The `LEAPP_DEVEL_ENABLE_LIVE_MODE` envar has been dropped (#1350)


---
Jira: RHEL-67627, RHEL-86226