### PR TITLE
Prevent sssdupdate actor from rising errors

### DIFF
--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/libraries/sssdchecks.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/libraries/sssdchecks.py
@@ -15,8 +15,8 @@ def check_config(model):
         'SSSD\'s sss_ssh_knownhostsproxy tool is replaced by the more '
         'reliable sss_ssh_knownhosts tool. SSH\'s configuration will be updated '
         'to reflect this by updating every mention of sss_ssh_knownhostsproxy by '
-        'the corresponding mention of sss_ssh_knownhosts, even those commented out.\n'
-        'SSSD\'s ssh service will be enabled if not already done.\n'
+        'the corresponding mention of sss_ssh_knownhosts, even those commented out. '
+        'SSSD\'s ssh service will be enabled if not already done.\n\n'
         'The following files will be updated:{}{}'.format(
             FMT_LIST_SEPARATOR,
             FMT_LIST_SEPARATOR.join(model.sssd_config_files + model.ssh_config_files)

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdfacts/libraries/sssdfacts.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdfacts/libraries/sssdfacts.py
@@ -19,7 +19,10 @@ def _does_file_contain_expression(file_path, expression):
         )
         return False
     except OSError as e:
-        raise StopActorExecutionError('Could not open file ' + file_path, details={'details': str(e)})
+        raise StopActorExecutionError(
+            'Could not open configuration file',
+            details={'details': 'Coudn\'t open {} file with error: {}.'.format(file_path, str(e))}
+            )
 
 
 def _look_for_files(expression: str, path_list: list[str]) -> list[str]:


### PR DESCRIPTION
Potential error rise (StopActorExecutionError) is replaced with warning logs in the SSSD update file processing function. This prevents the upgrade from failing when accessing non-critical files. Also fix minor formatting nit picks.

Jira: RHEL-108992