### PR TITLE
LiveMode: Add /etc/crypttab file to the target userspace container

### DIFF
--- a/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
+++ b/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
@@ -3,6 +3,7 @@ from leapp.libraries.common.config.version import get_source_major_version
 from leapp.libraries.stdlib import api
 from leapp.models import (
     CephInfo,
+    CopyFile,
     DracutModule,
     LuksDumps,
     StorageInfo,
@@ -156,7 +157,10 @@ def check_invalid_luks_devices():
                 'tpm2-tools',
                 'tpm2-abrmd'
             ]
-            api.produce(TargetUserSpaceUpgradeTasks(install_rpms=required_crypt_rpms))
+            api.produce(TargetUserSpaceUpgradeTasks(
+                copy_files=[CopyFile(src="/etc/crypttab")],
+                install_rpms=required_crypt_rpms)
+                )
             api.produce(UpgradeInitramfsTasks(include_dracut_modules=[
                     DracutModule(name='clevis'),
                     DracutModule(name='clevis-pin-tpm2')


### PR DESCRIPTION
When upgrading with LiveMode, the auto-unlock of encrypted devices fails because the /etc/crypttab configuration file is not present inside the squashfs, causing the boot process to fail.

This change copy /etc/crypttab file to the target userspace container during the upgrade process, allowing encrypted devices to be properly unlocked.

Jira: RHEL-90098