### PR TITLE
skip initramfs actors when livemode is enabled

### DIFF
--- a/repos/system_upgrade/common/actors/initramfs/mount_units_generator/actor.py
+++ b/repos/system_upgrade/common/actors/initramfs/mount_units_generator/actor.py
@@ -1,16 +1,19 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import mount_unit_generator as mount_unit_generator_lib
-from leapp.models import TargetUserSpaceInfo, UpgradeInitramfsTasks
+from leapp.models import LiveModeConfig, TargetUserSpaceInfo, UpgradeInitramfsTasks
 from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
 
 
 class MountUnitGenerator(Actor):
     """
     Sets up storage initialization using systemd's mount units in the upgrade container.
+
+    Note that this storage initialization is skipped when the LiveMode is enabled.
     """
 
     name = 'mount_unit_generator'
     consumes = (
+        LiveModeConfig,
         TargetUserSpaceInfo,
     )
     produces = (


### PR DESCRIPTION
The new storage initialization solution interfered with livemode. Since livemode is a different approach to the upgrade, the initramfs actors (enable_lvm_autoactivation and mount_unit_generator) related to the new storage initialization are now skipped when upgrading via this method.

Jira: RHEL-119516
