### PR TITLE
mount_unit_gen: bind mount /sysroot/boot to /boot

### DIFF
--- a/repos/system_upgrade/common/actors/initramfs/mount_units_generator/actor.py
+++ b/repos/system_upgrade/common/actors/initramfs/mount_units_generator/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import mount_unit_generator as mount_unit_generator_lib
-from leapp.models import LiveModeConfig, TargetUserSpaceInfo, UpgradeInitramfsTasks
+from leapp.models import LiveModeConfig, StorageInfo, TargetUserSpaceInfo, UpgradeInitramfsTasks
 from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
 
 
@@ -15,6 +15,7 @@ class MountUnitGenerator(Actor):
     consumes = (
         LiveModeConfig,
         TargetUserSpaceInfo,
+        StorageInfo,
     )
     produces = (
         UpgradeInitramfsTasks,

--- a/repos/system_upgrade/common/actors/initramfs/mount_units_generator/files/bundled_units/boot.mount
+++ b/repos/system_upgrade/common/actors/initramfs/mount_units_generator/files/bundled_units/boot.mount
@@ -1,0 +1,11 @@
+[Unit]
+DefaultDependencies=no
+Before=local-fs.target
+After=sysroot-boot.target
+Requires=sysroot-boot.target
+
+[Mount]
+What=/sysroot/boot
+Where=/boot
+Type=none
+Options=bind


### PR DESCRIPTION
Our changes towards using systemd-fstab-generator in the upgrade initramfs caused that we are mounting almost all partitions, including /boot (the actual mount target is /sysroot/boot) early in the boot process. When upgrading with FIPS, the dracut fips module tries to mount the device where the boot partition resides to check the integrity of the kernel, however, it fails as the boot block device is already mounted by us. This patch therefore introduces a static unit that bindmounts What=/sysroot/boot to Where=/boot, making the contents of /boot available to the fips module. Thefore, upgrades with FIPS enabled should be again possible.

Jira-ref: RHEL-123886