### PR TITLE
fix cgroups-v1 inhibitor remediation

### DIFF
--- a/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/libraries/inhibitcgroupsv1.py
+++ b/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/libraries/inhibitcgroupsv1.py
@@ -48,7 +48,7 @@ def process():
                     [
                         "grubby",
                         "--update-kernel=ALL",
-                        '--remove-args="{}"'.format(",".join(remediation_cmd_args)),
+                        '--remove-args="{}"'.format(" ".join(remediation_cmd_args)),
                     ],
                 ],
             ),


### PR DESCRIPTION
The inhibitor, that checks if cgroups-v1 are enabled, generated remediation command which had incorrect form. This patch fixes the separator used for kernel arguments that need to be removed.

The `man grubby` does specify the format for the `--args` option as: "Multiple, **space separated** arguments may be used". While this is not directly specified for the `--remove-args` option, it works the same way. The comma separated list is likely treated as a single option, and thus, nothing is removed when the command is run.

Relevant parts of the `man grubby` for reference:
```
--args=kernel-args
         When a new kernel is added, this specifies the command line  arguments  which
         should  be passed to the kernel by default (note they are merged with the ar‐
         guments of the default entry if --copy-default is used).  When  --update-ker‐
         nel is used, this specifies new arguments to add to the argument list. Multi‐
         ple, space separated arguments may be used. If an argument already exists the
         new  value  replaces  the  old values. The root= kernel argument gets special
         handling if the configuration file has special handling  for  specifying  the
         root filesystem.

--remove-args=kernel-args
         The arguments specified by kernel-args are removed from the kernels specified
         by --update-kernel. The root argument gets special handling for configuration
         files that support separate root filesystem configuration.

```
Tested with the arguments from the original [PR#1392:](https://github.com/oamg/leapp-repository/pull/1392)
```
# Add the arguments to the default kernel
$ grubby --update-kernel=$(grubby --default-kernel) --args="systemd.unified_cgroup_hierarchy=0 systemd.legacy_systemd_cgroup_controller=0"
$ grubby --info=$(grubby --default-kernel) | grep args

# Try to remove the arguments with using comma separated list
$ grubby --update-kernel=$(grubby --default-kernel) --remove-args="systemd.unified_cgroup_hierarchy,systemd.legacy_systemd_cgroup_controller"
$ grubby --info=$(grubby --default-kernel) | grep args
# Does NOT remove the arguments

# Try to remove the arguments with using space separated list
$ grubby --update-kernel=$(grubby --default-kernel) --remove-args="systemd.unified_cgroup_hierarchy systemd.legacy_systemd_cgroup_controller"
$ grubby --info=$(grubby --default-kernel) | grep args
# Does remove the arguments
```
