### PR TITLE
boot: fix deps when bindmounting /boot to /sysroot/boot

### DIFF
--- a/repos/system_upgrade/common/actors/initramfs/mount_units_generator/files/bundled_units/boot.mount
+++ b/repos/system_upgrade/common/actors/initramfs/mount_units_generator/files/bundled_units/boot.mount
@@ -1,8 +1,8 @@
 [Unit]
 DefaultDependencies=no
 Before=local-fs.target
-After=sysroot-boot.target
-Requires=sysroot-boot.target
+After=sysroot-boot.mount
+Requires=sysroot-boot.mount
 
 [Mount]
 What=/sysroot/boot


### PR DESCRIPTION
When /boot is a separate partition, we bindmount what=/sysroot/boot to /boot, so that we can perform necessary checks when booting with FIPS enabled. However, the current solution contains incorrect unit dependencies: it requires sysroot-boot.target. There is no such target, and the correct value should be sysroot-boot.mount. This patch corrects the dependencies.

Jira: RHEL-123886