### PR TITLE
add handling for LVM configuration

### DIFF
--- a/repos/system_upgrade/common/actors/checklvm/actor.py
+++ b/repos/system_upgrade/common/actors/checklvm/actor.py
@@ -1,0 +1,24 @@
+from leapp.actors import Actor
+from leapp.libraries.actor.checklvm import check_lvm
+from leapp.models import DistributionSignedRPM, LVMConfig, TargetUserSpaceUpgradeTasks, UpgradeInitramfsTasks
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckLVM(Actor):
+    """
+    Check if the LVM is installed and ensure the target userspace container
+    and initramfs are prepared to support it.
+
+    The LVM configuration files are copied into the target userspace container
+    so that the dracut is able to use them while creating the initramfs.
+    The dracut LVM module is enabled by this actor as well.
+    """
+
+    name = 'check_lvm'
+    consumes = (DistributionSignedRPM, LVMConfig)
+    produces = (Report, TargetUserSpaceUpgradeTasks, UpgradeInitramfsTasks)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        check_lvm()

--- a/repos/system_upgrade/common/actors/checklvm/libraries/checklvm.py
+++ b/repos/system_upgrade/common/actors/checklvm/libraries/checklvm.py
@@ -1,0 +1,74 @@
+import os
+
+from leapp import reporting
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import (
+    CopyFile,
+    DistributionSignedRPM,
+    DracutModule,
+    LVMConfig,
+    TargetUserSpaceUpgradeTasks,
+    UpgradeInitramfsTasks
+)
+
+LVM_CONFIG_PATH = '/etc/lvm/lvm.conf'
+LVM_DEVICES_FILE_PATH_PREFIX = '/etc/lvm/devices'
+
+
+def _report_filter_detection():
+    title = 'LVM filter definition detected.'
+    summary = (
+        'Beginning with RHEL 9, LVM devices file is used by default to select devices used by '
+        f'LVM. Since leapp detected the use of LVM filter in the {LVM_CONFIG_PATH} configuration '
+        'file, the configuration won\'t be modified to use devices file during the upgrade and '
+        'the LVM filter will remain in use after the upgrade.'
+    )
+
+    remediation_hint = (
+        'While not required, switching to the LVM devices file from the LVM filter is possible '
+        'using the following command. The command uses the existing LVM filter to create the system.devices '
+        'file which is then used instead of the LVM filter. Before running the command, '
+        f'make sure that \'use_devicesfile=1\' is set in {LVM_CONFIG_PATH}.'
+    )
+    remediation_command = ['vgimportdevices']
+
+    reporting.create_report([
+        reporting.Title(title),
+        reporting.Summary(summary),
+        reporting.Remediation(hint=remediation_hint, commands=[remediation_command]),
+        reporting.ExternalLink(
+            title='Limiting LVM device visibility and usage',
+            url='https://red.ht/limiting-lvm-devices-visibility-and-usage',
+        ),
+        reporting.Severity(reporting.Severity.INFO),
+    ])
+
+
+def check_lvm():
+    if not has_package(DistributionSignedRPM, 'lvm2'):
+        return
+
+    lvm_config = next(api.consume(LVMConfig), None)
+    if not lvm_config:
+        return
+
+    lvm_devices_file_path = os.path.join(LVM_DEVICES_FILE_PATH_PREFIX, lvm_config.devices.devicesfile)
+    lvm_devices_file_exists = os.path.isfile(lvm_devices_file_path)
+
+    filters_used = not lvm_config.devices.use_devicesfile or not lvm_devices_file_exists
+    if filters_used:
+        _report_filter_detection()
+
+    api.current_logger().debug('Including lvm dracut module.')
+    api.produce(UpgradeInitramfsTasks(include_dracut_modules=[DracutModule(name='lvm')]))
+
+    copy_files = []
+    api.current_logger().debug('Copying "{}" to the target userspace.'.format(LVM_CONFIG_PATH))
+    copy_files.append(CopyFile(src=LVM_CONFIG_PATH))
+
+    if lvm_devices_file_exists and lvm_config.devices.use_devicesfile:
+        api.current_logger().debug('Copying "{}" to the target userspace.'.format(lvm_devices_file_path))
+        copy_files.append(CopyFile(src=lvm_devices_file_path))
+
+    api.produce(TargetUserSpaceUpgradeTasks(copy_files=copy_files))

--- a/repos/system_upgrade/common/actors/checklvm/tests/test_checklvm.py
+++ b/repos/system_upgrade/common/actors/checklvm/tests/test_checklvm.py
@@ -1,0 +1,92 @@
+import os
+
+import pytest
+
+from leapp.libraries.actor import checklvm
+from leapp.libraries.common.testutils import produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import (
+    DistributionSignedRPM,
+    LVMConfig,
+    LVMConfigDevicesSection,
+    RPM,
+    TargetUserSpaceUpgradeTasks,
+    UpgradeInitramfsTasks
+)
+
+
+def test_check_lvm_when_lvm_not_installed(monkeypatch):
+    def consume_mocked(model):
+        if model == LVMConfig:
+            assert False
+        if model == DistributionSignedRPM:
+            yield DistributionSignedRPM(items=[])
+
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+
+    checklvm.check_lvm()
+
+    assert not api.produce.called
+
+
+@pytest.mark.parametrize(
+    ('config', 'create_report', 'devices_file_exists'),
+    [
+        (LVMConfig(devices=LVMConfigDevicesSection(use_devicesfile=False)), True, False),
+        (LVMConfig(devices=LVMConfigDevicesSection(use_devicesfile=True)), False, True),
+        (LVMConfig(devices=LVMConfigDevicesSection(use_devicesfile=True)), True, False),
+        (LVMConfig(devices=LVMConfigDevicesSection(use_devicesfile=False, devicesfile="test.devices")), True, False),
+        (LVMConfig(devices=LVMConfigDevicesSection(use_devicesfile=True, devicesfile="test.devices")), False, True),
+        (LVMConfig(devices=LVMConfigDevicesSection(use_devicesfile=True, devicesfile="test.devices")), True, False),
+    ]
+)
+def test_scan_when_lvm_installed(monkeypatch, config, create_report, devices_file_exists):
+    lvm_package = RPM(
+        name='lvm2',
+        version='2',
+        release='1',
+        epoch='1',
+        packager='',
+        arch='x86_64',
+        pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51'
+    )
+
+    def isfile_mocked(_):
+        return devices_file_exists
+
+    def consume_mocked(model):
+        if model == LVMConfig:
+            yield config
+        if model == DistributionSignedRPM:
+            yield DistributionSignedRPM(items=[lvm_package])
+
+    def report_filter_detection_mocked():
+        assert create_report
+
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+    monkeypatch.setattr(os.path, 'isfile', isfile_mocked)
+    monkeypatch.setattr(checklvm, '_report_filter_detection', report_filter_detection_mocked)
+
+    checklvm.check_lvm()
+
+    # The lvm is installed, thus the dracut module is enabled and at least the lvm.conf is copied
+    assert api.produce.called == 2
+    assert len(api.produce.model_instances) == 2
+
+    expected_copied_files = [checklvm.LVM_CONFIG_PATH]
+    if devices_file_exists and config.devices.use_devicesfile:
+        devices_file_path = os.path.join(checklvm.LVM_DEVICES_FILE_PATH_PREFIX, config.devices.devicesfile)
+        expected_copied_files.append(devices_file_path)
+
+    for produced_model in api.produce.model_instances:
+        assert isinstance(produced_model, (UpgradeInitramfsTasks, TargetUserSpaceUpgradeTasks))
+
+        if isinstance(produced_model, UpgradeInitramfsTasks):
+            assert len(produced_model.include_dracut_modules) == 1
+            assert produced_model.include_dracut_modules[0].name == 'lvm'
+        else:
+            assert len(produced_model.copy_files) == len(expected_copied_files)
+            for file in produced_model.copy_files:
+                assert file.src in expected_copied_files

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/actor.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/actor.py
@@ -6,6 +6,7 @@ from leapp.models import (
     BootContent,
     FIPSInfo,
     LiveModeConfig,
+    LVMConfig,
     TargetOSInstallationImage,
     TargetUserSpaceInfo,
     TargetUserSpaceUpgradeTasks,
@@ -31,6 +32,7 @@ class UpgradeInitramfsGenerator(Actor):
     consumes = (
         FIPSInfo,
         LiveModeConfig,
+        LVMConfig,
         RequiredUpgradeInitramPackages,  # deprecated
         TargetOSInstallationImage,
         TargetUserSpaceInfo,

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/libraries/upgradeinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/libraries/upgradeinitramfsgenerator.py
@@ -12,6 +12,7 @@ from leapp.models import UpgradeDracutModule  # deprecated
 from leapp.models import (
     BootContent,
     LiveModeConfig,
+    LVMConfig,
     TargetOSInstallationImage,
     TargetUserSpaceInfo,
     TargetUserSpaceUpgradeTasks,
@@ -363,20 +364,29 @@ def generate_initram_disk(context):
     def fmt_module_list(module_list):
         return ','.join(mod.name for mod in module_list)
 
+    env_variables = [
+        'LEAPP_KERNEL_VERSION={kernel_version}',
+        'LEAPP_ADD_DRACUT_MODULES="{dracut_modules}"',
+        'LEAPP_KERNEL_ARCH={arch}',
+        'LEAPP_ADD_KERNEL_MODULES="{kernel_modules}"',
+        'LEAPP_DRACUT_INSTALL_FILES="{files}"'
+    ]
+
+    if next(api.consume(LVMConfig), None):
+        env_variables.append('LEAPP_DRACUT_LVMCONF="1"')
+
+    env_variables = ' '.join(env_variables)
+    env_variables = env_variables.format(
+        kernel_version=_get_target_kernel_version(context),
+        dracut_modules=fmt_module_list(initramfs_includes.dracut_modules),
+        kernel_modules=fmt_module_list(initramfs_includes.kernel_modules),
+        arch=api.current_actor().configuration.architecture,
+        files=' '.join(initramfs_includes.files)
+    )
+    cmd = os.path.join('/', INITRAM_GEN_SCRIPT_NAME)
+
     # FIXME: issue #376
-    context.call([
-        '/bin/sh', '-c',
-        'LEAPP_KERNEL_VERSION={kernel_version} '
-        'LEAPP_ADD_DRACUT_MODULES="{dracut_modules}" LEAPP_KERNEL_ARCH={arch} '
-        'LEAPP_ADD_KERNEL_MODULES="{kernel_modules}" '
-        'LEAPP_DRACUT_INSTALL_FILES="{files}" {cmd}'.format(
-            kernel_version=_get_target_kernel_version(context),
-            dracut_modules=fmt_module_list(initramfs_includes.dracut_modules),
-            kernel_modules=fmt_module_list(initramfs_includes.kernel_modules),
-            arch=api.current_actor().configuration.architecture,
-            files=' '.join(initramfs_includes.files),
-            cmd=os.path.join('/', INITRAM_GEN_SCRIPT_NAME))
-    ], env=env)
+    context.call(['/bin/sh', '-c', f'{env_variables} {cmd}'], env=env)
 
     boot_files_info = copy_boot_files(context)
     return boot_files_info

--- a/repos/system_upgrade/common/actors/scanlvmconfig/actor.py
+++ b/repos/system_upgrade/common/actors/scanlvmconfig/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scanlvmconfig
+from leapp.models import DistributionSignedRPM, LVMConfig
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanLVMConfig(Actor):
+    """
+    Scan LVM configuration.
+    """
+
+    name = 'scan_lvm_config'
+    consumes = (DistributionSignedRPM,)
+    produces = (LVMConfig,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        scanlvmconfig.scan()

--- a/repos/system_upgrade/common/actors/scanlvmconfig/libraries/scanlvmconfig.py
+++ b/repos/system_upgrade/common/actors/scanlvmconfig/libraries/scanlvmconfig.py
@@ -1,0 +1,52 @@
+import os
+
+from leapp.libraries.common.config import version
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import DistributionSignedRPM, LVMConfig, LVMConfigDevicesSection
+
+LVM_CONFIG_PATH = '/etc/lvm/lvm.conf'
+
+
+def _lvm_config_devices_parser(lvm_config_lines):
+    in_section = False
+    config = {}
+    for line in lvm_config_lines:
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if "devices {" in line:
+            in_section = True
+            continue
+        if in_section and "}" in line:
+            in_section = False
+        if in_section:
+            value = line.split("=", 1)
+            config[value[0].strip()] = value[1].strip().strip('"')
+    return config
+
+
+def _read_config_lines(path):
+    with open(path) as lvm_conf_file:
+        return lvm_conf_file.readlines()
+
+
+def scan():
+    if not has_package(DistributionSignedRPM, 'lvm2'):
+        return
+
+    if not os.path.isfile(LVM_CONFIG_PATH):
+        api.current_logger().debug('The "{}" is not present on the system.'.format(LVM_CONFIG_PATH))
+        return
+
+    lvm_config_lines = _read_config_lines(LVM_CONFIG_PATH)
+    devices_section = _lvm_config_devices_parser(lvm_config_lines)
+
+    lvm_config_devices = LVMConfigDevicesSection(use_devicesfile=int(version.get_source_major_version()) > 8)
+    if 'devicesfile' in devices_section:
+        lvm_config_devices.devicesfile = devices_section['devicesfile']
+
+    if 'use_devicesfile' in devices_section and devices_section['use_devicesfile'] in ['0', '1']:
+        lvm_config_devices.use_devicesfile = devices_section['use_devicesfile'] == '1'
+
+    api.produce(LVMConfig(devices=lvm_config_devices))

--- a/repos/system_upgrade/common/actors/scanlvmconfig/tests/test_scanlvmconfig.py
+++ b/repos/system_upgrade/common/actors/scanlvmconfig/tests/test_scanlvmconfig.py
@@ -1,0 +1,176 @@
+import os
+
+import pytest
+
+from leapp.libraries.actor import scanlvmconfig
+from leapp.libraries.common.config import version
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import DistributionSignedRPM, LVMConfig, LVMConfigDevicesSection, RPM
+
+
+@pytest.mark.parametrize(
+    ("config_as_lines", "config_as_dict"),
+    [
+        ([], {}),
+        (
+            ['devices {\n',
+             '\t# comment\n'
+             '}\n'],
+            {}
+         ),
+        (
+            ['global {\n',
+             'use_lvmetad = 1\n',
+             '}\n'],
+            {}
+         ),
+        (
+            ['devices {\n',
+             'filter = [ "r|/dev/cdrom|", "a|.*|" ]\n',
+             'use_devicesfile=0\n',
+             'devicesfile="file-name.devices"\n',
+             '}'],
+            {'filter': '[ "r|/dev/cdrom|", "a|.*|" ]',
+             'use_devicesfile': '0',
+             'devicesfile': 'file-name.devices'}
+         ),
+        (
+            ['devices {\n',
+             'use_devicesfile = 1\n',
+             'devicesfile  =  "file-name.devices"\n',
+             ' }\n'],
+            {'use_devicesfile': '1',
+             'devicesfile': 'file-name.devices'}
+         ),
+        (
+            ['devices {\n',
+             '  # comment\n',
+             'use_devicesfile = 1 # comment\n',
+             '#devicesfile =  "file-name.devices"\n',
+             ' }\n'],
+            {'use_devicesfile': '1'}
+         ),
+        (
+            ['config {\n',
+             '# configuration section\n',
+             '\tabort_on_errors = 1\n',
+             '\tprofile_dir = "/etc/lvm/prifile\n',
+             '}\n',
+             'devices {\n',
+             '  \n',
+             '\tfilter =  ["a|.*|"] \n',
+             '\tuse_devicesfile=0\n',
+             '}\n',
+             'allocation {\n',
+             '\tcling_tag_list = [ "@site1", "@site2" ]\n',
+             '\tcache_settings {\n',
+             '\t}\n',
+             '}\n'
+             ],
+            {'filter': '["a|.*|"]', 'use_devicesfile': '0'}
+         ),
+    ]
+
+)
+def test_lvm_config_devices_parser(config_as_lines, config_as_dict):
+    lvm_config = scanlvmconfig._lvm_config_devices_parser(config_as_lines)
+    assert lvm_config == config_as_dict
+
+
+def test_scan_when_lvm_not_installed(monkeypatch):
+    def isfile_mocked(_):
+        assert False
+
+    def read_config_lines_mocked(_):
+        assert False
+
+    msgs = [
+        DistributionSignedRPM(items=[])
+    ]
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(os.path, 'isfile', isfile_mocked)
+    monkeypatch.setattr(scanlvmconfig, '_read_config_lines', read_config_lines_mocked)
+
+    scanlvmconfig.scan()
+
+    assert not api.produce.called
+
+
+@pytest.mark.parametrize(
+    ('source_major_version', 'devices_section_dict', 'produced_devices_section'),
+    [
+        ('8', {}, LVMConfigDevicesSection(use_devicesfile=False)),
+        ('9', {}, LVMConfigDevicesSection(use_devicesfile=True)),
+        ('8', {
+            'use_devicesfile': '0',
+        }, LVMConfigDevicesSection(use_devicesfile=False,
+                                   devicesfile='system.devices')
+         ),
+        ('9', {
+            'use_devicesfile': '0',
+            'devicesfile': 'file-name.devices'
+        }, LVMConfigDevicesSection(use_devicesfile=False,
+                                   devicesfile='file-name.devices')
+         ),
+
+        ('8', {
+            'use_devicesfile': '1',
+            'devicesfile': 'file-name.devices'
+        }, LVMConfigDevicesSection(use_devicesfile=True,
+                                   devicesfile='file-name.devices')
+         ),
+        ('9', {
+            'use_devicesfile': '1',
+        }, LVMConfigDevicesSection(use_devicesfile=True,
+                                   devicesfile='system.devices')
+         ),
+
+    ]
+
+)
+def test_scan_when_lvm_installed(monkeypatch, source_major_version, devices_section_dict, produced_devices_section):
+
+    def isfile_mocked(file):
+        assert file == scanlvmconfig.LVM_CONFIG_PATH
+        return True
+
+    def read_config_lines_mocked(file):
+        assert file == scanlvmconfig.LVM_CONFIG_PATH
+        return ["test_line"]
+
+    def lvm_config_devices_parser_mocked(lines):
+        assert lines == ["test_line"]
+        return devices_section_dict
+
+    lvm_package = RPM(
+        name='lvm2',
+        version='2',
+        release='1',
+        epoch='1',
+        packager='',
+        arch='x86_64',
+        pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51'
+    )
+
+    msgs = [
+        DistributionSignedRPM(items=[lvm_package])
+    ]
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(version, 'get_source_major_version', lambda: source_major_version)
+    monkeypatch.setattr(os.path, 'isfile', isfile_mocked)
+    monkeypatch.setattr(scanlvmconfig, '_read_config_lines', read_config_lines_mocked)
+    monkeypatch.setattr(scanlvmconfig, '_lvm_config_devices_parser', lvm_config_devices_parser_mocked)
+
+    scanlvmconfig.scan()
+
+    assert api.produce.called == 1
+    assert len(api.produce.model_instances) == 1
+
+    produced_model = api.produce.model_instances[0]
+    assert isinstance(produced_model, LVMConfig)
+    assert produced_model.devices == produced_devices_section

--- a/repos/system_upgrade/common/models/lvmconfig.py
+++ b/repos/system_upgrade/common/models/lvmconfig.py
@@ -1,0 +1,26 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class LVMConfigDevicesSection(Model):
+    """The devices section from the LVM configuration."""
+    topic = SystemInfoTopic
+
+    use_devicesfile = fields.Boolean()
+    """
+    Determines whether only the devices in the devices file are used by LVM. Note
+    that the default value changed on the RHEL 9 to True.
+    """
+
+    devicesfile = fields.String(default="system.devices")
+    """
+    Defines the name of the devices file that should be used. The default devices
+    file is located in '/etc/lvm/devices/system.devices'.
+    """
+
+
+class LVMConfig(Model):
+    """LVM configuration split into sections."""
+    topic = SystemInfoTopic
+
+    devices = fields.Model(LVMConfigDevicesSection)


### PR DESCRIPTION
The relevant user LVM configuration is now copied into the target userspace
container along with enabling LVM dracut module for upgrade initramfs creation.
The LVM configuration is copied into the target userspace container when
lvm2 package in installed. Based on the configuration, the devices file
is also copied in when present and enabled. The --nolvmconf option used when
executing dracut is changed into --lvmconf instead if the lvm configuration is
copied into the target userspace container.

Jira: RHEL-14712
