### PR TITLE
Replace EFI boot entry during conversion

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -42,7 +42,9 @@ disable=
  unnecessary-pass,
  raise-missing-from,  # no 'raise from' in python 2
  consider-using-f-string,  # sorry, not gonna happen, still have to support py2
- logging-format-interpolation
+ logging-format-interpolation,
+# problem betwee Python 3.6 and 3.8+ pylint
+ useless-option-value
 
 [FORMAT]
 # Maximum number of characters on a single line.

--- a/docs/source/libraries-and-api/deprecations-list.md
+++ b/docs/source/libraries-and-api/deprecations-list.md
@@ -15,6 +15,16 @@ Only the versions in which a deprecation has been made are listed.
 ## Next release <span style="font-size:0.5em; font-weight:normal">(till TODO date)</span>
 - Shared libraries
   - **`leapp.libraries.common.config.get_distro_id()`** - The function has been replaced by variants for source and target distros - `leapp.libraries.common.config.get_source_distro_id()` and `leapp.libraries.common.config.get_target_distro_id()`.
+  - Following UEFI related functions and classes have been moved from `leapp.libraries.common.grub` into `leapp.libraries.common.efi`:
+    - **`EFIBootInfo`** - raises `leapp.libraries.common.efi.EFIError` instead of `leapp.exceptions.StopActorExecutionError`
+    - **`EFIBootLoaderEntry`**
+    - **`canonical_path_to_efi_format()`**
+    - **`get_efi_device()`** - raises `leapp.libraries.common.efi.EFIError` instead of `leapp.exceptions.StopActorExecutionError`
+    - **`get_efi_partition()`** - raises `leapp.libraries.common.efi.EFIError` instead of `leapp.exceptions.StopActorExecutionError`
+    - **`is_efi()`**
+  - Functions related to manipulation of devices and partitions were moved from `leapp.libraries.common.grub` into `leapp.libraries.common.partitions`:
+    - **`get_device_number()`** - replaced by **`get_partition_number()`**
+    - **`blk_dev_from_partition()`**
 
 ## v0.23.0 <span style="font-size:0.5em; font-weight:normal">(till March 2026)</span>
 

--- a/repos/system_upgrade/common/actors/convert/securebootinhibit/actor.py
+++ b/repos/system_upgrade/common/actors/convert/securebootinhibit/actor.py
@@ -1,0 +1,19 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import securebootinhibit
+from leapp.models import FirmwareFacts
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class SecureBootInhibit(Actor):
+    """
+    Inhibit the conversion if SecureBoot is enabled.
+    """
+
+    name = 'secure_boot_inhibit'
+    consumes = (FirmwareFacts,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        securebootinhibit.process()

--- a/repos/system_upgrade/common/actors/convert/securebootinhibit/libraries/securebootinhibit.py
+++ b/repos/system_upgrade/common/actors/convert/securebootinhibit/libraries/securebootinhibit.py
@@ -1,0 +1,42 @@
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config import is_conversion
+from leapp.libraries.stdlib import api
+from leapp.models import FirmwareFacts
+
+
+def process():
+    if not is_conversion():
+        return
+
+    ff = next(api.consume(FirmwareFacts), None)
+    if not ff:
+        raise StopActorExecutionError(
+            "Could not identify system firmware",
+            details={"details": "Actor did not receive FirmwareFacts message."},
+        )
+
+    if ff.firmware == "efi" and ff.secureboot_enabled:
+        report = [
+            reporting.Title(
+                "Detected enabled Secure Boot when trying to convert the system"
+            ),
+            reporting.Summary(
+                "Conversion to a different Linux distribution is not possible"
+                " when the Secure Boot is enabled. Artifacts of the target"
+                " Linux distribution are signed by keys that are not accepted"
+                " by the source Linux distribution."
+            ),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.BOOT]),
+            # TODO some link
+            reporting.Remediation(
+                hint="Disable Secure Boot to be able to convert the system to"
+                " a different Linux distribution. Then re-enable Secure Boot"
+                " again after the upgrade process is finished successfully."
+                " Check instructions for your current OS, or hypervisor in"
+                " case of virtual machines, for more information how to"
+                " disable Secure Boot."
+            ),
+        ]
+        reporting.create_report(report)

--- a/repos/system_upgrade/common/actors/convert/securebootinhibit/tests/test_securebootinhibit.py
+++ b/repos/system_upgrade/common/actors/convert/securebootinhibit/tests/test_securebootinhibit.py
@@ -1,0 +1,58 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import securebootinhibit
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import FirmwareFacts
+
+
+@pytest.mark.parametrize(
+    'ff,is_conversion,should_inhibit', [
+        # conversion, secureboot enabled = inhibit
+        (
+            FirmwareFacts(firmware='efi', ppc64le_opal=None, secureboot_enabled=True),
+            True,
+            True
+        ),
+        (
+            FirmwareFacts(firmware='efi', ppc64le_opal=None, secureboot_enabled=True),
+            False,
+            False
+        ),
+        # bios is ok
+        (
+            FirmwareFacts(firmware='bios', ppc64le_opal=None, secureboot_enabled=False),
+            False,
+            False
+        ),
+        # bios is ok during conversion too
+        (
+            FirmwareFacts(firmware='bios', ppc64le_opal=None, secureboot_enabled=False),
+            True,
+            False
+        ),
+        (
+            FirmwareFacts(firmware='efi', ppc64le_opal=None, secureboot_enabled=False),
+            True,
+            False
+        ),
+        (
+            FirmwareFacts(firmware='efi', ppc64le_opal=None, secureboot_enabled=False),
+            False,
+            False
+        ),
+    ]
+)
+def test_process(monkeypatch, ff, is_conversion, should_inhibit):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[ff]))
+    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
+    monkeypatch.setattr(securebootinhibit, "is_conversion", lambda: is_conversion)
+
+    securebootinhibit.process()
+
+    if should_inhibit:
+        assert reporting.create_report.called == 1
+        assert reporting.Groups.INHIBITOR in reporting.create_report.report_fields['groups']
+    else:
+        assert not reporting.create_report.called

--- a/repos/system_upgrade/common/actors/convert/updateefi/actor.py
+++ b/repos/system_upgrade/common/actors/convert/updateefi/actor.py
@@ -1,0 +1,25 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import updateefi
+from leapp.models import FirmwareFacts
+from leapp.reporting import Report
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class UpdateEfiEntry(Actor):
+    """
+    Update EFI directory and entry during conversion.
+
+    During conversion, removes leftover source distro EFI directory on the ESP
+    (EFI System Partition) and it's EFI boot entry. It also adds a new boot
+    entry for the target distro.
+
+    This actor does nothing when not converting.
+    """
+
+    name = "update_efi"
+    consumes = (FirmwareFacts,)
+    produces = (Report,)
+    tags = (ApplicationsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        updateefi.process()

--- a/repos/system_upgrade/common/actors/convert/updateefi/libraries/updateefi.py
+++ b/repos/system_upgrade/common/actors/convert/updateefi/libraries/updateefi.py
@@ -1,0 +1,230 @@
+import errno
+import os
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import efi
+from leapp.libraries.common.config import architecture, get_source_distro_id, get_target_distro_id, is_conversion
+from leapp.libraries.common.distro import distro_id_to_pretty_name, get_distro_efidir_canon_path
+from leapp.libraries.stdlib import api
+
+
+def _get_target_efi_bin_path():
+    # Sorted by priority.
+    # NOTE: The shim-x64 package providing the shimx64.efi binary can be removed when
+    # not using secure boot, grubx64.efi should always be present (provided by
+    # grub-efi-x64).
+    # WARN: However it is expected to have the shim installed on the system to comply
+    # with the official guidelines.
+    #
+    # TODO: There are usually 2 more shim* files which appear unused on a fresh system:
+    # - shim.efi - seems like it's the same as shimx64.efi
+    # - shim64-<distro>.efi - ???
+    # What about them?
+    efibins_by_arch = {
+        architecture.ARCH_X86_64: ("shimx64.efi", "grubx64.efi"),
+        architecture.ARCH_ARM64: ("shimaa64.efi", "grubaa64.efi"),
+    }
+
+    arch = api.current_actor().configuration.architecture
+    for filename in efibins_by_arch[arch]:
+        efi_dir = get_distro_efidir_canon_path(get_target_distro_id())
+        canon_path = os.path.join(efi_dir, filename)
+        if os.path.exists(canon_path):
+            return efi.canonical_path_to_efi_format(canon_path)
+
+    return None
+
+
+def _add_boot_entry_for_target(efibootinfo):
+    """
+    Create a new UEFI bootloader entry for the target system.
+
+    Return the newly created bootloader entry.
+    """
+    efi_bin_path = _get_target_efi_bin_path()
+    if not efi_bin_path:
+        # this is a fatal error as at least one of the possible EFI binaries
+        # should be present
+        raise efi.EFIError("Unable to detect any UEFI binary file.")
+
+    label = distro_id_to_pretty_name(get_target_distro_id())
+
+    existing_entry = efi.get_boot_entry(efibootinfo, label, efi_bin_path)
+    if existing_entry:
+        api.current_logger().debug(
+            "The '{}' UEFI bootloader entry is already present.".format(label)
+        )
+        return existing_entry
+
+    return efi.add_boot_entry(label, efi_bin_path)
+
+
+def _remove_boot_entry_for_source(efibootinfo):
+    efibootinfo_fresh = efi.EFIBootInfo()
+    source_entry = efibootinfo_fresh.entries.get(efibootinfo.current_bootnum, None)
+
+    if not source_entry:
+        api.current_logger().debug(
+            "The currently booted source distro EFI boot entry has been already"
+            " removed since the target entry has been added, skipping removal."
+        )
+        return
+
+    original_source_entry = efibootinfo.entries[source_entry.boot_number]
+
+    if source_entry != original_source_entry:
+        api.current_logger().debug(
+            "The boot entry with current bootnum has changed since the target"
+            " distro entry has been added, skipping removal."
+        )
+        return
+
+    efi.remove_boot_entry(source_entry.boot_number)
+
+
+def _try_remove_source_efi_dir():
+    """
+    Try to remove the source distro EFI directory
+
+    The directory is not reported if it's not empty to preserve potential
+    custom files. In such a case a post upgrade report is produced informing
+    user to handle the leftover files.
+    """
+    efi_dir_source = get_distro_efidir_canon_path(get_source_distro_id())
+    if not os.path.exists(efi_dir_source):
+        api.current_logger().debug(
+            "Source distro EFI directory at {} does not exist, skipping removal.".format(efi_dir_source)
+        )
+        return
+
+    target_efi_dir = get_distro_efidir_canon_path(get_target_distro_id())
+    if efi_dir_source == target_efi_dir:
+        api.current_logger().debug(
+            "Source and target distros use the same '{}' EFI directory.".format(efi_dir_source)
+        )
+        return
+
+    try:
+        os.rmdir(efi_dir_source)
+        api.current_logger().debug(
+            "Deleted source system EFI directory at {}".format(efi_dir_source)
+        )
+    except FileNotFoundError:
+        api.current_logger().debug(
+            "Couldn't remove the source system EFI directory at {}: the directory no longer exists".format(
+                efi_dir_source
+            )
+        )
+    except OSError as e:
+        if e.errno == errno.ENOTEMPTY:
+            api.current_logger().debug(
+                "Didn't remove the source EFI directory {}, it does not exist".format(
+                    efi_dir_source
+                )
+            )
+            summary = (
+                "During the upgrade, the EFI binaries and grub configuration files"
+                f" were migrated from the source OS EFI directory {efi_dir_source}"
+                f" to the target OS EFI directory {target_efi_dir}."
+                f" Leftover files were detected in {target_efi_dir}, review them"
+                " and migrate them manually."
+            )
+            reporting.create_report([
+                reporting.Title("Review leftover files in the source OS EFI directory"),
+                reporting.Summary(summary),
+                reporting.Groups([
+                    reporting.Groups.BOOT,
+                    reporting.Groups.POST,
+                ]),
+                reporting.Severity(reporting.Severity.LOW),
+            ])
+        else:
+            api.current_logger().error(
+                "Failed to remove the source system EFI directory at {}: {}".format(
+                    efi_dir_source, e
+                )
+            )
+            summary = (
+                f"Removal of the source system EFI directory at {efi_dir_source} failed."
+                " Remove the directory manually if present."
+            )
+            reporting.create_report([
+                reporting.Title("Failed to remove source system EFI directory"),
+                reporting.Summary(summary),
+                reporting.Groups([
+                    reporting.Groups.BOOT,
+                    reporting.Groups.FAILURE,
+                    reporting.Groups.POST,
+                ]),
+                reporting.Severity(reporting.Severity.LOW),
+            ])
+
+
+def _replace_boot_entries():
+    try:
+        efibootinfo = efi.EFIBootInfo()
+        target_entry = _add_boot_entry_for_target(efibootinfo)
+        # NOTE: this isn't strictly necessary as UEFI should set the next entry
+        # to be the first in the BootOrder. This is a workaround to make sure
+        # the "efi_finalization_fix" actor doesn't attempt to set BootNext to
+        # the original entry which will be deleted below.
+        efi.set_bootnext(target_entry.boot_number)
+    except efi.EFIError as e:
+        raise StopActorExecutionError(
+            "Failed to add UEFI boot entry for the target system",
+            details={"details": str(e)},
+        )
+
+    # NOTE: Some UEFI implementations, such as OVMF used in qemu, automatically
+    # add entries for EFI directories. Though the entry is named after the EFI
+    # directory (so "redhat" on RHEL). However if the UEFI doesn't add an entry
+    # after we fail to do so, it might render the OS "unbootable".
+    # Let's keep the source entry and directory if we can't add the target entry as a
+    # backup.
+
+    _try_remove_source_efi_dir()
+
+    try:
+        # doesn't matter if the removal of source EFI dir failed, we don't want
+        # the source entry, we have the new one for target
+        _remove_boot_entry_for_source(efibootinfo)
+    except efi.EFIError as e:
+        api.current_logger().error("Failed to remove source distro EFI boot entry: {}".format(e))
+
+        # This is low severity, some UEFIs will automatically remove an entry
+        # whose EFI binary no longer exists at least OVMF, used by qemu, does.
+        summary = (
+            "Removal of the source system UEFI boot entry failed."
+            " Check UEFI boot entries and manually remove it if it's still present."
+        )
+        reporting.create_report(
+            [
+                reporting.Title("Failed to remove source system EFI boot entry"),
+                reporting.Summary(summary),
+                reporting.Groups(
+                    [
+                        reporting.Groups.BOOT,
+                        reporting.Groups.FAILURE,
+                        reporting.Groups.POST,
+                    ]
+                ),
+                reporting.Severity(reporting.Severity.LOW),
+            ]
+        )
+
+
+def process():
+    if not is_conversion():
+        return
+
+    if not architecture.matches_architecture(architecture.ARCH_X86_64, architecture.ARCH_ARM64):
+        return
+
+    if not efi.is_efi():
+        return
+
+    # NOTE no need to check whether we have the efibootmgr binary, the
+    # efi_check_boot actor does
+
+    _replace_boot_entries()

--- a/repos/system_upgrade/common/actors/convert/updateefi/tests/test_updateefi.py
+++ b/repos/system_upgrade/common/actors/convert/updateefi/tests/test_updateefi.py
@@ -1,0 +1,469 @@
+import copy
+import errno
+import os
+import types
+from unittest import mock
+
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import updateefi
+from leapp.libraries.common import efi
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, logger_mocked
+from leapp.libraries.stdlib import api
+
+
+@pytest.fixture
+def mock_logger():
+    with mock.patch(
+        "leapp.libraries.stdlib.api.current_logger", new_callable=logger_mocked
+    ) as mock_logger:
+        yield mock_logger
+
+
+@pytest.fixture
+def mock_create_report():
+    with mock.patch(
+        "leapp.reporting.create_report", new_callable=create_report_mocked
+    ) as mock_create_report:
+        yield mock_create_report
+
+
+@pytest.mark.parametrize(
+    "arch, exist, expect",
+    [
+        (architecture.ARCH_X86_64, ["shimx64.efi", "grubx64.efi"], r"\EFI\redhat\shimx64.efi"),
+        (architecture.ARCH_X86_64, ["shimx64.efi"], r"\EFI\redhat\shimx64.efi"),
+        (architecture.ARCH_X86_64, ["grubx64.efi"], r"\EFI\redhat\grubx64.efi"),
+        (architecture.ARCH_X86_64, [], None),
+
+        (architecture.ARCH_ARM64, ["shimaa64.efi", "grubaa64.efi"], r"\EFI\redhat\shimaa64.efi"),
+        (architecture.ARCH_ARM64, ["shimaa64.efi"], r"\EFI\redhat\shimaa64.efi"),
+        (architecture.ARCH_ARM64, ["grubaa64.efi"], r"\EFI\redhat\grubaa64.efi"),
+        (architecture.ARCH_ARM64, [], None),
+    ]
+)
+def test__get_target_efi_bin_path(monkeypatch, arch, exist, expect):
+    # distro is not important, just make it look like conversion
+    curr_actor = CurrentActorMocked(arch=arch, src_distro="centos", dst_distro="rhel")
+    monkeypatch.setattr(api, "current_actor", curr_actor)
+
+    def mock_exists(path):
+        efidir = "/boot/efi/EFI/redhat"
+        return path in [os.path.join(efidir, p) for p in exist]
+
+    monkeypatch.setattr(os.path, "exists", mock_exists)
+
+    actual = updateefi._get_target_efi_bin_path()
+    assert actual == expect
+
+
+TEST_ADD_ENTRY_INPUTS = [
+    ("Red Hat Enterprise Linux", r"\EFI\redhat\shimx64.efi"),
+    ("Red Hat Enterprise Linux", r"\EFI\redhat\grubx64.efi"),
+    ("Centos Stream", r"\EFI\centos\grubx64.efi"),
+]
+
+
+@pytest.mark.parametrize("label, efi_bin_path", TEST_ADD_ENTRY_INPUTS)
+@mock.patch("leapp.libraries.common.efi.get_boot_entry")
+@mock.patch("leapp.libraries.common.efi.add_boot_entry")
+def test__add_boot_entry_for_target(
+    mock_add_boot_entry, mock_get_boot_entry, monkeypatch, label, efi_bin_path
+):
+    # need to mock this but it's unused because distro_id_to_pretty_name is mocked
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked(dst_distro="whatever"))
+    monkeypatch.setattr(updateefi, "distro_id_to_pretty_name", lambda _distro: label)
+    monkeypatch.setattr(updateefi, "_get_target_efi_bin_path", lambda: efi_bin_path)
+
+    mock_efibootinfo = mock.MagicMock(name="EFIBootInfo_instance")
+    entry = efi.EFIBootLoaderEntry("0003", label, True, efi_bin_path)
+    mock_get_boot_entry.return_value = None
+    mock_add_boot_entry.return_value = entry
+
+    assert entry == updateefi._add_boot_entry_for_target(mock_efibootinfo)
+
+    mock_get_boot_entry.assert_called_once_with(mock_efibootinfo, label, efi_bin_path)
+    mock_add_boot_entry.assert_called_once_with(label, efi_bin_path)
+
+
+@pytest.mark.parametrize("label, efi_bin_path", TEST_ADD_ENTRY_INPUTS)
+@mock.patch("leapp.libraries.common.efi.get_boot_entry")
+@mock.patch("leapp.libraries.common.efi.add_boot_entry")
+def test__add_boot_entry_for_target_already_exists(
+    mock_add_boot_entry, mock_get_boot_entry, monkeypatch, label, efi_bin_path
+):
+    # need to mock this but it's unused because distro_id_to_pretty_name is mocked
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked(dst_distro="whatever"))
+    monkeypatch.setattr(updateefi, "distro_id_to_pretty_name", lambda _distro: label)
+    monkeypatch.setattr(updateefi, "_get_target_efi_bin_path", lambda: efi_bin_path)
+
+    mock_efibootinfo = mock.MagicMock(name="EFIBootInfo_instance")
+    entry = efi.EFIBootLoaderEntry("0003", label, True, efi_bin_path)
+    mock_get_boot_entry.return_value = entry
+
+    out = updateefi._add_boot_entry_for_target(mock_efibootinfo)
+
+    assert out == entry
+    mock_get_boot_entry.assert_called_once_with(mock_efibootinfo, label, efi_bin_path)
+    mock_add_boot_entry.assert_not_called()
+
+
+def test__add_boot_entry_for_target_no_efi_bin(monkeypatch):
+    monkeypatch.setattr(updateefi, "_get_target_efi_bin_path", lambda: None)
+
+    with pytest.raises(efi.EFIError, match="Unable to detect any UEFI binary file."):
+        mock_efibootinfo = mock.MagicMock(name="EFIBootInfo_instance")
+        updateefi._add_boot_entry_for_target(mock_efibootinfo)
+
+
+class MockEFIBootInfo:
+
+    def __init__(self, entries, current_bootnum=None):
+        # just to have some entries even when we don't need the entries
+        other_entry = efi.EFIBootLoaderEntry(
+            "0001",
+            "UEFI: Built-in EFI Shell",
+            True,
+            "VenMedia(5023b95c-db26-429b-a648-bd47664c8012)..BO",
+        )
+        entries = entries + [other_entry]
+
+        self.boot_order = tuple(entry.boot_number for entry in entries)
+        self.current_bootnum = current_bootnum or self.boot_order[0]
+        self.next_bootnum = None
+        self.entries = {entry.boot_number: entry for entry in entries}
+
+
+TEST_SOURCE_ENTRY = efi.EFIBootLoaderEntry(
+    "0002", "Centos Stream", True, r"File(\EFI\centos\shimx64.efi)"
+)
+TEST_TARGET_ENTRY = efi.EFIBootLoaderEntry(
+    "0003", "Red Hat Enterprise Linux", True, r"File(\EFI\redhat\shimx64.efi)"
+)
+
+
+@mock.patch("leapp.libraries.common.efi.remove_boot_entry")
+@mock.patch("leapp.libraries.common.efi.EFIBootInfo")
+def test__remove_boot_entry_for_source(
+    mock_efibootinfo,
+    mock_remove_boot_entry,
+):
+    efibootinfo = MockEFIBootInfo([TEST_SOURCE_ENTRY], current_bootnum="0002")
+    mock_efibootinfo.return_value = MockEFIBootInfo(
+        [TEST_TARGET_ENTRY, TEST_SOURCE_ENTRY], current_bootnum="0002"
+    )
+
+    updateefi._remove_boot_entry_for_source(efibootinfo)
+
+    mock_efibootinfo.assert_called_once()
+    mock_remove_boot_entry.assert_called_once_with("0002")
+
+
+@mock.patch("leapp.libraries.common.efi.remove_boot_entry")
+@mock.patch("leapp.libraries.common.efi.EFIBootInfo")
+def test__remove_boot_entry_for_source_no_longer_exists(
+    mock_efibootinfo, mock_remove_boot_entry, mock_logger
+):
+    efibootinfo = MockEFIBootInfo([TEST_SOURCE_ENTRY], current_bootnum="0002")
+    mock_efibootinfo.return_value = MockEFIBootInfo(
+        [TEST_TARGET_ENTRY], current_bootnum="0002"
+    )
+
+    updateefi._remove_boot_entry_for_source(efibootinfo)
+
+    msg = (
+        "The currently booted source distro EFI boot entry has been already"
+        " removed since the target entry has been added, skipping removal."
+    )
+    assert msg in mock_logger.dbgmsg
+    mock_efibootinfo.assert_called_once()
+    mock_remove_boot_entry.assert_not_called()
+
+
+@mock.patch("leapp.libraries.common.efi.remove_boot_entry")
+@mock.patch("leapp.libraries.common.efi.EFIBootInfo")
+def test__remove_boot_entry_for_source_has_changed(
+    mock_efibootinfo, mock_remove_boot_entry, mock_logger
+):
+    efibootinfo = MockEFIBootInfo([TEST_SOURCE_ENTRY], current_bootnum="0002")
+    modified_source_entry = copy.copy(TEST_SOURCE_ENTRY)
+    modified_source_entry.efi_bin_source = r"File(\EFI\centos\grubx64.efi)"
+    mock_efibootinfo.return_value = MockEFIBootInfo(
+        [TEST_TARGET_ENTRY, modified_source_entry], current_bootnum="0002"
+    )
+
+    updateefi._remove_boot_entry_for_source(efibootinfo)
+
+    msg = (
+        "The boot entry with current bootnum has changed since the target"
+        " distro entry has been added, skipping removal."
+    )
+    assert msg in mock_logger.dbgmsg
+    mock_efibootinfo.assert_called_once()
+    mock_remove_boot_entry.assert_not_called()
+
+
+class TestRemoveSourceEFIDir:
+    SOURCE_EFIDIR = "/boot/efi/EFI/centos"
+    TARGET_EFIDIR = "/boot/efi/EFI/redhat"
+
+    @pytest.fixture(autouse=True)
+    def mock_current_actor(self):  # pylint:disable=no-self-use
+        with mock.patch("leapp.libraries.stdlib.api.current_actor") as mock_current_actor:
+            mock_current_actor.return_value = CurrentActorMocked(
+                src_distro="centos", dst_distro="redhat"
+            )
+            yield
+
+    @mock.patch("os.path.exists")
+    @mock.patch("leapp.libraries.actor.updateefi.get_distro_efidir_canon_path")
+    @mock.patch("os.rmdir")
+    def test_success(
+        self, mock_rmdir, mock_efidir_path, mock_exists, mock_logger
+    ):
+        mock_efidir_path.side_effect = [self.SOURCE_EFIDIR, self.TARGET_EFIDIR]
+
+        updateefi._try_remove_source_efi_dir()
+
+        mock_exists.assert_called_once_with(self.SOURCE_EFIDIR)
+        mock_rmdir.assert_called_once_with(self.SOURCE_EFIDIR)
+        msg = f"Deleted source system EFI directory at {self.SOURCE_EFIDIR}"
+        assert msg in mock_logger.dbgmsg
+
+    @mock.patch("os.path.exists")
+    @mock.patch("leapp.libraries.actor.updateefi.get_distro_efidir_canon_path")
+    @mock.patch("os.rmdir")
+    def test__efi_dir_does_not_exist(
+        self, mock_rmdir, mock_efidir_path, mock_exists, mock_logger
+    ):
+        mock_efidir_path.return_value = self.SOURCE_EFIDIR
+        mock_exists.return_value = False
+
+        updateefi._try_remove_source_efi_dir()
+
+        mock_exists.assert_called_once_with(self.SOURCE_EFIDIR)
+        mock_rmdir.assert_not_called()
+        msg = f"Source distro EFI directory at {self.SOURCE_EFIDIR} does not exist, skipping removal."
+        assert msg in mock_logger.dbgmsg
+
+    @mock.patch("os.path.exists")
+    @mock.patch("leapp.libraries.actor.updateefi.get_distro_efidir_canon_path")
+    @mock.patch("os.rmdir")
+    def test_source_efi_dir_same_as_target(
+        self, mock_rmdir, mock_efidir_path, mock_exists, mock_logger
+    ):
+        """
+        Source and target dirs use the same directory
+        """
+        mock_efidir_path.side_effect = [self.TARGET_EFIDIR, self.TARGET_EFIDIR]
+        mock_exists.return_value = True
+
+        updateefi._try_remove_source_efi_dir()
+
+        mock_exists.assert_called_once_with(self.TARGET_EFIDIR)
+        mock_rmdir.assert_not_called()
+        msg = f"Source and target distros use the same '{self.TARGET_EFIDIR}' EFI directory."
+        assert msg in mock_logger.dbgmsg
+
+    @mock.patch("os.path.exists")
+    @mock.patch("leapp.libraries.actor.updateefi.get_distro_efidir_canon_path")
+    @mock.patch("os.rmdir")
+    def test_rmdir_fail(
+        self, mock_rmdir, mock_efidir_path, mock_exists, mock_logger, mock_create_report
+    ):
+        """
+        Test removal failures
+        """
+        mock_efidir_path.side_effect = [self.SOURCE_EFIDIR, self.TARGET_EFIDIR]
+        mock_rmdir.side_effect = OSError
+
+        updateefi._try_remove_source_efi_dir()
+
+        mock_exists.assert_called_once_with(self.SOURCE_EFIDIR)
+        mock_rmdir.assert_called_once_with(self.SOURCE_EFIDIR)
+        msg = f"Failed to remove the source system EFI directory at {self.SOURCE_EFIDIR}"
+        assert msg in mock_logger.errmsg[0]
+        assert mock_create_report.called == 1
+        title = "Failed to remove source system EFI directory"
+        assert mock_create_report.report_fields["title"] == title
+
+    @mock.patch("os.path.exists")
+    @mock.patch("leapp.libraries.actor.updateefi.get_distro_efidir_canon_path")
+    @mock.patch("os.rmdir")
+    def test_dir_no_longer_exists_failed_rmdir(
+        self, mock_rmdir, mock_efidir_path, mock_exists, mock_logger
+    ):
+        mock_efidir_path.side_effect = [self.SOURCE_EFIDIR, self.TARGET_EFIDIR]
+        mock_rmdir.side_effect = FileNotFoundError(
+            2, "No such file or directory", self.SOURCE_EFIDIR
+        )
+
+        updateefi._try_remove_source_efi_dir()
+
+        mock_exists.assert_called_once_with(self.SOURCE_EFIDIR)
+        mock_rmdir.assert_called_once_with(self.SOURCE_EFIDIR)
+        msg = (
+            "Couldn't remove the source system EFI directory at"
+            f" {self.SOURCE_EFIDIR}: the directory no longer exists"
+        )
+        assert msg in mock_logger.dbgmsg[0]
+
+    @mock.patch("os.path.exists")
+    @mock.patch("leapp.libraries.actor.updateefi.get_distro_efidir_canon_path")
+    @mock.patch("os.rmdir")
+    def test_dir_not_empty(
+        self, mock_rmdir, mock_efidir_path, mock_exists, mock_logger, mock_create_report
+    ):
+        """
+        Test that the directory is not removed if there are any leftover files
+
+        The distro provided files in the efi dir are usually removed during the RPM
+        upgrade transaction (shim and grub own them). If there are any leftover
+        files, such as custom user files, the directory should be preserved and
+        report created.
+        """
+        mock_efidir_path.side_effect = [self.SOURCE_EFIDIR, self.TARGET_EFIDIR]
+        mock_rmdir.side_effect = OSError(
+            errno.ENOTEMPTY, os.strerror(errno.ENOTEMPTY), self.SOURCE_EFIDIR
+        )
+
+        updateefi._try_remove_source_efi_dir()
+
+        mock_rmdir.assert_called_once_with(self.SOURCE_EFIDIR)
+        mock_exists.assert_called_once_with(self.SOURCE_EFIDIR)
+        msg = "Didn't remove the source EFI directory {}, it does not exist".format(
+            self.SOURCE_EFIDIR
+        )
+        assert msg in mock_logger.dbgmsg[0]
+        assert mock_create_report.called == 1
+        title = "Review leftover files in the source OS EFI directory"
+        assert mock_create_report.report_fields["title"] == title
+
+
+@pytest.mark.parametrize(
+    "is_conversion, arch, is_efi, should_skip",
+    [
+        # conversion, is efi
+        (True, architecture.ARCH_X86_64, True, False),
+        (True, architecture.ARCH_ARM64, True, False),
+        (True, architecture.ARCH_PPC64LE, True, True),
+        (True, architecture.ARCH_S390X, True, True),
+        # conversion, not efi
+        (True, architecture.ARCH_X86_64, False, True),
+        (True, architecture.ARCH_ARM64, False, True),
+        (True, architecture.ARCH_PPC64LE, False, True),
+        (True, architecture.ARCH_S390X, False, True),
+        # not conversion, is efi
+        (False, architecture.ARCH_X86_64, True, True),
+        (False, architecture.ARCH_ARM64, True, True),
+        (False, architecture.ARCH_PPC64LE, True, True),
+        (False, architecture.ARCH_S390X, True, True),
+        # not conversion, not efi
+        (False, architecture.ARCH_X86_64, False, True),
+        (False, architecture.ARCH_ARM64, False, True),
+        (False, architecture.ARCH_PPC64LE, False, True),
+        (False, architecture.ARCH_S390X, False, True),
+    ],
+)
+@mock.patch("leapp.libraries.actor.updateefi._replace_boot_entries")
+def test_process_skip(
+    mock_replace_boot_entries, monkeypatch, is_conversion, arch, is_efi, should_skip
+):
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked(arch=arch))
+    monkeypatch.setattr(updateefi, "is_conversion", lambda: is_conversion)
+    monkeypatch.setattr(efi, "is_efi", lambda: is_efi)
+
+    updateefi.process()
+
+    if should_skip:
+        mock_replace_boot_entries.assert_not_called()
+    else:
+        mock_replace_boot_entries.assert_called_once()
+
+
+class TestReplaceBootEntries:
+
+    @pytest.fixture
+    def mocks(self):  # pylint:disable=no-self-use
+        UPDATE_EFI = 'leapp.libraries.actor.updateefi'
+        EFI_LIB = 'leapp.libraries.common.efi'
+        with mock.patch(f'{UPDATE_EFI}._try_remove_source_efi_dir') as remove_source_dir, \
+             mock.patch(f'{UPDATE_EFI}._remove_boot_entry_for_source') as remove_source_entry, \
+             mock.patch(f'{UPDATE_EFI}._add_boot_entry_for_target') as add_target_entry, \
+             mock.patch(f'{EFI_LIB}.set_bootnext') as set_bootnext, \
+             mock.patch(f'{EFI_LIB}.EFIBootInfo') as efibootinfo:
+
+            # default for happy path
+            efibootinfo_obj = mock.MagicMock(name="EFIBootInfo_instance")
+            efibootinfo.return_value = efibootinfo_obj
+
+            entry = mock.MagicMock(name="target_entry")
+            entry.boot_number = "0003"
+            add_target_entry.return_value = entry
+
+            yield types.SimpleNamespace(
+                EFIBootInfo=efibootinfo,
+                set_bootnext=set_bootnext,
+                add_boot_entry_for_target=add_target_entry,
+                try_remove_source_efi_dir=remove_source_dir,
+                remove_boot_entry_for_source=remove_source_entry,
+                logger=mock_logger,
+            )
+
+    def test__fail_remove_source_entry(  # pylint:disable=no-self-use
+        self, mocks, mock_logger, mock_create_report
+    ):
+        mocks.remove_boot_entry_for_source.side_effect = efi.EFIError
+
+        updateefi._replace_boot_entries()
+
+        msg = "Failed to remove source distro EFI boot entry"
+        assert msg in mock_logger.errmsg[0]
+
+        assert mock_create_report.called == 1
+        title = "Failed to remove source system EFI boot entry"
+        assert mock_create_report.report_fields["title"] == title
+
+    @pytest.mark.parametrize(
+        "which_fail", ["EFIBootInfo", "add_target", "set_bootnext"]
+    )
+    def test__fail_add_target_entry(  # pylint:disable=no-self-use
+        self, mocks, mock_logger, mock_create_report, which_fail
+    ):
+        if which_fail == "EFIBootInfo":
+            mocks.EFIBootInfo.side_effect = efi.EFIError
+        elif which_fail == "add_target":
+            mocks.add_boot_entry_for_target.side_effect = efi.EFIError
+        elif which_fail == "set_bootnext":
+            mocks.set_bootnext.side_effect = efi.EFIError
+
+        with pytest.raises(StopActorExecutionError):
+            updateefi._replace_boot_entries()
+
+        mocks.try_remove_source_efi_dir.assert_not_called()
+        mocks.remove_boot_entry_for_source.assert_not_called()
+        assert not mock_create_report.called
+
+    def test__replace_boot_entries_success(  # pylint:disable=no-self-use
+        self, mocks, mock_logger
+    ):
+        """Test that operations are carried out in the right order"""
+        mgr = mock.MagicMock()
+        mgr.attach_mock(mocks.EFIBootInfo, "EFIBootInfo")
+        mgr.attach_mock(mocks.set_bootnext, "set_bootnext")
+        mgr.attach_mock(mocks.add_boot_entry_for_target, "add_target_entry")
+        mgr.attach_mock(mocks.remove_boot_entry_for_source, "remove_source_entry")
+        mgr.attach_mock(mocks.try_remove_source_efi_dir, "remove_source_efidir")
+
+        updateefi._replace_boot_entries()
+
+        expected_sequence = [
+            mock.call.EFIBootInfo(),
+            mock.call.add_target_entry(efi.EFIBootInfo.return_value),
+            mock.call.set_bootnext(mocks.add_boot_entry_for_target.return_value.boot_number),
+            mock.call.remove_source_efidir(),
+            mock.call.remove_source_entry(efi.EFIBootInfo.return_value),
+        ]
+        assert mgr.mock_calls == expected_sequence

--- a/repos/system_upgrade/common/actors/scangrubdevice/actor.py
+++ b/repos/system_upgrade/common/actors/scangrubdevice/actor.py
@@ -1,4 +1,5 @@
 from leapp.actors import Actor
+from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import grub
 from leapp.libraries.common.config import architecture
 from leapp.models import GrubInfo
@@ -19,7 +20,14 @@ class ScanGrubDeviceName(Actor):
         if architecture.matches_architecture(architecture.ARCH_S390X):
             return
 
-        devices = grub.get_grub_devices()
+        try:
+            devices = grub.get_grub_devices()
+        except grub.GRUBDeviceError as err:
+            # TODO(pstodulk): Tests missing
+            raise StopActorExecutionError(
+                message='Cannot detect GRUB devices',
+                details={'details': str(err)}
+            )
         grub_info = GrubInfo(orig_devices=devices)
         grub_info.orig_device_name = devices[0] if len(devices) == 1 else None
         self.produce(grub_info)

--- a/repos/system_upgrade/common/actors/updategrubcore/libraries/updategrubcore.py
+++ b/repos/system_upgrade/common/actors/updategrubcore/libraries/updategrubcore.py
@@ -1,4 +1,5 @@
 from leapp import reporting
+from leapp.exceptions import StopActorExecution
 from leapp.libraries.common import grub
 from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api, CalledProcessError, config, run
@@ -61,7 +62,11 @@ def process():
         return
     ff = next(api.consume(FirmwareFacts), None)
     if ff and ff.firmware == 'bios':
-        grub_devs = grub.get_grub_devices()
+        try:
+            grub_devs = grub.get_grub_devices()
+        except grub.GRUBDeviceError as err:
+            api.current_logger().warning('Failed to detect GRUB devices: %s', err)
+            raise StopActorExecution()
         if grub_devs:
             update_grub_core(grub_devs)
         else:

--- a/repos/system_upgrade/common/actors/updategrubcore/tests/test_updategrubcore.py
+++ b/repos/system_upgrade/common/actors/updategrubcore/tests/test_updategrubcore.py
@@ -107,9 +107,7 @@ def test_update_grub_nogrub_system_ibmz(monkeypatch):
 
 def test_update_grub_nogrub_system(monkeypatch):
     def get_grub_devices_mocked():
-        # this is not very well documented, but the grub.get_grub_devices function raises a StopActorExecution on error
-        # (whether that's caused by determining root partition or determining the block device a given partition is on
-        raise StopActorExecution()
+        raise grub.GRUBDeviceError()
 
     monkeypatch.setattr(grub, 'get_grub_devices', get_grub_devices_mocked)
     monkeypatch.setattr(reporting, 'create_report', testutils.create_report_mocked())

--- a/repos/system_upgrade/common/libraries/config/__init__.py
+++ b/repos/system_upgrade/common/libraries/config/__init__.py
@@ -141,3 +141,19 @@ def get_target_distro_id():
     :rtype: str
     """
     return api.current_actor().configuration.distro.target
+
+
+def is_conversion():
+    """
+    Return whether a conversion is happening during the upgrade.
+
+    Conversions in means that a target distro different from source distro was
+    specified.
+
+    This is a wrapper which compares source and target distro IDs. This can also
+    be helpful for testing.
+
+    :return: True if converting False otherwise
+    :rtype: bool
+    """
+    return get_source_distro_id() != get_target_distro_id()

--- a/repos/system_upgrade/common/libraries/distro.py
+++ b/repos/system_upgrade/common/libraries/distro.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common import repofileutils, rhsm
+from leapp.libraries.common import efi, repofileutils, rhsm
 from leapp.libraries.common.config import get_target_distro_id
 from leapp.libraries.common.config.architecture import ARCH_ACCEPTED, ARCH_X86_64
 from leapp.libraries.common.config.version import get_target_major_version
@@ -219,3 +219,16 @@ def get_distro_repoids(context, distro, major_version, arch):
                 distro_repoids.extend([repo.repoid for repo in rfile.data])
 
     return sorted(distro_repoids)
+
+
+def get_distro_efidir_canon_path(distro_id):
+    """
+    Get canonical path to the distro EFI directory in the EFI mountpoint.
+
+    NOTE: The path might be incorrect for distros not properly enabled for IPU,
+    when enabling new distros in the codebase, make sure the path is correct.
+    """
+    if distro_id == "rhel":
+        return os.path.join(efi.EFI_MOUNTPOINT, "EFI", "redhat")
+
+    return os.path.join(efi.EFI_MOUNTPOINT, "EFI", distro_id)

--- a/repos/system_upgrade/common/libraries/distro.py
+++ b/repos/system_upgrade/common/libraries/distro.py
@@ -221,6 +221,19 @@ def get_distro_repoids(context, distro, major_version, arch):
     return sorted(distro_repoids)
 
 
+def distro_id_to_pretty_name(distro_id):
+    """
+    Get pretty name for the given distro id.
+
+    The pretty name is what is found in the NAME field of /etc/os-release.
+    """
+    return {
+        "rhel": "Red Hat Enterprise Linux",
+        "centos": "CentOS Stream",
+        "almalinux": "AlmaLinux",
+    }[distro_id]
+
+
 def get_distro_efidir_canon_path(distro_id):
     """
     Get canonical path to the distro EFI directory in the EFI mountpoint.

--- a/repos/system_upgrade/common/libraries/efi.py
+++ b/repos/system_upgrade/common/libraries/efi.py
@@ -1,0 +1,244 @@
+import os
+import re
+
+from leapp.libraries.common.partitions import _get_partition_for_dir, blk_dev_from_partition, get_partition_number
+from leapp.libraries.stdlib import api, CalledProcessError, run
+
+EFI_MOUNTPOINT = '/boot/efi/'
+"""The path to the required mountpoint for ESP."""
+
+
+class EFIError(Exception):
+    """
+    Exception raised when EFI operation failed.
+    """
+
+
+def canonical_path_to_efi_format(canonical_path):
+    r"""
+    Transform the canonical path to the UEFI format.
+
+    e.g. /boot/efi/EFI/redhat/shimx64.efi -> \EFI\redhat\shimx64.efi
+    (just single backslash; so the string needs to be put into apostrophes
+    when used for /usr/sbin/efibootmgr cmd)
+
+    The path has to start with /boot/efi otherwise the path is invalid for UEFI.
+    """
+
+    # We want to keep the last "/" of the EFI_MOUNTPOINT
+    return canonical_path.replace(EFI_MOUNTPOINT[:-1], "").replace("/", "\\")
+
+
+class EFIBootLoaderEntry:
+    """
+    Representation of an UEFI boot loader entry.
+    """
+
+    def __init__(self, boot_number, label, active, efi_bin_source):
+        self.boot_number = boot_number
+        """Expected string, e.g. '0001'. """
+
+        self.label = label
+        """Label of the UEFI entry. E.g. 'Redhat'"""
+
+        self.active = active
+        """True when the UEFI entry is active (asterisk is present next to the boot number)"""
+
+        self.efi_bin_source = efi_bin_source
+        """Source of the UEFI binary.
+
+        It could contain various values, e.g.:
+            FvVol(7cb8bdc9-f8eb-4f34-aaea-3ee4af6516a1)/FvFile(462caa21-7614-4503-836e-8ab6f4662331)
+            HD(1,GPT,28c77f6b-3cd0-4b22-985f-c99903835d79,0x800,0x12c000)/File(\\EFI\\redhat\\shimx64.efi)
+            PciRoot(0x0)/Pci(0x2,0x3)/Pci(0x0,0x0)N.....YM....R,Y.
+        """
+
+    def __eq__(self, other):
+        return all(
+            [
+                self.boot_number == other.boot_number,
+                self.label == other.label,
+                self.active == other.active,
+                self.efi_bin_source == other.efi_bin_source,
+            ]
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return 'EFIBootLoaderEntry({boot_number}, {label}, {active}, {efi_bin_source})'.format(
+            boot_number=repr(self.boot_number),
+            label=repr(self.label),
+            active=repr(self.active),
+            efi_bin_source=repr(self.efi_bin_source)
+        )
+
+    def is_referring_to_file(self):
+        """Return True when the boot source is a file.
+
+        Some sources could refer e.g. to PXE boot. Return true if the source
+        refers to a file ("ends with /File(...path...)")
+
+        Does not matter whether the file exists or not.
+        """
+        return '/File(\\' in self.efi_bin_source
+
+    @staticmethod
+    def _efi_path_to_canonical(efi_path):
+        return os.path.join(EFI_MOUNTPOINT, efi_path.replace("\\", "/").lstrip("/"))
+
+    def get_canonical_path(self):
+        """Return expected canonical path for the referred UEFI bin or None.
+
+        Return None in case the entry is not referring to any UEFI bin
+        (e.g. when it refers to a PXE boot).
+        """
+        if not self.is_referring_to_file():
+            return None
+        match = re.search(r'/File\((?P<path>\\.*)\)$', self.efi_bin_source)
+        return EFIBootLoaderEntry._efi_path_to_canonical(match.groups('path')[0])
+
+
+class EFIBootInfo:
+    """
+    Data about the current UEFI boot configuration.
+
+    :raises EFIError: when unable to obtain info about the UEFI configuration,
+                      BIOS is detected or ESP is not mounted where expected.
+    """
+
+    def __init__(self):
+        if not is_efi():
+            raise EFIError('Unable to collect data about UEFI on a BIOS system.')
+        try:
+            result = run(['/usr/sbin/efibootmgr', '-v'])
+        except CalledProcessError:
+            raise EFIError('Unable to get information about UEFI boot entries.')
+
+        bootmgr_output = result['stdout']
+
+        self.current_bootnum = None
+        """The boot number (str) of the current boot."""
+        self.next_bootnum = None
+        """The boot number (str) of the next boot."""
+        self.boot_order = tuple()
+        """The tuple of the UEFI boot loader entries in the boot order."""
+        self.entries = {}
+        """The UEFI boot loader entries {'boot_number': EFIBootLoaderEntry}"""
+
+        self._parse_efi_boot_entries(bootmgr_output)
+        self._parse_current_bootnum(bootmgr_output)
+        self._parse_next_bootnum(bootmgr_output)
+        self._parse_boot_order(bootmgr_output)
+        self._print_loaded_info()
+
+    def _parse_efi_boot_entries(self, bootmgr_output):
+        """
+        Return dict of UEFI boot loader entries: {"<boot_number>": EFIBootLoader}
+        """
+
+        self.entries = {}
+        regexp_entry = re.compile(
+            r"^Boot(?P<bootnum>[a-zA-Z0-9]+)(?P<active>\*?)\s*(?P<label>.*?)\t(?P<bin_source>.*)$"
+        )
+
+        for line in bootmgr_output.splitlines():
+            match = regexp_entry.match(line)
+            if not match:
+                continue
+
+            self.entries[match.group('bootnum')] = EFIBootLoaderEntry(
+                boot_number=match.group('bootnum'),
+                label=match.group('label'),
+                active='*' in match.group('active'),
+                efi_bin_source=match.group('bin_source'),
+            )
+
+        if not self.entries:
+            # it's not expected that no entry exists
+            raise EFIError('Unable to detect any UEFI bootloader entry.')
+
+    @staticmethod
+    def _parse_key_value(bootmgr_output, key):
+        # e.g.: <key>: <value>
+        for line in bootmgr_output.splitlines():
+            if line.startswith(key + ':'):
+                return line.split(':')[1].strip()
+
+        return None
+
+    def _parse_current_bootnum(self, bootmgr_output):
+        # e.g.: BootCurrent: 0002
+        self.current_bootnum = self._parse_key_value(bootmgr_output, 'BootCurrent')
+
+        if self.current_bootnum is None:
+            raise EFIError('Unable to detect current boot number.')
+
+    def _parse_next_bootnum(self, bootmgr_output):
+        # e.g.: BootNext: 0002
+        self.next_bootnum = self._parse_key_value(bootmgr_output, 'BootNext')
+
+    def _parse_boot_order(self, bootmgr_output):
+        # e.g.:  BootOrder: 0001,0002,0000,0003
+        read_boot_order = self._parse_key_value(bootmgr_output, 'BootOrder')
+        self.boot_order = tuple(read_boot_order.split(','))
+
+        if self.boot_order is None:
+            raise EFIError('UEFI: Unable to detect current boot order.')
+
+    def _print_loaded_info(self):
+        msg = 'Bootloader setup:'
+        msg += '\nCurrent boot: %s' % self.current_bootnum
+        msg += '\nBoot order: %s\nBoot entries:' % ', '.join(self.boot_order)
+        for bootnum, entry in self.entries.items():
+            msg += '\n- %s: %s' % (bootnum, entry.label.rstrip())
+
+        api.current_logger().debug(msg)
+
+
+def is_efi():
+    """
+    Check whether the system firmware is UEFI
+
+    NOTE: the check might not be valid for hybrid boot (like on Azure)
+
+    :rtype: bool
+    """
+    return os.path.exists("/sys/firmware/efi")
+
+
+def get_efi_partition():
+    """
+    Return the EFI System Partition (ESP).
+
+    :raises EFIError: when UEFI is not detected, ESP is not mounted where
+                      expected, the partition can't be obtained from GRUB.
+    """
+
+    if not is_efi():
+        raise EFIError('Unable to get ESP when BIOS is used.')
+
+    if not os.path.exists(EFI_MOUNTPOINT) or not os.path.ismount(EFI_MOUNTPOINT):
+        raise EFIError(
+            'The UEFI has been detected but the ESP is not mounted in /boot/efi as required.'
+        )
+
+    return _get_partition_for_dir(EFI_MOUNTPOINT)
+
+
+def get_efi_device():
+    """
+    Get the block device on which GRUB is installed.
+
+    Uses get_efi_partition() under the hood.
+
+    :raises EFIError: When EFI device could not be retrieved.
+    """
+    try:
+        efi_part = get_efi_partition()
+    except EFIError as e:
+        raise EFIError("Failed to get EFI device") from e
+
+    return blk_dev_from_partition(efi_part)
+

--- a/repos/system_upgrade/common/libraries/partitions.py
+++ b/repos/system_upgrade/common/libraries/partitions.py
@@ -1,0 +1,102 @@
+from leapp.libraries.stdlib import api, CalledProcessError, run
+
+
+class StorageScanError(Exception):
+    """
+    Generic exception for errors when obtaining information about storage.
+    """
+
+
+def blk_dev_from_partition(partition):
+    """
+    Get the block device containing `partition`.
+
+    In case of the block device itself (e.g. /dev/sda), return just the block
+    device. In case of a partition, return its block device:
+        /dev/sda  -> /dev/sda
+        /dev/sda1 -> /dev/sda
+
+    :param partition: The partition for which the block device is searched
+    :type partition: str
+    :return: The block device containing the partition
+    :rtype: str
+    :raises StorageScanError: When unable to get the parent block device.
+    """
+
+    try:
+        result = run(['lsblk', '-spnlo', 'name', partition])
+    except CalledProcessError:
+        msg = 'Could not get parent device of {} partition'.format(partition)
+        api.current_logger().warning(msg)
+        raise StorageScanError(msg)
+
+    # lsblk "-s" option prints dependencies in inverse order, so the parent device will always
+    # be the last or the only device.
+    # Command result example:
+    # 'result', {'signal': 0, 'pid': 3872, 'exit_code': 0, 'stderr': u'', 'stdout': u'/dev/vda1\n/dev/vda\n'}
+    return result['stdout'].strip().split()[-1]
+
+
+def get_partition_number(partition):
+    """
+    Get the partition number of a particular device.
+
+    This method will use `blkid` to determinate what is the partition number
+    related to a particular device.
+
+    :param device: The device to be analyzed.
+    :type device: str
+    :return: The device partition number.
+    :rtype: int
+    :raises StorageScanError: When cannot obtain the partition number.
+    """
+
+    try:
+        result = run(
+            ['/usr/sbin/blkid', '-p', '-s', 'PART_ENTRY_NUMBER', partition],
+        )
+        output = result['stdout'].strip()
+    except CalledProcessError:
+        raise StorageScanError('Unable to get information about the {} device'.format(partition))
+
+    if not output:
+        raise StorageScanError('The {} device has no PART_ENTRY_NUMBER'.format(partition))
+
+    partition_number = output.split('PART_ENTRY_NUMBER=')[-1].replace('"', '')
+
+    return int(partition_number)
+
+
+def _get_partition_for_dir(directory):
+    """
+    Get the partition where `directory` resides.
+
+    WARNING: This function should not be used unless you know what you are doing.
+    It uses grub2-probe internally so it might not work on every architecture.
+    And even then it's not clear whether grub2-probe will work correctly for every input.
+    Currently it's used only in the efi and grub libraries.
+
+    :param directory: Path to the directory.
+    :type directory: str
+    :return: The partition, e.g. /dev/sda1
+    :rtype: str
+    :raises StorageScanError: When cannot identify the partition hosting specified directory
+    """
+
+    try:
+        result = run(['grub2-probe', '--target=device', directory])
+    except CalledProcessError:
+        msg = 'Could not get name of underlying {} partition'.format(directory)
+        api.current_logger().warning(msg)
+        raise StorageScanError(msg)
+    except OSError:
+        msg = ('Could not get name of underlying {} partition:'
+               ' grub2-probe is missing.'
+               ' Possibly called on system that does not use GRUB2?').format(directory)
+        api.current_logger().warning(msg)
+        raise StorageScanError(msg)
+
+    partition = result['stdout'].strip()
+    api.current_logger().info('{} is on {}'.format(directory, partition))
+
+    return partition

--- a/repos/system_upgrade/common/libraries/tests/test_efi.py
+++ b/repos/system_upgrade/common/libraries/tests/test_efi.py
@@ -1,0 +1,248 @@
+import os
+
+import pytest
+
+from leapp.libraries.common import partitions
+from leapp.libraries.common.firmware import efi
+from leapp.libraries.stdlib import CalledProcessError
+
+EFI_PARTITION = '/dev/vda1'
+EFI_DEVICE = '/dev/vda'
+
+# pylint: disable=line-too-long
+# flake8: noqa: E501
+EFIBOOTMGR_OUTPUT = r"""
+BootCurrent: 0006
+Timeout: 5 seconds
+BootOrder: 0003,0004,0001,0006,0000,0002,0007,0005
+Boot0000  redhat	VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)
+Boot0001* UEFI: Built-in EFI Shell	VenMedia(5023b95c-db26-429b-a648-bd47664c8012)..BO
+Boot0002  Fedora	VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)
+Boot0003* UEFI: PXE IPv4 Intel(R) Network D8:5E:D3:8F:A4:E8	PcieRoot(0x40000)/Pci(0x1,0x0)/Pci(0x0,0x0)/MAC(d85ed38fa4e8,1)/IPv4(0.0.0.00.0.0.0,0,0)..BO
+Boot0004* UEFI: PXE IPv4 Intel(R) Network D8:5E:D3:8F:A4:E9	PcieRoot(0x40000)/Pci(0x1,0x0)/Pci(0x0,0x1)/MAC(d85ed38fa4e9,1)/IPv4(0.0.0.00.0.0.0,0,0)..BO
+Boot0005  centos	VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)
+Boot0006* Red Hat Enterprise Linux	HD(1,GPT,050609f2-0ad0-43cf-8cdf-e53132b898c9,0x800,0x12c000)/File(\EFI\REDHAT\SHIMAA64.EFI)
+Boot0007  CentOS Stream	VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)
+"""
+EFIBOOTMGR_OUTPUT_ENTRIES = {
+    '0000': efi.EFIBootLoaderEntry(
+        '0000',
+        'redhat',
+        False,
+        'VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)'
+    ),
+    '0001': efi.EFIBootLoaderEntry(
+        '0001',
+        'UEFI: Built-in EFI Shell',
+        True,
+        'VenMedia(5023b95c-db26-429b-a648-bd47664c8012)..BO'
+    ),
+    '0002': efi.EFIBootLoaderEntry(
+        '0002',
+        'Fedora',
+        False,
+        'VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)'
+    ),
+    '0003': efi.EFIBootLoaderEntry(
+        '0003',
+        'UEFI: PXE IPv4 Intel(R) Network D8:5E:D3:8F:A4:E8',
+        True,
+        'PcieRoot(0x40000)/Pci(0x1,0x0)/Pci(0x0,0x0)/MAC(d85ed38fa4e8,1)/IPv4(0.0.0.00.0.0.0,0,0)..BO'
+    ),
+    '0004': efi.EFIBootLoaderEntry(
+        '0004',
+        'UEFI: PXE IPv4 Intel(R) Network D8:5E:D3:8F:A4:E9',
+        True,
+        'PcieRoot(0x40000)/Pci(0x1,0x0)/Pci(0x0,0x1)/MAC(d85ed38fa4e9,1)/IPv4(0.0.0.00.0.0.0,0,0)..BO'
+    ),
+    '0005': efi.EFIBootLoaderEntry(
+        '0005',
+        'centos',
+        False,
+        'VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)'
+    ),
+    '0006': efi.EFIBootLoaderEntry(
+        '0006',
+        'Red Hat Enterprise Linux',
+        True,
+        'HD(1,GPT,050609f2-0ad0-43cf-8cdf-e53132b898c9,0x800,0x12c000)/File(\\EFI\\REDHAT\\SHIMAA64.EFI)'
+    ),
+    '0007': efi.EFIBootLoaderEntry(
+        '0007',
+        'CentOS Stream',
+        False,
+        'VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)'
+    ),
+}
+
+
+def raise_call_error(args=None):
+    raise CalledProcessError(
+        message='A Leapp Command Error occurred.',
+        command=args,
+        result={'signal': None, 'exit_code': 1, 'pid': 0, 'stdout': 'fake', 'stderr': 'fake'}
+    )
+
+
+class RunMocked:
+
+    def __init__(self, raise_err=False):
+        self.called = 0
+        self.args = None
+        self.raise_err = raise_err
+
+    def __call__(self, args, encoding=None, checked=True):
+        self.called += 1
+        self.args = args
+        stdout = ''
+        if self.raise_err:
+            if checked is True:
+                raise_call_error(args)
+
+            return {'signal': None, 'exit_code': 1, 'pid': 0, 'stdout': 'fake', 'stderr': 'fake'}
+
+        if self.args[:-1] == ['grub2-probe', '--target=device']:
+            directory = self.args[-1]
+            if directory == '/boot/efi/':
+                stdout = EFI_PARTITION
+            else:
+                raise ValueError('Invalid argument {}'.format(directory))
+
+        elif self.args == ['lsblk', '-spnlo', 'name', EFI_PARTITION]:
+            stdout = EFI_DEVICE
+        elif self.args[:-1] == ['lsblk', '-spnlo', 'name']:
+            stdout = self.args[-1][:-1]
+        elif self.args == ['/usr/sbin/efibootmgr', '-v']:
+            stdout = EFIBOOTMGR_OUTPUT
+        else:
+            assert False, 'RunMockedError: Called unexpected cmd not covered by test: {}'.format(self.args)
+
+        return {'stdout': stdout, 'exit_code': 0}
+
+
+def test_canonical_path_to_efi_format():
+    assert efi.canonical_path_to_efi_format('/boot/efi/EFI/redhat/shimx64.efi') == r'\EFI\redhat\shimx64.efi'
+
+
+def test_EFIBootLoaderEntry__efi_path_to_canonical():
+    real = efi.EFIBootLoaderEntry._efi_path_to_canonical(r'\EFI\redhat\shimx64.efi')
+    expected = '/boot/efi/EFI/redhat/shimx64.efi'
+    assert real == expected
+
+
+def test_canonical_to_efi_to_canonical():
+    canonical = '/boot/efi/EFI/redhat/shimx64.efi'
+    efi_path = efi.canonical_path_to_efi_format(canonical)
+
+    assert efi.EFIBootLoaderEntry._efi_path_to_canonical(efi_path) == canonical
+
+
+def test_efi_path_to_canonical_to_efi():
+    efi_path = r'\EFI\redhat\shimx64.efi'
+    canonical = efi.EFIBootLoaderEntry._efi_path_to_canonical(efi_path)
+
+    assert efi.canonical_path_to_efi_format(canonical) == efi_path
+
+
+@pytest.mark.parametrize(
+    'efi_bin_source, expected',
+    [
+        ('FvVol(7cb8bdc9-f8eb-4f34-aaea-3ee4af6516a1)/FvFile(462caa21-7614-4503-836e-8ab6f4662331) ', False),
+        ('PciRoot(0x0)/Pci(0x2,0x3)/Pci(0x0,0x0)N.....YM....R,Y.', False),
+        ('HD(1,GPT,28c77f6b-3cd0-4b22-985f-c99903835d79,0x800,0x12c000)/File(\\EFI\\redhat\\shimx64.efi)', True),
+    ]
+)
+def test_EFIBootLoaderEntry_is_referring_to_file(efi_bin_source, expected):
+    bootloader_entry = efi.EFIBootLoaderEntry('0001', 'Redhat', False, efi_bin_source)
+    assert bootloader_entry.is_referring_to_file() is expected
+
+
+@pytest.mark.parametrize(
+    'efi_bin_source, expected',
+    [
+        ('FvVol(7cb8bdc9-f8eb-4f34-aaea-3ee4af6516a1)/FvFile(462caa21-7614-4503-836e-8ab6f4662331) ', None),
+        ('PciRoot(0x0)/Pci(0x2,0x3)/Pci(0x0,0x0)N.....YM....R,Y.', None),
+        ('HD(1,GPT,28c77f6b-3cd0-4b22-985f-c99903835d79,0x800,0x12c000)/File(\\EFI\\redhat\\shimx64.efi)',
+         '/boot/efi/EFI/redhat/shimx64.efi'),
+    ]
+)
+def test_EFIBootLoaderEntry_get_canonical_path(efi_bin_source, expected):
+    bootloader_entry = efi.EFIBootLoaderEntry('0001', 'Redhat', False, efi_bin_source)
+    assert bootloader_entry.get_canonical_path() == expected
+
+
+def test_get_efi_partition_success(monkeypatch):
+    monkeypatch.setattr(partitions, 'run', RunMocked())
+    monkeypatch.setattr(efi, 'is_efi', lambda: True)
+    monkeypatch.setattr(os.path, 'exists', lambda path: path == '/boot/efi/')
+    monkeypatch.setattr(os.path, 'ismount', lambda path: path == '/boot/efi/')
+
+    assert efi.get_efi_partition() == EFI_PARTITION
+
+
+def test_get_efi_partition_success_fail_not_efi(monkeypatch):
+    monkeypatch.setattr(partitions, 'run', RunMocked())
+    monkeypatch.setattr(efi, 'is_efi', lambda: False)
+    monkeypatch.setattr(os.path, 'exists', lambda path: path == '/boot/efi/')
+    monkeypatch.setattr(os.path, 'ismount', lambda path: path == '/boot/efi/')
+
+    with pytest.raises(efi.EFIError) as err:
+        efi.get_efi_partition()
+        assert 'Unable to get ESP when BIOS is used.' in err
+
+
+def test_get_efi_partition_success_fail_not_exists(monkeypatch):
+    monkeypatch.setattr(partitions, 'run', RunMocked())
+    monkeypatch.setattr(efi, 'is_efi', lambda: True)
+    monkeypatch.setattr(os.path, 'exists', lambda path: False)
+    monkeypatch.setattr(os.path, 'ismount', lambda path: path == '/boot/efi/')
+
+    with pytest.raises(efi.EFIError) as err:
+        efi.get_efi_partition()
+        assert 'The UEFI has been detected but' in err
+
+
+def test_get_efi_partition_success_fail_not_mounted(monkeypatch):
+    monkeypatch.setattr(partitions, 'run', RunMocked())
+    monkeypatch.setattr(efi, 'is_efi', lambda: True)
+    monkeypatch.setattr(os.path, 'exists', lambda path: path == '/boot/efi/')
+    monkeypatch.setattr(os.path, 'ismount', lambda path: False)
+
+    with pytest.raises(efi.EFIError) as err:
+        efi.get_efi_partition()
+        assert 'The UEFI has been detected but' in err
+
+
+def test_get_efi_device(monkeypatch):
+    monkeypatch.setattr(partitions, 'run', RunMocked())
+    monkeypatch.setattr(efi, 'get_efi_partition', lambda: EFI_PARTITION)
+
+    assert efi.get_efi_device() == EFI_DEVICE
+
+
+def test_EFIBootInfo_fail_not_efi(monkeypatch):
+    monkeypatch.setattr(efi, 'is_efi', lambda: False)
+
+    with pytest.raises(efi.EFIError) as err:
+        efi.EFIBootInfo()
+        assert 'Unable to collect data about UEFI on a BIOS system.' in err
+
+
+def test_EFIBootInfo_fail_efibootmgr_error(monkeypatch):
+    monkeypatch.setattr(efi, 'is_efi', lambda: True)
+    monkeypatch.setattr(efi, 'run', RunMocked(raise_err=True))
+
+    with pytest.raises(efi.EFIError) as err:
+        efi.EFIBootInfo()
+        assert 'Unable to get information about UEFI boot entries.' in err
+
+
+def test_EFIBootInfo_success(monkeypatch):
+    monkeypatch.setattr(efi, 'is_efi', lambda: True)
+    monkeypatch.setattr(efi, 'run', RunMocked())
+
+    efibootinfo = efi.EFIBootInfo()
+    assert efibootinfo.current_bootnum == '0006'
+    assert efibootinfo.next_bootnum is None
+    assert efibootinfo.boot_order == ('0003', '0004', '0001', '0006', '0000', '0002', '0007', '0005')
+    assert efibootinfo.entries == EFIBOOTMGR_OUTPUT_ENTRIES

--- a/repos/system_upgrade/common/libraries/tests/test_grub.py
+++ b/repos/system_upgrade/common/libraries/tests/test_grub.py
@@ -2,15 +2,11 @@ import os
 
 import pytest
 
-from leapp.exceptions import StopActorExecution
-from leapp.libraries.common import grub, mdraid
+from leapp.libraries.common import grub, mdraid, partitions
 from leapp.libraries.common.testutils import logger_mocked
 from leapp.libraries.stdlib import api, CalledProcessError
 from leapp.models import DefaultGrub, DefaultGrubInfo
 from leapp.utils.deprecation import suppress_deprecation
-
-EFI_PARTITION = '/dev/vda1'
-EFI_DEVICE = '/dev/vda'
 
 BOOT_PARTITION = '/dev/vda2'
 BOOT_DEVICE = '/dev/vda'
@@ -22,72 +18,6 @@ VALID_DD = b'GRUB GeomHard DiskRead Error'
 INVALID_DD = b'Nothing to see here!'
 
 CUR_DIR = os.path.dirname(os.path.abspath(__file__))
-
-# pylint: disable=line-too-long
-# flake8: noqa: E501
-EFIBOOTMGR_OUTPUT = r"""
-BootCurrent: 0006
-Timeout: 5 seconds
-BootOrder: 0003,0004,0001,0006,0000,0002,0007,0005
-Boot0000  redhat	VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)
-Boot0001* UEFI: Built-in EFI Shell	VenMedia(5023b95c-db26-429b-a648-bd47664c8012)..BO
-Boot0002  Fedora	VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)
-Boot0003* UEFI: PXE IPv4 Intel(R) Network D8:5E:D3:8F:A4:E8	PcieRoot(0x40000)/Pci(0x1,0x0)/Pci(0x0,0x0)/MAC(d85ed38fa4e8,1)/IPv4(0.0.0.00.0.0.0,0,0)..BO
-Boot0004* UEFI: PXE IPv4 Intel(R) Network D8:5E:D3:8F:A4:E9	PcieRoot(0x40000)/Pci(0x1,0x0)/Pci(0x0,0x1)/MAC(d85ed38fa4e9,1)/IPv4(0.0.0.00.0.0.0,0,0)..BO
-Boot0005  centos	VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)
-Boot0006* Red Hat Enterprise Linux	HD(1,GPT,050609f2-0ad0-43cf-8cdf-e53132b898c9,0x800,0x12c000)/File(\EFI\REDHAT\SHIMAA64.EFI)
-Boot0007  CentOS Stream	VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)
-"""
-EFIBOOTMGR_OUTPUT_ENTRIES = {
-    '0000': grub.EFIBootLoaderEntry(
-        '0000',
-        'redhat',
-        False,
-        'VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)'
-    ),
-    '0001': grub.EFIBootLoaderEntry(
-        '0001',
-        'UEFI: Built-in EFI Shell',
-        True,
-        'VenMedia(5023b95c-db26-429b-a648-bd47664c8012)..BO'
-    ),
-    '0002': grub.EFIBootLoaderEntry(
-        '0002',
-        'Fedora',
-        False,
-        'VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)'
-    ),
-    '0003': grub.EFIBootLoaderEntry(
-        '0003',
-        'UEFI: PXE IPv4 Intel(R) Network D8:5E:D3:8F:A4:E8',
-        True,
-        'PcieRoot(0x40000)/Pci(0x1,0x0)/Pci(0x0,0x0)/MAC(d85ed38fa4e8,1)/IPv4(0.0.0.00.0.0.0,0,0)..BO'
-    ),
-    '0004': grub.EFIBootLoaderEntry(
-        '0004',
-        'UEFI: PXE IPv4 Intel(R) Network D8:5E:D3:8F:A4:E9',
-        True,
-        'PcieRoot(0x40000)/Pci(0x1,0x0)/Pci(0x0,0x1)/MAC(d85ed38fa4e9,1)/IPv4(0.0.0.00.0.0.0,0,0)..BO'
-    ),
-    '0005': grub.EFIBootLoaderEntry(
-        '0005',
-        'centos',
-        False,
-        'VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)'
-    ),
-    '0006': grub.EFIBootLoaderEntry(
-        '0006',
-        'Red Hat Enterprise Linux',
-        True,
-        'HD(1,GPT,050609f2-0ad0-43cf-8cdf-e53132b898c9,0x800,0x12c000)/File(\\EFI\\REDHAT\\SHIMAA64.EFI)'
-    ),
-    '0007': grub.EFIBootLoaderEntry(
-        '0007',
-        'CentOS Stream',
-        False,
-        'VenHw(99e275e7-75a0-4b37-a2e6-c5385e6c00cb)'
-    ),
-}
 
 
 def raise_call_error(args=None):
@@ -120,19 +50,13 @@ class RunMocked:
             directory = self.args[-1]
             if directory == '/boot':
                 stdout = MD_BOOT_DEVICE if self.boot_on_raid else BOOT_PARTITION
-            elif directory == '/boot/efi/':
-                stdout = EFI_PARTITION
             else:
                 raise ValueError('Invalid argument {}'.format(directory))
 
         elif self.args == ['lsblk', '-spnlo', 'name', BOOT_PARTITION]:
             stdout = BOOT_DEVICE
-        elif self.args == ['lsblk', '-spnlo', 'name', EFI_PARTITION]:
-            stdout = EFI_DEVICE
         elif self.args[:-1] == ['lsblk', '-spnlo', 'name']:
             stdout = self.args[-1][:-1]
-        elif self.args == ['/usr/sbin/efibootmgr', '-v']:
-            stdout = EFIBOOTMGR_OUTPUT
         else:
             assert False, 'RunMockedError: Called unexpected cmd not covered by test: {}'.format(self.args)
 
@@ -162,13 +86,13 @@ def close_mocked(f):
 @suppress_deprecation(grub.get_grub_device)
 def test_get_grub_device_library(monkeypatch):
     run_mocked = RunMocked()
-    monkeypatch.setattr(grub, 'run', run_mocked)
+    monkeypatch.setattr(partitions, 'run', run_mocked)
     monkeypatch.setattr(os, 'open', open_mocked)
     monkeypatch.setattr(os, 'read', read_mocked)
     monkeypatch.setattr(os, 'close', close_mocked)
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
     result = grub.get_grub_device()
-    assert grub.run.called == 2
+    assert partitions.run.called == 2
     assert BOOT_DEVICE == result
     assert not api.current_logger.warnmsg
     assert 'GRUB is installed on {}'.format(result) in api.current_logger.infomsg
@@ -179,14 +103,14 @@ def test_get_grub_device_fail_library(monkeypatch):
     # TODO(pstodulk): cover here also case with OSError (covered now in actors,
     # so keeping for the future when we have a time)
     run_mocked = RunMocked(raise_err=True)
-    monkeypatch.setattr(grub, 'run', run_mocked)
+    monkeypatch.setattr(partitions, 'run', run_mocked)
     monkeypatch.setattr(os, 'open', open_mocked)
     monkeypatch.setattr(os, 'read', read_mocked)
     monkeypatch.setattr(os, 'close', close_mocked)
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
-    with pytest.raises(StopActorExecution):
+    with pytest.raises(partitions.StorageScanError):
         grub.get_grub_device()
-    assert grub.run.called == 1
+    assert partitions.run.called == 1
     err = 'Could not get name of underlying /boot partition'
     assert err in api.current_logger.warnmsg
 
@@ -194,13 +118,13 @@ def test_get_grub_device_fail_library(monkeypatch):
 @suppress_deprecation(grub.get_grub_device)
 def test_device_no_grub_library(monkeypatch):
     run_mocked = RunMocked()
-    monkeypatch.setattr(grub, 'run', run_mocked)
+    monkeypatch.setattr(partitions, 'run', run_mocked)
     monkeypatch.setattr(os, 'open', open_invalid)
     monkeypatch.setattr(os, 'read', read_mocked)
     monkeypatch.setattr(os, 'close', close_mocked)
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
     result = grub.get_grub_device()
-    assert grub.run.called == 2
+    assert partitions.run.called == 2
     assert not result
 
 
@@ -229,7 +153,7 @@ def is_mdraid_dev_mocked(dev):
 
 def test_get_grub_devices_one_device(monkeypatch):
     run_mocked = RunMocked()
-    monkeypatch.setattr(grub, 'run', run_mocked)
+    monkeypatch.setattr(partitions, 'run', run_mocked)
     monkeypatch.setattr(os, 'open', open_mocked)
     monkeypatch.setattr(os, 'read', read_mocked)
     monkeypatch.setattr(os, 'close', close_mocked)
@@ -237,7 +161,7 @@ def test_get_grub_devices_one_device(monkeypatch):
     monkeypatch.setattr(mdraid, 'is_mdraid_dev', is_mdraid_dev_mocked)
 
     result = grub.get_grub_devices()
-    assert grub.run.called == 2
+    assert partitions.run.called == 2
     assert [BOOT_DEVICE] == result
     assert not api.current_logger.warnmsg
     assert 'GRUB is installed on {}'.format(",".join(result)) in api.current_logger.infomsg
@@ -254,7 +178,7 @@ def test_get_grub_devices_one_device(monkeypatch):
 )
 def test_get_grub_devices_raid_device(monkeypatch, component_devs, expected):
     run_mocked = RunMocked(boot_on_raid=True)
-    monkeypatch.setattr(grub, 'run', run_mocked)
+    monkeypatch.setattr(partitions, 'run', run_mocked)
     monkeypatch.setattr(os, 'open', open_mocked)
     monkeypatch.setattr(os, 'read', read_mocked)
     monkeypatch.setattr(os, 'close', close_mocked)
@@ -268,157 +192,7 @@ def test_get_grub_devices_raid_device(monkeypatch, component_devs, expected):
     monkeypatch.setattr(mdraid, 'get_component_devices', get_component_devices_mocked)
 
     result = grub.get_grub_devices()
-    assert grub.run.called == 1 + len(component_devs)  # grub2-probe + Nx lsblk
+    assert partitions.run.called == 1 + len(component_devs)  # grub2-probe + Nx lsblk
     assert sorted(expected) == result
     assert not api.current_logger.warnmsg
     assert 'GRUB is installed on {}'.format(",".join(result)) in api.current_logger.infomsg
-
-
-def test_canonical_path_to_efi_format():
-    assert grub.canonical_path_to_efi_format('/boot/efi/EFI/redhat/shimx64.efi') == r'\EFI\redhat\shimx64.efi'
-
-
-def test_EFIBootLoaderEntry__efi_path_to_canonical():
-    real = grub.EFIBootLoaderEntry._efi_path_to_canonical(r'\EFI\redhat\shimx64.efi')
-    expected = '/boot/efi/EFI/redhat/shimx64.efi'
-    assert real == expected
-
-
-def test_canonical_to_efi_to_canonical():
-    canonical = '/boot/efi/EFI/redhat/shimx64.efi'
-    efi = grub.canonical_path_to_efi_format(canonical)
-
-    assert grub.EFIBootLoaderEntry._efi_path_to_canonical(efi) == canonical
-
-
-def test_efi_path_to_canonical_to_efi():
-    efi = r'\EFI\redhat\shimx64.efi'
-    canonical = grub.EFIBootLoaderEntry._efi_path_to_canonical(efi)
-
-    assert grub.canonical_path_to_efi_format(canonical) == efi
-
-
-@pytest.mark.parametrize(
-    'efi_bin_source, expected',
-    [
-        ('FvVol(7cb8bdc9-f8eb-4f34-aaea-3ee4af6516a1)/FvFile(462caa21-7614-4503-836e-8ab6f4662331) ', False),
-        ('PciRoot(0x0)/Pci(0x2,0x3)/Pci(0x0,0x0)N.....YM....R,Y.', False),
-        ('HD(1,GPT,28c77f6b-3cd0-4b22-985f-c99903835d79,0x800,0x12c000)/File(\\EFI\\redhat\\shimx64.efi)', True),
-    ]
-)
-def test_EFIBootLoaderEntry_is_referring_to_file(efi_bin_source, expected):
-    bootloader_entry = grub.EFIBootLoaderEntry('0001', 'Redhat', False, efi_bin_source)
-    assert bootloader_entry.is_referring_to_file() is expected
-
-
-@pytest.mark.parametrize(
-    'efi_bin_source, expected',
-    [
-        ('FvVol(7cb8bdc9-f8eb-4f34-aaea-3ee4af6516a1)/FvFile(462caa21-7614-4503-836e-8ab6f4662331) ', None),
-        ('PciRoot(0x0)/Pci(0x2,0x3)/Pci(0x0,0x0)N.....YM....R,Y.', None),
-        ('HD(1,GPT,28c77f6b-3cd0-4b22-985f-c99903835d79,0x800,0x12c000)/File(\\EFI\\redhat\\shimx64.efi)',
-         '/boot/efi/EFI/redhat/shimx64.efi'),
-    ]
-)
-def test_EFIBootLoaderEntry_get_canonical_path(efi_bin_source, expected):
-    bootloader_entry = grub.EFIBootLoaderEntry('0001', 'Redhat', False, efi_bin_source)
-    assert bootloader_entry.get_canonical_path() == expected
-
-
-def test_is_efi_success(monkeypatch):
-    def exists_mocked(path):
-        if path == '/sys/firmware/efi':
-            return True
-        raise ValueError('Unexpected path checked: {}'.format(path))
-
-    monkeypatch.setattr(os.path, 'exists', exists_mocked)
-
-    assert grub.is_efi() is True
-
-
-def test_is_efi_fail(monkeypatch):
-    def exists_mocked(path):
-        if path == '/sys/firmware/efi':
-            return False
-        raise ValueError('Unexpected path checked: {}'.format(path))
-
-    monkeypatch.setattr(os.path, 'exists', exists_mocked)
-
-    assert grub.is_efi() is False
-
-
-def test_get_efi_partition_success(monkeypatch):
-    monkeypatch.setattr(grub, 'run', RunMocked())
-    monkeypatch.setattr(grub, 'is_efi', lambda: True)
-    monkeypatch.setattr(os.path, 'exists', lambda path: path == '/boot/efi/')
-    monkeypatch.setattr(os.path, 'ismount', lambda path: path == '/boot/efi/')
-
-    assert grub.get_efi_partition() == EFI_PARTITION
-
-
-def test_get_efi_partition_success_fail_not_efi(monkeypatch):
-    monkeypatch.setattr(grub, 'run', RunMocked())
-    monkeypatch.setattr(grub, 'is_efi', lambda: False)
-    monkeypatch.setattr(os.path, 'exists', lambda path: path == '/boot/efi/')
-    monkeypatch.setattr(os.path, 'ismount', lambda path: path == '/boot/efi/')
-
-    with pytest.raises(StopActorExecution) as err:
-        grub.get_efi_partition()
-        assert 'Unable to get ESP when BIOS is used.' in err
-
-
-def test_get_efi_partition_success_fail_not_exists(monkeypatch):
-    monkeypatch.setattr(grub, 'run', RunMocked())
-    monkeypatch.setattr(grub, 'is_efi', lambda: True)
-    monkeypatch.setattr(os.path, 'exists', lambda path: False)
-    monkeypatch.setattr(os.path, 'ismount', lambda path: path == '/boot/efi/')
-
-    with pytest.raises(StopActorExecution) as err:
-        grub.get_efi_partition()
-        assert 'The UEFI has been detected but' in err
-
-
-def test_get_efi_partition_success_fail_not_mounted(monkeypatch):
-    monkeypatch.setattr(grub, 'run', RunMocked())
-    monkeypatch.setattr(grub, 'is_efi', lambda: True)
-    monkeypatch.setattr(os.path, 'exists', lambda path: path == '/boot/efi/')
-    monkeypatch.setattr(os.path, 'ismount', lambda path: False)
-
-    with pytest.raises(StopActorExecution) as err:
-        grub.get_efi_partition()
-        assert 'The UEFI has been detected but' in err
-
-
-def test_get_efi_device(monkeypatch):
-    monkeypatch.setattr(grub, 'run', RunMocked())
-    monkeypatch.setattr(grub, 'get_efi_partition', lambda: EFI_PARTITION)
-
-    assert grub.get_efi_device() == EFI_DEVICE
-
-
-def test_EFIBootInfo_fail_not_efi(monkeypatch):
-    monkeypatch.setattr(grub, 'is_efi', lambda: False)
-
-    with pytest.raises(StopActorExecution) as err:
-        grub.EFIBootInfo()
-        assert 'Unable to collect data about UEFI on a BIOS system.' in err
-
-
-def test_EFIBootInfo_fail_efibootmgr_error(monkeypatch):
-    monkeypatch.setattr(grub, 'is_efi', lambda: True)
-    monkeypatch.setattr(grub, 'run', RunMocked(raise_err=True))
-
-    with pytest.raises(StopActorExecution) as err:
-        grub.EFIBootInfo()
-        assert 'Unable to get information about UEFI boot entries.' in err
-
-
-def test_EFIBootInfo_success(monkeypatch):
-    monkeypatch.setattr(grub, 'is_efi', lambda: True)
-    monkeypatch.setattr(grub, 'run', RunMocked())
-
-    efibootinfo = grub.EFIBootInfo()
-    assert efibootinfo.current_bootnum == '0006'
-    assert efibootinfo.next_bootnum is None
-    assert efibootinfo.boot_order == ('0003', '0004', '0001', '0006', '0000', '0002', '0007', '0005')
-    assert efibootinfo.entries == EFIBOOTMGR_OUTPUT_ENTRIES

--- a/repos/system_upgrade/common/libraries/tests/test_partitions.py
+++ b/repos/system_upgrade/common/libraries/tests/test_partitions.py
@@ -1,0 +1,160 @@
+import re
+
+import pytest
+
+from leapp.libraries.common import partitions
+from leapp.libraries.stdlib import CalledProcessError
+
+
+class RunMocked:
+
+    def __init__(self, raise_err=False):
+        self.called = 0
+        self.args = None
+        self.raise_err = raise_err
+
+    def __call__(self, args, encoding=None, checked=True):
+        self.called += 1
+        self.args = args
+        stdout = ""
+        if self.raise_err:
+            result = {
+                "signal": None,
+                "exit_code": 1,
+                "pid": 0,
+                "stdout": "fake",
+                "stderr": "fake",
+            }
+            if checked is True:
+                raise CalledProcessError(
+                    message="A Leapp Command Error occurred.",
+                    command=args,
+                    result=result,
+                )
+            return result
+
+        if self.args == ["grub2-probe", "--target=device", "/boot"]:
+            stdout = "/dev/vda1"
+
+        elif self.args[:-1] == ["lsblk", "-spnlo", "name"]:
+            outputs = {
+                "/dev/vda1": "/dev/vda",
+                "/dev/vda8": "/dev/vda",
+                "/dev/sdb1": "/dev/sdb",
+                "/dev/sdb10": "/dev/sdb",
+            }
+            cmd_arg = self.args[-1]
+            if cmd_arg in outputs:
+                stdout = outputs[cmd_arg]
+            else:
+                # if the blk dev is not in the outputs above, let's treat it as
+                # if it's not a partition, i.e. return it back
+                assert not cmd_arg[:-1].isdigit()
+                stdout = cmd_arg
+
+        elif self.args[:-1] == ["/usr/sbin/blkid", "-p", "-s", "PART_ENTRY_NUMBER"]:
+            partnum = re.search(r"\d+$", self.args[-1])
+            if not partnum:
+                stdout = "\n"
+            else:
+                stdout = 'PART_ENTRY_NUMBER="{}"'.format(partnum.group())
+        else:
+            assert False, "Called unexpected cmd not covered by test: {}".format(
+                self.args
+            )
+
+        return {"stdout": stdout, "exit_code": 0}
+
+
+@pytest.mark.parametrize(
+    "partition,expect",
+    [
+        ("/dev/vda1", "/dev/vda"),
+        ("/dev/vda8", "/dev/vda"),
+        ("/dev/sdb1", "/dev/sdb"),
+        ("/dev/sdb10", "/dev/sdb"),
+        ("/dev/sdb", "/dev/sdb"),
+        ("/dev/sda", "/dev/sda"),
+    ],
+)
+def test_blk_dev_from_partition(monkeypatch, partition, expect):
+    monkeypatch.setattr(partitions, "run", RunMocked())
+
+    actual = partitions.blk_dev_from_partition(partition)
+    assert actual == expect
+
+
+def test_blk_dev_from_partition_fail(monkeypatch):
+    monkeypatch.setattr(partitions, "run", RunMocked(raise_err=True))
+
+    with pytest.raises(
+        partitions.StorageScanError, match="Could not get parent device of /dev/vda1 partition"
+    ):
+        partitions.blk_dev_from_partition("/dev/vda1")
+
+
+@pytest.mark.parametrize(
+    "partition,expect",
+    [
+        ("/dev/vda1", 1),
+        ("/dev/vda8", 8),
+        ("/dev/sdb1", 1),
+        ("/dev/sdb10", 10),
+    ],
+)
+def test_get_partition_number(monkeypatch, partition, expect):
+    monkeypatch.setattr(partitions, "run", RunMocked())
+    actual = partitions.get_partition_number(partition)
+    assert actual == expect
+
+
+def test_get_partition_number_not_a_partition(monkeypatch):
+    monkeypatch.setattr(partitions, "run", RunMocked())
+
+    dev = "/dev/vda"
+    with pytest.raises(
+        partitions.StorageScanError, match="The {} device has no PART_ENTRY_NUMBER".format(dev)
+    ):
+        partitions.get_partition_number(dev)
+
+
+def test_get_partition_number_fail(monkeypatch):
+    monkeypatch.setattr(partitions, "run", RunMocked(raise_err=True))
+
+    dev = "/dev/vda1"
+    with pytest.raises(
+        partitions.StorageScanError,
+        match="Unable to get information about the {} device".format(dev),
+    ):
+        partitions.get_partition_number(dev)
+
+
+def test__get_partition_for_dir(monkeypatch):
+    monkeypatch.setattr(partitions, "run", RunMocked())
+    actual = partitions._get_partition_for_dir('/boot')
+    assert actual == '/dev/vda1'
+
+
+def test__get_partition_for_dir_command_missing(monkeypatch):
+
+    def run_mocked(cmd, *args, **kwargs):
+        assert cmd == ['grub2-probe', '--target=device', '/boot']
+        raise OSError()
+
+    monkeypatch.setattr(partitions, "run", run_mocked)
+
+    msg = (
+        "Could not get name of underlying /boot partition:"
+        " grub2-probe is missing."
+        " Possibly called on system that does not use GRUB2?"
+    )
+    with pytest.raises(partitions.StorageScanError, match=msg):
+        partitions._get_partition_for_dir('/boot')
+
+
+def test__get_partition_for_dir_fail(monkeypatch):
+    monkeypatch.setattr(partitions, "run", RunMocked(raise_err=True))
+
+    msg = 'Could not get name of underlying /boot partition'
+    with pytest.raises(partitions.StorageScanError, match=msg):
+        partitions._get_partition_for_dir('/boot')

--- a/repos/system_upgrade/common/models/firmwarefacts.py
+++ b/repos/system_upgrade/common/models/firmwarefacts.py
@@ -7,5 +7,14 @@ class FirmwareFacts(Model):
 
     firmware = fields.StringEnum(['bios', 'efi'])
     """ System firmware interface (BIOS or EFI) """
+
     ppc64le_opal = fields.Nullable(fields.Boolean())
     """ Check OPAL presence to identify ppc64le bare metal systems """
+
+    secureboot_enabled = fields.Nullable(fields.Boolean())
+    """
+    Check whether SecureBoot is enabled, always False on BIOS systems
+
+    Note that some machines do not support SecureBoot at all - even for systems booted with UEFI.
+    For systems booted with UEFI that does not support SecureBoot set None.
+    """

--- a/repos/system_upgrade/el8toel9/actors/addarmbootloaderworkaround/libraries/addupgradebootloader.py
+++ b/repos/system_upgrade/el8toel9/actors/addarmbootloaderworkaround/libraries/addupgradebootloader.py
@@ -4,7 +4,6 @@ import shutil
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import efi, mounting
 from leapp.libraries.common.grub import get_boot_partition
-from leapp.libraries.common.partitions import blk_dev_from_partition, get_partition_number
 from leapp.libraries.stdlib import api, CalledProcessError, run
 from leapp.models import ArmWorkaroundEFIBootloaderInfo, EFIBootEntry, TargetUserSpaceInfo
 
@@ -63,7 +62,12 @@ def process():
 
         patch_efi_redhat_grubcfg_to_load_correct_grubenv()
 
-        _set_bootnext(upgrade_boot_entry.boot_number)
+        try:
+            efi.set_bootnext(upgrade_boot_entry.boot_number)
+        except efi.EFIError as e:
+            raise StopActorExecutionError(
+                'Could not set boot entry {} as BootNext: {}.'.format(upgrade_boot_entry.boot_number, e)
+            )
 
         efibootentry_fields = ['boot_number', 'label', 'active', 'efi_bin_source']
         api.produce(
@@ -124,75 +128,22 @@ def _add_upgrade_boot_entry(efibootinfo):
     Return the upgrade efi entry (EFIEntry).
     """
 
-    try:
-        efi_part = efi.get_efi_partition()
-    except efi.EFIError as e:
-        raise StopActorExecutionError("Failed to get EFI partition: {}".format(e))
-
-    dev_number = get_partition_number(efi_part)
-    blk_dev = blk_dev_from_partition(efi_part)
-
     tmp_efi_path = os.path.join(LEAPP_EFIDIR_CANONICAL_PATH, 'shimaa64.efi')
     if os.path.exists(tmp_efi_path):
         efi_path = efi.canonical_path_to_efi_format(tmp_efi_path)
     else:
         raise StopActorExecutionError('Unable to detect upgrade UEFI binary file.')
 
-    upgrade_boot_entry = _get_upgrade_boot_entry(efibootinfo, efi_path, UPGRADE_EFI_ENTRY_LABEL)
+    upgrade_boot_entry = efi.get_boot_entry(efibootinfo, UPGRADE_EFI_ENTRY_LABEL, efi_path)
     if upgrade_boot_entry is not None:
         return upgrade_boot_entry
 
-    cmd = [
-        "/usr/sbin/efibootmgr",
-        "--create",
-        "--disk",
-        blk_dev,
-        "--part",
-        str(dev_number),
-        "--loader",
-        efi_path,
-        "--label",
-        UPGRADE_EFI_ENTRY_LABEL,
-    ]
-
     try:
-        run(cmd)
-    except CalledProcessError:
-        raise StopActorExecutionError('Unable to add a new UEFI bootloader entry for upgrade.')
-
-    # Sanity check new boot entry has been added
-    efibootinfo_new = efi.EFIBootInfo()
-    upgrade_boot_entry = _get_upgrade_boot_entry(efibootinfo_new, efi_path, UPGRADE_EFI_ENTRY_LABEL)
-    if upgrade_boot_entry is None:
-        raise StopActorExecutionError('Unable to find the new UEFI bootloader entry after adding it.')
-
-    return upgrade_boot_entry
-
-
-def _get_upgrade_boot_entry(efibootinfo, efi_path, label):
-    """
-    Get the UEFI boot entry with label `label` and EFI binary path `efi_path`
-
-    Return EFIBootEntry or None if not found.
-    """
-
-    for entry in efibootinfo.entries.values():
-        if entry.label == label and efi_path in entry.efi_bin_source:
-            return entry
-
-    return None
-
-
-def _set_bootnext(boot_number):
-    """
-    Set the BootNext UEFI entry to `boot_number`.
-    """
-
-    api.current_logger().debug('Setting {} as BootNext'.format(boot_number))
-    try:
-        run(['/usr/sbin/efibootmgr', '--bootnext', boot_number])
-    except CalledProcessError:
-        raise StopActorExecutionError('Could not set boot entry {} as BootNext.'.format(boot_number))
+        return efi.add_boot_entry(UPGRADE_EFI_ENTRY_LABEL, efi_path)
+    except efi.EFIError as e:
+        raise StopActorExecutionError(
+            "Unable to add a new UEFI bootloader entry for upgrade: {}".format(e)
+        )
 
 
 def _notify_user_to_check_grub2_cfg():

--- a/repos/system_upgrade/el8toel9/actors/addarmbootloaderworkaround/libraries/addupgradebootloader.py
+++ b/repos/system_upgrade/el8toel9/actors/addarmbootloaderworkaround/libraries/addupgradebootloader.py
@@ -2,15 +2,9 @@ import os
 import shutil
 
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common import mounting
-from leapp.libraries.common.grub import (
-    canonical_path_to_efi_format,
-    EFIBootInfo,
-    get_boot_partition,
-    get_device_number,
-    get_efi_device,
-    get_efi_partition
-)
+from leapp.libraries.common import efi, mounting
+from leapp.libraries.common.grub import get_boot_partition
+from leapp.libraries.common.partitions import blk_dev_from_partition, get_partition_number
 from leapp.libraries.stdlib import api, CalledProcessError, run
 from leapp.models import ArmWorkaroundEFIBootloaderInfo, EFIBootEntry, TargetUserSpaceInfo
 
@@ -19,9 +13,8 @@ UPGRADE_EFI_ENTRY_LABEL = 'Leapp Upgrade'
 ARM_SHIM_PACKAGE_NAME = 'shim-aa64'
 ARM_GRUB_PACKAGE_NAME = 'grub2-efi-aa64'
 
-EFI_MOUNTPOINT = '/boot/efi/'
-LEAPP_EFIDIR_CANONICAL_PATH = os.path.join(EFI_MOUNTPOINT, 'EFI/leapp/')
-RHEL_EFIDIR_CANONICAL_PATH = os.path.join(EFI_MOUNTPOINT, 'EFI/redhat/')
+LEAPP_EFIDIR_CANONICAL_PATH = os.path.join(efi.EFI_MOUNTPOINT, 'EFI/leapp/')
+RHEL_EFIDIR_CANONICAL_PATH = os.path.join(efi.EFI_MOUNTPOINT, 'EFI/redhat/') # TODO
 UPGRADE_BLS_DIR = '/boot/upgrade-loader'
 
 CONTAINER_DOWNLOAD_DIR = '/tmp_pkg_download_dir'
@@ -59,7 +52,12 @@ def process():
 
         _copy_grub_files(['grubenv', 'grub.cfg'], ['user.cfg'])
 
-        efibootinfo = EFIBootInfo()
+        try:
+            efibootinfo = efi.EFIBootInfo()
+        except efi.EFIError as e:
+            raise StopActorExecutionError(
+                "Failed to obtain information about UEFI: {}".format(e)
+            )
         current_boot_entry = efibootinfo.entries[efibootinfo.current_bootnum]
         upgrade_boot_entry = _add_upgrade_boot_entry(efibootinfo)
 
@@ -73,7 +71,7 @@ def process():
                 original_entry=EFIBootEntry(**{f: getattr(current_boot_entry, f) for f in efibootentry_fields}),
                 upgrade_entry=EFIBootEntry(**{f: getattr(upgrade_boot_entry, f) for f in efibootentry_fields}),
                 upgrade_bls_dir=UPGRADE_BLS_DIR,
-                upgrade_entry_efi_path=os.path.join(EFI_MOUNTPOINT, LEAPP_EFIDIR_CANONICAL_PATH),
+                upgrade_entry_efi_path=LEAPP_EFIDIR_CANONICAL_PATH,
             )
         )
 
@@ -126,12 +124,17 @@ def _add_upgrade_boot_entry(efibootinfo):
     Return the upgrade efi entry (EFIEntry).
     """
 
-    dev_number = get_device_number(get_efi_partition())
-    blk_dev = get_efi_device()
+    try:
+        efi_part = efi.get_efi_partition()
+    except efi.EFIError as e:
+        raise StopActorExecutionError("Failed to get EFI partition: {}".format(e))
+
+    dev_number = get_partition_number(efi_part)
+    blk_dev = blk_dev_from_partition(efi_part)
 
     tmp_efi_path = os.path.join(LEAPP_EFIDIR_CANONICAL_PATH, 'shimaa64.efi')
     if os.path.exists(tmp_efi_path):
-        efi_path = canonical_path_to_efi_format(tmp_efi_path)
+        efi_path = efi.canonical_path_to_efi_format(tmp_efi_path)
     else:
         raise StopActorExecutionError('Unable to detect upgrade UEFI binary file.')
 
@@ -158,7 +161,7 @@ def _add_upgrade_boot_entry(efibootinfo):
         raise StopActorExecutionError('Unable to add a new UEFI bootloader entry for upgrade.')
 
     # Sanity check new boot entry has been added
-    efibootinfo_new = EFIBootInfo()
+    efibootinfo_new = efi.EFIBootInfo()
     upgrade_boot_entry = _get_upgrade_boot_entry(efibootinfo_new, efi_path, UPGRADE_EFI_ENTRY_LABEL)
     if upgrade_boot_entry is None:
         raise StopActorExecutionError('Unable to find the new UEFI bootloader entry after adding it.')
@@ -261,7 +264,7 @@ def patch_efi_redhat_grubcfg_to_load_correct_grubenv():
     EFI entries. Thus, we need to replace it with our own that will load grubenv shipped
     of our UEFI boot entry.
     """
-    leapp_grub_cfg_path = os.path.join(EFI_MOUNTPOINT, LEAPP_EFIDIR_CANONICAL_PATH, 'grub.cfg')
+    leapp_grub_cfg_path = os.path.join(LEAPP_EFIDIR_CANONICAL_PATH, 'grub.cfg')
 
     if not os.path.isfile(leapp_grub_cfg_path):
         msg = 'The file {} does not exists, cannot check whether bootloader is configured properly.'

--- a/repos/system_upgrade/el8toel9/actors/addarmbootloaderworkaround/tests/test_addarmbootloaderworkaround.py
+++ b/repos/system_upgrade/el8toel9/actors/addarmbootloaderworkaround/tests/test_addarmbootloaderworkaround.py
@@ -4,18 +4,18 @@ import pytest
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import addupgradebootloader
-from leapp.libraries.common.grub import EFIBootLoaderEntry
+from leapp.libraries.common import efi
 from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked, make_OSError, produce_mocked
 from leapp.libraries.stdlib import api, CalledProcessError
 from leapp.models import ArmWorkaroundEFIBootloaderInfo, EFIBootEntry, TargetUserSpaceInfo
 
-TEST_RHEL_EFI_ENTRY = EFIBootLoaderEntry(
+TEST_RHEL_EFI_ENTRY = efi.EFIBootLoaderEntry(
             '0000',
             'Red Hat Enterprise Linux',
             True,
             'File(\\EFI\\redhat\\shimaa64.efi)'
         )
-TEST_UPGRADE_EFI_ENTRY = EFIBootLoaderEntry(
+TEST_UPGRADE_EFI_ENTRY = efi.EFIBootLoaderEntry(
             '0001',
             addupgradebootloader.UPGRADE_EFI_ENTRY_LABEL,
             True,
@@ -169,9 +169,9 @@ def test_set_bootnext(monkeypatch):
 
 
 def test_add_upgrade_boot_entry_no_efi_binary(monkeypatch):
-    monkeypatch.setattr(addupgradebootloader, 'get_efi_partition', lambda: '/dev/sda1')
-    monkeypatch.setattr(addupgradebootloader, 'get_device_number', lambda device: '1')
-    monkeypatch.setattr(addupgradebootloader, 'get_efi_device', lambda: '/dev/sda')
+    monkeypatch.setattr(efi, 'get_efi_partition', lambda: '/dev/sda1')
+    monkeypatch.setattr(addupgradebootloader, 'get_partition_number', lambda device: '1')
+    monkeypatch.setattr(addupgradebootloader, 'blk_dev_from_partition', lambda part: '/dev/sda')
     monkeypatch.setattr(os.path, 'exists', lambda path: False)
 
     efibootinfo_mock = MockEFIBootInfo([TEST_RHEL_EFI_ENTRY])
@@ -182,9 +182,9 @@ def test_add_upgrade_boot_entry_no_efi_binary(monkeypatch):
 def test_add_upgrade_already_exists(monkeypatch):
     run_calls = []
 
-    monkeypatch.setattr(addupgradebootloader, 'get_efi_partition', lambda: '/dev/sda1')
-    monkeypatch.setattr(addupgradebootloader, 'get_device_number', lambda device: '1')
-    monkeypatch.setattr(addupgradebootloader, 'get_efi_device', lambda: '/dev/sda')
+    monkeypatch.setattr(efi, 'get_efi_partition', lambda: '/dev/sda1')
+    monkeypatch.setattr(addupgradebootloader, 'get_partition_number', lambda device: '1')
+    monkeypatch.setattr(addupgradebootloader, 'blk_dev_from_partition', lambda part: '/dev/sda')
     monkeypatch.setattr(os.path, 'exists', lambda path: True)
 
     def mock_run(cmd):
@@ -200,9 +200,9 @@ def test_add_upgrade_already_exists(monkeypatch):
 
 
 def test_add_upgrade_boot_entry_command_failure(monkeypatch):
-    monkeypatch.setattr(addupgradebootloader, 'get_efi_partition', lambda: '/dev/sda1')
-    monkeypatch.setattr(addupgradebootloader, 'get_device_number', lambda device: '1')
-    monkeypatch.setattr(addupgradebootloader, 'get_efi_device', lambda: '/dev/sda')
+    monkeypatch.setattr(efi, 'get_efi_partition', lambda: '/dev/sda1')
+    monkeypatch.setattr(addupgradebootloader, 'get_partition_number', lambda device: '1')
+    monkeypatch.setattr(addupgradebootloader, 'blk_dev_from_partition', lambda part: '/dev/sda')
     monkeypatch.setattr(addupgradebootloader, '_get_upgrade_boot_entry', lambda efi, path, label: None)
     monkeypatch.setattr(os.path, 'exists', lambda path: True)
 
@@ -223,9 +223,9 @@ def test_add_upgrade_boot_entry_command_failure(monkeypatch):
 def test_add_upgrade_boot_entry_verification_failure(monkeypatch):
     run_calls = []
 
-    monkeypatch.setattr(addupgradebootloader, 'get_efi_partition', lambda: '/dev/sda1')
-    monkeypatch.setattr(addupgradebootloader, 'get_device_number', lambda device: '1')
-    monkeypatch.setattr(addupgradebootloader, 'get_efi_device', lambda: '/dev/sda')
+    monkeypatch.setattr(efi, 'get_efi_partition', lambda: '/dev/sda1')
+    monkeypatch.setattr(addupgradebootloader, 'get_partition_number', lambda device: '1')
+    monkeypatch.setattr(addupgradebootloader, 'blk_dev_from_partition', lambda part: '/dev/sda')
     monkeypatch.setattr(addupgradebootloader, '_get_upgrade_boot_entry', lambda efi, path, label: None)
     monkeypatch.setattr(os.path, 'exists', lambda path: True)
 
@@ -233,7 +233,7 @@ def test_add_upgrade_boot_entry_verification_failure(monkeypatch):
         run_calls.append(cmd)
 
     monkeypatch.setattr(addupgradebootloader, 'run', mock_run)
-    monkeypatch.setattr(addupgradebootloader, 'EFIBootInfo', lambda: MockEFIBootInfo([TEST_RHEL_EFI_ENTRY]))
+    monkeypatch.setattr(efi, 'EFIBootInfo', lambda: MockEFIBootInfo([TEST_RHEL_EFI_ENTRY]))
 
     efibootinfo_mock = MockEFIBootInfo([TEST_RHEL_EFI_ENTRY])
     with pytest.raises(StopActorExecutionError, match="Unable to find the new UEFI bootloader entry after adding it"):
@@ -243,9 +243,9 @@ def test_add_upgrade_boot_entry_verification_failure(monkeypatch):
 def test_add_upgrade_boot_entry_success(monkeypatch):
     run_calls = []
 
-    monkeypatch.setattr(addupgradebootloader, 'get_efi_partition', lambda: '/dev/sda1')
-    monkeypatch.setattr(addupgradebootloader, 'get_device_number', lambda device: '1')
-    monkeypatch.setattr(addupgradebootloader, 'get_efi_device', lambda: '/dev/sda')
+    monkeypatch.setattr(efi, 'get_efi_partition', lambda: '/dev/sda1')
+    monkeypatch.setattr(addupgradebootloader, 'get_partition_number', lambda device: '1')
+    monkeypatch.setattr(addupgradebootloader, 'blk_dev_from_partition', lambda part: '/dev/sda')
     monkeypatch.setattr(os.path, 'exists', lambda path: True)
 
     def mock_run(cmd):
@@ -253,7 +253,7 @@ def test_add_upgrade_boot_entry_success(monkeypatch):
 
     monkeypatch.setattr(addupgradebootloader, 'run', mock_run)
     monkeypatch.setattr(
-        addupgradebootloader,
+        efi,
         'EFIBootInfo',
         lambda: MockEFIBootInfo([TEST_RHEL_EFI_ENTRY, TEST_UPGRADE_EFI_ENTRY])
     )
@@ -289,7 +289,7 @@ def test_process(monkeypatch):
     monkeypatch.setattr(addupgradebootloader, '_copy_grub_files', lambda optional, required: None)
 
     efibootinfo_mock = MockEFIBootInfo([TEST_RHEL_EFI_ENTRY])
-    monkeypatch.setattr(addupgradebootloader, 'EFIBootInfo', lambda: efibootinfo_mock)
+    monkeypatch.setattr(efi, 'EFIBootInfo', lambda: efibootinfo_mock)
 
     def mock_add_upgrade_boot_entry(efibootinfo):
         return TEST_UPGRADE_EFI_ENTRY
@@ -319,7 +319,7 @@ def test_process(monkeypatch):
 @pytest.mark.parametrize('is_config_ok', (True, False))
 def test_patch_grubcfg(is_config_ok, monkeypatch):
 
-    expected_grubcfg_path = os.path.join(addupgradebootloader.EFI_MOUNTPOINT,
+    expected_grubcfg_path = os.path.join(efi.EFI_MOUNTPOINT,
                                          addupgradebootloader.LEAPP_EFIDIR_CANONICAL_PATH,
                                          'grub.cfg')
 

--- a/repos/system_upgrade/el8toel9/actors/removeupgradeefientry/libraries/removeupgradeefientry.py
+++ b/repos/system_upgrade/el8toel9/actors/removeupgradeefientry/libraries/removeupgradeefientry.py
@@ -2,12 +2,11 @@ import os
 import shutil
 
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import efi
 from leapp.libraries.stdlib import api, CalledProcessError, run
 from leapp.models import ArmWorkaroundEFIBootloaderInfo
 
-EFI_MOUNTPOINT = '/boot/efi/'
-LEAPP_EFIDIR_CANONICAL_PATH = os.path.join(EFI_MOUNTPOINT, 'EFI/leapp/')
-RHEL_EFIDIR_CANONICAL_PATH = os.path.join(EFI_MOUNTPOINT, 'EFI/redhat/')
+LEAPP_EFIDIR_CANONICAL_PATH = os.path.join(efi.EFI_MOUNTPOINT, 'EFI/leapp/')
 
 
 def get_workaround_efi_info():
@@ -36,13 +35,8 @@ def remove_upgrade_efi_entry():
 
     upgrade_boot_number = bootloader_info.upgrade_entry.boot_number
     try:
-        run([
-            '/usr/sbin/efibootmgr',
-            '--delete-bootnum',
-            '--bootnum',
-            upgrade_boot_number
-        ])
-    except CalledProcessError:
+        efi.remove_boot_entry(upgrade_boot_number)
+    except efi.EFIError:
         api.current_logger().warning('Unable to remove Leapp upgrade efi entry.')
 
     try:
@@ -53,7 +47,7 @@ def remove_upgrade_efi_entry():
     _remove_upgrade_blsdir(bootloader_info)
 
     original_boot_number = bootloader_info.original_entry.boot_number
-    run(['/usr/sbin/efibootmgr', '--bootnext', original_boot_number])
+    efi.set_bootnext(original_boot_number)
 
     # TODO: Move calling `mount -a` to a separate actor as it is not really
     # related to removing the upgrade boot entry. It's worth to call it after

--- a/repos/system_upgrade/el8toel9/actors/removeupgradeefientry/libraries/removeupgradeefientry.py
+++ b/repos/system_upgrade/el8toel9/actors/removeupgradeefientry/libraries/removeupgradeefientry.py
@@ -47,6 +47,9 @@ def remove_upgrade_efi_entry():
     _remove_upgrade_blsdir(bootloader_info)
 
     original_boot_number = bootloader_info.original_entry.boot_number
+    # NOTE: during conversion this will be overwritten by the convert/updateefi
+    # actor, which is executed later and sets BootNext to a newly created entry
+    # for the target OS
     efi.set_bootnext(original_boot_number)
 
     # TODO: Move calling `mount -a` to a separate actor as it is not really


### PR DESCRIPTION
After an upgrade+conversion we want the EFI boot entry to have the name of the target OS (e.g. Red Hat Enterprise Linux, when converting from CS->RHEL). The source distro boot entry and also EFI directory (e.g. `/boot/efi/EFI/centos/`) should be removed.

This PR:
- splits out the functions from `common.grub` library that are not related to grub to 2 new libraries:
  - `common.efi` - functions related to UEFI; functions raise `EFIError` exception on errors instead
  - `common.partitons` (name suggestions are) welcome - operations on disks/parititions; this is used by both efi and grub lib; raise `StorageScanError` on errors
- functions from the `common.grub` library that are replaced by new libraries have been marked deprecated  
- refactor existing efi functions in the addarmbootloaderworkaround and removeupgradebootentry actors into the new efi lib
- adds a new actor that:
  - Removes the EFI dir of the source distro (e.g. `/boot/efi/EFI/centos/`).
    - If not empty create a post upgrade report to handle the leftover files manually.
  - Removes the EFI boot entry of the source distro.
  - Adds a new EFI boot entry for the target distro.
    - The contents of the target distro EFI dir are brought in by the grub-efi-x64 and shim-x64 packages.
- adds another actor that inhibits conversions on systems with secure boot enabled
  - At least for now, I am going with an inhibitor as this current solution doesn't work with secureboot enabled. The problem probably is, in my understanding, that the shim and grub only contain keys for verifying signatures of the source distro. Our upgrade boot entry uses the target distros kernel, which is signed by the target distro. And so the shim/grub of the source distro rejects it.
  - **A possible solution** IMO is to create an EFI boot entry for the upgrade pointing to the target distro's shim, similarly to how it's done in the addarmbootloaderworkaround actor.

Jira: RHEL-133549

### TODO
- [x] ARM - should work
- [X] secure boot - For now inhibited, see explanation above.
- [x] secure boot inhibitor - Need to get a better link for the report.