### PR TITLE
Enable LiveMode for non-x86_64 architectures

### DIFF
--- a/repos/system_upgrade/common/actors/livemode/emit_livemode_userspace_requirements/libraries/emit_livemode_userspace_requirements.py
+++ b/repos/system_upgrade/common/actors/livemode/emit_livemode_userspace_requirements/libraries/emit_livemode_userspace_requirements.py
@@ -11,16 +11,10 @@ _REQUIRED_PACKAGES_FOR_LIVE_MODE = [
     'util-linux',
     'dracut-live',
     'dracut-squash',
-    'dmidecode',
-    'pciutils',
-    'lsscsi',
     'passwd',
     'kexec-tools',
-    'vi',
     'less',
     'openssh-clients',
-    'strace',
-    'tcpdump',
 ]
 
 
@@ -32,6 +26,9 @@ def emit_livemode_userspace_requirements():
     packages = _REQUIRED_PACKAGES_FOR_LIVE_MODE + livemode_config.additional_packages
     if livemode_config.setup_opensshd_with_auth_keys:
         packages += ['openssh-server', 'crypto-policies']
+
+    if livemode_config.capture_upgrade_strace_into:
+        packages += ['strace']
 
     packages = sorted(set(packages))
 

--- a/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/libraries/scan_livemode_config.py
+++ b/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/libraries/scan_livemode_config.py
@@ -1,6 +1,6 @@
 from leapp.configs.actor import livemode as livemode_config_lib
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common.config import architecture, get_env
+from leapp.libraries.common.config import get_env
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import InstalledRPM, LiveModeConfig
@@ -14,14 +14,6 @@ def should_scan_config():
     if not is_unsupported:
         api.current_logger().debug('Will not scan livemode config - the upgrade is not unsupported.')
         return False
-
-    if not architecture.matches_architecture(architecture.ARCH_X86_64):
-        api.current_logger().debug('Will not scan livemode config - livemode is currently limited to x86_64.')
-        details = 'Live upgrades are currently limited to x86_64 only.'
-        raise StopActorExecutionError(
-            'CPU architecture does not meet requirements for live upgrades',
-            details={'Problem': details}
-        )
 
     if not has_package(InstalledRPM, 'squashfs-tools'):
         # This feature is not to be used by standard users, so stopping the upgrade and providing

--- a/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/tests/test_config_scanner.py
+++ b/repos/system_upgrade/common/actors/livemode/livemode_config_scanner/tests/test_config_scanner.py
@@ -37,7 +37,7 @@ EnablementTestCase = namedtuple('EnablementTestCase', ('env_vars', 'arch', 'pkgs
                            result=EnablementResult.DO_NOTHING),
         EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '1'},
                            arch=architecture.ARCH_ARM64, pkgs=('squashfs-tools', ),
-                           result=EnablementResult.RAISE),
+                           result=EnablementResult.SCAN_CONFIG),
         EnablementTestCase(env_vars={'LEAPP_UNSUPPORTED': '1'},
                            arch=architecture.ARCH_ARM64, pkgs=tuple(),
                            result=EnablementResult.RAISE),


### PR DESCRIPTION
This patch contains the necessary changes to enable LiveMode upgrades. All non-x86_64 upgrade paths were tested, motivating the changes in this PR. Primary obstacle was the non-existence of the `dmidecode` package on other architectures, other "required" packages were removed as they are not necessary to perform an upgrade.

Jira-ref: RHEL-141861
