### PR TITLE
workaround kernel-rt update candidate issues

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/checkkernelrt/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/checkkernelrt/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkkernelrt
+from leapp.models import DistributionSignedRPM, RpmTransactionTasks
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckKernelRT(Actor):
+    """
+    Workaround kernel-rt upgrade candidate issue during RHEL 8 to RHEL 9 upgrade.
+
+    Removes the kernel-rt metapackage to avoid RPM transaction failures and ensures
+    kernel-rt-core is explicitly upgraded so real-time kernels continue to work.
+    """
+
+    name = 'check_kernel_rt'
+    consumes = (DistributionSignedRPM,)
+    produces = (RpmTransactionTasks,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        checkkernelrt.process()

--- a/repos/system_upgrade/el8toel9/actors/checkkernelrt/libraries/checkkernelrt.py
+++ b/repos/system_upgrade/el8toel9/actors/checkkernelrt/libraries/checkkernelrt.py
@@ -1,0 +1,20 @@
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp.models import DistributionSignedRPM, RpmTransactionTasks
+
+KERNEL_RT_PKG = 'kernel-rt'
+KERNEL_RT_CORE_PKG = 'kernel-rt-core'
+
+
+def process():
+    pkgs = next(api.consume(DistributionSignedRPM), None)
+    if not pkgs:
+        raise StopActorExecutionError("Did not receive DistributionSignedRPM message.")
+
+    has_kernel_rt = any(pkg.name == KERNEL_RT_PKG for pkg in pkgs.items)
+    if has_kernel_rt:
+        api.current_logger().debug(
+            'Removing {} package as a workaround for problems with '
+            'finding its best upgrade candidate.'.format(KERNEL_RT_PKG)
+        )
+        api.produce(RpmTransactionTasks(to_remove=[KERNEL_RT_PKG], to_upgrade=[KERNEL_RT_CORE_PKG]))

--- a/repos/system_upgrade/el8toel9/actors/checkkernelrt/tests/unit_test_checkkernelrt.py
+++ b/repos/system_upgrade/el8toel9/actors/checkkernelrt/tests/unit_test_checkkernelrt.py
@@ -1,0 +1,42 @@
+import pytest
+
+from leapp.libraries.actor import checkkernelrt
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import DistributionSignedRPM, RPM
+
+
+def _rpm(name):
+    return RPM(
+        name=name,
+        arch='x86_64',
+        version='1',
+        release='1',
+        epoch='0',
+        packager='Red Hat',
+        pgpsig='SOME_SIG'
+    )
+
+
+@pytest.mark.parametrize(
+    ('pkgs', 'expect_produce'),
+    [
+        ([], False),
+        ([_rpm('kernel')], False),
+        ([_rpm('kernel-rt'), _rpm('kernel-rt-core'), _rpm('kernel-rt-modules'), _rpm('kernel')], True),
+    ]
+)
+def test_kernel_rt_workaround(monkeypatch, pkgs, expect_produce):
+    current_actor_mocked = CurrentActorMocked(msgs=[DistributionSignedRPM(items=pkgs)])
+    monkeypatch.setattr(api, "current_actor", current_actor_mocked)
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkkernelrt.process()
+
+    if expect_produce:
+        assert api.produce.called == 1
+        rpm_tasks = api.produce.model_instances[0]
+        assert rpm_tasks.to_remove == ['kernel-rt']
+        assert rpm_tasks.to_upgrade == ['kernel-rt-core']
+    else:
+        assert not api.produce.called


### PR DESCRIPTION
The `kernel-rt` package currently causes RPM transactions to fail during RHEL 8 upgrade because the best upgrade candidate cannot be determined. As a workaround, we are removing this package during the upgrade. Since it is a metapackage, its removal will not impact the upgrade process. To ensure related real-time kernel packages are still upgraded, we have explicitly marked `kernel-rt-core` package for upgrade.

Tested on RHEL 8 with the reproducer as specified in the Jira ticket. Some relevant parts of the `leapp-preupgrade.log` from my run:
```
[...]
leapp.workflow.Checks.check_kernel_rt: Removing kernel-rt package as a workaround for problems with finding its best upgrade candidate.
[...]
leapp.workflow.TargetTransactionCheck.dnf_transaction_check: ---> Package realtime-setup.x86_64 2.5-4.el9 will be installed
leapp.workflow.TargetTransactionCheck.dnf_transaction_check: ---> Package kernel-rt-core.x86_64 5.14.0-611.24.1.el9_7 will be installed
leapp.workflow.TargetTransactionCheck.dnf_transaction_check: ---> Package kernel-rt-modules.x86_64 5.14.0-611.24.1.el9_7 will be installed
leapp.workflow.TargetTransactionCheck.dnf_transaction_check: ---> Package kernel-rt-modules-core.x86_64 5.14.0-611.24.1.el9_7 will be installed
[...]
leapp.workflow.TargetTransactionCheck.dnf_transaction_check: ---> Package kernel-rt.x86_64 4.18.0-553.92.1.rt7.433.el8_10 will be erased
leapp.workflow.TargetTransactionCheck.dnf_transaction_check: ---> Package rt-setup.x86_64 2.1-5.el8 will be erased
[...]
```
I can provide the whole log if anyone is interested.

Jira: RHEL-95215