### PR TITLE
ISO actors: Make the actors more distro agnostic 

### DIFF
--- a/docs/source/libraries-and-api/deprecations-list.md
+++ b/docs/source/libraries-and-api/deprecations-list.md
@@ -13,7 +13,9 @@ framework, see {ref}`deprecation:list of the deprecated functionality in leapp`.
 Only the versions in which a deprecation has been made are listed.
 
 ## Next release <span style="font-size:0.5em; font-weight:normal">(till TODO date)</span>
-- Nothing deprecated yet
+- Models:
+- **`rhel_version`** field in the `TargetOSInstallationImage` model is replaced by the
+`os_version` field.
 
 ## v0.25.0 <span style="font-size:0.5em; font-weight:normal">(till January 2027)</span>
 - Environment variables

--- a/repos/system_upgrade/common/actors/checktargetiso/libraries/check_target_iso.py
+++ b/repos/system_upgrade/common/actors/checktargetiso/libraries/check_target_iso.py
@@ -3,42 +3,55 @@ import os
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.config import version
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api, CalledProcessError, run
 from leapp.models import StorageInfo, TargetOSInstallationImage
 
 
 def inhibit_if_not_valid_iso_file(iso):
-    inhibit_title = None
-    target_os = 'RHEL {}'.format(version.get_target_major_version())
+    target_os = f'{DISTRO_REPORT_NAMES.target} {version.get_target_major_version()}'
+    remediation_hint = (
+        'Check whether the supplied target OS installation path points to a valid'
+        f' {target_os} ISO image.'
+    )
+
     if not os.path.exists(iso.path):
-        inhibit_title = 'Provided {target_os} installation ISO does not exists.'.format(target_os=target_os)
-        inhibit_summary_tpl = 'The supplied {target_os} ISO path \'{iso_path}\' does not point to an existing file.'
-        inhibit_summary = inhibit_summary_tpl.format(target_os=target_os, iso_path=iso.path)
-    else:
-        try:
-            # TODO(mhecko): Figure out whether we will keep this since the scan actor is mounting the ISO anyway
-            file_cmd_output = run(['file', '--mime', iso.path])
-            if 'application/x-iso9660-image' not in file_cmd_output['stdout']:
-                inhibit_title = 'Provided {target_os} installation image is not a valid ISO.'.format(
-                        target_os=target_os)
-                summary_tpl = ('The provided {target_os} installation image path \'{iso_path}\''
-                               'does not point to a valid ISO image.')
-                inhibit_summary = summary_tpl.format(target_os=target_os, iso_path=iso.path)
-
-        except CalledProcessError as err:
-            raise StopActorExecutionError(message='Failed to check whether {0} is an ISO file.'.format(iso.path),
-                                          details={'details': '{}'.format(err)})
-    if inhibit_title:
-        remediation_hint = ('Check whether the supplied target OS installation path points to a valid'
-                            '{target_os} ISO image.'.format(target_os=target_os))
-
         reporting.create_report([
-            reporting.Title(inhibit_title),
-            reporting.Summary(inhibit_summary),
+            reporting.Title('Provided target OS installation ISO does not exist.'),
+            reporting.Summary(
+                f'The supplied {target_os} ISO path \'{iso.path}\' does not point to an existing file.'
+            ),
             reporting.Remediation(hint=remediation_hint),
-            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.INHIBITOR]),
             reporting.Groups([reporting.Groups.REPOSITORY]),
+            reporting.Key('e99b767d6b6623641ba06b5e9c7542ce4c69f35f'),
+        ])
+        return True
+
+    try:
+        # TODO(mhecko): Figure out whether we will keep this since the scan actor is mounting the ISO anyway
+        file_cmd_output = run(['file', '--mime', iso.path])
+    except CalledProcessError as err:
+        raise StopActorExecutionError(
+            message=f'Failed to check whether {iso.path} is an ISO file.',
+            details={'details': f'{err}'},
+        )
+
+    if 'application/x-iso9660-image' not in file_cmd_output['stdout']:
+        reporting.create_report([
+            reporting.Title(
+                'Provided target OS installation image is not a valid ISO.'
+            ),
+            reporting.Summary(
+                f'The provided {target_os} installation image path \'{iso.path}\''
+                ' does not point to a valid ISO image.'
+            ),
+            reporting.Remediation(hint=remediation_hint),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.INHIBITOR]),
+            reporting.Groups([reporting.Groups.REPOSITORY]),
+            reporting.Key('21bf7b8c7bf079baa038374ccbce66a8d6d7d775'),
         ])
         return True
     return False
@@ -48,51 +61,69 @@ def inhibit_if_failed_to_mount_iso(iso):
     if iso.was_mounted_successfully:
         return False
 
-    target_os = 'RHEL {0}'.format(version.get_target_major_version())
-    title = 'Failed to mount the provided {target_os} installation image.'
-    summary = 'The provided {target_os} installation image {iso_path} could not be mounted.'
-    hint = 'Verify that the provided ISO is a valid {target_os} installation image'
+    title = 'Failed to mount the provided target OS installation image.'
+    target_os = f'{DISTRO_REPORT_NAMES.target} {version.get_target_major_version()}'
+    summary = f'The provided {target_os} installation image {iso.path} could not be mounted.'
+    hint = f'Verify that the provided ISO is a valid {target_os} installation image'
+
     reporting.create_report([
-        reporting.Title(title.format(target_os=target_os)),
-        reporting.Summary(summary.format(target_os=target_os, iso_path=iso.path)),
-        reporting.Remediation(hint=hint.format(target_os=target_os)),
-        reporting.Severity(reporting.Severity.MEDIUM),
+        reporting.Title(title),
+        reporting.Summary(summary),
+        reporting.Remediation(hint=hint),
+        reporting.Severity(reporting.Severity.HIGH),
         reporting.Groups([reporting.Groups.INHIBITOR]),
         reporting.Groups([reporting.Groups.REPOSITORY]),
+        reporting.Key('156b28ab6ae13ccc2f2dddb6bca243e73eba7c6b'),
     ])
     return True
 
 
-def inhibit_if_wrong_iso_rhel_version(iso):
-    # If the major version could not be determined, the iso.rhel_version will be an empty string
-    if not iso.rhel_version:
+def inhibit_if_wrong_iso_os_version(iso):
+    # If the major version could not be determined, the iso.os_version will be an empty string
+    if not iso.os_version:
+        target_distro = DISTRO_REPORT_NAMES.target
+
         reporting.create_report([
             reporting.Title(
-                'Failed to determine RHEL version provided by the supplied installation image.'),
-            reporting.Summary(
-                'Could not determine what RHEL version does the supplied installation image'
-                ' located at {iso_path} provide.'.format(iso_path=iso.path)
+                'Failed to determine target OS version provided by the supplied installation image.'
             ),
-            reporting.Remediation(hint='Check that the supplied image is a valid RHEL installation image.'),
-            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Summary(
+                'Could not determine what {target_distro} version does the supplied installation image'
+                ' located at {iso_path} provide.'.format(
+                    target_distro=target_distro,
+                    iso_path=iso.path
+                )
+            ),
+            reporting.Remediation(
+                hint='Check that the supplied image is a valid {} installation image.'.format(
+                    target_distro
+                )
+            ),
+            reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.INHIBITOR]),
             reporting.Groups([reporting.Groups.REPOSITORY]),
+            reporting.Key('abfee8507fdb049fea07e4c29bc74a501780287d'),
         ])
         return
 
-    iso_rhel_major_version = iso.rhel_version.split('.')[0]
+    iso_os_major_version = iso.os_version.split('.')[0]
     req_major_ver = version.get_target_major_version()
-    if iso_rhel_major_version != req_major_ver:
-        summary = ('The provided RHEL installation image provides RHEL {iso_rhel_ver}, however, a RHEL '
-                   '{required_rhel_ver} image is required for the upgrade.')
+    if iso_os_major_version != req_major_ver:
+        target_distro = DISTRO_REPORT_NAMES.target
 
         reporting.create_report([
-            reporting.Title('The provided installation image provides invalid RHEL version.'),
-            reporting.Summary(summary.format(iso_rhel_ver=iso.rhel_version, required_rhel_ver=req_major_ver)),
-            reporting.Remediation(hint='Check that the supplied image is a valid RHEL installation image.'),
-            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Title('The provided installation image provides invalid target OS version.'),
+            reporting.Summary(
+                f'The provided {target_distro} installation image provides {target_distro} {iso.os_version},'
+                f' however, a {target_distro} {req_major_ver} image is required for the upgrade.'
+            ),
+            reporting.Remediation(
+                hint=f'Check that the supplied image is a valid {target_distro} installation image.'
+            ),
+            reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.INHIBITOR]),
             reporting.Groups([reporting.Groups.REPOSITORY]),
+            reporting.Key('e94ecfc02541adca3fa3c9703847425dde736afe'),
         ])
 
 
@@ -115,25 +146,29 @@ def inhibit_if_iso_not_located_on_persistent_partition(iso):
 
     if not is_iso_on_persistent_partition:
         target_ver = version.get_target_major_version()
-        title = 'The RHEL {target_ver} installation image is not located on a persistently mounted partition'
-        summary = ('The provided RHEL {target_ver} installation image {iso_path} is located'
-                   ' on a partition without an entry in /etc/fstab, causing the partition '
-                   ' to be persistently mounted.')
-        hint = ('Move the installation image to a partition that is persistently mounted, or create an /etc/fstab'
-                ' entry for the partition on which the installation image is located.')
+        title = 'The target OS installation image is not located on a persistently mounted partition'
+        summary = (
+            f'The provided {DISTRO_REPORT_NAMES.target} {target_ver} installation image {iso.path} is located'
+            ' on a partition without an entry in /etc/fstab, causing the partition to be persistently mounted.'
+        )
+        hint = (
+            'Move the installation image to a partition that is persistently mounted, or create an /etc/fstab'
+            ' entry for the partition on which the installation image is located.'
+        )
 
         reporting.create_report([
-            reporting.Title(title.format(target_ver=target_ver)),
-            reporting.Summary(summary.format(target_ver=target_ver, iso_path=iso.path)),
+            reporting.Title(title),
+            reporting.Summary(summary),
             reporting.Remediation(hint=hint),
             reporting.RelatedResource('file', '/etc/fstab'),
-            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.INHIBITOR]),
             reporting.Groups([reporting.Groups.REPOSITORY]),
+            reporting.Key('d379897ee3c164576c022fe68c8a43e6c9236bf5'),
         ])
 
 
-def inihibit_if_iso_does_not_contain_basic_repositories(iso):
+def inhibit_if_iso_does_not_contain_basic_repositories(iso):
     missing_basic_repoids = {'BaseOS', 'AppStream'}
 
     for custom_repo in iso.repositories:
@@ -142,23 +177,25 @@ def inihibit_if_iso_does_not_contain_basic_repositories(iso):
             break
 
     if missing_basic_repoids:
-        target_ver = version.get_target_major_version()
+        target_os = f'{DISTRO_REPORT_NAMES.target} {version.get_target_major_version()}'
+        title = 'Provided target OS installation ISO is missing fundamental repositories.'
 
-        title = 'Provided RHEL {target_ver} installation ISO is missing fundamental repositories.'
-        summary = ('The supplied RHEL {target_ver} installation ISO {iso_path} does not contain '
-                   '{missing_repos} repositor{suffix}')
-        hint = 'Check whether the supplied ISO is a valid RHEL {target_ver} installation image.'
+        missing_repos = ','.join(missing_basic_repoids)
+        suffix = ('y' if len(missing_basic_repoids) == 1 else 'ies')
+        summary = (
+            f'The supplied {target_os} installation ISO {iso.path} does not contain'
+            f' {missing_repos} repositor{suffix}'
+        )
+        hint = f'Check whether the supplied ISO is a valid {target_os} installation image.'
 
         reporting.create_report([
-            reporting.Title(title.format(target_ver=target_ver)),
-            reporting.Summary(summary.format(target_ver=target_ver,
-                                             iso_path=iso.path,
-                                             missing_repos=','.join(missing_basic_repoids),
-                                             suffix=('y' if len(missing_basic_repoids) == 1 else 'ies'))),
-            reporting.Remediation(hint=hint.format(target_ver=target_ver)),
-            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Remediation(hint),
+            reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.INHIBITOR]),
             reporting.Groups([reporting.Groups.REPOSITORY]),
+            reporting.Key('58fc6fc9530aabd7454d4b4a6381046cab60a189'),
         ])
 
 
@@ -177,6 +214,6 @@ def perform_target_iso_checks():
     if not is_iso_invalid:
         failed_to_mount_iso = inhibit_if_failed_to_mount_iso(target_iso)
         if not failed_to_mount_iso:
-            inhibit_if_wrong_iso_rhel_version(target_iso)
+            inhibit_if_wrong_iso_os_version(target_iso)
             inhibit_if_iso_not_located_on_persistent_partition(target_iso)
-            inihibit_if_iso_does_not_contain_basic_repositories(target_iso)
+            inhibit_if_iso_does_not_contain_basic_repositories(target_iso)

--- a/repos/system_upgrade/common/actors/checktargetiso/libraries/check_target_iso.py
+++ b/repos/system_upgrade/common/actors/checktargetiso/libraries/check_target_iso.py
@@ -81,22 +81,19 @@ def inhibit_if_failed_to_mount_iso(iso):
 def inhibit_if_wrong_iso_os_version(iso):
     # If the major version could not be determined, the iso.os_version will be an empty string
     if not iso.os_version:
-        target_distro = DISTRO_REPORT_NAMES.target
-
         reporting.create_report([
             reporting.Title(
-                'Failed to determine target OS version provided by the supplied installation image.'
+                'Failed to determine target OS provided by the supplied installation image.'
             ),
             reporting.Summary(
-                'Could not determine what {target_distro} version does the supplied installation image'
-                ' located at {iso_path} provide.'.format(
-                    target_distro=target_distro,
-                    iso_path=iso.path
-                )
+                'Could not determine what OS or OS version is provided by the supplied'
+                f' installation image located at {iso.path}.'
             ),
             reporting.Remediation(
-                hint='Check that the supplied image is a valid {} installation image.'.format(
-                    target_distro
+                hint=(
+                    'Check that the supplied image is a valid installation image of the'
+                    f' target OS and version for the upgrade - {DISTRO_REPORT_NAMES.target}'
+                    f' {version.get_target_major_version()}.'
                 )
             ),
             reporting.Severity(reporting.Severity.HIGH),

--- a/repos/system_upgrade/common/actors/checktargetiso/libraries/check_target_iso.py
+++ b/repos/system_upgrade/common/actors/checktargetiso/libraries/check_target_iso.py
@@ -131,13 +131,13 @@ def inhibit_if_iso_not_located_on_persistent_partition(iso):
         raise StopActorExecutionError('Actor did not receive any StorageInfo message.')
 
     # Assumes that the path has been already checked for validity, e.g., the ISO path points to a file
-    iso_mountpoint = iso.path
+    iso_mountpoint = os.path.realpath(iso.path)
     while not os.path.ismount(iso_mountpoint):  # Guaranteed to terminate because we must reach / eventually
         iso_mountpoint = os.path.dirname(iso_mountpoint)
 
     is_iso_on_persistent_partition = False
     for fstab_entry in storage_info.fstab:
-        if fstab_entry.fs_file == iso_mountpoint:
+        if os.path.realpath(fstab_entry.fs_file) == iso_mountpoint:
             is_iso_on_persistent_partition = True
             break
 

--- a/repos/system_upgrade/common/actors/checktargetiso/tests/test_check_target_iso.py
+++ b/repos/system_upgrade/common/actors/checktargetiso/tests/test_check_target_iso.py
@@ -29,9 +29,9 @@ def test_inhibit_on_iso_mount_failure(monkeypatch, mount_successful):
         assert is_inhibitor(create_report_mock.reports[0])
 
 
-@pytest.mark.parametrize(('detected_iso_rhel_ver', 'required_target_ver', 'should_inhibit'),
+@pytest.mark.parametrize(('detected_iso_os_ver', 'required_target_ver', 'should_inhibit'),
                          (('8.6', '8.6', False), ('7.9', '8.6', True), ('8.5', '8.6', False), ('', '8.6', True)))
-def test_inhibit_on_detected_rhel_version(monkeypatch, detected_iso_rhel_ver, required_target_ver, should_inhibit):
+def test_inhibit_on_detected_iso_version(monkeypatch, detected_iso_os_ver, required_target_ver, should_inhibit):
     create_report_mock = create_report_mocked()
     monkeypatch.setattr(reporting, 'create_report', create_report_mock)
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(dst_ver=required_target_ver))
@@ -39,10 +39,10 @@ def test_inhibit_on_detected_rhel_version(monkeypatch, detected_iso_rhel_ver, re
     target_iso_msg = TargetOSInstallationImage(path='',
                                                mountpoint='',
                                                repositories=[],
-                                               rhel_version=detected_iso_rhel_ver,
+                                               os_version=detected_iso_os_ver,
                                                was_mounted_successfully=True)
 
-    check_target_iso.inhibit_if_wrong_iso_rhel_version(target_iso_msg)
+    check_target_iso.inhibit_if_wrong_iso_os_version(target_iso_msg)
 
     expected_report_count = 1 if should_inhibit else 0
     assert create_report_mock.called == expected_report_count
@@ -52,7 +52,7 @@ def test_inhibit_on_detected_rhel_version(monkeypatch, detected_iso_rhel_ver, re
 
 @pytest.mark.parametrize(('iso_repoids', 'should_inhibit'),
                          ((('BaseOS', 'AppStream'), False), (('BaseOS',), True), (('AppStream',), True), ((), True)))
-def test_inhibit_on_invalid_rhel_version(monkeypatch, iso_repoids, should_inhibit):
+def test_inhibit_on_invalid_os_version(monkeypatch, iso_repoids, should_inhibit):
     create_report_mock = create_report_mocked()
     monkeypatch.setattr(reporting, 'create_report', create_report_mock)
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
@@ -64,7 +64,7 @@ def test_inhibit_on_invalid_rhel_version(monkeypatch, iso_repoids, should_inhibi
                                                repositories=iso_repositories,
                                                was_mounted_successfully=True)
 
-    check_target_iso.inihibit_if_iso_does_not_contain_basic_repositories(target_iso_msg)
+    check_target_iso.inhibit_if_iso_does_not_contain_basic_repositories(target_iso_msg)
 
     expected_report_count = 1 if should_inhibit else 0
     assert create_report_mock.called == expected_report_count

--- a/repos/system_upgrade/common/actors/scantargetiso/libraries/scan_target_os_iso.py
+++ b/repos/system_upgrade/common/actors/scantargetiso/libraries/scan_target_os_iso.py
@@ -5,44 +5,83 @@ from leapp.libraries.common.mounting import LoopMount, MountError
 from leapp.libraries.stdlib import api, CalledProcessError, run
 from leapp.models import CustomTargetRepository, TargetOSInstallationImage
 
+DISTRO_RELEASE_PKGS = {
+    'rhel': 'redhat-release',
+    'centos': 'centos-stream-release',
+    'almalinux': 'almalinux-release',
+}
+
+DISTRO_RELEASE_FILES = {
+    'rhel': '/etc/redhat-release',
+    'centos': '/etc/centos-release',
+    'almalinux': '/etc/almalinux-release',
+}
+
+# TODO move these out
+DISTRO_NAMES = {
+    'rhel': 'Red Hat Enterprise Linux',
+    'centos': 'CentOS Stream',
+    'almalinux': 'AlmaLinux',
+}
+
 
 def determine_rhel_version_from_iso_mountpoint(iso_mountpoint):
     baseos_packages = os.path.join(iso_mountpoint, 'BaseOS/Packages')
     if os.path.isdir(baseos_packages):
-        def is_rh_release_pkg(pkg_name):
-            return pkg_name.startswith('redhat-release') and 'eula' not in pkg_name
+        target_distro = ipu_config.get_target_distro_id()
 
-        redhat_release_pkgs = [pkg for pkg in os.listdir(baseos_packages) if is_rh_release_pkg(pkg)]
+        def is_release_pkg(pkg_name):
+            return pkg_name.startswith(DISTRO_RELEASE_PKGS[target_distro]) and 'eula' not in pkg_name
 
-        if not redhat_release_pkgs:
+        distro_release_pkgs = [pkg for pkg in os.listdir(baseos_packages) if is_release_pkg(pkg)]
+
+        if not distro_release_pkgs:
             return ''  # We did not determine anything
 
-        if len(redhat_release_pkgs) > 1:
-            api.current_logger().warning('Multiple packages with name redhat-release* found when '
-                                         'determining RHEL version of the supplied installation ISO.')
+        if len(distro_release_pkgs) > 1:
+            api.current_logger().warning(
+                "Multiple packages with name {}* found when determining target version of the supplied"
+                " installation ISO.".format(DISTRO_RELEASE_PKGS[target_distro])
+            )
 
-        redhat_release_pkg = redhat_release_pkgs[0]
+        distro_release_pkg = distro_release_pkgs[0]
 
-        determined_rhel_ver = ''
         try:
-            rh_release_pkg_path = os.path.join(baseos_packages, redhat_release_pkg)
+            release_pkg_path = os.path.join(baseos_packages, distro_release_pkg)
             # rpm2cpio is provided by rpm; cpio is a dependency of yum (rhel7) and a dependency of dracut which is
             # a dependency for leapp (rhel8+)
-            cpio_archive = run(['rpm2cpio', rh_release_pkg_path])
-            etc_rh_release_contents = run(['cpio', '--extract', '--to-stdout', './etc/redhat-release'],
-                                          stdin=cpio_archive['stdout'])
+            cpio_archive = run(['rpm2cpio', release_pkg_path])
+            etc_release_contents = run(
+                [
+                    "cpio",
+                    "--extract",
+                    "--to-stdout",
+                    f".{DISTRO_RELEASE_FILES[target_distro]}",
+                ],
+                stdin=cpio_archive["stdout"],
+            )
 
-            # 'Red Hat Enterprise Linux Server release 7.9 (Maipo)' -> ['Red Hat...', '7.9 (Maipo']
-            product_release_fragments = etc_rh_release_contents['stdout'].split('release')
+            # 'Red Hat Enterprise Linux Server release 7.9 (Maipo)' -> ['Red Hat...', '7.9 (Maipo)']
+            # Red Hat Enterprise Linux release 8.10 (Ootpa)
+            # CentOS Stream release 8
+            product_release_fragments = etc_release_contents['stdout'].split('release')
             if len(product_release_fragments) != 2:
                 return ''  # Unlikely. Either way we failed to parse the release
 
-            if not product_release_fragments[0].startswith('Red Hat'):
+            if not product_release_fragments[0].startswith(DISTRO_NAMES[target_distro]):
                 return ''
 
-            determined_rhel_ver = product_release_fragments[1].strip().split(' ', 1)[0]  # Remove release name (Maipo)
-            return determined_rhel_ver
+            determined_ver = product_release_fragments[1].strip().split(' ', 1)[0]  # Remove release name (Maipo)
+            return determined_ver
         except CalledProcessError:
+            # FIXME?: This might fail e.g. if the ISO isn't complete
+            # (download/scp/...) interrupted. Maybe we should at include
+            # info that in the report?
+            # Leaving an exact example from the logs (yes the empty line is there):
+            # error: /var/lib/leapp/iso_scan_mountpoint/BaseOS/Packages/centos-stream-release-9.0-26.el9.noarch.rpm: read failed: Input/output error (5)
+
+            # error reading header from package
+
             return ''
     return ''
 
@@ -62,7 +101,7 @@ def inform_ipu_about_request_to_use_target_iso():
                                               was_mounted_successfully=False))
         return
 
-    # Mount the given ISO, extract the available repositories and determine provided RHEL version
+    # Mount the given ISO, extract the available repositories and determine provided target version
     iso_scan_mountpoint = '/var/lib/leapp/iso_scan_mountpoint'
     try:
         with LoopMount(source=target_iso_path, target=iso_scan_mountpoint):

--- a/repos/system_upgrade/common/actors/scantargetiso/libraries/scan_target_os_iso.py
+++ b/repos/system_upgrade/common/actors/scantargetiso/libraries/scan_target_os_iso.py
@@ -1,11 +1,13 @@
 import os
 
 import leapp.libraries.common.config as ipu_config
+from leapp.libraries.common.distro import distro_id_to_pretty_name
 from leapp.libraries.common.mounting import LoopMount, MountError
 from leapp.libraries.stdlib import api, CalledProcessError, run
 from leapp.models import CustomTargetRepository, TargetOSInstallationImage
 
-DISTRO_RELEASE_PKGS = {
+
+RELEASE_PKG_NAME_PREFIX = {
     'rhel': 'redhat-release',
     'centos': 'centos-stream-release',
     'almalinux': 'almalinux-release',
@@ -17,21 +19,37 @@ DISTRO_RELEASE_FILES = {
     'almalinux': '/etc/almalinux-release',
 }
 
-# TODO move these out
-DISTRO_NAMES = {
-    'rhel': 'Red Hat Enterprise Linux',
-    'centos': 'CentOS Stream',
-    'almalinux': 'AlmaLinux',
-}
+def etc_release_extract_version(etc_release_contents, target_distro):
+    """
+    Extract product release version from /etc/release content
+
+    :return: The parse version or None if it couldn't be determined
+    :rtype: str | None
+    """
+    # 'Red Hat Enterprise Linux Server release 7.9 (Maipo)' -> ['Red Hat...', '7.9 (Maipo)']
+    # Red Hat Enterprise Linux release 8.10 (Ootpa)
+    # CentOS Stream release 8
+    product_release_fragments = etc_release_contents['stdout'].split('release')
+    if len(product_release_fragments) != 2:
+        return None  # Unlikely. Either way we failed to parse the release
+
+    if not product_release_fragments[0].startswith(distro_id_to_pretty_name(target_distro)):
+        return None
+
+    determined_ver = product_release_fragments[1].strip().split(' ', 1)[0]  # Remove release name (Maipo)
+    return determined_ver
 
 
-def determine_rhel_version_from_iso_mountpoint(iso_mountpoint):
+def determine_distro_version_from_iso_mountpoint(iso_mountpoint):
     baseos_packages = os.path.join(iso_mountpoint, 'BaseOS/Packages')
     if os.path.isdir(baseos_packages):
         target_distro = ipu_config.get_target_distro_id()
 
         def is_release_pkg(pkg_name):
-            return pkg_name.startswith(DISTRO_RELEASE_PKGS[target_distro]) and 'eula' not in pkg_name
+            return (
+                pkg_name.startswith(RELEASE_PKG_NAME_PREFIX[target_distro])
+                and "eula" not in pkg_name
+            )
 
         distro_release_pkgs = [pkg for pkg in os.listdir(baseos_packages) if is_release_pkg(pkg)]
 
@@ -41,7 +59,7 @@ def determine_rhel_version_from_iso_mountpoint(iso_mountpoint):
         if len(distro_release_pkgs) > 1:
             api.current_logger().warning(
                 "Multiple packages with name {}* found when determining target version of the supplied"
-                " installation ISO.".format(DISTRO_RELEASE_PKGS[target_distro])
+                " installation ISO.".format(RELEASE_PKG_NAME_PREFIX[target_distro])
             )
 
         distro_release_pkg = distro_release_pkgs[0]
@@ -61,18 +79,7 @@ def determine_rhel_version_from_iso_mountpoint(iso_mountpoint):
                 stdin=cpio_archive["stdout"],
             )
 
-            # 'Red Hat Enterprise Linux Server release 7.9 (Maipo)' -> ['Red Hat...', '7.9 (Maipo)']
-            # Red Hat Enterprise Linux release 8.10 (Ootpa)
-            # CentOS Stream release 8
-            product_release_fragments = etc_release_contents['stdout'].split('release')
-            if len(product_release_fragments) != 2:
-                return ''  # Unlikely. Either way we failed to parse the release
-
-            if not product_release_fragments[0].startswith(DISTRO_NAMES[target_distro]):
-                return ''
-
-            determined_ver = product_release_fragments[1].strip().split(' ', 1)[0]  # Remove release name (Maipo)
-            return determined_ver
+            return etc_release_extract_version(etc_release_contents, target_distro) or ''
         except CalledProcessError:
             # FIXME?: This might fail e.g. if the ISO isn't complete
             # (download/scp/...) interrupted. Maybe we should at include
@@ -119,7 +126,7 @@ def inform_ipu_about_request_to_use_target_iso():
                 api.produce(iso_repo)
                 iso_repos.append(iso_repo)
 
-            rhel_version = determine_rhel_version_from_iso_mountpoint(iso_scan_mountpoint)
+            rhel_version = determine_distro_version_from_iso_mountpoint(iso_scan_mountpoint)
 
             api.produce(TargetOSInstallationImage(path=target_iso_path,
                                                   repositories=iso_repos,

--- a/repos/system_upgrade/common/actors/scantargetiso/libraries/scan_target_os_iso.py
+++ b/repos/system_upgrade/common/actors/scantargetiso/libraries/scan_target_os_iso.py
@@ -85,7 +85,9 @@ def determine_distro_version_from_iso_mountpoint(iso_mountpoint):
             # (download/scp/...) interrupted. Maybe we should at include
             # info that in the report?
             # Leaving an exact example from the logs (yes the empty line is there):
-            # error: /var/lib/leapp/iso_scan_mountpoint/BaseOS/Packages/centos-stream-release-9.0-26.el9.noarch.rpm: read failed: Input/output error (5)
+            # error:
+            # /var/lib/leapp/iso_scan_mountpoint/BaseOS/Packages/centos-stream-release-9.0-26.el9.noarch.rpm:
+            # read failed: Input/output error (5)
 
             # error reading header from package
 

--- a/repos/system_upgrade/common/actors/scantargetiso/libraries/scan_target_os_iso.py
+++ b/repos/system_upgrade/common/actors/scantargetiso/libraries/scan_target_os_iso.py
@@ -1,50 +1,89 @@
 import os
 
 import leapp.libraries.common.config as ipu_config
+from leapp.libraries.common.distro import distro_id_to_pretty_name, get_distro_iso_config
 from leapp.libraries.common.mounting import LoopMount, MountError
 from leapp.libraries.stdlib import api, CalledProcessError, run
 from leapp.models import CustomTargetRepository, TargetOSInstallationImage
 
 
-def determine_rhel_version_from_iso_mountpoint(iso_mountpoint):
+def etc_release_extract_version(etc_release_contents, target_distro):
+    """
+    Extract product release version from /etc/release content
+
+    :return: The parsed version or None if it couldn't be determined
+    :rtype: str | None
+    """
+    # 'Red Hat Enterprise Linux Server release 7.9 (Maipo)' -> ['Red Hat...', '7.9 (Maipo)']
+    # Red Hat Enterprise Linux release 8.10 (Ootpa)
+    # CentOS Stream release 8
+    product_release_fragments = etc_release_contents.split('release')
+    if len(product_release_fragments) != 2:
+        return None  # Unlikely. Either way we failed to parse the release
+
+    if not product_release_fragments[0].startswith(distro_id_to_pretty_name(target_distro)):
+        return None
+
+    determined_ver = product_release_fragments[1].strip().split(' ', 1)[0]  # Remove release name (Maipo)
+    return determined_ver
+
+
+def determine_os_version_from_iso_mountpoint(iso_mountpoint):
     baseos_packages = os.path.join(iso_mountpoint, 'BaseOS/Packages')
-    if os.path.isdir(baseos_packages):
-        def is_rh_release_pkg(pkg_name):
-            return pkg_name.startswith('redhat-release') and 'eula' not in pkg_name
 
-        redhat_release_pkgs = [pkg for pkg in os.listdir(baseos_packages) if is_rh_release_pkg(pkg)]
+    if not os.path.isdir(baseos_packages):
+        return ''
 
-        if not redhat_release_pkgs:
-            return ''  # We did not determine anything
+    target_distro = ipu_config.get_target_distro_id()
+    distro_iso_config = get_distro_iso_config(target_distro)
 
-        if len(redhat_release_pkgs) > 1:
-            api.current_logger().warning('Multiple packages with name redhat-release* found when '
-                                         'determining RHEL version of the supplied installation ISO.')
+    def is_release_pkg(pkg_name):
+        return (
+            pkg_name.startswith(distro_iso_config.release_pkg_name_prefix)
+            and 'eula' not in pkg_name
+        )
 
-        redhat_release_pkg = redhat_release_pkgs[0]
+    distro_release_pkgs = [pkg for pkg in os.listdir(baseos_packages) if is_release_pkg(pkg)]
 
-        determined_rhel_ver = ''
-        try:
-            rh_release_pkg_path = os.path.join(baseos_packages, redhat_release_pkg)
-            # rpm2cpio is provided by rpm; cpio is a dependency of yum (rhel7) and a dependency of dracut which is
-            # a dependency for leapp (rhel8+)
-            cpio_archive = run(['rpm2cpio', rh_release_pkg_path])
-            etc_rh_release_contents = run(['cpio', '--extract', '--to-stdout', './etc/redhat-release'],
-                                          stdin=cpio_archive['stdout'])
+    if not distro_release_pkgs:
+        return ''  # We did not determine anything
 
-            # 'Red Hat Enterprise Linux Server release 7.9 (Maipo)' -> ['Red Hat...', '7.9 (Maipo']
-            product_release_fragments = etc_rh_release_contents['stdout'].split('release')
-            if len(product_release_fragments) != 2:
-                return ''  # Unlikely. Either way we failed to parse the release
+    if len(distro_release_pkgs) > 1:
+        api.current_logger().warning(
+            'Multiple packages with name {}* found when determining target version of the supplied'
+            ' installation ISO.'.format(distro_iso_config.release_pkg_name_prefix)
+        )
 
-            if not product_release_fragments[0].startswith('Red Hat'):
-                return ''
+    distro_release_pkg = distro_release_pkgs[0]
 
-            determined_rhel_ver = product_release_fragments[1].strip().split(' ', 1)[0]  # Remove release name (Maipo)
-            return determined_rhel_ver
-        except CalledProcessError:
-            return ''
-    return ''
+    try:
+        release_pkg_path = os.path.join(baseos_packages, distro_release_pkg)
+        # rpm2cpio is provided by rpm; cpio is a dependency of yum (rhel7) and a dependency of dracut which is
+        # a dependency for leapp (rhel8+)
+        cpio_archive = run(['rpm2cpio', release_pkg_path])
+        etc_release_contents = run(
+            [
+                'cpio',
+                '--extract',
+                '--to-stdout',
+                f'.{distro_iso_config.etc_release_file}',
+            ],
+            stdin=cpio_archive['stdout'],
+        )
+
+        return etc_release_extract_version(etc_release_contents['stdout'], target_distro) or ''
+    except CalledProcessError:
+        # FIXME?: This might fail e.g. if the ISO isn't complete
+        # (download/scp/...) interrupted. Maybe we should at include
+        # info that in the report?
+        # Leaving an exact example from the logs (yes the empty line is there):
+        # error:
+        # /var/lib/leapp/iso_scan_mountpoint/BaseOS/Packages/centos-stream-release-9.0-26.el9.noarch.rpm:
+        # read failed: Input/output error (5)
+
+        # error reading header from package
+
+        return ''
 
 
 def inform_ipu_about_request_to_use_target_iso():
@@ -62,7 +101,7 @@ def inform_ipu_about_request_to_use_target_iso():
                                               was_mounted_successfully=False))
         return
 
-    # Mount the given ISO, extract the available repositories and determine provided RHEL version
+    # Mount the given ISO, extract the available repositories and determine provided target version
     iso_scan_mountpoint = '/var/lib/leapp/iso_scan_mountpoint'
     try:
         with LoopMount(source=target_iso_path, target=iso_scan_mountpoint):
@@ -80,12 +119,13 @@ def inform_ipu_about_request_to_use_target_iso():
                 api.produce(iso_repo)
                 iso_repos.append(iso_repo)
 
-            rhel_version = determine_rhel_version_from_iso_mountpoint(iso_scan_mountpoint)
+            os_version = determine_os_version_from_iso_mountpoint(iso_scan_mountpoint)
 
             api.produce(TargetOSInstallationImage(path=target_iso_path,
                                                   repositories=iso_repos,
                                                   mountpoint=iso_mountpoint,
-                                                  rhel_version=rhel_version,
+                                                  rhel_version=os_version,
+                                                  os_version=os_version,
                                                   was_mounted_successfully=True))
     except MountError:
         # Do not analyze the situation any further as ISO checks will be done by another actor

--- a/repos/system_upgrade/common/actors/scantargetiso/libraries/scan_target_os_iso.py
+++ b/repos/system_upgrade/common/actors/scantargetiso/libraries/scan_target_os_iso.py
@@ -14,14 +14,24 @@ def etc_release_extract_version(etc_release_contents, target_distro):
     :return: The parsed version or None if it couldn't be determined
     :rtype: str | None
     """
-    # 'Red Hat Enterprise Linux Server release 7.9 (Maipo)' -> ['Red Hat...', '7.9 (Maipo)']
-    # Red Hat Enterprise Linux release 8.10 (Ootpa)
+    # 'Red Hat Enterprise Linux release 8.10 (Ootpa)' -> ['Red Hat Enterprise Linux', '8.10 (Ootpa)']
+    # Red Hat Enterprise Linux release 9.8 (Plow)
     # CentOS Stream release 8
+    api.current_logger().debug(
+        'Determining OS version from etc release contents: {}'.format(etc_release_contents)
+    )
     product_release_fragments = etc_release_contents.split('release')
     if len(product_release_fragments) != 2:
+        api.current_logger().debug('Failed to determine OS version: Unexpected format of etc release')
         return None  # Unlikely. Either way we failed to parse the release
 
-    if not product_release_fragments[0].startswith(distro_id_to_pretty_name(target_distro)):
+    required_distro = distro_id_to_pretty_name(target_distro)
+    determined_distro = product_release_fragments[0].strip()
+    if not determined_distro.startswith(required_distro):
+        api.current_logger().debug(
+            'Failed to determine OS version: The OS name from etc release ({}) does not match the'
+            ' requested target distro ({})'.format(determined_distro, required_distro)
+        )
         return None
 
     determined_ver = product_release_fragments[1].strip().split(' ', 1)[0]  # Remove release name (Maipo)

--- a/repos/system_upgrade/common/actors/scantargetiso/tests/test_scan_target_iso.py
+++ b/repos/system_upgrade/common/actors/scantargetiso/tests/test_scan_target_iso.py
@@ -15,7 +15,7 @@ def fail_if_called(fail_reason, *args, **kwargs):
     assert False, fail_reason
 
 
-def test_determine_rhel_version_determination_unexpected_iso_structure_or_invalid_mountpoint(monkeypatch):
+def test_determine_distro_version_determination_unexpected_iso_structure_or_invalid_mountpoint(monkeypatch):
     iso_mountpoint = '/some/mountpoint'
 
     run_mocked = partial(fail_if_called,
@@ -28,7 +28,7 @@ def test_determine_rhel_version_determination_unexpected_iso_structure_or_invali
 
     monkeypatch.setattr(os.path, 'isdir', isdir_mocked)
 
-    determined_version = scan_target_os_iso.determine_rhel_version_from_iso_mountpoint(iso_mountpoint)
+    determined_version = scan_target_os_iso.determine_distro_version_from_iso_mountpoint(iso_mountpoint)
     assert not determined_version
 
 
@@ -52,9 +52,31 @@ def test_determine_rhel_version_determination_unexpected_iso_structure_or_invali
             "CentOS Stream release 9",
             "9"
         ),
+        (
+            "centos",
+            ["centos-stream-release-10.0-19.el10.noarch.rpm"],
+            "./etc/centos-release",
+            "CentOS Stream release 10 (Coughlan)",
+            "10"
+        ),
+        (
+            "almalinux",
+            ["almalinux-release-9.7-1.el9.x86_64.rpm"],
+            "./etc/almalinux-release",
+            "AlmaLinux release 9.7 (Moss Jungle Cat)",
+            "9.7"
+        ),
+        (
+            "almalinux",
+            ["almalinux-release-10.1-16.el10.x86_64.rpm"],
+            "./etc/almalinux-release",
+            "AlmaLinux release 10.1 (Heliotrope Lion)",
+            "10.1"
+        ),
+
     ],
 )
-def test_determine_rhel_version_valid_iso(
+def test_determine_distro_version_valid_iso(
     monkeypatch, distro, pkgs, etc_release_fname, etc_release_content, expect
 ):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(release_id=distro))
@@ -82,11 +104,11 @@ def test_determine_rhel_version_valid_iso(
     monkeypatch.setattr(os, 'listdir', listdir_mocked)
     monkeypatch.setattr(scan_target_os_iso, 'run', run_mocked)
 
-    determined_version = scan_target_os_iso.determine_rhel_version_from_iso_mountpoint(iso_mountpoint)
+    determined_version = scan_target_os_iso.determine_distro_version_from_iso_mountpoint(iso_mountpoint)
     assert determined_version == expect
 
 
-def test_determine_rhel_version_valid_iso_no_rh_release(monkeypatch):
+def test_determine_distro_version_valid_iso_no_release_file(monkeypatch):
     iso_mountpoint = '/some/mountpoint'
 
     def isdir_mocked(path):
@@ -103,12 +125,13 @@ def test_determine_rhel_version_valid_iso_no_rh_release(monkeypatch):
     monkeypatch.setattr(os.path, 'isdir', isdir_mocked)
     monkeypatch.setattr(os, 'listdir', listdir_mocked)
     monkeypatch.setattr(scan_target_os_iso, 'run', run_mocked)
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
 
-    determined_version = scan_target_os_iso.determine_rhel_version_from_iso_mountpoint(iso_mountpoint)
+    determined_version = scan_target_os_iso.determine_distro_version_from_iso_mountpoint(iso_mountpoint)
     assert determined_version == ''
 
 
-def test_determine_rhel_version_rpm_extract_fails(monkeypatch):
+def test_determine_distro_version_rpm_extract_fails(monkeypatch):
     iso_mountpoint = '/some/mountpoint'
 
     def isdir_mocked(path):
@@ -124,15 +147,17 @@ def test_determine_rhel_version_rpm_extract_fails(monkeypatch):
     monkeypatch.setattr(os.path, 'isdir', isdir_mocked)
     monkeypatch.setattr(os, 'listdir', listdir_mocked)
     monkeypatch.setattr(scan_target_os_iso, 'run', run_mocked)
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
 
-    determined_version = scan_target_os_iso.determine_rhel_version_from_iso_mountpoint(iso_mountpoint)
+    determined_version = scan_target_os_iso.determine_distro_version_from_iso_mountpoint(iso_mountpoint)
     assert determined_version == ''
 
 
-@pytest.mark.parametrize('etc_rh_release_contents', ('',
-                                                     'Red Hat Enterprise Linux Server',
-                                                     'Fedora release 35 (Thirty Five)'))
-def test_determine_rhel_version_unexpected_etc_distro_release_contents(monkeypatch, etc_rh_release_contents):
+@pytest.mark.parametrize(
+    "etc_rh_release_contents",
+    ("", "Red Hat Enterprise Linux Server", "Fedora release 35 (Thirty Five)"),
+)
+def test_determine_distro_version_unexpected_etc_distro_release_contents(monkeypatch, etc_rh_release_contents):
     iso_mountpoint = '/some/mountpoint'
 
     def isdir_mocked(path):
@@ -152,8 +177,9 @@ def test_determine_rhel_version_unexpected_etc_distro_release_contents(monkeypat
     monkeypatch.setattr(os.path, 'isdir', isdir_mocked)
     monkeypatch.setattr(os, 'listdir', listdir_mocked)
     monkeypatch.setattr(scan_target_os_iso, 'run', run_mocked)
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
 
-    determined_version = scan_target_os_iso.determine_rhel_version_from_iso_mountpoint(iso_mountpoint)
+    determined_version = scan_target_os_iso.determine_distro_version_from_iso_mountpoint(iso_mountpoint)
     assert determined_version == ''
 
 
@@ -214,7 +240,7 @@ def test_iso_repository_detection(monkeypatch, repodirs_in_iso, expected_repoids
     monkeypatch.setattr(scan_target_os_iso, 'LoopMount', always_successful_loop_mount)
     monkeypatch.setattr(os.path, 'exists', mocked_os_path_exits)
     monkeypatch.setattr(os, 'listdir', mocked_os_listdir)
-    monkeypatch.setattr(scan_target_os_iso, 'determine_rhel_version_from_iso_mountpoint', lambda iso_mountpoint: '7.9')
+    monkeypatch.setattr(scan_target_os_iso, 'determine_distro_version_from_iso_mountpoint', lambda iso_mountpoint: '7.9')
 
     scan_target_os_iso.inform_ipu_about_request_to_use_target_iso()
 

--- a/repos/system_upgrade/common/actors/scantargetiso/tests/test_scan_target_iso.py
+++ b/repos/system_upgrade/common/actors/scantargetiso/tests/test_scan_target_iso.py
@@ -240,7 +240,11 @@ def test_iso_repository_detection(monkeypatch, repodirs_in_iso, expected_repoids
     monkeypatch.setattr(scan_target_os_iso, 'LoopMount', always_successful_loop_mount)
     monkeypatch.setattr(os.path, 'exists', mocked_os_path_exits)
     monkeypatch.setattr(os, 'listdir', mocked_os_listdir)
-    monkeypatch.setattr(scan_target_os_iso, 'determine_distro_version_from_iso_mountpoint', lambda iso_mountpoint: '7.9')
+    monkeypatch.setattr(
+        scan_target_os_iso,
+        "determine_distro_version_from_iso_mountpoint",
+        lambda iso_mountpoint: "7.9",
+    )
 
     scan_target_os_iso.inform_ipu_about_request_to_use_target_iso()
 

--- a/repos/system_upgrade/common/actors/scantargetiso/tests/test_scan_target_iso.py
+++ b/repos/system_upgrade/common/actors/scantargetiso/tests/test_scan_target_iso.py
@@ -15,7 +15,7 @@ def fail_if_called(fail_reason, *args, **kwargs):
     assert False, fail_reason
 
 
-def test_determine_rhel_version_determination_unexpected_iso_structure_or_invalid_mountpoint(monkeypatch):
+def test_determine_distro_version_determination_unexpected_iso_structure_or_invalid_mountpoint(monkeypatch):
     iso_mountpoint = '/some/mountpoint'
 
     run_mocked = partial(fail_if_called,
@@ -28,11 +28,65 @@ def test_determine_rhel_version_determination_unexpected_iso_structure_or_invali
 
     monkeypatch.setattr(os.path, 'isdir', isdir_mocked)
 
-    determined_version = scan_target_os_iso.determine_rhel_version_from_iso_mountpoint(iso_mountpoint)
+    determined_version = scan_target_os_iso.determine_os_version_from_iso_mountpoint(iso_mountpoint)
     assert not determined_version
 
 
-def test_determine_rhel_version_valid_iso(monkeypatch):
+@pytest.mark.parametrize(
+    "distro, pkgs, etc_release_fname, etc_release_content, expect",
+    [
+        (
+            "rhel",
+            [
+                "redhat-release-8.7-0.3.el8.x86_64.rpm",
+                "redhat-release-eula-8.7-0.3.el8.x86_64.rpm",  # test that this one isn't picked up
+            ],
+            "./etc/redhat-release",
+            "Red Hat Enterprise Linux Server release 7.9 (Maipo)",
+            "7.9",
+        ),
+        (
+            "centos",
+            ["centos-stream-release-9.0-34.el9.x86_64.rpm"],
+            "./etc/centos-release",
+            "CentOS Stream release 9",
+            "9"
+        ),
+        (
+            "centos",
+            ["centos-stream-release-10.0-19.el10.noarch.rpm"],
+            "./etc/centos-release",
+            "CentOS Stream release 10 (Coughlan)",
+            "10"
+        ),
+        (
+            "almalinux",
+            ["almalinux-release-9.7-1.el9.x86_64.rpm"],
+            "./etc/almalinux-release",
+            "AlmaLinux release 9.7 (Moss Jungle Cat)",
+            "9.7"
+        ),
+        (
+            "almalinux",
+            ["almalinux-release-10.1-16.el10.x86_64.rpm"],
+            "./etc/almalinux-release",
+            "AlmaLinux release 10.1 (Heliotrope Lion)",
+            "10.1"
+        ),
+        (
+            "rocky",
+            ["rocky-release-10.2-1.1.el10.noarch"],
+            "./etc/rocky-release",
+            "Rocky Linux release 10.2 (Red Quartz)",
+            "10.2"
+        ),
+
+    ],
+)
+def test_determine_distro_version_valid_iso(
+    monkeypatch, distro, pkgs, etc_release_fname, etc_release_content, expect
+):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(release_id=distro))
     iso_mountpoint = '/some/mountpoint'
 
     def isdir_mocked(path):
@@ -40,31 +94,28 @@ def test_determine_rhel_version_valid_iso(monkeypatch):
 
     def listdir_mocked(path):
         assert path == '/some/mountpoint/BaseOS/Packages', 'Only the contents of BaseOS/Packages should be examined.'
-        return ['xz-5.2.4-4.el8_6.x86_64.rpm',
-                'libmodman-2.0.1-17.el8.i686.rpm',
-                'redhat-release-8.7-0.3.el8.x86_64.rpm',
-                'redhat-release-eula-8.7-0.3.el8.x86_64.rpm']
+        return ['xz-5.2.4-4.el8_6.x86_64.rpm', 'libmodman-2.0.1-17.el8.i686.rpm'] + pkgs
 
     def run_mocked(cmd, *args, **kwargs):
         rpm2cpio_output = 'rpm2cpio_output'
         if cmd[0] == 'rpm2cpio':
-            assert cmd == ['rpm2cpio', '/some/mountpoint/BaseOS/Packages/redhat-release-8.7-0.3.el8.x86_64.rpm']
+            assert cmd == ['rpm2cpio', f'/some/mountpoint/BaseOS/Packages/{pkgs[0]}']
             return {'stdout': rpm2cpio_output}
         if cmd[0] == 'cpio':
-            assert cmd == ['cpio', '--extract', '--to-stdout', './etc/redhat-release']
+            assert cmd == ['cpio', '--extract', '--to-stdout', etc_release_fname]
             assert kwargs['stdin'] == rpm2cpio_output
-            return {'stdout': 'Red Hat Enterprise Linux Server release 7.9 (Maipo)'}
+            return {'stdout': etc_release_content}
         raise ValueError('Unexpected command has been called.')
 
     monkeypatch.setattr(os.path, 'isdir', isdir_mocked)
     monkeypatch.setattr(os, 'listdir', listdir_mocked)
     monkeypatch.setattr(scan_target_os_iso, 'run', run_mocked)
 
-    determined_version = scan_target_os_iso.determine_rhel_version_from_iso_mountpoint(iso_mountpoint)
-    assert determined_version == '7.9'
+    determined_version = scan_target_os_iso.determine_os_version_from_iso_mountpoint(iso_mountpoint)
+    assert determined_version == expect
 
 
-def test_determine_rhel_version_valid_iso_no_rh_release(monkeypatch):
+def test_determine_distro_version_valid_iso_no_release_file(monkeypatch):
     iso_mountpoint = '/some/mountpoint'
 
     def isdir_mocked(path):
@@ -81,12 +132,13 @@ def test_determine_rhel_version_valid_iso_no_rh_release(monkeypatch):
     monkeypatch.setattr(os.path, 'isdir', isdir_mocked)
     monkeypatch.setattr(os, 'listdir', listdir_mocked)
     monkeypatch.setattr(scan_target_os_iso, 'run', run_mocked)
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
 
-    determined_version = scan_target_os_iso.determine_rhel_version_from_iso_mountpoint(iso_mountpoint)
+    determined_version = scan_target_os_iso.determine_os_version_from_iso_mountpoint(iso_mountpoint)
     assert determined_version == ''
 
 
-def test_determine_rhel_version_rpm_extract_fails(monkeypatch):
+def test_determine_distro_version_rpm_extract_fails(monkeypatch):
     iso_mountpoint = '/some/mountpoint'
 
     def isdir_mocked(path):
@@ -102,15 +154,17 @@ def test_determine_rhel_version_rpm_extract_fails(monkeypatch):
     monkeypatch.setattr(os.path, 'isdir', isdir_mocked)
     monkeypatch.setattr(os, 'listdir', listdir_mocked)
     monkeypatch.setattr(scan_target_os_iso, 'run', run_mocked)
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
 
-    determined_version = scan_target_os_iso.determine_rhel_version_from_iso_mountpoint(iso_mountpoint)
+    determined_version = scan_target_os_iso.determine_os_version_from_iso_mountpoint(iso_mountpoint)
     assert determined_version == ''
 
 
-@pytest.mark.parametrize('etc_rh_release_contents', ('',
-                                                     'Red Hat Enterprise Linux Server',
-                                                     'Fedora release 35 (Thirty Five)'))
-def test_determine_rhel_version_unexpected_etc_rh_release_contents(monkeypatch, etc_rh_release_contents):
+@pytest.mark.parametrize(
+    "etc_rh_release_contents",
+    ("", "Red Hat Enterprise Linux Server", "Fedora release 35 (Thirty Five)"),
+)
+def test_determine_distro_version_unexpected_etc_distro_release_contents(monkeypatch, etc_rh_release_contents):
     iso_mountpoint = '/some/mountpoint'
 
     def isdir_mocked(path):
@@ -130,8 +184,9 @@ def test_determine_rhel_version_unexpected_etc_rh_release_contents(monkeypatch, 
     monkeypatch.setattr(os.path, 'isdir', isdir_mocked)
     monkeypatch.setattr(os, 'listdir', listdir_mocked)
     monkeypatch.setattr(scan_target_os_iso, 'run', run_mocked)
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
 
-    determined_version = scan_target_os_iso.determine_rhel_version_from_iso_mountpoint(iso_mountpoint)
+    determined_version = scan_target_os_iso.determine_os_version_from_iso_mountpoint(iso_mountpoint)
     assert determined_version == ''
 
 
@@ -192,7 +247,11 @@ def test_iso_repository_detection(monkeypatch, repodirs_in_iso, expected_repoids
     monkeypatch.setattr(scan_target_os_iso, 'LoopMount', always_successful_loop_mount)
     monkeypatch.setattr(os.path, 'exists', mocked_os_path_exits)
     monkeypatch.setattr(os, 'listdir', mocked_os_listdir)
-    monkeypatch.setattr(scan_target_os_iso, 'determine_rhel_version_from_iso_mountpoint', lambda iso_mountpoint: '7.9')
+    monkeypatch.setattr(
+        scan_target_os_iso,
+        "determine_os_version_from_iso_mountpoint",
+        lambda iso_mountpoint: "7.9",
+    )
 
     scan_target_os_iso.inform_ipu_about_request_to_use_target_iso()
 
@@ -214,7 +273,7 @@ def test_iso_repository_detection(monkeypatch, repodirs_in_iso, expected_repoids
     iso_mountpoint = target_iso.mountpoint
 
     assert target_iso.was_mounted_successfully
-    assert target_iso.rhel_version == '7.9'
+    assert target_iso.os_version == '7.9'
 
     expected_repos = {(repoid, 'file://' + os.path.join(iso_mountpoint, repoid)) for repoid in expected_repoids}
     actual_repos = {(repo.repoid, repo.baseurl) for repo in produced_custom_repo_msgs}

--- a/repos/system_upgrade/common/libraries/distro.py
+++ b/repos/system_upgrade/common/libraries/distro.py
@@ -1,5 +1,6 @@
 import json
 import os
+from collections import namedtuple
 from collections.abc import Mapping
 
 from leapp.exceptions import StopActorExecutionError
@@ -350,3 +351,18 @@ def get_distro_efidir_canon_path(distro_id):
         return os.path.join(efi.EFI_MOUNTPOINT, "EFI", "redhat")
 
     return os.path.join(efi.EFI_MOUNTPOINT, "EFI", distro_id)
+
+
+DistroIsoConfig = namedtuple('DistroIsoConfig', ('release_pkg_name_prefix', 'etc_release_file'))
+"""
+Holds distro-specific information about ISO images.
+"""
+
+
+def get_distro_iso_config(distro_id):
+    return {
+        "rhel": DistroIsoConfig("redhat-release", "/etc/redhat-release"),
+        "centos": DistroIsoConfig("centos-stream-release", "/etc/centos-release"),
+        "almalinux": DistroIsoConfig("almalinux-release", "/etc/almalinux-release"),
+        "rocky": DistroIsoConfig("rocky-release", "/etc/rocky-release"),
+    }[distro_id]

--- a/repos/system_upgrade/common/models/upgradeiso.py
+++ b/repos/system_upgrade/common/models/upgradeiso.py
@@ -5,10 +5,27 @@ from leapp.topics import SystemFactsTopic
 class TargetOSInstallationImage(Model):
     """
     An installation image of a target OS requested to be the source of target OS packages.
+
+    Note: `rhel_version` is deprecated, use `os_version` instead.
     """
     topic = SystemFactsTopic
     path = fields.String()
     mountpoint = fields.String()
     repositories = fields.List(fields.Model(CustomTargetRepository))
     rhel_version = fields.String(default='')
+    """
+    The RHEL version provided by the ISO
+
+    DEPRECATED - use os_version instead.
+    """
+
+    os_version = fields.String(default='')
+    """
+    The OS version provided by the ISO
+
+    The version is the full version available in /etc/<distro>-release,
+    i.e. it is in the versioning schema used by the distribution, which is
+    usually MAJOR.MINOR except for CentOS Stream where it's MAJOR.
+    """
+
     was_mounted_successfully = fields.Boolean(default=False)


### PR DESCRIPTION
Adjust the `scan_target_os_iso` and `check_target_iso` and also the `TargetOSInstallationImage` model actors to be more distro agnostic:

- `scan_target_os_iso` actor
   - Add hardcoded information that we are looking for in the ISO (release package name, release file name in /etc) for other distros - CentOS Stream, Alma Linux, Rocky Linux.
   - Note that this does not mean that ISOs of all of the mapped distros are working, see the note below.
- `check_target_iso` actor
  - Make the reports distro agnostic, this was probably a leftover from #1505 or maybe left for this PR. I kept the convention for choosing stable report keys used in #1505, i.e. if a report had a source or target version in it's title, the key was generated as if it was a 7->8 upgrade.
   - The report about failed target OS version determination is adjusted to cover the case where we even fail to determine the OS or the OS doesn't match the requested target OS. This is all handled with a generic report that OS or OS version couldn't be determined, hint is adjusted accordingly.
- `TargetOSInstallationImage` model - deprecate the `rhel_version` field in favor of `os_version`
- Fix ISO path resolution when the path is a symlink
- Fix ISO path resolution when the fstab entry for a the device containing the ISO has a trailing slash in the mountpoint path.

> [!NOTE]
>  These changes do not necessarily enable upgrades (and conversions) with ISOs of distros other than RHEL or CentOS Stream. There might be more work required, especially in the `scan_target_os_iso` actor to get them working. 

## Tests
### Rocky 9.8 -> 10.2
<details><summary>Outputs</summary>
<p>

```
[root@localhost ~]# leapp-inspector messages --type TargetOSInstallationImage
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T10:30:29.316702Z
Actor: scan_target_os_image
Phase: FactsCollection
Type: TargetOSInstallationImage
Message_data:
{
    "mountpoint": "/iso",
    "os_version": "10.2",
    "path": "/root/RHEL-10.2-x86_64-dvd1.iso",
    "repositories": [
        {
            "baseurl": "file:///iso/BaseOS",
            "enabled": true,
            "name": "BaseOS",
            "repoid": "BaseOS"
        },
        {
            "baseurl": "file:///iso/AppStream",
            "enabled": true,
            "name": "AppStream",
            "repoid": "AppStream"
        }
    ],
    "rhel_version": "10.2",
    "was_mounted_successfully": true
}
######################################################################
```
```
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T10:30:43.089548Z
Actor: target_content_resolver
Phase: FactsCollection
Type: TargetRepositories
Message_data:
{
    "custom_repos": [
        {
            "baseurl": "file:///iso/AppStream",
            "enabled": true,
            "name": "AppStream",
            "repoid": "AppStream"
        },
        {
            "baseurl": "file:///iso/BaseOS",
            "enabled": true,
            "name": "BaseOS",
            "repoid": "BaseOS"
        }
    ],
    "distro_repos": [
        {
            "repoid": "rhel-10-for-x86_64-appstream-rpms"
        },
        {
            "repoid": "rhel-10-for-x86_64-baseos-rpms"
        }
    ],
    "rhel_repos": [
        {
            "repoid": "rhel-10-for-x86_64-appstream-rpms"
        },
        {
            "repoid": "rhel-10-for-x86_64-baseos-rpms"
        }
    ]
}
######################################################################
```
```
[root@localhost ~]# leapp-inspector messages --type UsedTargetRepositories
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T10:31:50.280256Z
Actor: target_userspace_creator
Phase: TargetTransactionFactsCollection
Type: UsedTargetRepositories
Message_data:
{
    "repos": [
        {
            "repoid": "BaseOS"
        },
        {
            "repoid": "AppStream"
        }
    ]
}
######################################################################
```

</p>
</details> 

The ISO is properly recognized and the system is upgraded and converted properly.

### RHEL 9.8 -> RHEL 10.2 (regression test)
<details><summary>Outputs</summary>
<p>

```
[root@leapp-rhel-20260728143950 ~]# leapp-inspector messages --type TargetOSInstallationImage
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T10:55:14.847340Z
Actor: scan_target_os_image
Phase: FactsCollection
Type: TargetOSInstallationImage
Message_data:
{
    "mountpoint": "/iso",
    "path": "/root/RHEL-10.2-x86_64-dvd1.iso",
    "repositories": [
        {
            "baseurl": "file:///iso/BaseOS",
            "enabled": true,
            "name": "BaseOS",
            "repoid": "BaseOS"
        },
        {
            "baseurl": "file:///iso/AppStream",
            "enabled": true,
            "name": "AppStream",
            "repoid": "AppStream"
        }
    ],
    "rhel_version": "10.2",
    "was_mounted_successfully": true
}
######################################################################
```
```
[root@leapp-rhel-20260728143950 ~]# leapp-inspector messages --type TargetRepositories
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T10:55:19.166446Z
Actor: target_content_resolver
Phase: FactsCollection
Type: TargetRepositories
Message_data:
{
    "custom_repos": [
        {
            "baseurl": "file:///iso/AppStream",
            "enabled": true,
            "name": "AppStream",
            "repoid": "AppStream"
        },
        {
            "baseurl": "file:///iso/BaseOS",
            "enabled": true,
            "name": "BaseOS",
            "repoid": "BaseOS"
        }
    ],
    "distro_repos": [
        {
            "repoid": "rhel-10-for-x86_64-appstream-rpms"
        },
        {
            "repoid": "rhel-10-for-x86_64-baseos-rpms"
        }
    ],
    "rhel_repos": [
        {
            "repoid": "rhel-10-for-x86_64-appstream-rpms"
        },
        {
            "repoid": "rhel-10-for-x86_64-baseos-rpms"
        }
    ]
}
######################################################################
```
```
[root@leapp-rhel-20260728143950 ~]# leapp-inspector messages --type UsedTargetRepositories
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T10:56:12.618796Z
Actor: target_userspace_creator
Phase: TargetTransactionFactsCollection
Type: UsedTargetRepositories
Message_data:
{
    "repos": [
        {
            "repoid": "AppStream"
        },
        {
            "repoid": "BaseOS"
        }
    ]
}
######################################################################
```

</p>
</details> 
the ISO is properly recognized, the ISO repos picked up, upgrade is successful. The other repos are there determined by repomapping, but are not available.

### CentOS Stream 9 -> RHEL 10.2
#### ISO only
Basically the same outputs and results as above.

#### ISO + custom repos
<details><summary>Outputs</summary>
<p>

```
[root@localhost ~]# leapp-inspector messages --type TargetRepositories
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T13:48:47.065730Z
Actor: target_content_resolver
Phase: FactsCollection
Type: TargetRepositories
Message_data:
{
    "custom_repos": [
        {
            "baseurl": "file:///iso/AppStream",
            "enabled": true,
            "name": "AppStream",
            "repoid": "AppStream"
        },
        {
            "baseurl": "file:///iso/BaseOS",
            "enabled": true,
            "name": "BaseOS",
            "repoid": "BaseOS"
        },
        {
            "baseurl": <RHEL 10.2 RT repo>,
            "enabled": false,
            "name": "APPSTREAM",
            "repoid": "RT"
        }
    ],
    "distro_repos": [
        {
            "repoid": "rhel-10-for-x86_64-appstream-rpms"
        },
        {
            "repoid": "rhel-10-for-x86_64-baseos-rpms"
        },
        {
            "repoid": "rhel-10-for-x86_64-rt-rpms"
        }
    ],
    "rhel_repos": [
        {
            "repoid": "rhel-10-for-x86_64-appstream-rpms"
        },
        {
            "repoid": "rhel-10-for-x86_64-baseos-rpms"
        },
        {
            "repoid": "rhel-10-for-x86_64-rt-rpms"
        }
    ]
}
######################################################################
```
```
[root@localhost ~]# leapp-inspector messages --type UsedTargetRepositories
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T13:49:56.160534Z
Actor: target_userspace_creator
Phase: TargetTransactionFactsCollection
Type: UsedTargetRepositories
Message_data:
{
    "repos": [
        {
            "repoid": "RT"
        },
        {
            "repoid": "BaseOS"
        },
        {
            "repoid": "AppStream"
        }
    ]
}
######################################################################
```

</p>
</details>

### CentOS Stream 9 -> CentOS Stream 10

Used an rt machine (has baseos, appstream and rt repos enabled).

#### ISO only 
<details><summary>Outputs</summary>
<p>

```
[root@localhost ~]# leapp-inspector messages --type TargetOSInstallationImage
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T15:07:36.057812Z
Actor: scan_target_os_image
Phase: FactsCollection
Type: TargetOSInstallationImage
Message_data:
{
    "mountpoint": "/iso",
    "os_version": "10",
    "path": "/mnt/CentOS-Stream-10-latest-x86_64-dvd1.iso",
    "repositories": [
        {
            "baseurl": "file:///iso/BaseOS",
            "enabled": true,
            "name": "BaseOS",
            "repoid": "BaseOS"
        },
        {
            "baseurl": "file:///iso/AppStream",
            "enabled": true,
            "name": "AppStream",
            "repoid": "AppStream"
        }
    ],
    "rhel_version": "10",
    "was_mounted_successfully": true
}
######################################################################
```
```
[root@localhost ~]# leapp-inspector messages --type TargetRepositories
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T15:07:54.164315Z
Actor: target_content_resolver
Phase: FactsCollection
Type: TargetRepositories
Message_data:
{
    "custom_repos": [
        {
            "baseurl": "file:///iso/AppStream",
            "enabled": true,
            "name": "AppStream",
            "repoid": "AppStream"
        },
        {
            "baseurl": "file:///iso/BaseOS",
            "enabled": true,
            "name": "BaseOS",
            "repoid": "BaseOS"
        }
    ],
    "distro_repos": [
        {
            "repoid": "appstream"
        },
        {
            "repoid": "baseos"
        },
        {
            "repoid": "rt"
        }
    ],
    "rhel_repos": []
}
######################################################################
```
```
[root@localhost ~]# leapp-inspector messages --type UsedTargetRepositories
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T15:08:31.653138Z
Actor: target_userspace_creator
Phase: TargetTransactionFactsCollection
Type: UsedTargetRepositories
Message_data:
{
    "repos": [
        {
            "repoid": "appstream"
        },
        {
            "repoid": "rt"
        },
        {
            "repoid": "BaseOS"
        },
        {
            "repoid": "AppStream"
        },
        {
            "repoid": "baseos"
        }
    ]
}
######################################################################
```


</p>
</details>

**There is the known problem that we currently have no way to tell leapp not to use distro-provided repos.**
Otherwise works ok.

#### ISO and custom repos
<details><summary>Outputs</summary>
<p>

```
[root@localhost ~]# leapp-inspector messages --type TargetOSInstallationImage
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T14:30:07.838663Z
Actor: scan_target_os_image
Phase: FactsCollection
Type: TargetOSInstallationImage
Message_data:
{
    "mountpoint": "/iso",
    "os_version": "10",
    "path": "/mnt/CentOS-Stream-10-latest-x86_64-dvd1.iso",
    "repositories": [
        {
            "baseurl": "file:///iso/BaseOS",
            "enabled": true,
            "name": "BaseOS",
            "repoid": "BaseOS"
        },
        {
            "baseurl": "file:///iso/AppStream",
            "enabled": true,
            "name": "AppStream",
            "repoid": "AppStream"
        }
    ],
    "rhel_version": "10",
    "was_mounted_successfully": true
}
######################################################################
```
```
[root@localhost ~]# leapp-inspector messages --type TargetRepositories
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T14:30:22.182622Z
Actor: target_content_resolver
Phase: FactsCollection
Type: TargetRepositories
Message_data:
{
    "custom_repos": [
        {
            "baseurl": "file:///iso/AppStream",
            "enabled": true,
            "name": "AppStream",
            "repoid": "AppStream"
        },
        {
            "baseurl": "file:///iso/BaseOS",
            "enabled": true,
            "name": "BaseOS",
            "repoid": "BaseOS"
        },
        {
            "baseurl": "https://mirror.stream.centos.org/10-stream/RT/x86_64/os/",
            "enabled": false,
            "name": "APPSTREAM",
            "repoid": "RT"
        }
    ],
    "distro_repos": [
        {
            "repoid": "appstream"
        },
        {
            "repoid": "baseos"
        },
        {
            "repoid": "rt"
        }
    ],
    "rhel_repos": []
}
######################################################################
```
```
[root@localhost ~]# leapp-inspector messages --type UsedTargetRepositories
######################################################################
                          PRODUCED MESSAGES
######################################################################
Stamp: 2026-08-18T14:31:56.264114Z
Actor: target_userspace_creator
Phase: TargetTransactionFactsCollection
Type: UsedTargetRepositories
Message_data:
{
    "repos": [
        {
            "repoid": "appstream"
        },
        {
            "repoid": "rt"
        },
        {
            "repoid": "BaseOS"
        },
        {
            "repoid": "AppStream"
        },
        {
            "repoid": "RT"
        },
        {
            "repoid": "baseos"
        }
    ]
}
######################################################################
```

</p>
</details>

**There is the known problem that we currently have no way to tell leapp not to use distro-provided repos.**
Otherwise works ok.


Jira: RHEL-143786