### PR TITLE
feat(net-naming-scheme): enable by default on CS 9to10

### DIFF
--- a/repos/system_upgrade/common/actors/emit_net_naming_scheme/libraries/emit_net_naming.py
+++ b/repos/system_upgrade/common/actors/emit_net_naming_scheme/libraries/emit_net_naming.py
@@ -1,5 +1,5 @@
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common.config import get_env, get_target_distro_id, version
+from leapp.libraries.common.config import get_env, version
 from leapp.libraries.stdlib import api
 from leapp.models import (
     KernelCmdline,
@@ -49,11 +49,9 @@ def is_net_scheme_compatible_with_current_cmdline():
 def emit_msgs_to_use_net_naming_schemes():
     is_feature_enabled = get_env('LEAPP_DISABLE_NET_NAMING_SCHEMES', '0') != '1'
 
-    is_net_naming_available = version.get_target_major_version() == "9" or (
-        version.matches_target_version(">= 10.2")
-        # TODO the net-naming-sysattrs pkg is not yet available on CS10, remove
-        # this when it becomes
-        and not get_target_distro_id() == "centos"
+    is_net_naming_available = (
+        version.get_target_major_version() == "9"
+        or version.matches_target_version(">= 10.2")
     )
 
     if not (is_feature_enabled and is_net_naming_available):

--- a/repos/system_upgrade/common/actors/emit_net_naming_scheme/tests/test_emit_net_naming_scheme.py
+++ b/repos/system_upgrade/common/actors/emit_net_naming_scheme/tests/test_emit_net_naming_scheme.py
@@ -95,13 +95,8 @@ def test_emit_msgs_to_use_net_naming_schemes(
     pkg_name = emit_net_naming_lib.NET_NAMING_SYSATTRS_RPM_NAME[target_major]
     produced_messages = api.produce.model_instances
 
-    if (
-        is_net_scheme_enabled
-        # the package is available since 10.2
-        and target_ver != "10.0"
-        # TODO not yet available in CS 10, remove this when it is
-        and not (target_distro == "centos" and target_major == "10")
-    ):
+    # the package is available since 10.2
+    if is_net_scheme_enabled and target_ver != "10.0":
         userspace_tasks = ensure_one_msg_of_type_produced(produced_messages, TargetUserSpaceUpgradeTasks)
         assert userspace_tasks.install_rpms == [pkg_name]
 


### PR DESCRIPTION
This was done for RHEL 9to10 in 91f37a3913c1608b24c9aa583ac3b13a08aace71.

Jira: RHEL-148291