### PR TITLE
Enable logrotate.timer during 8to9 IPU

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/enablelogrotatetimer/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/enablelogrotatetimer/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import enablelogrotatetimer
+from leapp.models import SystemdServicesInfoTarget, SystemdServicesTasks
+from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
+
+
+class EnableLogrotateTimer(Actor):
+    """
+    Enable logrotate.timer on the target system after upgrade
+
+    The logrotate.timer systemd timer unit replaces the traditional cron-based
+    logrotate execution used in RHEL 8. This actor ensures the timer is enabled
+    after the in-place upgrade is complete.
+    """
+
+    name = 'enable_logrotate_timer'
+    consumes = (SystemdServicesInfoTarget,)
+    produces = (SystemdServicesTasks,)
+    tags = (FinalizationPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        enablelogrotatetimer.process()

--- a/repos/system_upgrade/el8toel9/actors/enablelogrotatetimer/libraries/enablelogrotatetimer.py
+++ b/repos/system_upgrade/el8toel9/actors/enablelogrotatetimer/libraries/enablelogrotatetimer.py
@@ -1,0 +1,13 @@
+from leapp.libraries.common.systemd import enable_unit
+from leapp.libraries.stdlib import api, CalledProcessError
+
+LOGROTATE_TIMER = 'logrotate.timer'
+
+
+def process():
+    try:
+        enable_unit(LOGROTATE_TIMER)
+    except CalledProcessError as e:
+        api.current_logger().error(
+            "Failed to enable {}: {}".format(LOGROTATE_TIMER, e)
+        )

--- a/repos/system_upgrade/el8toel9/actors/enablelogrotatetimer/tests/test_enablelogrotatetimer.py
+++ b/repos/system_upgrade/el8toel9/actors/enablelogrotatetimer/tests/test_enablelogrotatetimer.py
@@ -1,0 +1,31 @@
+from leapp.libraries.actor import enablelogrotatetimer
+from leapp.libraries.common.testutils import logger_mocked
+from leapp.libraries.stdlib import api, CalledProcessError
+
+
+def test_success(monkeypatch):
+
+    def mock_enable_unit(unit):
+        assert unit == 'logrotate.timer'
+
+    monkeypatch.setattr(enablelogrotatetimer, "enable_unit", mock_enable_unit)
+    enablelogrotatetimer.process()
+
+
+def test_failed_to_enable(monkeypatch):
+
+    def mock_enable_unit(unit):
+        assert unit == 'logrotate.timer'
+        raise CalledProcessError(
+            "Failed to enable logrotate.titmer",
+            ["systemctl", "enable", "logrotate.timer"],
+            {
+                "exit_code": 1,
+                "stderr": "err",
+            },
+        )
+
+    monkeypatch.setattr(enablelogrotatetimer, "enable_unit", mock_enable_unit)
+    monkeypatch.setattr(api, "current_logger", logger_mocked())
+    enablelogrotatetimer.process()
+    assert "Failed to enable logrotate.timer" in api.current_logger.errmsg[0]


### PR DESCRIPTION
On el8 logrotate uses cron, on el9 a systemd timer is used. This is not automatically migrated during an IPU, this patch adds a actor that does so.

Jira: RHEL-17361