### PR TITLE
Respect distro names in reports

### DIFF
--- a/repos/system_upgrade/common/actors/checkdetecteddevicesanddrivers/libraries/checkdddd.py
+++ b/repos/system_upgrade/common/actors/checkdetecteddevicesanddrivers/libraries/checkdddd.py
@@ -3,6 +3,7 @@ from enum import IntEnum
 
 from leapp import reporting
 from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import DetectedDeviceOrDriver
 
@@ -22,17 +23,19 @@ def create_inhibitors(inhibiting_entries):
     if drivers:
         reporting.create_report([
             reporting.Title(
-                'Leapp detected loaded kernel drivers which have been removed '
-                'in RHEL {}. Upgrade cannot proceed.'.format(get_target_major_version())
+                'Leapp detected loaded kernel drivers that have been removed in'
+                ' the target OS. Upgrade cannot proceed.'
             ),
             reporting.Summary(
                 (
-                    'Support for the following RHEL {source} device drivers has been removed in RHEL {target}:\n'
+                    'Support for the following {source_distro} {source_version} device drivers has'
+                    ' been removed in {target_distro} {target_version}:\n'
                     '     - {drivers}\n'
                 ).format(
                     drivers='\n     - '.join([entry.driver_name for entry in drivers]),
-                    target=get_target_major_version(),
-                    source=get_source_major_version(),
+                    target_version=get_target_major_version(),
+                    source_version=get_source_major_version(),
+                    **DISTRO_REPORT_NAMES
                 )
             ),
             reporting.ExternalLink(
@@ -52,52 +55,57 @@ def create_inhibitors(inhibiting_entries):
             reporting.Audience('sysadmin'),
             reporting.Groups([reporting.Groups.KERNEL, reporting.Groups.DRIVERS]),
             reporting.Severity(reporting.Severity.HIGH),
-            reporting.Groups([reporting.Groups.INHIBITOR])
+            reporting.Groups([reporting.Groups.INHIBITOR]),
+            reporting.Key('f08a07da902958defa4f5c2699fae9ec2eb67c5b'),
         ])
 
     devices = inhibiting_entries.get(MessagingClass.DEVICES)
     if devices:
         reporting.create_report([
             reporting.Title(
-                'Leapp detected devices which are no longer supported in RHEL {}. Upgrade cannot proceed.'.format(
-                    get_target_major_version())
+                'Leapp detected devices no longer supported by the target OS.'
+                ' Upgrade cannot proceed.'
             ),
             reporting.Summary(
                 (
-                    'Support for the following devices has been removed in RHEL {target}:\n'
+                    'Support for the following devices has been removed in {target_distro} {version}:\n'
                     '     - {devices}\n'
                 ).format(
                     devices='\n     - '.join(['{name} ({pci})'.format(name=entry.device_name,
                                              pci=entry.device_id) for entry in devices]),
-                    target=get_target_major_version(),
+                    version=get_target_major_version(),
+                    **DISTRO_REPORT_NAMES
                 )
             ),
             reporting.Audience('sysadmin'),
             reporting.Groups([reporting.Groups.KERNEL]),
             reporting.Severity(reporting.Severity.HIGH),
-            reporting.Groups([reporting.Groups.INHIBITOR])
+            reporting.Groups([reporting.Groups.INHIBITOR]),
+            reporting.Key('ccfc28592c82123649fc824c6c1c89cabfceae7c'),
         ])
 
     cpus = inhibiting_entries.get(MessagingClass.CPUS)
     if cpus:
         reporting.create_report([
             reporting.Title(
-                'Leapp detected a processor which is no longer supported in RHEL {}. Upgrade cannot proceed.'.format(
-                    get_target_major_version())
+                'Leapp detected a processor no longer supported by the target OS.'
+                ' Upgrade cannot proceed.'
             ),
             reporting.Summary(
                 (
-                    'Support for the following processors has been removed in RHEL {target}:\n'
+                    'Support for the following processors has been removed in {target_distro} {version}:\n'
                     '     - {processors}\n'
                 ).format(
                     processors='\n     - '.join([entry.device_name for entry in cpus]),
-                    target=get_target_major_version(),
+                    version=get_target_major_version(),
+                    **DISTRO_REPORT_NAMES
                 )
             ),
             reporting.Audience('sysadmin'),
             reporting.Groups([reporting.Groups.KERNEL, reporting.Groups.BOOT]),
             reporting.Severity(reporting.Severity.HIGH),
-            reporting.Groups([reporting.Groups.INHIBITOR])
+            reporting.Groups([reporting.Groups.INHIBITOR]),
+            reporting.Key('e3e9e4d2566733e2f843db9823c8568b9b6922f9'),
         ])
 
 
@@ -109,65 +117,69 @@ def create_warnings(unmaintained_entries):
     if drivers:
         reporting.create_report([
             reporting.Title(
-                'Leapp detected loaded kernel drivers which are no longer maintained in RHEL {}.'.format(
-                    get_target_major_version())
+                'Leapp detected loaded kernel drivers no longer maintained in the target OS'
             ),
             reporting.Summary(
                 (
-                    'The following RHEL {source} device drivers are no longer maintained RHEL {target}:\n'
+                    'The following {source_distro} {source_version} device drivers are no longer'
+                    ' maintained {target_distro} {target_version}:\n'
                     '     - {drivers}\n'
                 ).format(
                     drivers='\n     - '.join([entry.driver_name for entry in drivers]),
-                    target=get_target_major_version(),
-                    source=get_source_major_version(),
+                    target_version=get_target_major_version(),
+                    source_version=get_source_major_version(),
+                    **DISTRO_REPORT_NAMES
                 )
             ),
             reporting.Audience('sysadmin'),
             reporting.Groups([reporting.Groups.KERNEL, reporting.Groups.DRIVERS]),
             reporting.Severity(reporting.Severity.HIGH),
+            reporting.Key('0ff2413fd3cb0358736bf9be597f4dbdf58f2c4d'),
         ])
 
     devices = unmaintained_entries.get(MessagingClass.DEVICES)
     if devices:
         reporting.create_report([
             reporting.Title(
-                'Leapp detected devices which are no longer maintained in RHEL {}'.format(
-                    get_target_major_version())
+                'Leapp detected devices no longer maintained in the target OS'
             ),
             reporting.Summary(
                 (
-                    'The support for the following devices has been removed in RHEL {target} and '
+                    'The support for the following devices has been removed in {target_distro} {version} and '
                     'are no longer maintained:\n     - {devices}\n'
                 ).format(
                     devices='\n     - '.join(['{name} ({pci})'.format(name=entry.device_name,
                                              pci=entry.device_id) for entry in devices]),
-                    target=get_target_major_version(),
+                    version=get_target_major_version(),
+                    **DISTRO_REPORT_NAMES
                 )
             ),
             reporting.Audience('sysadmin'),
             reporting.Groups([reporting.Groups.KERNEL]),
             reporting.Severity(reporting.Severity.HIGH),
+            reporting.Key('261e3e55a3a80346f2fcc2a1e59c64f7a4caa263'),
         ])
 
     cpus = unmaintained_entries.get(MessagingClass.CPUS)
     if cpus:
         reporting.create_report([
             reporting.Title(
-                'Leapp detected a processor which is no longer maintained in RHEL {}.'.format(
-                    get_target_major_version())
+                'Leapp detected a processor no longer maintained in the target OS'
             ),
             reporting.Summary(
                 (
-                    'The following processors are no longer maintained in RHEL {target}:\n'
+                    'The following processors are no longer maintained in {target_distro} {version}:\n'
                     '     - {processors}\n'
                 ).format(
                     processors='\n     - '.join([entry.device_name for entry in cpus]),
-                    target=get_target_major_version(),
+                    version=get_target_major_version(),
+                    **DISTRO_REPORT_NAMES
                 )
             ),
             reporting.Audience('sysadmin'),
             reporting.Groups([reporting.Groups.KERNEL, reporting.Groups.BOOT]),
             reporting.Severity(reporting.Severity.HIGH),
+            reporting.Key('61eb181bbc56328fbe03b5229d25a8ea5ebdc7a2'),
         ])
 
 

--- a/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
+++ b/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.libraries.common.config.version import get_source_major_version
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import (
     CephInfo,
@@ -50,18 +51,18 @@ def report_inhibitor(luks1_partitions, no_tpm2_partitions):
     if luks1_partitions:
 
         summary += (
-            '\n\nSince RHEL 8 the default format for LUKS encryption is LUKS2.'
-            ' Despite the old LUKS1 format is still supported on RHEL systems'
+            '\n\nSince {target_distro} 8 the default format for LUKS encryption is LUKS2.'
+            ' Despite the old LUKS1 format is still supported on {target_distro} systems'
             ' it has some limitations in comparison to LUKS2.'
             ' Only the LUKS2 format is supported for upgrades.'
-            ' The following LUKS1 partitions have been discovered on your system:{}'
-            .format(''.join(_formatted_list_output(luks1_partitions)))
+            ' The following LUKS1 partitions have been discovered on your system:{partitions}'
+            .format(**DISTRO_REPORT_NAMES, partitions=''.join(_formatted_list_output(luks1_partitions)))
         )
         report_hints.append(reporting.Remediation(
             hint=(
                 'Convert your LUKS1 encrypted devices to LUKS2 and bind it to TPM2 using clevis.'
                 ' If this is not possible in your case consider clean installation'
-                ' of the target RHEL system instead.'
+                ' of the target {target_distro} system instead.'.format_map(DISTRO_REPORT_NAMES)
             )
         ))
         report_hints.append(reporting.ExternalLink(

--- a/repos/system_upgrade/common/actors/checkluks/tests/test_checkluks.py
+++ b/repos/system_upgrade/common/actors/checkluks/tests/test_checkluks.py
@@ -1,3 +1,4 @@
+from leapp.libraries.common import distro
 from leapp.libraries.common.config import version
 from leapp.models import (
     CephInfo,
@@ -17,6 +18,9 @@ _REPORT_TITLE_UNSUITABLE = 'Detected LUKS devices unsuitable for in-place upgrad
 
 def test_actor_with_luks1_notpm(monkeypatch, current_actor_context):
     monkeypatch.setattr(version, 'get_source_major_version', lambda: '8')
+    monkeypatch.setattr(distro, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
+
     luks_dump = LuksDump(
         version=1,
         uuid='dd09e6d4-b595-4f1c-80b8-fd47540e6464',

--- a/repos/system_upgrade/common/actors/checklvm/libraries/checklvm.py
+++ b/repos/system_upgrade/common/actors/checklvm/libraries/checklvm.py
@@ -1,6 +1,7 @@
 import os
 
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import (
@@ -19,9 +20,9 @@ LVM_DEVICES_FILE_PATH_PREFIX = '/etc/lvm/devices'
 def _report_filter_detection():
     title = 'LVM filter definition detected.'
     summary = (
-        'Beginning with RHEL 9, LVM devices file is used by default to select devices used by '
-        f'LVM. Since leapp detected the use of LVM filter in the {LVM_CONFIG_PATH} configuration '
-        'file, the configuration won\'t be modified to use devices file during the upgrade and '
+        f'Beginning with {DISTRO_REPORT_NAMES.target} 9, LVM devices file is used by default to '
+        f'select devices used by LVM. Since leapp detected the use of LVM filter in the {LVM_CONFIG_PATH} '
+        'configuration file, the configuration won\'t be modified to use devices file during the upgrade and '
         'the LVM filter will remain in use after the upgrade.'
     )
 

--- a/repos/system_upgrade/common/actors/checkmemory/libraries/checkmemory.py
+++ b/repos/system_upgrade/common/actors/checkmemory/libraries/checkmemory.py
@@ -1,6 +1,6 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common.config import architecture, version
+from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 from leapp.models import MemoryInfo
 
@@ -32,23 +32,24 @@ def process():
     minimum_req_error = _check_memory(memoryinfo)
 
     if minimum_req_error:
-        title = 'Minimum memory requirements for RHEL {} are not met'.format(version.get_target_major_version())
+        title = "Minimum memory requirements for the target OS are not met"
         summary = 'Memory detected: {} MiB, required: {} MiB'.format(
             int(minimum_req_error['detected'] / 1024),
             int(minimum_req_error['minimal_req'] / 1024),
         )
         reporting.create_report([
-                          reporting.Title(title),
-                          reporting.Summary(summary),
-                          reporting.Severity(reporting.Severity.HIGH),
-                          reporting.Groups([reporting.Groups.SANITY, reporting.Groups.INHIBITOR]),
-                          reporting.ExternalLink(
-                              url='https://access.redhat.com/solutions/7014179',
-                              title='Leapp upgrade fail with error"Minimum memory requirements '
-                                    'for RHEL 8 are not met"Upgrade cannot proceed'
-                          ),
-                          reporting.ExternalLink(
-                            url='https://access.redhat.com/articles/rhel-limits',
-                            title='Red Hat Enterprise Linux Technology Capabilities and Limits'
-                          ),
-                      ])
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.SANITY, reporting.Groups.INHIBITOR]),
+            reporting.ExternalLink(
+                url='https://access.redhat.com/solutions/7014179',
+                title='Leapp upgrade fail with error "Minimum memory requirements '
+                    'for RHEL 8 are not met"Upgrade cannot proceed'
+            ),
+            reporting.ExternalLink(
+                url='https://access.redhat.com/articles/rhel-limits',
+                title='Red Hat Enterprise Linux Technology Capabilities and Limits'
+            ),
+            reporting.Key('be50646b45beb8304c13daf5380d836a4be8e1cc'),
+        ])

--- a/repos/system_upgrade/common/actors/checkmemory/tests/test_checkmemory.py
+++ b/repos/system_upgrade/common/actors/checkmemory/tests/test_checkmemory.py
@@ -21,7 +21,7 @@ def test_check_memory_high(monkeypatch):
 
 
 def test_report(monkeypatch):
-    title_msg = 'Minimum memory requirements for RHEL 9 are not met'
+    title_msg = 'Minimum memory requirements for the target OS are not met'
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
     monkeypatch.setattr(api, 'consume', lambda x: iter([MemoryInfo(mem_total=129)]))
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())

--- a/repos/system_upgrade/common/actors/checkmicroarchitecture/libraries/checkmicroarchitecture.py
+++ b/repos/system_upgrade/common/actors/checkmicroarchitecture/libraries/checkmicroarchitecture.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from leapp import reporting
 from leapp.libraries.common.config.architecture import ARCH_X86_64, matches_architecture
 from leapp.libraries.common.config.version import get_target_major_version
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import CPUInfo
 
@@ -13,11 +14,11 @@ X86_64_V3_FLAGS = ['avx2', 'bmi1', 'bmi2', 'f16c', 'fma', 'abm', 'movbe', 'xsave
 MicroarchInfo = namedtuple('MicroarchInfo', ('required_flags', 'extra_report_fields', 'microarch_ver'))
 
 
-def _inhibit_upgrade(missing_flags, target_rhel, microarch_ver, extra_report_fields=None):
-    title = 'Current x86-64 microarchitecture is unsupported in {0}'.format(target_rhel)
+def _inhibit_upgrade(missing_flags, target_distro, microarch_ver, extra_report_fields=None):
+    title = 'Current x86-64 microarchitecture is unsupported in the target OS'
     summary = ('{0} has a higher CPU requirement than older versions, it now requires a CPU '
                'compatible with {1} instruction set or higher.\n\n'
-               'Missings flags detected are: {2}\n').format(target_rhel, microarch_ver, ', '.join(missing_flags))
+               'Missings flags detected are: {2}\n').format(target_distro, microarch_ver, ', '.join(missing_flags))
 
     report_fields = [
         reporting.Title(title),
@@ -28,7 +29,8 @@ def _inhibit_upgrade(missing_flags, target_rhel, microarch_ver, extra_report_fie
         reporting.Remediation(hint=('If a case of using virtualization, virtualization platforms often allow '
                                     'configuring a minimum denominator CPU model for compatibility when migrating '
                                     'between different CPU models. Ensure that minimum requirements are not below '
-                                    'that of {0}\n').format(target_rhel)),
+                                    'that of {0}\n').format(target_distro)),
+        reporting.Key('0f48cdbe5aa2584e2ca7f4eb470b9b79da9e515d')
     ]
 
     if extra_report_fields:
@@ -69,14 +71,15 @@ def process():
 
     microarch_info = rhel_major_to_microarch_reqs.get(get_target_major_version())
     if not microarch_info:
-        api.current_logger().info('No known microarchitecture requirements are known for target RHEL%s.',
-                                  get_target_major_version())
+        api.current_logger().info(
+            'No known microarchitecture requirements are known'
+            ' for target {target_distro} {version}.'.format(**DISTRO_REPORT_NAMES, version=get_target_major_version()))
         return
 
     missing_flags = [flag for flag in microarch_info.required_flags if flag not in cpuinfo.flags]
     api.current_logger().debug('Required flags missing: %s', missing_flags)
     if missing_flags:
         _inhibit_upgrade(missing_flags,
-                         'RHEL{0}'.format(get_target_major_version()),
+                         '{target_distro} {version}'.format(**DISTRO_REPORT_NAMES, version=get_target_major_version()),
                          microarch_info.microarch_ver,
                          extra_report_fields=microarch_info.extra_report_fields)

--- a/repos/system_upgrade/common/actors/checkosrelease/actor.py
+++ b/repos/system_upgrade/common/actors/checkosrelease/actor.py
@@ -6,7 +6,7 @@ from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 class CheckOSRelease(Actor):
     """
-    Check if the current RHEL minor version is supported. If not, inhibit the upgrade process.
+    Check if the current distro version is supported. If not, inhibit the upgrade process.
 
     This check can be skipped by using the LEAPP_DEVEL_SKIP_CHECK_OS_RELEASE environment variable.
     """

--- a/repos/system_upgrade/common/actors/checkosrelease/libraries/checkosrelease.py
+++ b/repos/system_upgrade/common/actors/checkosrelease/libraries/checkosrelease.py
@@ -2,6 +2,7 @@ import os
 
 from leapp import reporting
 from leapp.libraries.common.config import version
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 
 COMMON_REPORT_TAGS = [reporting.Groups.SANITY]
 FMT_LIST_SEPARATOR = '\n    - '
@@ -14,7 +15,9 @@ def skip_check():
     if os.getenv('LEAPP_DEVEL_SKIP_CHECK_OS_RELEASE'):
         reporting.create_report([
             reporting.Title('Skipped OS release check'),
-            reporting.Summary('Source RHEL release check skipped via LEAPP_DEVEL_SKIP_CHECK_OS_RELEASE env var.'),
+            reporting.Summary(
+                'Source system release check skipped via LEAPP_DEVEL_SKIP_CHECK_OS_RELEASE env variable.'
+            ),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups(COMMON_REPORT_TAGS)
         ] + related)
@@ -24,7 +27,7 @@ def skip_check():
 
 
 def check_os_version():
-    """ Check the RHEL minor version and inhibit the upgrade if it does not match the supported ones """
+    """ Check the distro version and inhibit the upgrade if it does not match the supported ones """
     if not version.is_supported_version():
         supported_releases = []
         for rel in version.SUPPORTED_VERSIONS:
@@ -33,7 +36,8 @@ def check_os_version():
         current_release = ' '.join(version.current_version()).upper()
         reporting.create_report([
             reporting.Title(
-                'The installed OS version is not supported for the in-place upgrade to the target RHEL version'
+                'The installed OS version is not supported for the in-place upgrade'
+                ' to the target {target_distro} version'.format_map(DISTRO_REPORT_NAMES)
             ),
             reporting.Summary(
                 'The supported OS releases for the upgrade process:'

--- a/repos/system_upgrade/common/actors/checkosrelease/tests/test_checkosrelease.py
+++ b/repos/system_upgrade/common/actors/checkosrelease/tests/test_checkosrelease.py
@@ -3,7 +3,8 @@ import os
 from leapp import reporting
 from leapp.libraries.actor import checkosrelease
 from leapp.libraries.common.config import version
-from leapp.libraries.common.testutils import create_report_mocked, produce_mocked
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
 from leapp.utils.report import is_inhibitor
 
 
@@ -26,6 +27,7 @@ def test_no_skip_check(monkeypatch):
 
 
 def test_not_supported_release(monkeypatch):
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
     monkeypatch.setattr(version, "is_supported_version", lambda: False)
     monkeypatch.setattr(version, "get_source_major_version", lambda: '8')
     monkeypatch.setattr(version, "current_version", lambda: ('bad', '8'))

--- a/repos/system_upgrade/common/actors/checkselinux/libraries/checkselinux.py
+++ b/repos/system_upgrade/common/actors/checkselinux/libraries/checkselinux.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.libraries.common.config.version import get_target_major_version
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import KernelCmdlineArg, SELinuxFacts, SelinuxPermissiveDecision, SelinuxRelabelDecision
 
@@ -20,10 +21,10 @@ def process():
             reporting.create_report([
                 reporting.Title('LEAPP detected SELinux disabled in "/etc/selinux/config"'),
                 reporting.Summary(
-                    'On RHEL 9, disabling SELinux in "/etc/selinux/config" is no longer possible. '
-                    'This way, the system starts with SELinux enabled but with no policy loaded. LEAPP '
+                    'On {target_distro} 9, disabling SELinux in "/etc/selinux/config" is no longer possible. '
+                    'This way, the system starts with SELinux enabled but with no policy loaded. Leapp '
                     'will automatically disable SELinux using "SELINUX=0" kernel command line parameter. '
-                    'However, Red Hat strongly recommends to have SELinux enabled'
+                    'However, it is strongly recommended to have SELinux enabled'.format_map(DISTRO_REPORT_NAMES)
                 ),
                 reporting.Severity(reporting.Severity.INFO),
                 reporting.Groups([reporting.Groups.SELINUX]),

--- a/repos/system_upgrade/common/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
+++ b/repos/system_upgrade/common/actors/kernelcmdlineconfig/libraries/kernelcmdlineconfig.py
@@ -5,6 +5,8 @@ from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries import stdlib
 from leapp.libraries.common.config import architecture, version
+from leapp.libraries.common.config.version import get_target_major_version
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import (
     InstalledTargetKernelInfo,
@@ -120,13 +122,13 @@ def _extract_grubby_value(record):
 def report_multple_entries_for_default_kernel():
     if use_cmdline_file():
         report_hint = (
-            'After the system has been rebooted into the new version of RHEL,'
+            'After the system has been rebooted into the {target_distro} {target_version},'
             ' check that configured default kernel cmdline arguments in /etc/kernel/cmdline '
             ' are correct. In case that different arguments are expected, update the file as needed.'
-        )
+        ).format(**DISTRO_REPORT_NAMES, target_version=get_target_major_version())
     else:
         report_hint = (
-            'After the system has been rebooted into the new version of RHEL,'
+            'After the system has been rebooted into the {target_distro} {target_version},'
             ' check that configured default kernel cmdline arguments are set as expected, using'
             ' the `grub2-editenv list` command. '
             ' If different default arguments are expected, update them using grub2-editenv.\n'
@@ -138,7 +140,7 @@ def report_multple_entries_for_default_kernel():
             ' then run the following grub2-editenv command:\n\n'
             '    # grub2-editenv - set "kernelopts=root=/dev/mapper/rhel_ibm--root'
             ' ro console=tty0 console=ttyS0,115200 rd_NO_PLYMOUTH"'
-        )
+        ).format(**DISTRO_REPORT_NAMES, target_version=get_target_major_version())
 
     reporting.create_report([
         reporting.Title('Ensure that expected default kernel cmdline arguments are set'),
@@ -243,14 +245,14 @@ def entrypoint(configs=None):
 
         if use_cmdline_file():
             report_hint = (
-                'After the system has been rebooted into the new version of RHEL, you'
+                'After the system has been rebooted into the {target_distro} {target_version}, you'
                 ' should take the kernel cmdline arguments from /proc/cmdline (Everything'
                 ' except the BOOT_IMAGE entry and initrd entries) and copy them into'
                 ' /etc/kernel/cmdline before installing any new kernels.'
-            )
+            ).format(**DISTRO_REPORT_NAMES, target_version=get_target_major_version())
         else:
             report_hint = (
-                'After the system has been rebooted into the new version of RHEL, you'
+                'After the system has been rebooted into the {target_distro} {target_version}, you'
                 ' should take the kernel cmdline arguments from /proc/cmdline (Everything'
                 ' except the BOOT_IMAGE entry and initrd entries) and then use the'
                 ' grub2-editenv command to make them the default kernel args.  For example,'
@@ -261,7 +263,7 @@ def entrypoint(configs=None):
                 ' then run the following grub2-editenv command:\n\n'
                 '    # grub2-editenv - set "kernelopts=root=/dev/mapper/rhel_ibm--root'
                 ' ro console=tty0 console=ttyS0,115200 rd_NO_PLYMOUTH"'
-            )
+            ).format(**DISTRO_REPORT_NAMES, target_version=get_target_major_version())
 
         reporting.create_report([
             reporting.Title('Could not set the kernel arguments for future kernels'),

--- a/repos/system_upgrade/common/actors/opensshpermitrootlogincheck/actor.py
+++ b/repos/system_upgrade/common/actors/opensshpermitrootlogincheck/actor.py
@@ -3,6 +3,7 @@ from leapp.actors import Actor
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor.opensshpermitrootlogincheck import global_value
 from leapp.libraries.common.config.version import get_source_major_version
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import OpenSshConfig, Report
 from leapp.reporting import create_report
@@ -62,12 +63,12 @@ class OpenSshPermitRootLoginCheck(Actor):
             create_report([
                 reporting.Title('Possible problems with remote login using root account'),
                 reporting.Summary(
-                    'OpenSSH configuration file will get updated to RHEL9 '
+                    'OpenSSH configuration file will get updated to {target_distro} 9 '
                     'version, no longer allowing root login with password. '
                     'It is a good practice to use non-root administrative '
                     'user and non-password authentications, but if you rely '
                     'on the remote root login, this change can lock you out '
-                    'of this system.'
+                    'of this system.'.format_map(DISTRO_REPORT_NAMES)
                 ),
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Groups(COMMON_REPORT_TAGS),
@@ -93,11 +94,13 @@ class OpenSshPermitRootLoginCheck(Actor):
             create_report([
                 reporting.Title('Remote root logins globally allowed using password'),
                 reporting.Summary(
-                    'RHEL9 no longer allows remote root logins, but the '
-                    'server configuration explicitly overrides this default. '
-                    'The configuration file will not be updated and root is '
-                    'still going to be allowed to login with password. '
-                    'This is not recommended and considered as a security risk.'
+                    '{target_distro} 9 no longer allows remote root logins, but '
+                    'the server configuration explicitly overrides this default. '
+                    'The configuration file will not be updated and root is still'
+                    'going to be allowed to login with password. This is not '
+                    'recommended and considered as a security risk. '.format_map(
+                        DISTRO_REPORT_NAMES
+                    )
                 ),
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Groups(COMMON_REPORT_TAGS),

--- a/repos/system_upgrade/common/actors/opensshpermitrootlogincheck/actor.py
+++ b/repos/system_upgrade/common/actors/opensshpermitrootlogincheck/actor.py
@@ -1,7 +1,7 @@
 from leapp import reporting
 from leapp.actors import Actor
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.actor.opensshpermitrootlogincheck import global_value, semantics_changes
+from leapp.libraries.actor.opensshpermitrootlogincheck import global_value
 from leapp.libraries.common.config.version import get_source_major_version
 from leapp.libraries.stdlib import api
 from leapp.models import OpenSshConfig, Report
@@ -46,72 +46,12 @@ class OpenSshPermitRootLoginCheck(Actor):
                 'Could not check openssh configuration', details={'details': 'No OpenSshConfig facts found.'}
             )
 
-        if get_source_major_version() == '7':
-            self.process7to8(config)
-        elif get_source_major_version() == '8':
+        if get_source_major_version() == '8':
             self.process8to9(config)
         elif int(get_source_major_version()) >= 9:
             pass
         else:
             api.current_logger().warning('Unknown source major version: {}'.format(get_source_major_version()))
-
-    @staticmethod
-    def process7to8(config):
-        # when the config was not modified, we can pass this check and let the
-        # rpm handle the configuration file update
-        if not config.modified:
-            return
-
-        # When the configuration does not contain *any* PermitRootLogin directive and
-        # the configuration file was locally modified, it will not get updated by
-        # RPM and the user might be locked away from the server with new default
-        if not config.permit_root_login:
-            create_report([
-                reporting.Title('Possible problems with remote login using root account'),
-                reporting.Summary(
-                    'OpenSSH configuration file does not explicitly state '
-                    'the option PermitRootLogin in sshd_config file, '
-                    'which will default in RHEL8 to "prohibit-password".'
-                ),
-                reporting.Severity(reporting.Severity.HIGH),
-                reporting.Groups(COMMON_REPORT_TAGS),
-                reporting.Remediation(
-                    hint='If you depend on remote root logins using passwords, consider '
-                         'setting up a different user for remote administration or adding '
-                         '"PermitRootLogin yes" to sshd_config. '
-                         'If this change is ok for you, add explicit '
-                         '"PermitRootLogin prohibit-password" to your sshd_config '
-                         'to ignore this inhibitor'
-                ),
-                reporting.Groups([reporting.Groups.INHIBITOR])
-            ] + COMMON_RESOURCES)
-            return
-
-        # Check if there is at least one PermitRootLogin other than "no"
-        # in match blocks (other than Match All).
-        # This usually means some more complicated setup depending on the
-        # default value being globally "yes" and being overwritten by this
-        # match block
-        if semantics_changes(config):
-            create_report([
-                reporting.Title('OpenSSH configured to allow root login'),
-                reporting.Summary(
-                    'OpenSSH is configured to deny root logins in match '
-                    'blocks, but not explicitly enabled in global or '
-                    '"Match all" context. This update changes the '
-                    'default to disable root logins using passwords '
-                    'so your server might get inaccessible.'
-                ),
-                reporting.Severity(reporting.Severity.HIGH),
-                reporting.Groups(COMMON_REPORT_TAGS),
-                reporting.Remediation(
-                    hint='Consider using different user for administrative '
-                         'logins or make sure your configuration file '
-                         'contains the line "PermitRootLogin yes" '
-                         'in global context if desired.'
-                ),
-                reporting.Groups([reporting.Groups.INHIBITOR])
-            ] + COMMON_RESOURCES)
 
     @staticmethod
     def process8to9(config):

--- a/repos/system_upgrade/common/actors/openssl/checkopensslconf/libraries/checkopensslconf.py
+++ b/repos/system_upgrade/common/actors/openssl/checkopensslconf/libraries/checkopensslconf.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.libraries.common.config import architecture, version
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import DistributionSignedRPM, TrackedFilesInfoSource
@@ -8,7 +9,7 @@ DEFAULT_OPENSSL_CONF = '/etc/pki/tls/openssl.cnf'
 URL_CRYPTOPOLICIES = {
     '8': 'https://red.ht/rhel-8-system-wide-crypto-policies',
     '9': 'https://red.ht/rhel-9-system-wide-crypto-policies',
-    '10': 'https://red.ht/rhel-10-system-wide-crypto-policies',  # TODO actually make the url
+    '10': 'https://red.ht/rhel-10-system-wide-crypto-policies',
 }
 
 
@@ -22,14 +23,14 @@ def check_ibmca():
     # is deprecated, so keep proper teminology to not confuse users.
     summary = (
         'The presence of openssl-ibmca package suggests that the system may be configured'
-        ' to use the IBMCA OpenSSL engine.'
-        ' Due to major changes in OpenSSL and libica between RHEL {source} and RHEL {target} it is not'
-        ' possible to migrate OpenSSL configuration files automatically. Therefore,'
-        ' it is necessary to enable IBMCA providers in the OpenSSL config file manually'
-        ' after the system upgrade.'
-        .format(
-            source=version.get_source_major_version(),
-            target=version.get_target_major_version(),
+        ' to use the IBMCA OpenSSL engine. Due to major changes in OpenSSL and libica'
+        ' between {source_distro} {source_version} and {target_distro} {target_version}'
+        ' it is not possible to migrate OpenSSL configuration files automatically.'
+        ' Therefore, it is necessary to enable IBMCA providers in the OpenSSL config file'
+        ' manually after the system upgrade.'.format(
+            source_version=version.get_source_major_version(),
+            target_version=version.get_target_major_version(),
+            **DISTRO_REPORT_NAMES
         )
     )
 
@@ -79,7 +80,7 @@ def check_default_openssl():
     # current wording could be inaccurate.
     summary = (
         'The OpenSSL configuration file ({fpath}) has been'
-        ' modified on the system. RHEL 8 (and newer) systems provide a crypto-policies'
+        ' modified on the system. {target_distro} 8 (and newer) systems provide a crypto-policies'
         ' mechanism ensuring usage of system-wide secure cryptography algorithms.'
         ' Also the target system uses newer version of OpenSSL that is not fully'
         ' compatible with the current one.'
@@ -92,20 +93,22 @@ def check_default_openssl():
         ' the upgrade if it depends on the current OpenSSL configuration.'
         ' Such a problem may be caused by using a particular OpenSSL engine, as'
         ' OpenSSL engines built for the'
-        ' RHEL {source} system are not compatible with RHEL {target}.'
+        ' {source_distro} {source_version} system are not compatible with'
+        ' {target_distro} {target_version}.'
         .format(
             fpath=DEFAULT_OPENSSL_CONF,
-            source=version.get_source_major_version(),
-            target=version.get_target_major_version()
+            source_version=version.get_source_major_version(),
+            target_version=version.get_target_major_version(),
+            **DISTRO_REPORT_NAMES
         )
     )
     if version.get_target_major_version() == '9':
         # NOTE(pstodulk): that a try to make things with engine/providers a
         # little bit better (see my TODO note above)
         summary += (
-            '\n\nNote the legacy ENGINE API is deprecated since RHEL 8 and'
+            '\n\nNote the legacy ENGINE API is deprecated since {target_distro} 8 and'
             ' it is required to use the new OpenSSL providers API instead on'
-            ' RHEL 9 systems.'
+            ' {target_distro} 9 systems.'.format_map(DISTRO_REPORT_NAMES)
         )
     hint = (
         'Check that your ability to login to the system does not depend on'

--- a/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
+++ b/repos/system_upgrade/common/actors/peseventsscanner/libraries/pes_events_scanner.py
@@ -7,6 +7,7 @@ from leapp.libraries.actor import peseventsscanner_repomap
 from leapp.libraries.actor.pes_event_parsing import Action, get_pes_events, Package
 from leapp.libraries.common import rpms
 from leapp.libraries.common.config import get_target_distro_id, version
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.libraries.stdlib.config import is_verbose
 from leapp.models import (
@@ -457,30 +458,37 @@ def replace_pesids_with_repoids_in_packages(packages, source_pkgs_repoids):
 
     required_target_pesids = {pkg.repository for pkg in packages_with_pesid}
 
-    pesid_to_repoid_map = get_pesid_to_repoid_map(required_target_pesids)
+    pesid_to_target_repoid_map = get_pesid_to_repoid_map(required_target_pesids)
 
-    packages_without_known_repoid = {pkg for pkg in packages_with_pesid if pkg.repository not in pesid_to_repoid_map}
+    packages_with_unknown_target_repoid = {
+        pkg
+        for pkg in packages_with_pesid
+        if pkg.repository not in pesid_to_target_repoid_map
+    }
 
-    if packages_without_known_repoid:
+    if packages_with_unknown_target_repoid:
         report_skipped_packages(
             title='Packages from unknown repositories may not be installed',
             message='packages may not be installed or upgraded due to repositories unknown to leapp:',
-            skipped_pkgs=packages_without_known_repoid,
+            skipped_pkgs=packages_with_unknown_target_repoid,
             remediation=(
-                'In case the listed repositories are mirrors of official repositories for RHEL'
-                ' (provided by Red Hat on CDN)'
-                ' and their repositories IDs has been customized, you can change'
+                'In case the listed repositories are mirrors of official repositories for {}'
+                ' and their repositories IDs have been customized, you can change'
                 ' the configuration to use the official IDs instead of fixing the problem.'
                 ' You can also review the projected DNF upgrade transaction result'
                 ' in the logs to see what is going to happen, as this does not necessarily mean'
                 ' that the listed packages will not be upgraded. You can also'
-                ' install any missing packages after the in-place upgrade manually.'
+                ' install any missing packages after the in-place upgrade manually.'.format(
+                    'RHEL (provided by Red Hat on CDN)'
+                    if get_target_distro_id() == 'rhel'
+                    else DISTRO_REPORT_NAMES.target
+                )
             ),
         )
 
-    packages_with_known_repoid = packages_with_pesid.difference(packages_without_known_repoid)
+    packages_with_known_repoid = packages_with_pesid.difference(packages_with_unknown_target_repoid)
     packages_with_repoid = {
-        Package(p.name, pesid_to_repoid_map[p.repository], p.modulestream) for p in packages_with_known_repoid
+        Package(p.name, pesid_to_target_repoid_map[p.repository], p.modulestream) for p in packages_with_known_repoid
     }
     # Packages without pesid are those for which we do not have an event, keep them in target packages
     return packages_with_repoid.union(packages_without_pesid)

--- a/repos/system_upgrade/common/actors/reportleftoverpackages/actor.py
+++ b/repos/system_upgrade/common/actors/reportleftoverpackages/actor.py
@@ -7,11 +7,11 @@ from leapp.tags import IPUWorkflowTag, RPMUpgradePhaseTag
 
 class ReportLeftoverPackages(Actor):
     """
-    Collect messages about leftover RHEL packages from older major versions and generate a report.
+    Generate a report about leftover distribution packages from older major versions.
 
-    Depending on execution of previous actors,
-    generated report contains information that there are still old RHEL packages
-    present on the system, which makes it unsupported or lists packages that have been removed.
+    Generated report informs about old distribution packages present on the system,
+    which makes it unsupported, and lists packages that have been removed if there
+    were any.
     """
 
     name = 'report_leftover_packages'

--- a/repos/system_upgrade/common/actors/reportleftoverpackages/libraries/reportleftoverpackages.py
+++ b/repos/system_upgrade/common/actors/reportleftoverpackages/libraries/reportleftoverpackages.py
@@ -1,4 +1,5 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import LeftoverPackages, RemovedPackages
 
@@ -11,15 +12,16 @@ def process():
     leftover_pkgs_to_remove = ['-'.join([pkg.name, pkg.version, pkg.release]) for pkg in leftover_packages.items]
 
     if removed_packages and removed_packages.items:
-        title = 'Leftover RHEL packages have been removed'
+        title = 'Leftover packages from the original OS have been removed'
         removed = ['-'.join([pkg.name, pkg.version, pkg.release]) for pkg in removed_packages.items]
         summary = (
-            'Following packages have been removed:{sep}{list}\n'
+            'Following {source_distro} packages have been removed:{sep}{list}\n'
             'Dependent packages may have been removed as well, please check that you are not missing '
             'any packages.'
             .format(
                 sep=FMT_LIST_SEPARATOR,
-                list=FMT_LIST_SEPARATOR.join(removed)
+                list=FMT_LIST_SEPARATOR.join(removed),
+                **DISTRO_REPORT_NAMES
             )
         )
         reporting.create_report([
@@ -27,23 +29,26 @@ def process():
             reporting.Summary(summary),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.SANITY]),
+            reporting.Key('5afbad560709afa4e40a160e40dfd44788ba9c3b'),
         ] + [reporting.RelatedResource('package', pkg.name) for pkg in removed_packages.items])
         return
 
     if leftover_packages and leftover_packages.items:
         summary = (
-            'Following RHEL packages have not been upgraded:{sep}{list}\n'
+            'Following {source_distro} packages have not been upgraded:{sep}{list}\n'
             'Please remove these packages to keep your system in supported state.'
             .format(
                 sep=FMT_LIST_SEPARATOR,
-                list=FMT_LIST_SEPARATOR.join(leftover_pkgs_to_remove)
+                list=FMT_LIST_SEPARATOR.join(leftover_pkgs_to_remove),
+                **DISTRO_REPORT_NAMES
             )
         )
         reporting.create_report([
-            reporting.Title('Some RHEL packages have not been upgraded'),
+            reporting.Title('Some packages from the original OS have not been upgraded'),
             reporting.Summary(summary),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.SANITY]),
+            reporting.Key('d424c3132ed78a8632b5c73d919909e453107c06'),
         ] + [reporting.RelatedResource('package', pkg.name) for pkg in leftover_packages.items])
     else:
         api.current_logger().info('No leftover packages, skipping...')

--- a/repos/system_upgrade/common/actors/reportleftoverpackages/tests/test_reportleftoverpackages.py
+++ b/repos/system_upgrade/common/actors/reportleftoverpackages/tests/test_reportleftoverpackages.py
@@ -27,7 +27,10 @@ def test_no_removed_packages_leftover_present(monkeypatch):
     reportleftoverpackages.process()
 
     assert reporting.create_report.called == 1
-    assert 'Some RHEL packages have not been upgraded' in reporting.create_report.report_fields['title']
+    assert (
+        'Some packages from the original OS have not been upgraded'
+        in reporting.create_report.report_fields['title']
+    )
     assert 'Following RHEL packages have not been upgraded' in reporting.create_report.report_fields['summary']
     summary = 'Please remove these packages to keep your system in supported state.'
     assert summary in reporting.create_report.report_fields['summary']
@@ -44,6 +47,6 @@ def test_removed_packages(monkeypatch):
     reportleftoverpackages.process()
 
     assert reporting.create_report.called == 1
-    assert 'Leftover RHEL packages have been removed' in reporting.create_report.report_fields['title']
-    assert 'Following packages have been removed' in reporting.create_report.report_fields['summary']
+    assert 'Leftover packages from the original OS have been removed' in reporting.create_report.report_fields['title']
+    assert 'Following RHEL packages have been removed' in reporting.create_report.report_fields['summary']
     assert 'rpm-1.0-1.el7' in reporting.create_report.report_fields['summary']

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -844,9 +844,8 @@ def _inhibit_if_no_base_repos(distro_repoids):
     no_baseos = all("baseos" not in ri for ri in distro_repoids)
     no_appstream = all("appstream" not in ri for ri in distro_repoids)
     if no_baseos or no_appstream:
-        reporting.create_report([
-            # TODO: Make the report distro agnostic
-            reporting.Title('Cannot find required basic RHEL target repositories.'),
+        report = [
+            reporting.Title('Cannot find required basic target OS repositories.'),
             reporting.Summary(
                 'This can happen when a repository ID was entered incorrectly either while using the --enablerepo'
                 ' option of leapp or in a third party actor that produces a CustomTargetRepositoryMessage.'
@@ -854,17 +853,6 @@ def _inhibit_if_no_base_repos(distro_repoids):
             reporting.Groups([reporting.Groups.REPOSITORY]),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.INHIBITOR]),
-            reporting.Remediation(hint=(
-                'It is required to have RHEL repositories on the system'
-                ' provided by the subscription-manager unless the --no-rhsm'
-                ' option is specified. You might be missing a valid SKU for'
-                ' the target system or have a failed network connection.'
-                ' Check whether your system is attached to a valid SKU that is'
-                ' providing RHEL {} repositories.'
-                ' If you are using Red Hat Satellite, read the upgrade documentation'
-                ' to set up Satellite and the system properly.'
-
-            ).format(target_major_version)),
             reporting.ExternalLink(
                 url='https://access.redhat.com/solutions/5392811',
                 title='RHEL 7 to RHEL 8 LEAPP Upgrade Failing When Using Red Hat Satellite'
@@ -874,8 +862,22 @@ def _inhibit_if_no_base_repos(distro_repoids):
                 # https://red.ht/preparing-for-upgrade-to-rhel9
                 # https://red.ht/preparing-for-upgrade-to-rhel10
                 url='https://red.ht/preparing-for-upgrade-to-rhel{}'.format(target_major_version),
-                title='Preparing for the upgrade')
-            ])
+                title='Preparing for the upgrade'),
+            reporting.Key('f5770a56e540f27d370da7b697cb4a2e81e2c30d'),
+        ]
+        if get_target_distro_id() == 'rhel':
+            report.append(reporting.Remediation(hint=(
+                'It is required to have RHEL repositories on the system'
+                ' provided by the subscription-manager unless the --no-rhsm'
+                ' option is specified. You might be missing a valid SKU for'
+                ' the target system or have a failed network connection.'
+                ' Check whether your system is attached to a valid SKU that is'
+                ' providing RHEL {} repositories.'
+                ' If you are using Red Hat Satellite, read the upgrade documentation'
+                ' to set up Satellite and the system properly.'
+                .format(target_major_version)))
+            )
+        reporting.create_report(report)
         raise StopActorExecution()
 
 

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/tests/unit_test_targetuserspacecreator.py
@@ -1103,7 +1103,7 @@ def test_gather_target_repositories_none_available(monkeypatch):
         reports = [m.report for m in mocked_produce.model_instances if isinstance(m, reporting.Report)]
         inhibitors = [m for m in reports if 'INHIBITOR' in m.get('flags', ())]
         assert len(inhibitors) == 1
-        assert inhibitors[0].get('title', '') == 'Cannot find required basic RHEL target repositories.'
+        assert inhibitors[0].get('title', '') == 'Cannot find required basic target OS repositories.'
 
 
 @suppress_deprecation(models.RHELTargetRepository)
@@ -1166,7 +1166,7 @@ def test_gather_target_repositories_baseos_appstream_not_available(monkeypatch):
     reports = [m.report for m in mocked_produce.model_instances if isinstance(m, reporting.Report)]
     inhibitors = [m for m in reports if 'inhibitor' in m.get('groups', ())]
     assert len(inhibitors) == 1
-    assert inhibitors[0].get('title', '') == 'Cannot find required basic RHEL target repositories.'
+    assert inhibitors[0].get('title', '') == 'Cannot find required basic target OS repositories.'
     # Now test the case when either of AppStream and BaseOs is not available, upgrade should be inhibited
     mocked_produce = produce_mocked()
     monkeypatch.setattr(userspacegen.api, 'current_actor', CurrentActorMocked())
@@ -1181,7 +1181,7 @@ def test_gather_target_repositories_baseos_appstream_not_available(monkeypatch):
     reports = [m.report for m in mocked_produce.model_instances if isinstance(m, reporting.Report)]
     inhibitors = [m for m in reports if 'inhibitor' in m.get('groups', ())]
     assert len(inhibitors) == 1
-    assert inhibitors[0].get('title', '') == 'Cannot find required basic RHEL target repositories.'
+    assert inhibitors[0].get('title', '') == 'Cannot find required basic target OS repositories.'
     mocked_produce = produce_mocked()
     monkeypatch.setattr(userspacegen.api, 'current_actor', CurrentActorMocked())
     monkeypatch.setattr(userspacegen.api.current_actor(), 'produce', mocked_produce)
@@ -1195,7 +1195,7 @@ def test_gather_target_repositories_baseos_appstream_not_available(monkeypatch):
     reports = [m.report for m in mocked_produce.model_instances if isinstance(m, reporting.Report)]
     inhibitors = [m for m in reports if 'inhibitor' in m.get('groups', ())]
     assert len(inhibitors) == 1
-    assert inhibitors[0].get('title', '') == 'Cannot find required basic RHEL target repositories.'
+    assert inhibitors[0].get('title', '') == 'Cannot find required basic target OS repositories.'
 
 
 def test__get_distro_available_repoids_norhsm_norhui(monkeypatch):
@@ -1254,7 +1254,7 @@ def test__get_distro_available_repoids_nobaserepos_inhibit(
         # TODO adjust the asserts when the report is made distro agnostic
         assert reporting.create_report.called == 1
         report = reporting.create_report.reports[0]
-        assert "Cannot find required basic RHEL target repositories" in report["title"]
+        assert "Cannot find required basic target OS repositories" in report["title"]
         assert reporting.Groups.INHIBITOR in report["groups"]
 
 

--- a/repos/system_upgrade/el8toel9/actors/checkblacklistca/libraries/checkblacklistca.py
+++ b/repos/system_upgrade/el8toel9/actors/checkblacklistca/libraries/checkblacklistca.py
@@ -1,4 +1,5 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import BlackListCA, BlackListError
 
@@ -50,9 +51,14 @@ def process():
             reporting.Title('Distrusted CA certificates will be moved from blacklist to blocklist'),
             reporting.Summary(
                 'The directories which store user and administrator supplied '
-                'distrusted certificates have change names from blacklist in '
-                'RHEL8 to blocklist in RHEL9. As a result {} and '
-                '{} will be deleted.'.format(reportString, deleteString)),
+                'distrusted certificates were renamed from blacklist in '
+                '{source_distro} 8 to blocklist in {target_distro} 9. '
+                'As a result {report_string} and {delete_string} will be deleted.'.format(
+                    report_string=reportString,
+                    delete_string=deleteString,
+                    **DISTRO_REPORT_NAMES,
+                )
+            ),
             reporting.Severity(reporting.Severity.INFO),
             reporting.Groups([reporting.Groups.SECURITY]),
             reporting.Groups([reporting.Groups.AUTHENTICATION])
@@ -63,11 +69,17 @@ def process():
             reporting.Summary(
                 'The directories which stores user and administrator supplied '
                 'distrusted certificates has change names from blacklist in '
-                'RHEL8 to blocklist in RHEL9. But we are unable to access the '
-                'RHEL8 directory {} because {}. You can clear this error by '
-                'correcting the condition, or by moving the contents to {} '
-                'and removing {} completely'
-                '. '.format(ble.sourceDir, ble.error, ble.targetDir, ble.sourceDir)),
+                '{source_distro} 8 to blocklist in {target_distro} 9. '
+                'But we are unable to access the {source_distro} 8 directory '
+                '{source_dir} because {error}. You can clear this error by '
+                'correcting the condition, or by moving the contents to '
+                '{target_dir} and removing {source_dir} completely'.format(
+                    source_dir=ble.sourceDir,
+                    error=ble.error,
+                    target_dir=ble.targetDir,
+                    **DISTRO_REPORT_NAMES,
+                )
+            ),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.SECURITY]),
             reporting.Groups([reporting.Groups.INHIBITOR]),

--- a/repos/system_upgrade/el8toel9/actors/checkblacklistca/tests/component_test_checkblacklistca.py
+++ b/repos/system_upgrade/el8toel9/actors/checkblacklistca/tests/component_test_checkblacklistca.py
@@ -1,5 +1,14 @@
+import pytest
+
+from leapp.libraries.common import distro
 from leapp.models import BlackListCA, BlackListError, Report
 from leapp.utils.report import is_inhibitor
+
+
+@pytest.fixture(autouse=True)
+def common_mocks(monkeypatch):
+    monkeypatch.setattr(distro, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
 
 
 def test_actor_execution_empty(current_actor_context):

--- a/repos/system_upgrade/el8toel9/actors/checkblsgrubcfgonppc64/libraries/blsgrubcfgonppc64.py
+++ b/repos/system_upgrade/el8toel9/actors/checkblsgrubcfgonppc64/libraries/blsgrubcfgonppc64.py
@@ -1,6 +1,7 @@
 from leapp import reporting
 from leapp.libraries.common import grub
 from leapp.libraries.common.config import architecture
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import DefaultGrubInfo, FirmwareFacts, GrubCfgBios
 
@@ -31,8 +32,9 @@ def process():
                 'Leapp cannot continue with upgrade on "ppc64le" bare metal systems'
             ),
             reporting.Summary(
-                'In-place upgrade to RHEL 9 is not supported on POWER8 and POWER9 bare metal systems. '
-                'For more information, refer to the following article: {}'.format(URL)
+                f'In-place upgrade to {DISTRO_REPORT_NAMES.target} 9 is not'
+                ' supported on POWER8 and POWER9 bare metal systems. For more'
+                ' information, refer to the attached article.'
             ),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups(['inhibitor']),
@@ -54,8 +56,9 @@ def process():
                 'On "ppc64le" systems with BLS enabled, the GRUB configuration is not '
                 'properly converted after the upgrade and Leapp has to run "grub2-mkconfig" '
                 '-o /boot/grub2/grub.cfg command in order to fix an issue with booting into '
-                'the RHEL 8 kernel instead of RHEL 9.'
-
+                'the {source_distro} 8 kernel instead of {target_distro} 9.'.format_map(
+                    DISTRO_REPORT_NAMES
+                )
             ),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.BOOT]),

--- a/repos/system_upgrade/el8toel9/actors/checkcustomnetworkscripts/libraries/customnetworkscripts.py
+++ b/repos/system_upgrade/el8toel9/actors/checkcustomnetworkscripts/libraries/customnetworkscripts.py
@@ -1,6 +1,7 @@
 import os
 
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 
 CUSTOM_NETWORK_SCRIPTS = [
     "/sbin/ifup-local",
@@ -17,9 +18,9 @@ def generate_report(existing_custom_network_scripts):
     # Show documentation url if custom network-scripts detected
     title = "custom network-scripts detected"
     summary = (
-        "RHEL 9 does not support the legacy network-scripts package that was"
-        " deprecated in RHEL 8. Custom network-scripts have been detected."
-    )
+        "{target_distro} 9 does not support the legacy network-scripts package that was"
+        " deprecated in {source_distro} 8. Custom network-scripts have been detected."
+    ).format_map(DISTRO_REPORT_NAMES)
 
     reporting.create_report(
         [

--- a/repos/system_upgrade/el8toel9/actors/checkcustomnetworkscripts/tests/unit_test_customnetworkscripts.py
+++ b/repos/system_upgrade/el8toel9/actors/checkcustomnetworkscripts/tests/unit_test_customnetworkscripts.py
@@ -3,11 +3,13 @@ import os
 from leapp import reporting
 from leapp.libraries.actor import customnetworkscripts
 from leapp.libraries.common import testutils
+from leapp.libraries.stdlib import api
 
 
 def test_customnetworkscripts_exists(monkeypatch):
     monkeypatch.setattr(os.path, "isfile", lambda dummy: True)
     monkeypatch.setattr(reporting, "create_report", testutils.create_report_mocked())
+    monkeypatch.setattr(api, "current_actor", testutils.CurrentActorMocked())
     customnetworkscripts.process()
     assert reporting.create_report.called
 

--- a/repos/system_upgrade/el8toel9/actors/checkdeprecatedrpmsignature/libraries/checkdeprecatedrpmsignature.py
+++ b/repos/system_upgrade/el8toel9/actors/checkdeprecatedrpmsignature/libraries/checkdeprecatedrpmsignature.py
@@ -1,4 +1,5 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import CryptoPolicyInfo, InstalledRPM
 
@@ -11,7 +12,7 @@ FMT_LIST_SEPARATOR = '\n    - '
 # framework prints external links in the file as well.
 SUMMARY_FMT = (
     'Digital signatures using SHA-1 hash algorithm are no longer considered'
-    ' secure and are not allowed to be used on RHEL 9 systems by default.'
+    ' secure and are not allowed to be used on {target_distro} 9 systems by default.'
     ' This causes issues when using DNF/RPM to handle packages with RSA/SHA1'
     ' signatures as the signature cannot be checked with the default'
     ' cryptographic policy. Any such packages cannot be installed, removed,'
@@ -68,6 +69,7 @@ def process():
         report = [
             reporting.Title('Detected RPMs with RSA/SHA1 signature'),
             reporting.Summary(SUMMARY_FMT.format(
+                target_distro=DISTRO_REPORT_NAMES.target,
                 major_changes_url=MAJOR_CHANGE_URL,
                 crypto_policies_url=CRYPTO_POLICIES_URL,
                 bad_pkgs=bad_rpms_str

--- a/repos/system_upgrade/el8toel9/actors/checkifcfg/libraries/checkifcfg_ifcfg.py
+++ b/repos/system_upgrade/el8toel9/actors/checkifcfg/libraries/checkifcfg_ifcfg.py
@@ -1,11 +1,18 @@
 import os
 
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import IfCfg, InstalledRPM, RpmTransactionTasks
 
 FMT_LIST_SEPARATOR = '\n    - '
+
+
+def _format_files_list(files):
+    return "".join(
+        ["{}{}".format(FMT_LIST_SEPARATOR, f) for f in files]
+    )
 
 
 def process():
@@ -74,12 +81,15 @@ def process():
 
     if bad_type_files:
         title = 'Network configuration for unsupported device types detected'
-        summary = ('RHEL 9 does not support the legacy network-scripts'
-                   ' package that was deprecated in RHEL 8 in favor of'
-                   ' NetworkManager. Files for device types that are not'
-                   ' supported by NetworkManager are present in the system.'
-                   ' Files with the problematic configuration:{}').format(
-            ''.join(['{}{}'.format(FMT_LIST_SEPARATOR, bfile) for bfile in bad_type_files])
+        summary = (
+            "{target_distro} 9 does not support the legacy network-scripts"
+            " package that was deprecated in {source_distro} 8 in favor of"
+            " NetworkManager. Files for device types that are not"
+            " supported by NetworkManager are present in the system."
+            " Files with the problematic configuration:{bad_files}".format(
+                bad_files=_format_files_list(bad_type_files),
+                **DISTRO_REPORT_NAMES,
+            )
         )
         remediation = ('Consult the nm-settings-ifcfg-rh(5) manual for'
                        ' valid types of ifcfg files. Remove configuration'
@@ -104,12 +114,15 @@ def process():
 
     if not_controlled_files:
         title = 'Network configuration with disabled NetworkManager support detected'
-        summary = ('RHEL 9 does not support the legacy network-scripts'
-                   ' package that was deprecated in RHEL 8 in favor of'
-                   ' NetworkManager. Configuration present in the system'
-                   ' prohibit NetworkManager from loading it.'
-                   ' Files with the problematic configuration:{}').format(
-            ''.join(['{}{}'.format(FMT_LIST_SEPARATOR, bfile) for bfile in not_controlled_files])
+        summary = (
+            '{target_distro} 9 does not support the legacy network-scripts'
+            ' package that was deprecated in {source_distro} 8 in favor of'
+            ' NetworkManager. Configuration present in the system'
+            ' prohibit NetworkManager from loading it.'
+            ' Files with the problematic configuration:{bad_files}'
+        ).format(
+            bad_files=_format_files_list(not_controlled_files),
+            **DISTRO_REPORT_NAMES,
         )
         remediation = ('Ensure the ifcfg files comply with format described in'
                        ' nm-settings-ifcfg-rh(5) manual and remove the'

--- a/repos/system_upgrade/el8toel9/actors/checkifcfg/tests/unit_test_ifcfg.py
+++ b/repos/system_upgrade/el8toel9/actors/checkifcfg/tests/unit_test_ifcfg.py
@@ -1,3 +1,4 @@
+from leapp.libraries.common import distro
 from leapp.models import IfCfg, IfCfgProperty, InstalledRPM, RPM, RpmTransactionTasks
 from leapp.reporting import Report
 from leapp.utils.report import is_inhibitor
@@ -85,10 +86,12 @@ def test_ifcfg_good_type(current_actor_context):
     assert rpm_transaction.to_install == ["NetworkManager"]
 
 
-def test_ifcfg_not_controlled(current_actor_context):
+def test_ifcfg_not_controlled(monkeypatch, current_actor_context):
     """
     Report if there's a NM_CONTROLLED=no file.
     """
+    monkeypatch.setattr(distro, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
 
     current_actor_context.feed(IfCfg(
         filename="/NM/ifcfg-eth0",
@@ -105,10 +108,12 @@ def test_ifcfg_not_controlled(current_actor_context):
     assert "disabled NetworkManager" in report_fields['title']
 
 
-def test_ifcfg_unknown_type(current_actor_context):
+def test_ifcfg_unknown_type(monkeypatch, current_actor_context):
     """
     Report if there's configuration for a type we don't recognize.
     """
+    monkeypatch.setattr(distro, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
 
     current_actor_context.feed(IfCfg(
         filename="/NM/ifcfg-pigeon0",

--- a/repos/system_upgrade/el8toel9/actors/firewalldcheckallowzonedrifting/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/firewalldcheckallowzonedrifting/actor.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.actors import Actor
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.models import FirewalldGlobalConfig, FirewallsFacts
 from leapp.reporting import create_report, Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
@@ -34,10 +35,14 @@ class FirewalldCheckAllowZoneDrifting(Actor):
 
         create_report([
             reporting.Title('Firewalld Configuration AllowZoneDrifting Is Unsupported'),
-            reporting.Summary('Firewalld has enabled configuration option '
-                              '"{conf_key}" which has been removed in RHEL-9. '
-                              'New behavior is as if "{conf_key}" was set to "no".'.format(
-                                  conf_key='AllowZoneDrifting')),
+            reporting.Summary(
+                'Firewalld has enabled configuration option "{conf_key}" which'
+                ' has been removed in {target_distro} 9. New behavior is as if '
+                '"{conf_key}" was set to "no".'.format(
+                    target_distro=DISTRO_REPORT_NAMES.target,
+                    conf_key='AllowZoneDrifting',
+                )
+            ),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups([reporting.Groups.SANITY, reporting.Groups.FIREWALL]),
             reporting.Groups([reporting.Groups.INHIBITOR]),

--- a/repos/system_upgrade/el8toel9/actors/firewalldcheckallowzonedrifting/tests/component_test_firewalldcheckallowzonedrifting.py
+++ b/repos/system_upgrade/el8toel9/actors/firewalldcheckallowzonedrifting/tests/component_test_firewalldcheckallowzonedrifting.py
@@ -1,8 +1,11 @@
+from leapp.libraries.common import distro
 from leapp.models import FirewalldGlobalConfig, FirewallsFacts, FirewallStatus
 from leapp.reporting import Report
 
 
-def test_actor_firewalldcheckallowzonedrifting(current_actor_context):
+def test_actor_firewalldcheckallowzonedrifting(current_actor_context, monkeypatch):
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
+
     status = FirewallStatus(enabled=True, active=True)
     current_actor_context.feed(FirewallsFacts(firewalld=status,
                                               iptables=status,

--- a/repos/system_upgrade/el8toel9/actors/firewalldcheckservicetftpclient/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/firewalldcheckservicetftpclient/actor.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.actors import Actor
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.models import FirewalldUsedObjectNames
 from leapp.reporting import create_report, Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
@@ -27,9 +28,13 @@ class FirewalldCheckServiceTftpClient(Actor):
         if send_report:
             create_report([
                 reporting.Title('Firewalld Service tftp-client Is Unsupported'),
-                reporting.Summary('Firewalld has service "{service}" enabled. '
-                                  'Service "{service}" has been removed in RHEL-9.'.format(
-                                      service=tftp_client_service)),
+                reporting.Summary(
+                    'Firewalld has service "{service}" enabled. '
+                    'Service "{service}" has been removed in {target_distro} 9.'.format(
+                        service=tftp_client_service,
+                        target_distro=DISTRO_REPORT_NAMES.target,
+                    )
+                ),
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Groups([reporting.Groups.SANITY, reporting.Groups.FIREWALL]),
                 reporting.Groups([reporting.Groups.INHIBITOR]),

--- a/repos/system_upgrade/el8toel9/actors/firewalldcheckservicetftpclient/tests/component_test_firewalldcollectusedobjectnames.py
+++ b/repos/system_upgrade/el8toel9/actors/firewalldcheckservicetftpclient/tests/component_test_firewalldcollectusedobjectnames.py
@@ -1,11 +1,13 @@
+from leapp.libraries.common import distro
 from leapp.models import FirewalldUsedObjectNames
 from leapp.reporting import Report
 
 
-def test_actor_firewalldcheckservicetftpclient(current_actor_context):
+def test_actor_firewalldcheckservicetftpclient(current_actor_context, monkeypatch):
     services = ['cockpit', 'tftp-client', 'ssh', 'https']
     policies = []
     zones = []
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
 
     current_actor_context.feed(FirewalldUsedObjectNames(services=services,
                                                         policies=policies,

--- a/repos/system_upgrade/el8toel9/actors/mariadbcheck/libraries/mariadbcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/mariadbcheck/libraries/mariadbcheck.py
@@ -1,24 +1,8 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import DistributionSignedRPM
-
-# Summary for mariadb-server report
-report_server_inst_summary = (
-    'MariaDB server component will be upgraded. Since RHEL-9 includes'
-    ' MariaDB server 10.5 by default, which is incompatible with 10.3'
-    ' included in RHEL-8, it is necessary to proceed with additional steps'
-    ' for the complete upgrade of the MariaDB data.'
-)
-
-report_server_inst_hint = (
-    'Back up your data before proceeding with the upgrade'
-    ' and follow steps in the documentation section "Migrating to a RHEL 9 version of MariaDB"'
-    ' after the upgrade.'
-)
-
-# Link URL for mariadb-server report
-report_server_inst_link_url = 'https://access.redhat.com/articles/6743671'
 
 
 def _report_server_installed():
@@ -29,15 +13,30 @@ def _report_server_installed():
     installation, warn them about necessary additional steps, and
     redirect them to online documentation for the upgrade process.
     """
+    summary = (
+        'MariaDB server component will be upgraded. Since {target_distro} 9'
+        ' includes MariaDB server 10.5 by default, which is incompatible with'
+        ' 10.3 included in {source_distro} 8, it is necessary to proceed with'
+        ' additional steps for the complete upgrade of the MariaDB data.'
+    ).format_map(DISTRO_REPORT_NAMES)
+
+    hint = (
+        'Back up your data before proceeding with the upgrade and follow steps'
+        ' in the documentation section "Migrating to a RHEL 9 version of MariaDB"'
+        ' after the upgrade.'
+    )
+
     reporting.create_report([
         reporting.Title('MariaDB (mariadb-server) has been detected on your system'),
-        reporting.Summary(report_server_inst_summary),
+        reporting.Summary(summary),
         reporting.Severity(reporting.Severity.MEDIUM),
         reporting.Groups([reporting.Groups.SERVICES]),
-        reporting.ExternalLink(title='Migrating to a RHEL 9 version of MariaDB',
-                               url=report_server_inst_link_url),
+        reporting.ExternalLink(
+            title='Migrating to a RHEL 9 version of MariaDB',
+            url='https://access.redhat.com/articles/6743671'
+        ),
         reporting.RelatedResource('package', 'mariadb-server'),
-        reporting.Remediation(hint=report_server_inst_hint),
+        reporting.Remediation(hint=hint),
         ])
 
 

--- a/repos/system_upgrade/el8toel9/actors/multipathconfcheck/libraries/multipathconfcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/multipathconfcheck/libraries/multipathconfcheck.py
@@ -1,4 +1,5 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.reporting import create_report
 
 
@@ -8,15 +9,18 @@ def _report_foreign():
             'device-mapper-multipath now defaults to ignoring foreign devices'
         ),
         reporting.Summary(
-            'In RHEL-9, the default value for the "enable_foreign" option has '
-            'changed to "NONE". This means that multipath will no longer list '
-            'devices that are not managed by device-mapper. In order to retain '
-            'the default RHEL-8 behavior of listing foreign multipath devices, '
-            '\'enable_foreign ""\' will be added to the defaults section of '
-            '"/etc/multipath.conf". If you wish to change to the default '
-            'RHEL-9 behavior, please remove this line. This option only '
-            'effects the devices that multipath lists. It has no impact on '
-            'what devices are managed.'),
+            'In {target_distro} 9, the default value for the "enable_foreign" '
+            'option has changed to "NONE". This means that multipath will no '
+            'longer list devices that are not managed by device-mapper. In '
+            'order to retain the default {source_distro} 8 behavior of listing '
+            'foreign multipath devices, \'enable_foreign ""\' will be added to '
+            'the defaults section of "/etc/multipath.conf". If you wish to '
+            'change to the default {target_distro} 9 behavior, please remove '
+            'this line. This option only affects the devices that multipath '
+            'lists. It has no impact on what devices are managed.'.format_map(
+                DISTRO_REPORT_NAMES
+            )
+        ),
         reporting.Severity(reporting.Severity.INFO),
         reporting.Groups([reporting.Groups.SERVICES]),
         reporting.RelatedResource('package', 'device-mapper-multipath')
@@ -29,13 +33,15 @@ def _report_allow_usb():
             'device-mapper-multipath now defaults to ignoring USB devices'
         ),
         reporting.Summary(
-            'In RHEL-9, the default multipath configuration has changed to '
-            'ignore USB devices. A new config option, "allow_usb_devices" has '
-            'been added to control this.  In order to retain the RHEL-8 '
-            'behavior of treating USB devices like other block devices. '
-            '"allow_usb_devices yes" will be added to the defaults section '
-            'of "/etc/multipath.conf". If you wish to change to the default '
-            'RHEL-9 behavior, please remove this line.'),
+            'In {target_distro} 9, the default multipath configuration has '
+            'changed to ignore USB devices. A new config option, '
+            '"allow_usb_devices" has been added to control this. In order to '
+            'retain the {source_distro} 8 behavior of treating USB devices '
+            'like other block devices. "allow_usb_devices yes" will be added '
+            'to the defaults section of "/etc/multipath.conf". If you wish to '
+            'change to the default {target_distro} 9 behavior, please remove '
+            'this line.'.format_map(DISTRO_REPORT_NAMES)
+        ),
         reporting.Severity(reporting.Severity.INFO),
         reporting.Groups([reporting.Groups.SERVICES]),
         reporting.RelatedResource('package', 'device-mapper-multipath')
@@ -56,11 +62,16 @@ def _report_invalid_regexes(paths):
         ),
         reporting.Summary(
             'Some options in device-mapper-multipath configuration files '
-            'have values that are regular expressions. In RHEL-8, if such an '
-            'option had a value of "*", multipath would internally convert it '
-            'to ".*". In RHEL-9, values of "*" are no longer accepted. '
-            'These regular expression values have been found in {}. They '
-            'will be converted to ".*"'.format(paths_str)),
+            ' have values that are regular expressions. In {source_distro} 8,'
+            ' if such an option had a value of "*", multipath would internally'
+            'convert it to ".*". In {target_distro} 9, values of "*" are no '
+            'longer accepted. '
+            'These regular expression values have been found in {paths}. They '
+            'will be converted to ".*"'.format(
+                paths=paths_str,
+                **DISTRO_REPORT_NAMES
+            )
+        ),
         reporting.Severity(reporting.Severity.INFO),
         reporting.Groups([reporting.Groups.SERVICES]),
         reporting.RelatedResource('package', 'device-mapper-multipath')

--- a/repos/system_upgrade/el8toel9/actors/multipathconfcheck/tests/test_multipath_conf_check_8to9.py
+++ b/repos/system_upgrade/el8toel9/actors/multipathconfcheck/tests/test_multipath_conf_check_8to9.py
@@ -1,3 +1,6 @@
+import pytest
+
+from leapp.libraries.common import distro
 from leapp.models import MultipathConfFacts8to9, MultipathConfig8to9
 from leapp.reporting import Report
 
@@ -33,6 +36,12 @@ def _build_config(pathname, config_dir, enable_foreign_exists, invalid_regexes_e
 
 def _build_facts(confs):
     return MultipathConfFacts8to9(configs=confs)
+
+
+@pytest.fixture(autouse=True)
+def mock_distro_names(monkeypatch):
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(distro, 'get_source_distro_id', lambda: 'rhel')
 
 
 def test_need_everything(current_actor_context):

--- a/repos/system_upgrade/el8toel9/actors/mysqlcheck/libraries/mysqlcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/mysqlcheck/libraries/mysqlcheck.py
@@ -1,4 +1,5 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.models import DistributionSignedRPM
 
@@ -14,16 +15,18 @@ def _report_server_installed():
     reporting.create_report([
         reporting.Title('Further action to upgrade MySQL might be needed'),
         reporting.Summary(
-            'The MySQL server component will be reinstalled during the upgrade with a RHEL 9'
-            ' version. Since RHEL 9 includes the same MySQL version 8.0 by default, no action'
+            'The MySQL server component will be reinstalled during the upgrade with a {target_distro} 9'
+            ' version. Since {target_distro} 9 includes the same MySQL version 8.0 by default, no action'
             ' should be required and there should not be any compatibility issues. However,'
             ' it is still advisable to follow the documentation on this topic for up to date'
             ' recommendations.'
-            ' Keep in mind that MySQL 8.0, which is the default in RHEL 9, will reach the end'
+            ' Keep in mind that MySQL 8.0, which is the default in {target_distro} 9, will reach the end'
             ' of \'Extended Support\' in April 2026. As such it is advisable to upgrade to'
             ' MySQL version 8.4, which is provided via a module. MySQL 8.4 is also the'
-            ' default version for RHEL 10, therefore having MySQL 8.4 on the RHEL 9 system'
-            ' will make a future upgrade process to RHEL 10 smoother.'
+            ' default version for {target_distro} 10, therefore having MySQL 8.4 on the {target_distro} 9 system'
+            ' will make a future upgrade process to {target_distro} 10 smoother.'.format_map(
+                DISTRO_REPORT_NAMES
+            )
         ),
         reporting.Severity(reporting.Severity.MEDIUM),
         reporting.Groups([reporting.Groups.SERVICES]),

--- a/repos/system_upgrade/el8toel9/actors/nischeck/libraries/nischeck.py
+++ b/repos/system_upgrade/el8toel9/actors/nischeck/libraries/nischeck.py
@@ -1,21 +1,9 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import DistributionSignedRPM, NISConfig
-
-report_summary = (
-    'The NIS components (ypserv, ypbind, and yp-tools) are no longer available in RHEL-9.'
-    ' The technology behind those packages is based an outdated design patterns, which are'
-    ' no longer considered as secure. There is no direct alternative with fully compatible'
-    ' features.'
-)
-
-report_hint = (
-    'The alternatives are LDAP and for some use cases Kerberos or migrating to IPA.'
-)
-
-report_link_url = 'https://access.redhat.com/solutions/5991271'
 
 
 def report_nis():
@@ -55,15 +43,26 @@ def report_nis():
     if not rpms_configured_installed:
         return
 
+    report_summary = (
+        'The NIS components (ypserv, ypbind, and yp-tools) are no longer available'
+        ' in {target_distro} 9. The technology behind those packages is based an '
+        ' outdated design patterns, which are no longer considered as secure. There'
+        ' is no direct alternative with fully compatible features.'
+    ).format_map(DISTRO_REPORT_NAMES)
+
     # Create report
     report_content = [
         reporting.Title('NIS component has been detected on your system'),
         reporting.Summary(report_summary),
         reporting.Severity(reporting.Severity.MEDIUM),
         reporting.Groups([reporting.Groups.SERVICES]),
-        reporting.ExternalLink(title='RHEL 9 (NIS) discontinuation',
-                               url=report_link_url),
-        reporting.Remediation(hint=report_hint),
+        reporting.ExternalLink(
+            title='RHEL 9 (NIS) discontinuation',
+            url='https://access.redhat.com/solutions/5991271',
+        ),
+        reporting.Remediation(
+            hint='The alternatives are LDAP and for some use cases Kerberos or migrating to IPA.'
+        ),
     ]
 
     related_resources = [reporting.RelatedResource('package', pkg) for pkg in rpms_configured_installed]

--- a/repos/system_upgrade/el8toel9/actors/opensshdropindirectorycheck/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/opensshdropindirectorycheck/actor.py
@@ -50,7 +50,7 @@ class OpenSshDropInDirectoryCheck(Actor):
             reporting.Title('The upgrade will prepend the Include directive to OpenSSH sshd_config'),
             reporting.Summary(
                 'OpenSSH server configuration needs to be modified to contain Include directive '
-                'for the RHEL9 to work properly and integrate with the other parts of the OS. '
+                'for the target system to work properly and integrate with the other parts of the OS. '
                 'The following snippet will be added to the /etc/ssh/sshd_config during the '
                 'ApplicationsPhase: `Include /etc/ssh/sshd_config.d/*.conf`'
             ),

--- a/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/libraries/opensshsubsystemsftp.py
+++ b/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/libraries/opensshsubsystemsftp.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 
 
@@ -32,9 +33,10 @@ def process(openssh_messages):
         reporting.create_report([
             reporting.Title('OpenSSH configured without SFTP subsystem'),
             reporting.Summary(
-                'The RHEL9 is changing the default SCP behaviour to use SFTP internally '
+                'The {target_distro} 9 is changing the default SCP behaviour to use SFTP internally '
                 'so not having SFTP server enabled can prevent interoperability and break existing '
-                'scripts on other systems updated to RHEL9 to copy files to or from this machine.'
+                'scripts on other systems updated to {target_distro} 9 to copy files to or from '
+                'this machine.'.format_map(DISTRO_REPORT_NAMES)
             ),
             reporting.Remediation(
                 hint='Add the following line to the /etc/ssh/sshd_config to enable SFTP server: '

--- a/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/tests/test_opensshsubsystemsftp.py
+++ b/repos/system_upgrade/el8toel9/actors/opensshsubsystemsftp/tests/test_opensshsubsystemsftp.py
@@ -2,6 +2,7 @@ import pytest
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import opensshsubsystemsftp
+from leapp.libraries.common import distro
 from leapp.models import OpenSshConfig, Report
 
 
@@ -17,7 +18,9 @@ def test_no_config(current_actor_context):
     (True, 'internal-sftp', False),
     (True, '/usr/libexec/openssh/sftp-server', False)
 ])
-def test_subsystem(current_actor_context, modified, subsystem, expected_report):
+def test_subsystem(monkeypatch, current_actor_context, modified, subsystem, expected_report):
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
+
     conf = OpenSshConfig(
         modified=modified,
         permit_root_login=[],

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/libraries/opensslconfigcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/libraries/opensslconfigcheck.py
@@ -1,4 +1,5 @@
 from leapp import reporting
+from leapp.libraries.common.config import get_target_distro_id
 from leapp.libraries.stdlib import api
 
 
@@ -228,14 +229,18 @@ def check_crypto_policies(config):
                                    path=("default_modules", "ssl_conf", "ssl_module",
                                          "system_default", "crypto_policy", ".include"),
                                    value="/etc/crypto-policies/back-ends/opensslcnf.config"):
+
         reporting.create_report([
             reporting.Title('The OpenSSL configuration is missing the crypto policies integration'),
+
             reporting.Summary(
                 'The OpenSSL configuration file `/etc/pki/tls/openssl.cnf` does not contain the '
                 'directive to include the system-wide crypto policies. This is not recommended '
-                'by Red Hat and can lead to decreasing overall system security and inconsistent '
+                '{} can lead to decreasing overall system security and inconsistent '
                 'behavior between applications. If you need to adjust the crypto policies to your '
-                'needs, it is recommended to use custom crypto policies.'
+                'needs, it is recommended to use custom crypto policies.'.format(
+                    "by Red Hat and" if get_target_distro_id() == "rhel" else "as it"
+                )
             ),
             reporting.Severity(reporting.Severity.MEDIUM),
             reporting.Groups([

--- a/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/tests/component_test_opensslconfigcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslconfigcheck/tests/component_test_opensslconfigcheck.py
@@ -1,3 +1,4 @@
+from leapp.libraries.actor import opensslconfigcheck
 from leapp.models import OpenSslConfig, OpenSslConfigBlock, OpenSslConfigPair, Report
 
 
@@ -12,7 +13,8 @@ def test_actor_execution_empty(current_actor_context):
     assert not current_actor_context.consume(Report)
 
 
-def test_actor_execution_empty_modified(current_actor_context):
+def test_actor_execution_empty_modified(current_actor_context, monkeypatch):
+    monkeypatch.setattr(opensslconfigcheck, 'get_target_distro_id', lambda: 'rhel')
     current_actor_context.feed(
         OpenSslConfig(
             blocks=[],
@@ -25,7 +27,8 @@ def test_actor_execution_empty_modified(current_actor_context):
     assert 'missing the crypto policies integration' in r[0].report['title']
 
 
-def test_actor_execution_default_modified(current_actor_context):
+def test_actor_execution_default_modified(current_actor_context, monkeypatch):
+    monkeypatch.setattr(opensslconfigcheck, 'get_target_distro_id', lambda: 'rhel')
     current_actor_context.feed(
         OpenSslConfig(
             openssl_conf='default_modules',

--- a/repos/system_upgrade/el8toel9/actors/opensslproviders/libraries/add_provider.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslproviders/libraries/add_provider.py
@@ -2,13 +2,13 @@ import re
 
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 
 # The openssl configuration file
 # TODO copied from opensslconfigscanner/libraries/readconf.py
 CONFIG = '/etc/pki/tls/openssl.cnf'
 
-LEAPP_COMMENT = '# Modified by leapp during upgrade to RHEL 9\n'
 APPEND_STRING = (
     '[provider_sect]\n'
     'default = default_sect\n'
@@ -20,6 +20,11 @@ APPEND_STRING = (
     '##[legacy_sect]\n'
     '##activate = 1\n'
 )
+
+
+def _get_leapp_comment():
+    # cannot access DISTRO_REPORT_NAMES at top level
+    return f"# Modified by leapp during upgrade to {DISTRO_REPORT_NAMES.target} 9\n"
 
 
 def _add_lines(lines, add):
@@ -76,12 +81,12 @@ def _modify_file(f, fail_on_error=True):
     lines = f.readlines()
     lines = _replace(lines, r"openssl_conf\s*=\s*default_modules",
                      "openssl_conf = openssl_init",
-                     LEAPP_COMMENT, True, fail_on_error)
+                     _get_leapp_comment(), True, fail_on_error)
     lines = _replace(lines, r"\[\s*default_modules\s*\]",
                      "[openssl_init]\n"
                      "providers = provider_sect",
-                     LEAPP_COMMENT, True, fail_on_error)
-    lines = _append(lines, APPEND_STRING, LEAPP_COMMENT)
+                     _get_leapp_comment(), True, fail_on_error)
+    lines = _append(lines, APPEND_STRING, _get_leapp_comment())
     f.seek(0)
     f.write(''.join(lines))
 

--- a/repos/system_upgrade/el8toel9/actors/opensslproviders/tests/test_add_provider.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslproviders/tests/test_add_provider.py
@@ -3,12 +3,14 @@ import pytest
 from leapp.libraries.actor.add_provider import (
     _add_lines,
     _append,
+    _get_leapp_comment,
     _modify_file,
     _replace,
     APPEND_STRING,
-    LEAPP_COMMENT,
     NotFoundException
 )
+from leapp.libraries.common.testutils import CurrentActorMocked
+from leapp.libraries.stdlib import api
 
 testdata = (
     ([], 'one', ['one\n']),
@@ -80,32 +82,52 @@ class MockFile:
 
 
 testdata = (
-    ('', ''),
-    ('openssl_conf=default_modules\n',
-     '{}# openssl_conf=default_modules\nopenssl_conf = openssl_init\n'.format(LEAPP_COMMENT)),
-    ('openssl_conf = default_modules\n',
-     '{}# openssl_conf = default_modules\nopenssl_conf = openssl_init\n'.format(LEAPP_COMMENT)),
-    ('openssl_conf  =  default_modules\n',
-     '{}# openssl_conf  =  default_modules\nopenssl_conf = openssl_init\n'.format(LEAPP_COMMENT)),
-    ('  openssl_conf = default_modules  \n',
-     '{}#   openssl_conf = default_modules  \nopenssl_conf = openssl_init\n'.format(LEAPP_COMMENT)),
-    ('[default_modules]\n',
-     '{}# [default_modules]\n[openssl_init]\nproviders = provider_sect\n'.format(LEAPP_COMMENT)),
-    ('[  default_modules  ]\n',
-     '{}# [  default_modules  ]\n[openssl_init]\nproviders = provider_sect\n'.format(LEAPP_COMMENT)),
-    ('  [ default_modules ] \n',
-     '{}#   [ default_modules ] \n[openssl_init]\nproviders = provider_sect\n'.format(LEAPP_COMMENT)),
-    ('openssl_conf=default_modules\n[default_modules]\n',
-     '{c}# openssl_conf=default_modules\nopenssl_conf = openssl_init\n'
-     '{c}# [default_modules]\n[openssl_init]\nproviders = provider_sect\n'.format(c=LEAPP_COMMENT)),
+    ("", ""),
+    (
+        "openssl_conf=default_modules\n",
+        "{c}# openssl_conf=default_modules\nopenssl_conf = openssl_init\n",
+    ),
+    (
+        "openssl_conf = default_modules\n",
+        "{c}# openssl_conf = default_modules\nopenssl_conf = openssl_init\n",
+    ),
+    (
+        "openssl_conf  =  default_modules\n",
+        "{c}# openssl_conf  =  default_modules\nopenssl_conf = openssl_init\n",
+    ),
+    (
+        "  openssl_conf = default_modules  \n",
+        "{c}#   openssl_conf = default_modules  \nopenssl_conf = openssl_init\n",
+    ),
+    (
+        "[default_modules]\n",
+        "{c}# [default_modules]\n[openssl_init]\nproviders = provider_sect\n",
+    ),
+    (
+        "[  default_modules  ]\n",
+        "{c}# [  default_modules  ]\n[openssl_init]\nproviders = provider_sect\n",
+    ),
+    (
+        "  [ default_modules ] \n",
+        "{c}#   [ default_modules ] \n[openssl_init]\nproviders = provider_sect\n",
+    ),
+    (
+        "openssl_conf=default_modules\n[default_modules]\n",
+        "{c}# openssl_conf=default_modules\nopenssl_conf = openssl_init\n"
+        "{c}# [default_modules]\n[openssl_init]\nproviders = provider_sect\n",
+    ),
 )
 
 
 @pytest.mark.parametrize('file_content,expected', testdata)
-def test_modify_file(file_content, expected):
-    f = MockFile(file_content)
+def test_modify_file(monkeypatch, file_content, expected):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+
+    f = MockFile(file_content.format(c=_get_leapp_comment()))
 
     # Test separate replaces and do not fail if pattern is not found
     _modify_file(f, False)
 
-    assert f.content == "{}{}{}\n".format(expected, LEAPP_COMMENT, APPEND_STRING)
+    assert f.content == "{}{}{}\n".format(
+        expected.format(c=_get_leapp_comment()), _get_leapp_comment(), APPEND_STRING
+    )

--- a/repos/system_upgrade/el8toel9/actors/postgresqlcheck/libraries/postgresqlcheck.py
+++ b/repos/system_upgrade/el8toel9/actors/postgresqlcheck/libraries/postgresqlcheck.py
@@ -1,26 +1,8 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import DistributionSignedRPM
-
-# Summary for postgresql-server report
-report_server_inst_summary = (
-    'PostgreSQL server component will be upgraded. Since RHEL-9 includes'
-    ' PostgreSQL server 13 by default, which is incompatible with 9.6, 10 and 12'
-    ' included in RHEL-8, in those cases, it is necessary to proceed with additional steps'
-    ' for the complete upgrade of the PostgreSQL data.'
-    'If the database has already been upgraded, meaning the system is already using PostgreSQL 13,'
-    ' then no further actions are required.'
-)
-
-report_server_inst_hint = (
-    'Back up your data before proceeding with the upgrade'
-    ' and follow steps in the documentation section "Migrating to a RHEL 9 version of PostgreSQL"'
-    ' after the upgrade.'
-)
-
-# Link URL for postgresql-server report
-report_server_inst_link_url = 'https://access.redhat.com/articles/6654721'
 
 
 def _report_server_installed():
@@ -31,16 +13,37 @@ def _report_server_installed():
     installation, warn them about necessary additional steps, and
     redirect them to online documentation for the upgrade process.
     """
-    reporting.create_report([
-        reporting.Title('PostgreSQL (postgresql-server) has been detected on your system'),
-        reporting.Summary(report_server_inst_summary),
-        reporting.Severity(reporting.Severity.MEDIUM),
-        reporting.Groups([reporting.Groups.SERVICES]),
-        reporting.ExternalLink(title='Migrating to a RHEL 9 version of PostgreSQL',
-                               url=report_server_inst_link_url),
-        reporting.RelatedResource('package', 'postgresql-server'),
-        reporting.Remediation(hint=report_server_inst_hint),
-        ])
+    summary = (
+        'PostgreSQL server component will be upgraded. Since {target_distro} 9'
+        ' includes PostgreSQL server 13 by default, which is incompatible with 9.6,'
+        ' 10 and 12 included in {source_distro} 8, in those cases, it is necessary'
+        ' to proceed with additional steps for the complete upgrade of the PostgreSQL'
+        ' data. If the database has already been upgraded, meaning the system is'
+        ' already using PostgreSQL 13, then no further actions are required.'
+    ).format_map(DISTRO_REPORT_NAMES)
+
+    hint = (
+        'Back up your data before proceeding with the upgrade'
+        ' and follow steps in the documentation section "Migrating to a RHEL 9 version of PostgreSQL"'
+        ' after the upgrade.'
+    )
+
+    reporting.create_report(
+        [
+            reporting.Title(
+                "PostgreSQL (postgresql-server) has been detected on your system"
+            ),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Groups([reporting.Groups.SERVICES]),
+            reporting.ExternalLink(
+                title="Migrating to a RHEL 9 version of PostgreSQL",
+                url='https://access.redhat.com/articles/6654721',
+            ),
+            reporting.RelatedResource("package", "postgresql-server"),
+            reporting.Remediation(hint=hint),
+        ]
+    )
 
 
 def report_installed_packages(_context=api):

--- a/repos/system_upgrade/el8toel9/actors/rocecheck/libraries/rocecheck.py
+++ b/repos/system_upgrade/el8toel9/actors/rocecheck/libraries/rocecheck.py
@@ -1,6 +1,6 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common.config import architecture, version
+from leapp.libraries.common.config import architecture
 from leapp.libraries.stdlib import api
 from leapp.models import KernelCmdline, RoceDetected
 
@@ -37,36 +37,8 @@ def _fmt_list(items):
     return ''.join([FMT_LIST_SEPARATOR.format(i) for i in items])
 
 
-def _report_old_version(roce):
+def _report_wrong_setup(roce):
     roce_nics = roce.roce_nics_connected + roce.roce_nics_connecting
-    reporting.create_report([
-        reporting.Title('A newer version of RHEL 8 is required for the upgrade with RoCE.'),
-        reporting.Summary(
-            'The RHEL 9 system uses different network schemes for NIC names'
-            ' than RHEL 8.'
-            ' RHEL {version} does not provide functionality to be able'
-            ' to set the system configuration in a way the network interface'
-            ' names used by RoCE are persistent on both (RHEL 8 and RHEL 9)'
-            ' systems.'
-            ' The in-place upgrade from the current version of RHEL to RHEL 9'
-            ' will break the RoCE network configuration.'
-            '\n\nRoCE detected on following NICs:{nics}'
-            .format(
-                version=version.get_source_version(),
-                nics=_fmt_list(roce_nics)
-            )
-        ),
-        reporting.Remediation(hint=(
-            'Update the system to RHEL 8.8 or newer using DNF and then reboot'
-            ' the system prior the in-place upgrade to RHEL 9.'
-        )),
-        reporting.Severity(reporting.Severity.HIGH),
-        reporting.Groups([
-            reporting.Groups.INHIBITOR,
-            reporting.Groups.ACCESSIBILITY,
-            reporting.Groups.SANITY,
-        ]),
-    ])
 
 
 def _report_wrong_setup(roce):
@@ -128,7 +100,6 @@ def process():
         # No used RoCE detected - nothing to do
         api.current_logger().debug('Skipping RoCE checks: No RoCE card detected.')
         return
-    if version.matches_source_version('<= 8.6'):
-        _report_old_version(roce)
+
     if not is_kernel_arg_set():
         _report_wrong_setup(roce)

--- a/repos/system_upgrade/el8toel9/actors/rocecheck/libraries/rocecheck.py
+++ b/repos/system_upgrade/el8toel9/actors/rocecheck/libraries/rocecheck.py
@@ -1,6 +1,7 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common.config import architecture
+from leapp.libraries.common.config import architecture, get_target_distro_id
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import KernelCmdline, RoceDetected
 
@@ -40,45 +41,51 @@ def _fmt_list(items):
 def _report_wrong_setup(roce):
     roce_nics = roce.roce_nics_connected + roce.roce_nics_connecting
 
+    summary = (
+        'The {target_distro} 9 system uses different network schemes for NIC names'
+        ' than {source_distro} 8.'
+        ' The below listed RoCE NICs need to be reconfigured to the new'
+        ' interface naming scheme in order to prevent loss of network'
+        ' access to your system via these interfaces after the upgrade.'
+        ' For more information, see: {url}'
+        '\n\nRoCE detected on the following NICs:{nics}'
+    ).format(
+        nics=_fmt_list(roce_nics),
+        url=DOC_URL,
+        **DISTRO_REPORT_NAMES,
+    )
+    remmediation_hint = (
+        'Prerequisite for upgrading to {target_distro} {target_version}:'
+        'In {source_distro} 8, all RoCE cards must be configured with the interface'
+        ' names they should have in {target_distro} {target_version}.\n'
+        'For more information, see chapter 1.4 of the RHEL 8 Product'
+        ' Documentation (see the attached link) and follow these steps:\n'
+        '1.) determine the current interface device names of the RoCE'
+        ' cards that are in "connected to" or in "connecting" state\n'
+        '2.) determine if UID uniqueness is set for these cards\n'
+        '3.) compute new interface device names from the UID or the'
+        ' function ID, respectively\n'
+        '4.) change the network interface device names in ifcfg'
+        ' files\n'
+        '5.) set the kernel parameter net.naming-scheme=rhel-8.7 in the'
+        ' effective .conf file in /boot/loader/entries\n'
+        '6.) adjust other settings that rely on the interface device names'
+        ' (e.g. firewall) by changing the interface device names'
+        ' accordingly\n'
+        '7.) run `zipl -V` and reboot the system\n'
+        '8.) check your network connectivity\n'
+        '\n'
+        'Caution: Creating an incorrect configuration might cause the loss'
+        ' of your network connection after reboot!'
+    ).format(
+        target_version="9" if get_target_distro_id() == "centos" else "9.x",
+        **DISTRO_REPORT_NAMES,
+    )
 
-def _report_wrong_setup(roce):
-    roce_nics = roce.roce_nics_connected + roce.roce_nics_connecting
     reporting.create_report([
         reporting.Title('Invalid RoCE configuration for the in-place upgrade'),
-        reporting.Summary(
-            'The RHEL 9 system uses different network schemes for NIC names'
-            ' than RHEL 8.'
-            ' The below listed RoCE NICs need to be reconfigured to the new'
-            ' interface naming scheme in order to prevent loss of network'
-            ' access to your system via these interfaces after the upgrade.'
-            ' For more information, see: {url}'
-            '\n\nRoCE detected on the following NICs:{nics}'
-            .format(nics=_fmt_list(roce_nics), url=DOC_URL)
-        ),
-        reporting.Remediation(hint=(
-            'Prerequisite for upgrading to RHEL9.x:'
-            'In RHEL 8, all RoCE cards must be configured with the interface'
-            ' names they should have in RHEL9.x.\n'
-            'For more information, see chapter 1.4 of the RHEL8 Product'
-            ' Documentation (see the attached link) and follow these steps:\n'
-            '1.) determine the current interface device names of the RoCE'
-            ' cards that are in "connected to" or in "connecting" state\n'
-            '2.) determine if UID uniqueness is set for these cards\n'
-            '3.) compute new interface device names from the UID or the'
-            ' function ID, respectively\n'
-            '4.) change the network interface device names in ifcfg'
-            ' files\n'
-            '5.) set the kernel parameter net.naming-scheme=rhel-8.7 in the'
-            ' effective .conf file in /boot/loader/entries\n'
-            '6.) adjust other settings that rely on the interface device names'
-            ' (e.g. firewall) by changing the interface device names'
-            ' accordingly\n'
-            '7.) run `zipl -V` and reboot the system\n'
-            '8.) check your network connectivity\n'
-            '\n'
-            'Caution: Creating an incorrect configuration might cause the loss'
-            ' of your network connection after reboot!'
-        )),
+        reporting.Summary(summary),
+        reporting.Remediation(hint=remmediation_hint),
         reporting.ExternalLink(
             title='Predictable network interface device names on the System z platform',
             url=DOC_URL),

--- a/repos/system_upgrade/el8toel9/actors/rocecheck/tests/unit_test_rocecheck.py
+++ b/repos/system_upgrade/el8toel9/actors/rocecheck/tests/unit_test_rocecheck.py
@@ -52,7 +52,6 @@ def test_roce_noibmz(monkeypatch, arch):
 
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=arch))
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-    monkeypatch.setattr(rocecheck, '_report_old_version', mocked_do_not_call_me)
     monkeypatch.setattr(rocecheck, '_report_wrong_setup', mocked_do_not_call_me)
     monkeypatch.setattr(rocecheck, 'is_kernel_arg_set', mocked_do_not_call_me)
     monkeypatch.setattr(rocecheck.api, 'consume', mocked_do_not_call_me)
@@ -74,27 +73,6 @@ def test_roce_ok(monkeypatch, msgs, version):
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
     rocecheck.process()
     assert not reporting.create_report.called
-
-
-@pytest.mark.parametrize('msgs', (
-    [_kernel_cmdline(['net.naming-scheme=rhel-8.7']), _roce(['eno'], [])],
-    [_kernel_cmdline(['net.naming-scheme=rhel-8.7']), _roce([], ['eno'])],
-    [_kernel_cmdline(['net.naming-scheme=rhel-8.6']), _roce(['eno'], [])],
-    [_kernel_cmdline(['net.naming-scheme=rhel-8.6']), _roce(['eno', 'eno1'], ['enp'])],
-    [_kernel_cmdline(['foo=bar']), _roce(['eno'], [])],
-    [_kernel_cmdline(), _roce(['eno'], [])],
-))
-@pytest.mark.parametrize('version', ['8.0', '8.3', '8.6'])
-def test_roce_old_rhel(monkeypatch, msgs, version):
-    curr_actor_mocked = CurrentActorMocked(arch=architecture.ARCH_S390X, src_ver=version, msgs=msgs)
-    monkeypatch.setattr(api, 'current_actor', curr_actor_mocked)
-    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-    rocecheck.process()
-    assert reporting.create_report.called
-    assert any(
-        'version of RHEL' in report['title']
-        for report in reporting.create_report.reports
-    )
 
 
 # NOTE: what about the situation when net.naming-scheme is configured multiple times???

--- a/repos/system_upgrade/el9toel10/actors/check_default_initramfs/libraries/check_default_initramfs.py
+++ b/repos/system_upgrade/el9toel10/actors/check_default_initramfs/libraries/check_default_initramfs.py
@@ -2,6 +2,7 @@ import os
 
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import DefaultInitramfsInfo
 
@@ -14,15 +15,17 @@ def check_default_initramfs():
 
     if 'network-legacy' in default_initramfs_info.used_dracut_modules:
         summary = (
-            f'Initramfs ({default_initramfs_info.path}) of the default boot entry uses dracut '
+            'Initramfs ({initramfs_path}) of the default boot entry uses dracut '
             'modules that are missing on the target system. This could cause a fatal '
             'failure during the upgrade, resulting in unbootable system as '
             'the missing dracut module could prevent creation of the required target '
             'initramfs.\n\n'
             'Namely, the legacy-network dracut module is used on this system, which '
-            'could originate from older system installations. The problem is typical '
-            'for RHEL 7 and early RHEL 8 systems that were in-place-upgraded to RHEL 9.'
-        )
+            'could originate from older system installations. '
+            'The problem is typical for {source_distro} 7 and early {source_distro} 8 '
+            'systems that were in-place-upgraded to {source_distro} 9.'
+        ).format(**DISTRO_REPORT_NAMES, initramfs_path=default_initramfs_info.path)
+
         remediation_hint = (
             'Remove the dracut config file which adds the `network-legacy` dracut module. '
             'Then rebuild existing initramfs images to remove the dracut module from them.'

--- a/repos/system_upgrade/el9toel10/actors/checkoldxfs/libraries/checkoldxfs.py
+++ b/repos/system_upgrade/el9toel10/actors/checkoldxfs/libraries/checkoldxfs.py
@@ -1,9 +1,8 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import XFSInfoFacts
-
-RHEL_9_TO_10_BACKUP_RESTORE_LINK = 'https://red.ht/rhel_9_to_10_backup_restore_xfs'
 
 FMT_LIST_SEPARATOR = '\n    - '
 
@@ -71,14 +70,16 @@ def _inhibit_upgrade(invalid_bigtime, invalid_crc):
 def _report_bigtime(invalid_bigtime):
     title = 'Detected XFS filesystems without bigtime feature.'
     summary = (
-        'The XFS v5 filesystem format introduced the "bigtime" feature in RHEL 9,'
-        ' to support timestamps beyond the year 2038. XFS filesystems that'
+        'The XFS v5 filesystem format introduced the "bigtime" feature in'
+        ' {distro} 9, to support timestamps beyond the year 2038. XFS filesystems that'
         ' do not have the "bigtime" feature enabled remain vulnerable to timestamp'
         ' overflow issues. It is recommended to enable this feature on all'
         ' XFS filesystems to ensure long-term compatibility and prevent potential'
         ' failures.'
-        ' Following XFS file systems have not enabled the "bigtime" feature:{}'
-        .format(''.join(_formatted_list_output(invalid_bigtime)))
+        ' Following XFS file systems have not enabled the "bigtime" feature:{fs_list}'.format(
+            distro=DISTRO_REPORT_NAMES.target,
+            fs_list=''.join(_formatted_list_output(invalid_bigtime))
+        )
     )
 
     # NOTE(pstodulk): This will affect any system which upgraded from RHEL 8 so

--- a/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/libraries/inhibitcgroupsv1.py
+++ b/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/libraries/inhibitcgroupsv1.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import KernelCmdline
 
@@ -30,10 +31,12 @@ def process():
         remediation_cmd_args.append('systemd.legacy_systemd_cgroup_controller')
 
     summary = (
-        "Leapp detected cgroups-v1 is enabled on the system."
-        " The support of cgroups-v1 was deprecated in RHEL 9 and is removed in RHEL 10."
-        " Software requiring cgroups-v1 might not work correctly or at all on RHEL 10."
-    )
+        "Leapp detected cgroups-v1 is enabled on the system. The support of"
+        " cgroups-v1 was deprecated in {source_distro} 9 and is removed in"
+        " {target_distro} 10. Software requiring cgroups-v1 might not work"
+        " correctly or at all on {target_distro} 10."
+    ).format_map(DISTRO_REPORT_NAMES)
+
     reporting.create_report(
         [
             reporting.Title("cgroups-v1 enabled on the system"),

--- a/repos/system_upgrade/el9toel10/actors/krb5conf/checkkrb5conf/libraries/checkkrb5conf.py
+++ b/repos/system_upgrade/el9toel10/actors/krb5conf/checkkrb5conf/libraries/checkkrb5conf.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import OutdatedKrb5conf
 
@@ -22,7 +23,8 @@ def process():
             reporting.Title('Unmanaged MIT krb5 configuration file(s) will be '
                             'updated to point to the new X.509 CA bundle file'),
             reporting.Summary(
-                'On RHEL 10, the location of the reference X.509 CA bundle '
+                f'On {DISTRO_REPORT_NAMES.target} 10, '
+                'the location of the reference X.509 CA bundle '
                 'file was modified. The following unmanaged MIT krb5 '
                 'configuration files have to be updated to point to the new '
                 'bundle file:' + __human_readable_list(msg.unmanaged_files)),
@@ -36,7 +38,8 @@ def process():
             reporting.Title('RPM-provided MIT krb5 configuration file(s) are '
                             'pointing to outdated X.509 CA bundle file'),
             reporting.Summary(
-                'On RHEL 10, the location of the reference X.509 CA bundle '
+                f'On {DISTRO_REPORT_NAMES.target} 10, '
+                'the location of the reference X.509 CA bundle '
                 'file was modified. Some MIT krb5 configuration files on this '
                 'system are pointing to the old bundle file, but are provided '
                 'by third-party RPMs. You must make sure these third-party '

--- a/repos/system_upgrade/el9toel10/actors/libdbcheck/libraries/libdbcheck.py
+++ b/repos/system_upgrade/el9toel10/actors/libdbcheck/libraries/libdbcheck.py
@@ -1,26 +1,8 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import DistributionSignedRPM
-
-# Summary for libdb report
-report_libdb_inst_summary = (
-    'Libdb was marked as deprecated in RHEL-9 and in RHEL-10 is not included anymore.'
-    ' There are a couple of alternatives in RHEL-10; the applications that'
-    ' depend on libdb will not work. Such applications must implement another'
-    ' type of backend storage. And migrate existing data to the new database format.'
-)
-
-report_libdb_inst_hint = (
-    'Back up your data before proceeding with the data upgrade/migration.'
-    ' For the conversion, the tool db_converter from the libdb-utils'
-    ' rpm could be used. This database format conversion must be performed'
-    ' before the system upgrade. The db_converter is not available in RHEL 10'
-    ' systems. For more information, see the provided article.'
-)
-
-# Link URL for libdb report
-report_libdb_inst_link_url = 'https://access.redhat.com/articles/7099256'
 
 
 def _report_libdb_installed():
@@ -31,16 +13,32 @@ def _report_libdb_installed():
     installation, warn them about the lack of libdb support in RHEL 10, and
     redirect them to online documentation for the migration process.
     """
+    summary = (
+        'Libdb was marked as deprecated in {source_distro} 9 and in'
+        ' {target_distro} 10 is not included anymore.'
+        ' There are a couple of alternatives in {target_distro} 10; the applications that'
+        ' depend on libdb will not work. Such applications must implement another'
+        ' type of backend storage. And migrate existing data to the new database format.'
+    ).format_map(DISTRO_REPORT_NAMES)
+
+    hint_text = (
+        'Back up your data before proceeding with the data upgrade/migration.'
+        ' For the conversion, the tool db_converter from the libdb-utils'
+        ' rpm could be used. This database format conversion must be performed'
+        ' before the system upgrade. The db_converter is not available in'
+        ' {target_distro} 10 systems. For more information, see the provided article.'
+    ).format_map(DISTRO_REPORT_NAMES)
+
     reporting.create_report([
         reporting.Title('Berkeley DB (libdb) has been detected on your system'),
-        reporting.Summary(report_libdb_inst_summary),
+        reporting.Summary(summary),
         reporting.Severity(reporting.Severity.MEDIUM),
         reporting.Groups([reporting.Groups.SERVICES]),
         reporting.ExternalLink(title='Migrating to a RHEL 10 without libdb',
-                               url=report_libdb_inst_link_url),
+                               url='https://access.redhat.com/articles/7099256'),
         reporting.RelatedResource('package', 'libdb'),
-        reporting.Remediation(hint=report_libdb_inst_hint),
-        ])
+        reporting.Remediation(hint=hint_text),
+    ])
 
 
 def report_installed_packages(_context=api):

--- a/repos/system_upgrade/el9toel10/actors/mariadbcheck/libraries/mariadbcheck.py
+++ b/repos/system_upgrade/el9toel10/actors/mariadbcheck/libraries/mariadbcheck.py
@@ -1,26 +1,8 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import DistributionSignedRPM
-
-# Summary for mariadb-server report
-report_server_inst_summary = (
-    'MariaDB server component will be upgraded. Since RHEL-10 includes'
-    ' MariaDB server 10.11 by default, which is incompatible with 10.5'
-    ' included in RHEL-9 as default stream, it is necessary to proceed with'
-    ' additional steps for the complete upgrade of the MariaDB data.'
-)
-
-report_server_inst_hint = (
-    'Back up your data before proceeding with the upgrade'
-    ' and follow steps in the documentation section "Migrating to a RHEL 10 version of MariaDB"'
-    ' after the upgrade. If the database has already been upgraded,'
-    ' meaning the system is already using MariaDB 10.11 then no further'
-    ' actions are required.'
-)
-
-# Link URL for mariadb-server report
-report_server_inst_link_url = 'https://access.redhat.com/articles/7097551'
 
 
 def _report_server_installed():
@@ -31,16 +13,31 @@ def _report_server_installed():
     installation, warn them about necessary additional steps, and
     redirect them to online documentation for the upgrade process.
     """
+    summary = (
+        'MariaDB server component will be upgraded.'
+        ' Since {target_distro} 10 includes MariaDB server 10.11 by default,'
+        ' which is incompatible with 10.5 included in {source_distro} 9 as default stream,'
+        ' it is necessary to proceed with additional steps for the complete upgrade of the MariaDB data.'
+    ).format_map(DISTRO_REPORT_NAMES)
+
+    hint = (
+        'Back up your data before proceeding with the upgrade and follow'
+        ' steps in the documentation section "Migrating to a RHEL 10 version of'
+        ' MariaDB" after the upgrade. If the database has already been'
+        ' upgraded, meaning the system is already using MariaDB 10.11 then no'
+        ' further actions are required.'
+    )
+
     reporting.create_report([
         reporting.Title('MariaDB (mariadb-server) has been detected on your system'),
-        reporting.Summary(report_server_inst_summary),
+        reporting.Summary(summary),
         reporting.Severity(reporting.Severity.MEDIUM),
         reporting.Groups([reporting.Groups.SERVICES]),
         reporting.ExternalLink(title='Migrating to a RHEL 10 version of MariaDB',
-                               url=report_server_inst_link_url),
+                               url='https://access.redhat.com/articles/7097551'),
         reporting.RelatedResource('package', 'mariadb-server'),
-        reporting.Remediation(hint=report_server_inst_hint),
-        ])
+        reporting.Remediation(hint=hint),
+    ])
 
 
 def report_installed_packages(_context=api):

--- a/repos/system_upgrade/el9toel10/actors/motifcheck/libraries/motifcheck.py
+++ b/repos/system_upgrade/el9toel10/actors/motifcheck/libraries/motifcheck.py
@@ -1,21 +1,7 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.models import DistributionSignedRPM
-
-# Summary for motif report
-report_motif_inst_summary = (
-    'The Motif package has been detected on your system. Motif is no longer available in RHEL 10.'
-    ' Applications that depend on Motif will not work after the upgrade.'
-    ' You will need to either migrate to an alternative GUI toolkit (such as GTK or Qt)'
-    ' or maintain the Motif package through alternative means.'
-)
-
-report_motif_inst_hint = (
-    'Consider migrating applications to a modern GUI toolkit before proceeding with the upgrade.'
-)
-
-# Link URL for motif report
-report_motif_inst_link_url = 'https://red.ht/rhel-10-removed-features-graphics-infrastructures'
 
 
 def _report_motif_installed():
@@ -26,16 +12,28 @@ def _report_motif_installed():
     installation, warn them about the lack of motif support in RHEL 10, and
     redirect them to online documentation for the migration process.
     """
+    summary = (
+        'The Motif package has been detected on your system. Motif is no longer'
+        ' available in {target_distro} 10. Applications that depend on Motif'
+        ' will not work after the upgrade. You will need to either migrate to'
+        ' an alternative GUI toolkit (such as GTK or Qt) or maintain the Motif'
+        ' package through alternative means.'
+    ).format_map(DISTRO_REPORT_NAMES)
+
     reporting.create_report([
         reporting.Title('Motif has been detected on your system'),
-        reporting.Summary(report_motif_inst_summary),
+        reporting.Summary(summary),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Groups([reporting.Groups.SERVICES]),
-        reporting.ExternalLink(title='RHEL 10 Removed Features - Graphics Infrastructures',
-                               url=report_motif_inst_link_url),
+        reporting.ExternalLink(
+            title='RHEL 10 Removed Features - Graphics Infrastructures',
+            url='https://red.ht/rhel-10-removed-features-graphics-infrastructures'
+        ),
         reporting.RelatedResource('package', 'motif'),
-        reporting.Remediation(hint=report_motif_inst_hint),
-        ])
+        reporting.Remediation(
+            hint='Consider migrating applications to a modern GUI toolkit before proceeding with the upgrade.'
+        ),
+    ])
 
 
 def report_installed_packages():

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 
 if TYPE_CHECKING:
@@ -32,14 +33,16 @@ def _generate_mysql_present_report() -> None:
     """
     reporting.create_report([
         reporting.Title('Manual migration of data from MySQL database might be needed'),
-        reporting.Summary((
-            'MySQL server component will be upgraded. '
-            'Since RHEL-10 includes MySQL server 8.4 by default, '
-            'it might be necessary to proceed with additional steps after '
-            'RHEL upgrade is completed. In simple setups MySQL server should '
-            'automatically upgrade all data on first start, but in more '
-            'complicated setups manual intervention might be needed.'
-        )),
+        reporting.Summary(
+            (
+                'MySQL server component will be upgraded. '
+                'Since {target_distro} 10 includes MySQL server 8.4 by default, '
+                'it might be necessary to proceed with additional steps after '
+                'the upgrade is completed. In simple setups MySQL server should '
+                'automatically upgrade all data on first start, but in more '
+                'complicated setups manual intervention might be needed.'
+            ).format_map(DISTRO_REPORT_NAMES)
+        ),
         reporting.Severity(reporting.Severity.MEDIUM),
         reporting.Groups([reporting.Groups.SERVICES]),
         reporting.ExternalLink(title='Migrating MySQL databases from RHEL 9 to RHEL 10',
@@ -51,7 +54,7 @@ def _generate_mysql_present_report() -> None:
             '"Migrating MySQL databases from RHEL 9 to RHEL 10" '
             'with up to date recommended steps before and after the upgrade.'
         )),
-        ])
+    ])
 
 
 def _generate_deprecated_config_report(found_options: list,

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/tests/test_checkmysql.py
@@ -3,7 +3,7 @@ import pytest
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import checkmysql
-from leapp.libraries.common.testutils import create_report_mocked, logger_mocked
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, logger_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import MySQLConfiguration
 
@@ -42,6 +42,7 @@ def test_process_no_deprecated(monkeypatch):
                                  removed_options=[],
                                  removed_arguments=[])
 
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
     monkeypatch.setattr(api, 'consume', consume_mocked)
 
@@ -57,6 +58,7 @@ def test_process_deprecated(monkeypatch):
                                  removed_options=['avoid_temporal_upgrade', '--old'],
                                  removed_arguments=['--language'])
 
+    monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
     monkeypatch.setattr(api, 'consume', consume_mocked)
 

--- a/repos/system_upgrade/el9toel10/actors/networkdeprecations/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/networkdeprecations/actor.py
@@ -2,6 +2,7 @@ import os
 
 from leapp import reporting
 from leapp.actors import Actor
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.models import IfCfg, NetworkManagerConfig, Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
@@ -30,9 +31,12 @@ class CheckNetworkDeprecations9to10(Actor):
     @staticmethod
     def report_dhclient():
         title = 'Deprecated DHCP plugin configured'
-        summary = ('NetworkManager is configured to use the "dhclient" DHCP module.'
-                   ' In Red Hat Enterprise Linux 10, this setting will be ignored'
-                   ' along with any dhcp-client specific configuration.')
+        summary = (
+            'NetworkManager is configured to use the "dhclient" DHCP module.'
+            ' In {target_distro} 10, this setting will be ignored'
+            ' along with any dhcp-client specific configuration.'
+        ).format_map(DISTRO_REPORT_NAMES)
+
         remediation = ('Remove "dhcp=dhclient" line from "[main]" section from all'
                        ' configuration files in "/etc/NetworkManager". Review'
                        ' configuration in "/etc/dhcp", which will be ignored.')
@@ -53,12 +57,15 @@ class CheckNetworkDeprecations9to10(Actor):
             reporting.Title('Legacy network configuration with policy routing rules found'),
             reporting.Summary(
                 'Network configuration files in "ifcfg" format are present accompanied'
-                ' by legacy routing rules. In Red Hat Enterprise Linux 10, support'
+                ' by legacy routing rules. In {target_distro} 10, support'
                 ' for these files is no longer enabled and the configuration will be'
                 ' ignored. Legacy routing rules are not supported by NetworkManager'
                 ' natively and therefore can not be migrated automatically.'
-                ' The following configuration files were found:{}'
-                .format(''.join(_formatted_list_output(conn.values())))
+                ' The following configuration files were found:{files}'
+                .format(
+                    files=''.join(_formatted_list_output(conn.values())),
+                    target_distro=DISTRO_REPORT_NAMES.target
+                )
             ),
             reporting.Remediation(hint='Replace the routing rules with equivalent'
                                        ' "ipv4.routing-rules" or "ipv6.routing-rules" properties,'
@@ -81,7 +88,6 @@ class CheckNetworkDeprecations9to10(Actor):
             reporting.RelatedResource('package', 'NetworkManager'),
             reporting.RelatedResource('package', 'NetworkManager-dispatcher-routing-rules'),
         ] + [reporting.RelatedResource('file', file) for file in conn.values()])
-        pass
 
     @staticmethod
     def report_ifcfg_leftover(conn):
@@ -110,9 +116,12 @@ class CheckNetworkDeprecations9to10(Actor):
             reporting.Title('Legacy network configuration found'),
             reporting.Summary(
                 'Network configuration files in legacy "ifcfg" format are present.'
-                'In Red Hat Enterprise Linux 10, support for these files is no longer'
+                'In {target_distro} 10, support for these files is no longer'
                 ' enabled and the configuration will be ignored. The following files'
-                ' were found:{}'.format(''.join(_formatted_list_output(conn.values())))
+                ' were found:{conns}'.format(
+                    conns=''.join(_formatted_list_output(conn.values())),
+                    target_distro=DISTRO_REPORT_NAMES.target,
+                )
             ),
             reporting.Remediation(
                 hint='Convert the configuration into NetworkManager native "keyfile" format.',

--- a/repos/system_upgrade/el9toel10/actors/networkdeprecations/tests/unit_test_networkdeprecations_9to10.py
+++ b/repos/system_upgrade/el9toel10/actors/networkdeprecations/tests/unit_test_networkdeprecations_9to10.py
@@ -1,7 +1,14 @@
 import pytest
 
+from leapp.libraries.common import distro
 from leapp.models import IfCfg, NetworkManagerConfig, Report
 from leapp.utils.report import is_inhibitor
+
+
+@pytest.fixture(autouse=True)
+def common_mocks(monkeypatch):
+    monkeypatch.setattr(distro, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
 
 
 def test_dhcp_dhclient(current_actor_context):

--- a/repos/system_upgrade/el9toel10/actors/opensslenginescheck/libraries/opensslenginescheck.py
+++ b/repos/system_upgrade/el9toel10/actors/opensslenginescheck/libraries/opensslenginescheck.py
@@ -1,4 +1,5 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 
 FMT_LIST_SEPARATOR = '\n    - '
@@ -110,11 +111,14 @@ def check_openssl_engines(config):
             reporting.Summary(
                 'OpenSSL engines are deprecated since OpenSSL version 3.0'
                 ' and they are no longer supported nor available on the target'
-                ' RHEL 10 system. Any applications depending on OpenSSL engines'
-                ' might not work correctly on the target system and should be configured'
-                ' to use OpenSSL providers instead.'
-                ' The following OpenSSL engines are configured inside the /etc/pki/tls/openssl.cnf file:{}'
-                .format(''.join(_formatted_list_output(enabled_engines)))
+                ' {target} 10 system. Any applications depending on OpenSSL engines'
+                ' might not work correctly on the target system and should be'
+                ' configured to use OpenSSL providers instead.'
+                ' The following OpenSSL engines are configured inside the'
+                ' /etc/pki/tls/openssl.cnf file:{engines}'.format(
+                    target=DISTRO_REPORT_NAMES.target,
+                    engines=''.join(_formatted_list_output(enabled_engines)),
+                )
             ),
             reporting.Remediation(hint=(
                 'After the upgrade configure your system and applications'

--- a/repos/system_upgrade/el9toel10/actors/opensslenginescheck/tests/component_test_opensslenginescheck.py
+++ b/repos/system_upgrade/el9toel10/actors/opensslenginescheck/tests/component_test_opensslenginescheck.py
@@ -1,3 +1,4 @@
+from leapp.libraries.common import distro
 from leapp.models import OpenSslConfig, OpenSslConfigBlock, OpenSslConfigPair, Report
 
 
@@ -93,7 +94,9 @@ def test_actor_execution_default_modified(current_actor_context):
     assert not current_actor_context.consume(Report)
 
 
-def test_actor_execution_other_engine_modified(current_actor_context):
+def test_actor_execution_other_engine_modified(current_actor_context, monkeypatch):
+    monkeypatch.setattr(distro, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
     # default, but removing contents unrelated for the checks
     current_actor_context.feed(
         OpenSslConfig(

--- a/repos/system_upgrade/el9toel10/actors/pamuserdb/checkpamuserdb/libraries/checkpamuserdb.py
+++ b/repos/system_upgrade/el9toel10/actors/pamuserdb/checkpamuserdb/libraries/checkpamuserdb.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
 from leapp.models import PamUserDbLocation
 
@@ -15,10 +16,15 @@ def process():
         reporting.create_report([
             reporting.Title('pam_userdb databases will be converted to GDBM'),
             reporting.Summary(
-                'On RHEL 10, GDMB is used by pam_userdb as it\'s backend database,'
+                'On {target_distro} 10, GDMB is used by pam_userdb as it\'s backend database,'
                 ' replacing BerkeleyDB. Existing pam_userdb databases will be'
                 ' converted to GDBM. The following databases will be converted:'
-                '{sep}{locations}'.format(sep=FMT_LIST_SEPARATOR, locations=FMT_LIST_SEPARATOR.join(msg.locations))),
+                '{sep}{locations}'.format(
+                    sep=FMT_LIST_SEPARATOR,
+                    locations=FMT_LIST_SEPARATOR.join(msg.locations),
+                    target_distro=DISTRO_REPORT_NAMES.target,
+                )
+            ),
             reporting.Severity(reporting.Severity.INFO),
             reporting.Groups([reporting.Groups.SECURITY, reporting.Groups.AUTHENTICATION])
         ])

--- a/repos/system_upgrade/el9toel10/actors/pamuserdb/checkpamuserdb/tests/test_checkpamuserdb.py
+++ b/repos/system_upgrade/el9toel10/actors/pamuserdb/checkpamuserdb/tests/test_checkpamuserdb.py
@@ -3,6 +3,7 @@ import pytest
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import checkpamuserdb
+from leapp.libraries.common import distro
 from leapp.libraries.common.testutils import create_report_mocked, logger_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import PamUserDbLocation
@@ -38,6 +39,8 @@ def test_process_locations(monkeypatch):
 
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
     monkeypatch.setattr(api, 'consume', consume_mocked)
+    monkeypatch.setattr(distro, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
 
     checkpamuserdb.process()
     assert reporting.create_report.called == 1

--- a/repos/system_upgrade/el9toel10/actors/postgresqlcheck/libraries/postgresqlcheck.py
+++ b/repos/system_upgrade/el9toel10/actors/postgresqlcheck/libraries/postgresqlcheck.py
@@ -1,26 +1,8 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import DistributionSignedRPM
-
-# Summary for postgresql-server report
-report_server_inst_summary = (
-    'PostgreSQL server component will be upgraded. Since RHEL-10 includes'
-    ' PostgreSQL server 16 by default, which is incompatible with 13 and 15'
-    ' included in RHEL-9, in those cases, it is necessary to proceed with additional steps'
-    ' for the complete upgrade of the PostgreSQL data.'
-    'If the database has already been upgraded, meaning the system is already using PostgreSQL 16,'
-    ' then no further actions are required.'
-)
-
-report_server_inst_hint = (
-    'Back up your data before proceeding with the upgrade'
-    ' and follow steps in the documentation section "Migrating to a RHEL 10 version of PostgreSQL"'
-    ' after the upgrade.'
-)
-
-# Link URL for postgresql-server report
-report_server_inst_link_url = 'https://access.redhat.com/articles/7097228'
 
 
 def _report_server_installed():
@@ -31,16 +13,34 @@ def _report_server_installed():
     installation, warn them about necessary additional steps, and
     redirect them to online documentation for the upgrade process.
     """
+
+    summary = (
+        'PostgreSQL server component will be upgraded. Since {target_distro} 10 includes'
+        ' PostgreSQL server 16 by default, which is incompatible with 13 and 15'
+        ' included in {source_distro} 9, in those cases, it is necessary to'
+        ' proceed with additional steps for the complete upgrade of the PostgreSQL data.'
+        ' If the database has already been upgraded, meaning the system is'
+        ' already using PostgreSQL 16, then no further actions are required.'
+    ).format_map(DISTRO_REPORT_NAMES)
+
+    hint_text = (
+        'Back up your data before proceeding with the upgrade'
+        ' and follow steps in the documentation section "Migrating to a RHEL 10 version of PostgreSQL"'
+        ' after the upgrade.'
+    )
+
     reporting.create_report([
-        reporting.Title('PostgreSQL (postgresql-server) has been detected on your system'),
-        reporting.Summary(report_server_inst_summary),
-        reporting.Severity(reporting.Severity.MEDIUM),
-        reporting.Groups([reporting.Groups.SERVICES]),
-        reporting.ExternalLink(title='Migrating to a RHEL 10 version of PostgreSQL',
-                               url=report_server_inst_link_url),
-        reporting.RelatedResource('package', 'postgresql-server'),
-        reporting.Remediation(hint=report_server_inst_hint),
-        ])
+            reporting.Title('PostgreSQL (postgresql-server) has been detected on your system'),
+            reporting.Summary(summary),
+            reporting.Severity(reporting.Severity.MEDIUM),
+            reporting.Groups([reporting.Groups.SERVICES]),
+            reporting.ExternalLink(
+                title='Migrating to a RHEL 10 version of PostgreSQL',
+                url='https://access.redhat.com/articles/7097228',
+            ),
+            reporting.RelatedResource('package', 'postgresql-server'),
+            reporting.Remediation(hint=hint_text),
+    ])
 
 
 def report_installed_packages(_context=api):

--- a/repos/system_upgrade/el9toel10/actors/xorgcheck/libraries/xorgcheck.py
+++ b/repos/system_upgrade/el9toel10/actors/xorgcheck/libraries/xorgcheck.py
@@ -1,4 +1,5 @@
 from leapp import reporting
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
 from leapp.models import DistributionSignedRPM
 
@@ -16,21 +17,6 @@ _XORG_PACKAGES = [
 # Separator for list formatting in reports
 FMT_LIST_SEPARATOR = '\n    - '
 
-# Summary template for Xorg report
-_report_xorg_inst_summary_template = (
-    'Xorg server packages have been detected on your system. The Xorg server is no longer available '
-    'in RHEL 10. Applications and services that depend on Xorg server packages will not work '
-    'after the upgrade. Migrate to Wayland or maintain the Xorg packages through '
-    'alternative means. The following Xorg server packages have been detected and are not available in RHEL 10:{}{}'
-)
-
-_report_xorg_inst_hint = (
-    'Consider migrating to Wayland before proceeding with the upgrade.'
-)
-
-# Link URL for Xorg report
-_report_xorg_inst_link_url = 'https://red.ht/rhel-10-removed-features-graphics-infrastructures'
-
 
 def _report_xorg_installed(packages):
     """
@@ -43,15 +29,25 @@ def _report_xorg_installed(packages):
     :param packages: List of installed Xorg package names
     :type packages: list
     """
-    summary = _report_xorg_inst_summary_template.format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(packages))
+    summary = (
+        "Xorg server packages have been detected on your system. The Xorg server is no longer available "
+        "in {distro} 10. Applications and services that depend on Xorg server packages will "
+        "not work after the upgrade. Migrate to Wayland or maintain the Xorg packages through alternative means. "
+        "The following Xorg server packages have been detected and are not available in {distro} 10:{sep}{list}"
+    ).format(
+        distro=DISTRO_REPORT_NAMES.target,
+        sep=FMT_LIST_SEPARATOR,
+        list=FMT_LIST_SEPARATOR.join(packages),
+    )
+
     reporting.create_report([
         reporting.Title('Xorg server packages have been detected on your system'),
         reporting.Summary(summary),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Groups([reporting.Groups.SERVICES]),
         reporting.ExternalLink(title='RHEL 10 Removed Features - Graphics Infrastructures',
-                               url=_report_xorg_inst_link_url),
-        reporting.Remediation(hint=_report_xorg_inst_hint),
+                               url='https://red.ht/rhel-10-removed-features-graphics-infrastructures'),
+        reporting.Remediation(hint='Consider migrating to Wayland before proceeding with the upgrade.'),
         ] + [reporting.RelatedResource('package', pkg) for pkg in packages])
 
 


### PR DESCRIPTION
In recent releases we've introduced the ability to upgrade other CentOS-like distros and also to convert between them, therefore the reports are changed to contain the actual distro names instead of just RHEL or Red Hat Enterprise Linux.

Note that I also standardized the way the distro and version is printed to `{distro} {verison}`, replacing other formats such as `{distro}{version}` or `{distro}-{version}`. This look weird when the distro name consist of multiple words such as CentOS Stream.

Most of the changes are just simple replacements of the hardcoded value with a variable distro name.
Changes other than these are kept in separate commits, at least for now.

In some cases it was necessary to move top level variables with report summaries and such to some local scope so that any fstrings or formats don't attempt to retrieve the distro names at import time because the workflow config is not yet available and crashes the actor. 

The following report keys are no longer used as the keys were unified for all upgrades path and only the keys for 7->8 upgrade paths are kept:

| Corresponding title | Original Key | New Key
|--------|--------|--------|
| Leapp detected loaded kernel drivers which have been removed in RHEL 9. Upgrade cannot proceed. | 7ae2961239eec9905e2580fa6309a589b1dca953 |f08a07da902958defa4f5c2699fae9ec2eb67c5b|
| Leapp detected devices which are no longer supported in RHEL 9. Upgrade cannot proceed. | 0e042eba4d14bd1f1ae691db6389621f778f21ad |ccfc28592c82123649fc824c6c1c89cabfceae7c|
| Leapp detected a processor which is no longer supported in RHEL 9. Upgrade cannot proceed. | f79672290945c09de12a14b28906b98d5c8ed68a |e3e9e4d2566733e2f843db9823c8568b9b6922f9|
| Leapp detected loaded kernel drivers which are no longer maintained in RHEL 9. | b03c306f274b33b4cf3c7cd3764366c599681481 |0ff2413fd3cb0358736bf9be597f4dbdf58f2c4d|
| Leapp detected devices which are no longer maintained in RHEL 9 | 65ac6710649c928288162900e8df8316ac8e1bda |261e3e55a3a80346f2fcc2a1e59c64f7a4caa263|
| Leapp detected a processor which is no longer maintained in RHEL 9. | 93f6cf039f01095a59ebaf581ced33316e034ef8 |61eb181bbc56328fbe03b5229d25a8ea5ebdc7a2|
| Leapp detected loaded kernel drivers which have been removed in RHEL 10. Upgrade cannot proceed. | 48e04852631245aa4afee9adcdc7c2375b8cffb8 |f08a07da902958defa4f5c2699fae9ec2eb67c5b|
| Leapp detected devices which are no longer supported in RHEL 10. Upgrade cannot proceed. | fa9da5bf370c8477eb4f8366b68ffac2aaae6374 |ccfc28592c82123649fc824c6c1c89cabfceae7c|
| Leapp detected a processor which is no longer supported in RHEL 10. Upgrade cannot proceed. | f6199d8526ee41c3e89b4ed11b3f8ee90cfc6f9f |e3e9e4d2566733e2f843db9823c8568b9b6922f9 |
| Leapp detected loaded kernel drivers which are no longer maintained in RHEL 10. | fbb11ae5828d624c4e4c91e73d766c8e27b066d9 |0ff2413fd3cb0358736bf9be597f4dbdf58f2c4d|
| Leapp detected devices which are no longer maintained in RHEL 10 | 93f67baabd93c00625fce5ad47edbf19972e41a0 |261e3e55a3a80346f2fcc2a1e59c64f7a4caa263|
| Leapp detected a processor which is no longer maintained in RHEL 10. | 9dde4bcd8b458bd6803462216785df3a1476c1f8 |61eb181bbc56328fbe03b5229d25a8ea5ebdc7a2|
| Minimum memory requirements for RHEL 9 are not met | e3066f6fae135718b3158597145554c4f22b9372 |be50646b45beb8304c13daf5380d836a4be8e1cc|
| Minimum memory requirements for RHEL 10 are not met | ccf14c3ac899f3cdc3123dadac399cafe28ce2ef |be50646b45beb8304c13daf5380d836a4be8e1cc|


Jira: RHEL-130950