### PR TITLE
Add new Leapp actor to preinstall gnome-settings-daemon-server-defaults on "Server with GUI" el9 -> el10 upgrades

### DIFF
--- a/repos/system_upgrade/common/actors/scandnfcomps/actor.py
+++ b/repos/system_upgrade/common/actors/scandnfcomps/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scandnfcomps
+from leapp.models import InstalledDNFComps
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanDNFComps(Actor):
+    """
+    Scan installed DNF comps (environments and groups).
+
+    Collects information about DNF package environments and groups that are
+    currently installed on the source system and produce InstalledDNFComps
+    message.
+    """
+
+    name = 'scan_dnf_comps'
+    consumes = ()
+    produces = (InstalledDNFComps,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        scandnfcomps.process()

--- a/repos/system_upgrade/common/actors/scandnfcomps/libraries/scandnfcomps.py
+++ b/repos/system_upgrade/common/actors/scandnfcomps/libraries/scandnfcomps.py
@@ -1,0 +1,87 @@
+import warnings
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.dnflibs import create_dnf_base, DNFRepoError
+from leapp.libraries.stdlib import api
+from leapp.models import DNFEnvironment, DNFGroup, InstalledDNFComps
+
+try:
+    import dnf
+except ImportError:
+    # NOTE(pstodulk): To stay consistent with other DNF related actors, but
+    # I guess we can get rid of it nowadays.
+    dnf = None
+    warnings.warn('Could not import the `dnf` python module.', ImportWarning)
+
+
+def _get_installed_groups(base):
+    """
+    Query installed DNF comps groups via the DNF base object.
+
+    Iterates over all available comps groups and filters to those recorded
+    as installed in the DNF history.
+
+    :param base: Initialized dnf.Base object with filled sack
+    :type base: dnf.Base
+    :returns: List of DNFGroup model instances sorted by group id
+    :rtype: List[DNFGroup]
+    """
+    groups = []
+    for grp in base.comps.groups_iter():
+        if not base.history.group.get(grp.id):
+            # not installed
+            continue
+        groups.append(DNFGroup(
+            id=grp.id,
+            name=grp.ui_name,
+        ))
+    return sorted(groups, key=lambda x: x.id)
+
+
+def _get_installed_environments(base):
+    """
+    Query installed DNF comps environments via the DNF base object.
+
+    Iterates over all available comps environments and filters to those
+    recorded as installed in the DNF history.
+
+    :param base: Initialized dnf.Base object with filled sack
+    :type base: dnf.Base
+    :returns: List of DNFEnvironment model instances sorted by environment id
+    :rtype: List[DNFEnvironment]
+    """
+    environments = []
+    for env in base.comps.environments_iter():
+        if not base.history.env.get(env.id):
+            continue
+        environments.append(DNFEnvironment(
+            id=env.id,
+            name=env.ui_name,
+        ))
+    return sorted(environments, key=lambda x: x.id)
+
+
+def process():
+    """
+    Scan installed DNF comps and produce InstalledDNFComps message.
+
+    .. seealso::
+        :func:`create_dnf_base` for exceptions raised when creating dnf.Base
+    """
+    if not dnf:
+        api.current_logger().debug('DNF is not available, skipping DNF comps scan.')
+        return
+
+    try:
+        base = create_dnf_base()
+    except DNFRepoError as e:
+        e.details['details'] = e.message
+        raise StopActorExecutionError(
+            message='Cannot obtain information about DNF Groups and Environments',
+            details=e.details
+        )
+
+    api.produce(InstalledDNFComps(
+        environments=_get_installed_environments(base),
+        groups=_get_installed_groups(base),
+    ))

--- a/repos/system_upgrade/common/actors/scandnfcomps/tests/test_scandnfcomps.py
+++ b/repos/system_upgrade/common/actors/scandnfcomps/tests/test_scandnfcomps.py
@@ -1,0 +1,175 @@
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import scandnfcomps
+from leapp.libraries.common.dnflibs import DNFRepoError
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import DNFEnvironment, DNFGroup, InstalledDNFComps
+
+
+class MockCompsGroup():
+    def __init__(self, gid, ui_name):
+        self.id = gid
+        self.ui_name = ui_name
+
+
+class MockCompsEnvironment():
+    def __init__(self, env_id, ui_name):
+        self.id = env_id
+        self.ui_name = ui_name
+
+
+class MockComps():
+    def __init__(self, groups=None, environments=None):
+        self._groups = groups or []
+        self._environments = environments or []
+
+    def groups_iter(self):
+        return iter(self._groups)
+
+    def environments_iter(self):
+        return iter(self._environments)
+
+
+class MockHistory():
+
+    class _Lookup():
+        """
+        Simulates base.history.group or base.history.env
+
+        group & env have have same "API" that we use, so no need to create
+        a different class for each one.
+        """
+
+        def __init__(self, installed_ids):
+            self._installed = set(installed_ids)
+
+        def get(self, item_id):
+            return item_id in self._installed
+
+    def __init__(self, installed_group_ids=None, installed_env_ids=None):
+        self.group = MockHistory._Lookup(installed_group_ids or [])
+        self.env = MockHistory._Lookup(installed_env_ids or [])
+
+
+class MockDNFBase():
+    def __init__(self, comps=None, history=None):
+        self.comps = comps or MockComps()
+        self.history = history or MockHistory()
+
+
+def test_process_with_groups_and_environments(monkeypatch):
+    comps = MockComps(
+        groups=[
+            MockCompsGroup('core', 'Core'),
+            MockCompsGroup('base', 'Base'),
+        ],
+        environments=[
+            MockCompsEnvironment('minimal-environment', 'Minimal Install'),
+        ],
+    )
+    history = MockHistory(
+        installed_group_ids=['core', 'base'],
+        installed_env_ids=['minimal-environment'],
+    )
+    base = MockDNFBase(comps=comps, history=history)
+
+    mocked_producer = produce_mocked()
+    monkeypatch.setattr(scandnfcomps, 'create_dnf_base', lambda: base)
+    monkeypatch.setattr(scandnfcomps, 'dnf', True)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', mocked_producer)
+
+    scandnfcomps.process()
+
+    assert mocked_producer.called == 1
+    msg = mocked_producer.model_instances[0]
+    assert isinstance(msg, InstalledDNFComps)
+    assert len(msg.groups) == 2
+    assert msg.groups[0].id == 'base'
+    assert msg.groups[0].name == 'Base'
+    assert msg.groups[1].id == 'core'
+    assert msg.groups[1].name == 'Core'
+    assert len(msg.environments) == 1
+    assert msg.environments[0].id == 'minimal-environment'
+    assert msg.environments[0].name == 'Minimal Install'
+
+
+def test_process_filters_not_installed(monkeypatch):
+    """Only groups/environments recorded as installed in history are returned."""
+    comps = MockComps(
+        groups=[
+            MockCompsGroup('core', 'Core'),
+            MockCompsGroup('base', 'Base'),
+            MockCompsGroup('extra', 'Extra'),
+        ],
+        environments=[
+            MockCompsEnvironment('minimal-environment', 'Minimal Install'),
+            MockCompsEnvironment('server-product-environment', 'Server'),
+        ],
+    )
+    history = MockHistory(
+        installed_group_ids=['core'],
+        installed_env_ids=['server-product-environment'],
+    )
+    base = MockDNFBase(comps=comps, history=history)
+
+    mocked_producer = produce_mocked()
+    monkeypatch.setattr(scandnfcomps, 'create_dnf_base', lambda: base)
+    monkeypatch.setattr(scandnfcomps, 'dnf', True)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', mocked_producer)
+
+    scandnfcomps.process()
+
+    assert mocked_producer.called == 1
+    msg = mocked_producer.model_instances[0]
+    assert len(msg.groups) == 1
+    assert msg.groups[0].id == 'core'
+    assert len(msg.environments) == 1
+    assert msg.environments[0].id == 'server-product-environment'
+
+
+def test_process_empty_comps(monkeypatch):
+    base = MockDNFBase()
+
+    mocked_producer = produce_mocked()
+    monkeypatch.setattr(scandnfcomps, 'create_dnf_base', lambda: base)
+    monkeypatch.setattr(scandnfcomps, 'dnf', True)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', mocked_producer)
+
+    scandnfcomps.process()
+
+    assert mocked_producer.called == 1
+    msg = mocked_producer.model_instances[0]
+    assert isinstance(msg, InstalledDNFComps)
+    assert msg.groups == []
+    assert msg.environments == []
+
+
+def test_process_no_dnf(monkeypatch):
+    mocked_producer = produce_mocked()
+    monkeypatch.setattr(scandnfcomps, 'dnf', None)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', mocked_producer)
+
+    scandnfcomps.process()
+    assert mocked_producer.called == 0
+
+
+def test_process_dnf_repo_error(monkeypatch):
+    def raise_repo_error():
+        raise DNFRepoError(
+            message='DNF failed to load repositories: repo error',
+            details={'hint': 'Ensure the myrepo repository definition is correct.'}
+        )
+
+    monkeypatch.setattr(scandnfcomps, 'create_dnf_base', raise_repo_error)
+    monkeypatch.setattr(scandnfcomps, 'dnf', True)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    with pytest.raises(StopActorExecutionError, match='Cannot obtain information about DNF Groups and Environments'):
+        scandnfcomps.process()

--- a/repos/system_upgrade/common/models/dnfcomps.py
+++ b/repos/system_upgrade/common/models/dnfcomps.py
@@ -1,0 +1,76 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemFactsTopic
+
+
+class DNFGroup(Model):
+    """
+    Provide information about a single installed DNF comps group.
+
+    This model is not expected to be produced or consumed by any actors as
+    a standalone message. It is always part of InstalledDNFComps message.
+    """
+
+    topic = SystemFactsTopic
+
+    id = fields.String()
+    """
+    The DNF comps group identifier (e.g. "core", "base").
+    """
+
+    name = fields.String()
+    """
+    Human-readable display name of the group.
+    """
+
+    # NOTE(pstodulk): possible extension if needed in future, but not implemented now:
+    # (( to list installed packages, split by various groups ))
+    # mandatory_packages = fields.List(fields.String, default=[])
+    # default_packages = fields.List(fields.String, default=[])
+    # conditional_packages = fields.List(fields.String, default=[])
+    # optional_packages = fields.List(fields.String, default=[])
+
+
+class DNFEnvironment(Model):
+    """
+    Provide information about a single installed DNF comps environment.
+
+    This model is not expected to be produced or consumed by any actors as
+    a standalone message. It is always part of InstalledDNFComps message.
+    """
+
+    topic = SystemFactsTopic
+
+    id = fields.String()
+    """
+    The DNF comps environment identifier (e.g. "minimal-environment").
+    """
+
+    name = fields.String()
+    """
+    Human-readable display name of the environment.
+    """
+
+    # NOTE(pstodulk): possible extension if needed in future, but not implemented now:
+    # mandatory_groups = fields.List(fields.String(), default=[])
+    # optional_groups = fields.List(fields.String(), default=[])
+
+
+class InstalledDNFComps(Model):
+    """
+    Provide information about installed DNF comps on the source system.
+
+    Contains lists of installed DNF package environments and groups as
+    tracked by the DNF history database.
+    """
+
+    topic = SystemFactsTopic
+
+    environments = fields.List(fields.Model(DNFEnvironment), default=[])
+    """
+    List of installed DNF comps environments.
+    """
+
+    groups = fields.List(fields.Model(DNFGroup), default=[])
+    """
+    List of installed DNF comps groups.
+    """

--- a/repos/system_upgrade/el9toel10/actors/gnomesettingsdaemoncheck/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/gnomesettingsdaemoncheck/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import gnomesettingsdaemoncheck
+from leapp.models import InstalledDNFComps, RpmTransactionTasks
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class GnomeSettingsDaemonCheck(Actor):
+    """
+    Install gnome-settings-daemon-server-defaults on graphical server upgrades.
+
+    If the graphical-server-environment comps environment group was installed
+    on the source RHEL 9 system, schedules the installation of the
+    gnome-settings-daemon-server-defaults package during the upgrade to RHEL 10.
+    """
+
+    name = 'gnome_settings_daemon_check'
+    consumes = (InstalledDNFComps,)
+    produces = (RpmTransactionTasks,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        gnomesettingsdaemoncheck.process()

--- a/repos/system_upgrade/el9toel10/actors/gnomesettingsdaemoncheck/libraries/gnomesettingsdaemoncheck.py
+++ b/repos/system_upgrade/el9toel10/actors/gnomesettingsdaemoncheck/libraries/gnomesettingsdaemoncheck.py
@@ -1,0 +1,36 @@
+from leapp.libraries.stdlib import api
+from leapp.models import InstalledDNFComps, RpmTransactionTasks
+
+GSD_SERVER_DEFAULTS_PKG = 'gnome-settings-daemon-server-defaults'
+GRAPHICAL_SERVER_ENV = 'graphical-server-environment'
+
+
+def _is_graphical_server_environment_installed(installed_comps):
+    """
+    Return True if the `GRAPHICAL_SERVER_ENV` comps environment group
+    is installed on the source system, False otherwise.
+    """
+    return any(env.id == GRAPHICAL_SERVER_ENV for env in installed_comps.environments)
+
+
+def process():
+    installed_comps = next(api.consume(InstalledDNFComps), None)
+    if not installed_comps:
+        api.current_logger().warning(
+            'Missing information about installed DNF comps: No InstalledDNFComps message.'
+        )
+        return
+
+    if not _is_graphical_server_environment_installed(installed_comps):
+        api.current_logger().debug(
+            'The {} comps environment is not installed; skipping.'
+            .format(GRAPHICAL_SERVER_ENV)
+        )
+        return
+
+    api.current_logger().info(
+        'The {} comps environment is installed.'
+        ' Scheduling installation of {} for the upgrade.'
+        .format(GRAPHICAL_SERVER_ENV, GSD_SERVER_DEFAULTS_PKG)
+    )
+    api.produce(RpmTransactionTasks(to_install=[GSD_SERVER_DEFAULTS_PKG]))

--- a/repos/system_upgrade/el9toel10/actors/gnomesettingsdaemoncheck/tests/test_gnomesettingsdaemoncheck.py
+++ b/repos/system_upgrade/el9toel10/actors/gnomesettingsdaemoncheck/tests/test_gnomesettingsdaemoncheck.py
@@ -1,0 +1,54 @@
+import pytest
+
+from leapp.libraries.actor import gnomesettingsdaemoncheck
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import DNFEnvironment, InstalledDNFComps, RpmTransactionTasks
+
+
+def _installed_comps(env_ids=None):
+    envs = [DNFEnvironment(id=eid, name=eid) for eid in (env_ids or [])]
+    return InstalledDNFComps(environments=envs)
+
+
+@pytest.mark.parametrize('env_ids,expected', [
+    ([gnomesettingsdaemoncheck.GRAPHICAL_SERVER_ENV], True),
+    ([gnomesettingsdaemoncheck.GRAPHICAL_SERVER_ENV, 'minimal-environment'], True),
+    (['minimal-environment'], False),
+    ([], False),
+])
+def test_is_graphical_server_environment_installed(env_ids, expected):
+    comps = _installed_comps(env_ids)
+    assert gnomesettingsdaemoncheck._is_graphical_server_environment_installed(comps) is expected
+
+
+def test_process_produces_install_task(monkeypatch):
+    comps = _installed_comps([gnomesettingsdaemoncheck.GRAPHICAL_SERVER_ENV])
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[comps]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    gnomesettingsdaemoncheck.process()
+
+    assert api.produce.called == 1
+    task = api.produce.model_instances[0]
+    assert isinstance(task, RpmTransactionTasks)
+    assert gnomesettingsdaemoncheck.GSD_SERVER_DEFAULTS_PKG in task.to_install
+
+
+def test_process_no_install_when_env_not_present(monkeypatch):
+    comps = _installed_comps(['minimal-environment'])
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[comps]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    gnomesettingsdaemoncheck.process()
+
+    assert api.produce.called == 0
+
+
+def test_process_no_install_when_no_comps_message(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    gnomesettingsdaemoncheck.process()
+
+    assert api.produce.called == 0


### PR DESCRIPTION
Prior to RHEL 10 we didn't have a way to enforce some of the desktop environment changes to be only Server specific (such as disabling the power button handling or disabling automatic suspendand) hence we had to enable everything for everyone. In RHEL 10 we've added a new subpackage of gnome-settings-daemon, the gnome-settings-daemon-server-defaults which is only preinstalled on "Server with GUI" product and on nothing else. But this only works for clean installations as the comps groups are not synced when doing the upgrades with Leapp. To fix that we've created this Leapp actor which will detect if the graphical-server-environment comps group was installed and only in the case it will preinstall the server-defaults subpackage.

Developed by Claude Code.

Jira: RHEL-148697 