### PR TITLE
fix(livemode): make live.dir is relative to device root

### DIFF
--- a/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
@@ -270,14 +270,26 @@ def local_os_stat(path):
     return os.stat(path)
 
 
-def _get_device_uuid(path):
-    """
-    Find the UUID of a device in which the given path is located.
-    """
-    while not os.path.ismount(path):
-        path = os.path.dirname(path)
+def _split_path_on_mount_point(path):
+    """ Split a given path into a prefix where a device is mounted and suffix relative to the device root. """
+    mount_point = path
+    while not os.path.ismount(mount_point):
+        mount_point = os.path.dirname(mount_point)
 
-    needle_dev_id = local_os_stat(path).st_dev
+    relative_suffix = path[len(mount_point):]
+    if len(relative_suffix) == 0 or relative_suffix[0] != '/':
+        # relative_suffix is '' if the squashfs dir is set to root (/)
+        # relative_suffix does not start with '/' if the dir is located in /, i.e., /mydir
+        relative_suffix = '/{}'.format(relative_suffix)
+
+    return (mount_point, relative_suffix)
+
+
+def _get_device_uuid(mount_point):
+    """
+    Find the UUID of a device mounted at a given mount point.
+    """
+    needle_dev_id = local_os_stat(mount_point).st_dev
 
     for uuid in os.listdir('/dev/disk/by-uuid'):
         uuid_fullpath = os.path.join('/dev/disk/by-uuid/', uuid)
@@ -333,8 +345,9 @@ def construct_cmdline_args_for_livemode():
     if livemode_config.url_to_load_squashfs_from:
         args['root'] = 'live:{}'.format(livemode_config.url_to_load_squashfs_from)
     else:
-        args['root'] = 'live:UUID={}'.format(_get_device_uuid(dir_path_containing_liveimg))
-        args['rd.live.dir'] = dir_path_containing_liveimg
+        dev_mount_point, dir_location_on_dev = _split_path_on_mount_point(dir_path_containing_liveimg)
+        args['root'] = 'live:UUID={}'.format(_get_device_uuid(dev_mount_point))
+        args['rd.live.dir'] = dir_location_on_dev
         args['rd.live.squashimg'] = liveimg_filename
 
     if livemode_config.dracut_network:

--- a/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
@@ -279,23 +279,31 @@ def test_get_rdlvm_arg_values(monkeypatch):
     assert args == ('A', 'B')
 
 
+@pytest.mark.parametrize(
+    ('path', 'mount_point', 'suffix'),
+    [
+        ('/', '/', '/'),
+        ('/dir', '/', '/dir'),
+        ('/dir/squashfs', '/', '/dir/squashfs'),
+        ('/dir/squashfs', '/dir', '/squashfs'),
+    ]
+)
+def test_split_path_on_mount_point(monkeypatch, path, mount_point, suffix):
+    def is_mount_mock(_path):
+        return _path == mount_point
+
+    monkeypatch.setattr(os.path, 'ismount', is_mount_mock)
+
+    ret_mount_point, ret_suffix = addupgradebootentry._split_path_on_mount_point(path)
+    assert ret_mount_point == mount_point
+    assert ret_suffix == suffix
+
+
 def test_get_device_uuid(monkeypatch):
     """
     The file in question is /var/lib/file
     Underlying partition /var is a device /dev/sda1 (dev_id=10) linked to from /dev/disk/by-uuid/MY_UUID1
     """
-
-    execution_stats = {
-        'is_mount_call_count': 0
-    }
-
-    def is_mount_mock(path):
-        execution_stats['is_mount_call_count'] += 1
-        assert execution_stats['is_mount_call_count'] <= 3
-        return path == '/var'
-
-    monkeypatch.setattr(os.path, 'ismount', is_mount_mock)
-
     StatResult = namedtuple('StatResult', ('st_dev', 'st_rdev'))
 
     def stat_mock(path):
@@ -325,8 +333,8 @@ def test_get_device_uuid(monkeypatch):
 
     monkeypatch.setattr(os, 'readlink', readlink_mock)
 
-    path = '/var/lib/file'
-    uuid = addupgradebootentry._get_device_uuid(path)
+    mount_point = '/var'
+    uuid = addupgradebootentry._get_device_uuid(mount_point)
 
     assert uuid == 'MY_UUID1'
 

--- a/repos/system_upgrade/common/actors/livemode/modify_userspace_for_livemode/files/do-upgrade.sh
+++ b/repos/system_upgrade/common/actors/livemode/modify_userspace_for_livemode/files/do-upgrade.sh
@@ -28,8 +28,8 @@ export LEAPPHOME=/root/tmp_leapp_py3
 export LEAPP3_BIN=$LEAPPHOME/leapp3
 
 # this was initially a dracut script, hence $NEWROOT.
-# the rootfs is mounted on /run/initramfs/live when booted with dmsquash-live
-export NEWROOT=/run/initramfs/live
+# the rootfs is mounted on /run/upgrade when booted with dmsquash-live
+export NEWROOT=/run/upgrade
 
 NSPAWN_OPTS="--capability=all --bind=/dev --bind=/dev/pts --bind=/proc --bind=/run/udev --bind=/run/lock"
 [ -d /dev/mapper ] && NSPAWN_OPTS="$NSPAWN_OPTS --bind=/dev/mapper"

--- a/repos/system_upgrade/common/actors/livemode/modify_userspace_for_livemode/libraries/prepareliveimage.py
+++ b/repos/system_upgrade/common/actors/livemode/modify_userspace_for_livemode/libraries/prepareliveimage.py
@@ -18,8 +18,16 @@ LEAPP_CONSOLE_SERVICE_FILE = 'console.service'
 LEAPP_STRACE_SERVICE_FILE = 'upgrade-strace.service'
 """ Service that executes the upgrade while strace-ing the corresponding Leapp's process tree. """
 
-SOURCE_ROOT_MOUNT_LOCATION = '/run/initramfs/live'
-""" Controls where the source system's root will be mounted inside the upgrade image. """
+SOURCE_ROOT_MOUNT_LOCATION = '/run/upgrade'
+"""
+Controls where the source system's root will be mounted inside the upgrade image.
+
+Note: This cannot be set to /run/initramfs/live as the path is used by
+      dmsquash-live by default to mount the block device that holds the squashfs
+      image. As this device can be arbitrary (e.g., it can be mounted as /var on the
+      source system), using /run/initramfs/live would cause mounting problems - we
+      would attempt to mount / and also (for example) /var on the same location.
+"""
 
 
 def create_fstab_mounting_current_root_elsewhere(context, host_fstab):


### PR DESCRIPTION
Booting from an squashfs image (from a local block dev) requires to parameters:
- identifier of the device where the squashfs image resides
- path to the squashfs image on the given device (aka live.dir) Therefore, live.dir needs to be set up with a path that is relative to the device where the image resides. This patch fixes the current behavior where the path is being taken as it is, i.e., relative to the root of the source system.

Jira-ref: RHEL-104379