### PR TITLE
fix quoting in list representation of commands

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -120,7 +120,7 @@ Requires:       leapp-repository-dependencies = %{leapp_repo_deps}
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' instead of the real framework rpm version.
-Requires:       leapp-framework >= 6.2, leapp-framework < 7
+Requires:       leapp-framework >= 6.4, leapp-framework < 7
 
 # Since we provide sub-commands for the leapp utility, we expect the leapp
 # tool to be installed as well.

--- a/repos/system_upgrade/common/actors/checkdnfpluginpath/libraries/checkdnfpluginpath.py
+++ b/repos/system_upgrade/common/actors/checkdnfpluginpath/libraries/checkdnfpluginpath.py
@@ -21,7 +21,7 @@ def check_dnf_pluginpath(dnf_pluginpath_detected):
         reporting.Remediation(
             hint='Remove or comment out the pluginpath option in the DNF '
                  'configuration file to be able to upgrade the system',
-            commands=[['sed', '-i', '\'s/^pluginpath[[:space:]]*=/#pluginpath=/\'', DNF_CONFIG_PATH]],
+            commands=[['sed', '-i', 's/^pluginpath[[:space:]]*=/#pluginpath=/', DNF_CONFIG_PATH]],
         ),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Groups([reporting.Groups.INHIBITOR]),

--- a/repos/system_upgrade/common/actors/checkrootsymlinks/actor.py
+++ b/repos/system_upgrade/common/actors/checkrootsymlinks/actor.py
@@ -55,7 +55,7 @@ class CheckRootSymlinks(Actor):
                                     os.path.relpath(item.target, '/'),
                                     os.path.join('/', item.name)])
                 commands.append(command)
-            rem_commands = [['sh', '-c', '"{}"'.format(' && '.join(commands))]]
+            rem_commands = [['sh', '-c', '{}'.format(' && '.join(commands))]]
         # Generate reports about non-utf8 absolute links presence
         nonutf_count = len(absolute_links_nonutf)
         if nonutf_count > 0:

--- a/repos/system_upgrade/common/actors/checkrootsymlinks/actor.py
+++ b/repos/system_upgrade/common/actors/checkrootsymlinks/actor.py
@@ -52,10 +52,10 @@ class CheckRootSymlinks(Actor):
             for item in absolute_links:
                 command = ' '.join(['ln',
                                     '-snf',
-                                    os.path.relpath(item.target, '/'),
-                                    os.path.join('/', item.name)])
+                                    f"'{os.path.relpath(item.target, '/')}'",
+                                    f"'{os.path.join('/', item.name)}'"])
                 commands.append(command)
-            rem_commands = [['sh', '-c', '{}'.format(' && '.join(commands))]]
+            rem_commands = [['bash', '-c', '{}'.format(' && '.join(commands))]]
         # Generate reports about non-utf8 absolute links presence
         nonutf_count = len(absolute_links_nonutf)
         if nonutf_count > 0:

--- a/repos/system_upgrade/common/actors/checkyumpluginsenabled/libraries/checkyumpluginsenabled.py
+++ b/repos/system_upgrade/common/actors/checkyumpluginsenabled/libraries/checkyumpluginsenabled.py
@@ -53,7 +53,7 @@ def check_required_dnf_plugins_enabled(pkg_manager_info):
                     .format(dnf_conf_path, plugin_configs_dir)
                 ),
                 # Provide all commands as one due to problems with satellites
-                commands=[['bash', '-c', '"{0}"'.format('; '.join(remediation_commands))]]
+                commands=[['bash', '-c', '{0}'.format('; '.join(remediation_commands))]]
             ),
             reporting.ExternalLink(
                 url='https://access.redhat.com/solutions/7028063',

--- a/repos/system_upgrade/common/actors/verifydialogs/libraries/verifydialogs.py
+++ b/repos/system_upgrade/common/actors/verifydialogs/libraries/verifydialogs.py
@@ -13,13 +13,14 @@ def check_dialogs(inhibit_if_no_userchoice=True):
         dialogs_remediation = ('Please register user choices with leapp answer cli command or by manually editing '
                                'the answerfile.')
         # FIXME: Enable more choices once we can do multi-command remediations
-        cmd_remediation = [['leapp', 'answer', '--section', "{}={}".format(s, choice)]
-                           for s, choices in dialog.answerfile_sections.items() for choice in choices[:1]]
+        cmd_remediations = [['leapp', 'answer', '--section', '{}={}'.format(s, choice)]
+                            for s, choices in dialog.answerfile_sections.items()
+                            for choice in choices[:1]]
         report_data = [reporting.Title('Missing required answers in the answer file'),
                        reporting.Severity(reporting.Severity.HIGH),
                        reporting.Summary(summary.format('\n'.join(sections))),
                        reporting.Groups([reporting.Groups.INHIBITOR] if inhibit_if_no_userchoice else []),
-                       reporting.Remediation(hint=dialogs_remediation, commands=cmd_remediation),
+                       reporting.Remediation(hint=dialogs_remediation, commands=cmd_remediations),
                        reporting.ExternalLink(
                            url='https://access.redhat.com/solutions/7035321',
                            title='Leapp upgrade fail with error "Inhibitor: Missing required answers '

--- a/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/libraries/inhibitcgroupsv1.py
+++ b/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/libraries/inhibitcgroupsv1.py
@@ -46,9 +46,9 @@ def process():
                 # remove the args from commandline, the defaults are the desired values
                 commands=[
                     [
-                        "grubby",
-                        "--update-kernel=ALL",
-                        '--remove-args="{}"'.format(" ".join(remediation_cmd_args)),
+                        'grubby',
+                        '--update-kernel', 'ALL',
+                        '--remove-args', '{}'.format(' '.join(remediation_cmd_args))
                     ],
                 ],
             ),

--- a/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/tests/test_inhibitcgroupsv1.py
+++ b/repos/system_upgrade/el9toel10/actors/inhibitcgroupsv1/tests/test_inhibitcgroupsv1.py
@@ -39,9 +39,9 @@ def test_inhibit_should_inhibit(monkeypatch, cmdline_params):
     assert reporting.Groups.INHIBITOR in report["groups"]
 
     command = [r for r in report["detail"]["remediations"] if r["type"] == "command"][0]
-    assert "systemd.unified_cgroup_hierarchy" in command['context'][2]
+    assert "systemd.unified_cgroup_hierarchy" in command['context'][4]
     if len(cmdline_params) == 2:
-        assert "systemd.legacy_systemd_cgroup_controller" in command['context'][2]
+        assert "systemd.legacy_systemd_cgroup_controller" in command['context'][4]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Removed redundant quotes included due to incorrect handling of command conversion to string representation in leapp framework's reporting module. The reporting module is fixed by RHEL-156521 and this patch is a followup that fixes usage of the module so that the commands are propagated to the leapp-report.txt correctly.

### Note: This depends on the reporting module change in the leapp framework: https://github.com/oamg/leapp/pull/919. For a better description of the problem see the RHEL-156521 and the framework PR description.

### Example with both leapp and leapp-repository PRs

leapp-report.txt
```
Risk Factor: high (inhibitor) 
Title: Upgrade requires links in root directory to be relative 
Summary: After rebooting, parts of the upgrade process can fail if symbolic links in / point to absolute paths. 
Please change these links to relative ones. 
Related links: 
    - leapp upgrade stops with Inhibitor "Upgrade requires links in root directory to be relative": https://access.redhat.com/solutions/6989732 
Remediation: [command] sh -c 'ln -snf usr/bin /bin && ln -snf usr/lib /lib' 
Key: 3d895ad37ceaf4157864d439edb6bd75562061fa 
---------------------------------------- 
```

leapp-report.json
```
    {
      "audience": "sysadmin",
      "detail": {
        "external": [
          {
            "title": "leapp upgrade stops with Inhibitor \"Upgrade requires links in root directory to be relative\"",
            "url": "https://access.redhat.com/solutions/6989732"
          }
        ],
        "remediations": [
          {
            "context": [
              "sh",
              "-c",
              "ln -snf usr/bin /bin && ln -snf usr/lib /lib"
            ],
            "type": "command"
          }
        ]
      },
      "flags": [
        "inhibitor"
      ],
      "key": "3d895ad37ceaf4157864d439edb6bd75562061fa", 
      "severity": "high", 
      "summary": "After rebooting, parts of the upgrade process can fail if symbolic links in / point to absolute paths.\nPlease change these links to relative ones.", 
      "title": "Upgrade requires links in root directory to be relative", 
      "timeStamp": "2026-03-17T12:23:38.556773Z", 
      "hostname": "leapp-20260313125304", 
      "actor": "check_root_symlinks", 
      "id": "7d784af5714dfbe4a1d13e17ab97163a2139bf32336dd7c665756eca5d5b41d9", 
      "tags": [] 
    }, 
```

Both have correct equivalent representation of the command.

Jira: RHEL-155517, RHEL-155515