### PR TITLE
fix(overlaygen): exclude hugetlbfs from overlay mounts

### DIFF
--- a/repos/system_upgrade/common/libraries/overlaygen.py
+++ b/repos/system_upgrade/common/libraries/overlaygen.py
@@ -10,7 +10,7 @@ from leapp.libraries.common.config import get_env
 from leapp.libraries.common.config.version import get_target_major_version
 from leapp.libraries.stdlib import api, CalledProcessError, run
 
-OVERLAY_DO_NOT_MOUNT = ('tmpfs', 'devtmpfs', 'devpts', 'sysfs', 'proc', 'cramfs', 'sysv', 'vfat')
+OVERLAY_DO_NOT_MOUNT = ('tmpfs', 'devtmpfs', 'devpts', 'sysfs', 'proc', 'cramfs', 'sysv', 'vfat', 'hugetlbfs')
 
 # NOTE(pstodulk): what about using more closer values and than just multiply
 # the final result by magical constant?... this number is most likely going to


### PR DESCRIPTION
hugetlbfs should not be mounted in the overlay environment during the upgrade. It's not a regular mount point. This patch adds it to the OVERLAY_DO_NOT_MOUNT exclusion list.

Resolves: RHEL-156902