### PR TITLE
[selinux][avc] leapp_resume.service: set install type context

### DIFF
--- a/repos/system_upgrade/common/actors/createresumeservice/files/leapp_resume.service
+++ b/repos/system_upgrade/common/actors/createresumeservice/files/leapp_resume.service
@@ -8,8 +8,15 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-# FIXME: this is temporary workaround for Python3
-ExecStart=/bin/sh -c "/root/tmp_leapp_py3/leapp3 upgrade --resume"
+# NOTE(pstodulk): After discussion with the SELinux team, we try to stay
+# out of unconfined mode for now.
+#SELinuxContext=unconfined_u:unconfined_r:unconfined_t:s0
+
+# NOTE(pstodulk): Correction of the selinux type context. This one should fit to leapp
+# Ignore the exit code as this cmd is expected to fail if selinux is disabled
+ExecStartPre=-chcon -t install_exec_t /root/tmp_leapp_py3/leapp3
+ExecStart=/root/tmp_leapp_py3/leapp3 upgrade --resume
 StandardOutput=journal+console
-# FIXME: this shouldn't be needed, but Satellite upgrade runs installer, and that's slow
+
+# NOTE(pstodulk): some actions can take a lot of time (e.g. satellite installer)
 TimeoutStartSec=infinity


### PR DESCRIPTION
The original fix to deal with AVC during execution of leapp when booting to the upgraded system appeared to leave still a space to generate new AVC messages during some operations. From our side, the only way how we could be sure that we do not hit any additional error on top of what root user would see, is to set an unconfined context.

However, after discussion with SELinux guys, we decided to not do that yet. Currently dealing with the RH Insights client, it has been discovered that bug is in new SELinux policies for the client and not in leapp-repository. So for now let's keep the situation as it is and wait for the proper fix in other components.

Also after the discussion, we are going to switch to the install_exec type context which should fits to our process better than the original one. We will monitor the situation around AVC messages and make possible further changes based on the feedback.

Jira: RHEL-161684