### PR TITLE
Regenerate grub config during 8->9 conversions

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/regenerategrubcfg/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/regenerategrubcfg/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import regenerategrubcfg
+from leapp.models import DefaultGrubInfo, TransactionCompleted
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class RegenerateGrubCfg(Actor):
+    """
+    Regenerate GRUB2 configuration during conversion from EL8 to EL9.
+
+    During distribution conversions (e.g. CentOS to RHEL), the GRUB2
+    configuration may need to be regenerated to ensure compatibility
+    with the target distribution's GRUB2 tooling. This actor runs
+    grub2-mkconfig when BLS is enabled in /etc/default/grub.
+    """
+
+    name = 'regenerate_grub_cfg'
+    consumes = (DefaultGrubInfo, TransactionCompleted)
+    produces = ()
+    tags = (IPUWorkflowTag, ApplicationsPhaseTag)
+
+    def process(self):
+        regenerategrubcfg.process()

--- a/repos/system_upgrade/el8toel9/actors/regenerategrubcfg/libraries/regenerategrubcfg.py
+++ b/repos/system_upgrade/el8toel9/actors/regenerategrubcfg/libraries/regenerategrubcfg.py
@@ -1,0 +1,28 @@
+from leapp.libraries.common import grub
+from leapp.libraries.common.config import architecture, is_conversion
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import DefaultGrubInfo
+
+GRUB_CFG_PATH = '/boot/grub2/grub.cfg'
+
+
+def process():
+    if architecture.matches_architecture(architecture.ARCH_S390X):
+        return
+
+    if not is_conversion():
+        return
+
+    default_grub_msg = next(api.consume(DefaultGrubInfo), None)
+    if not default_grub_msg:
+        api.current_logger().warning('No DefaultGrubInfo message, skipping GRUB config regeneration.')
+        return
+
+    if not grub.is_blscfg_enabled_in_defaultgrub(default_grub_msg):
+        return
+
+    api.current_logger().info('Conversion detected with BLS enabled, regenerating GRUB config')
+    try:
+        run(['grub2-mkconfig', '-o', GRUB_CFG_PATH])
+    except CalledProcessError as e:
+        api.current_logger().error('Failed to regenerate GRUB config: {}'.format(e))

--- a/repos/system_upgrade/el8toel9/actors/regenerategrubcfg/tests/test_regenerategrubcfg.py
+++ b/repos/system_upgrade/el8toel9/actors/regenerategrubcfg/tests/test_regenerategrubcfg.py
@@ -1,0 +1,102 @@
+from unittest import mock
+
+import pytest
+
+from leapp.libraries.actor import regenerategrubcfg
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
+from leapp.libraries.stdlib import api, CalledProcessError
+from leapp.models import DefaultGrub, DefaultGrubInfo
+
+GRUB2_MKCONFIG_CMD = ['grub2-mkconfig', '-o', '/boot/grub2/grub.cfg']
+
+BLS_ENABLED = DefaultGrubInfo(
+    default_grub_info=[DefaultGrub(name='GRUB_ENABLE_BLSCFG', value='true')]
+)
+BLS_DISABLED = DefaultGrubInfo(
+    default_grub_info=[DefaultGrub(name='GRUB_ENABLE_BLSCFG', value='false')]
+)
+
+
+@pytest.fixture
+def mocked_run():
+    with mock.patch.object(regenerategrubcfg, 'run') as m:
+        yield m
+
+
+@pytest.fixture(autouse=True)
+def mocked_logger():
+    with mock.patch.object(api, 'current_logger', logger_mocked()):
+        yield api.current_logger
+
+
+@pytest.fixture
+def mock_actor(monkeypatch):
+
+    def make_mock(msgs, arch=architecture.ARCH_X86_64, is_conversion=False):
+        instance = CurrentActorMocked(
+            msgs=msgs,
+            arch=arch,
+            src_ver="8.10",
+            dst_ver="9.6",
+        )
+        monkeypatch.setattr(api, 'current_actor', instance)
+        # let's use this to cover all conversion paths
+        monkeypatch.setattr(regenerategrubcfg, 'is_conversion', lambda: is_conversion)
+        return instance
+
+    return make_mock
+
+
+def test_conversion_bls_enabled_regenerates(mock_actor, mocked_run):
+    """Conversion with BLS enabled -> regenerate."""
+    mock_actor([BLS_ENABLED], is_conversion=True)
+    regenerategrubcfg.process()
+    mocked_run.assert_called_once_with(GRUB2_MKCONFIG_CMD)
+
+
+def test_conversion_bls_disabled_skips(mock_actor, mocked_run):
+    """Conversion with BLS not enabled -> skip."""
+    mock_actor([BLS_DISABLED], is_conversion=True)
+    regenerategrubcfg.process()
+    mocked_run.assert_not_called()
+
+
+def test_non_conversion_skips(mock_actor, mocked_run):
+    """Non-conversion upgrade -> skip."""
+    mock_actor([BLS_ENABLED])
+    regenerategrubcfg.process()
+    mocked_run.assert_not_called()
+
+
+def test_s390x_skips(mock_actor, mocked_run):
+    """s390x -> skip (uses ZIPL)."""
+    mock_actor([BLS_ENABLED], arch=architecture.ARCH_S390X)
+    regenerategrubcfg.process()
+    mocked_run.assert_not_called()
+
+
+def test_no_default_grub_info_skips(mock_actor, mocked_run, mocked_logger):
+    """No DefaultGrubInfo -> skip."""
+    mock_actor([], is_conversion=True)
+    regenerategrubcfg.process()
+    mocked_run.assert_not_called()
+    assert any(
+        "No DefaultGrubInfo message, skipping GRUB config regeneration." in msg
+        for msg in mocked_logger.warnmsg
+    )
+
+
+def test_failure_nonfatal(mock_actor, mocked_run, mocked_logger):
+    """grub2-mkconfig failure -> non-fatal, logs error."""
+    mocked_run.side_effect = CalledProcessError(
+        message='A Leapp Command Error occurred.',
+        command=GRUB2_MKCONFIG_CMD,
+        result={'signal': None, 'exit_code': 1, 'pid': 0, 'stdout': 'fake', 'stderr': 'fake'}
+    )
+    mock_actor([BLS_ENABLED], is_conversion=True)
+
+    regenerategrubcfg.process()
+
+    mocked_run.assert_called_once_with(GRUB2_MKCONFIG_CMD)
+    assert any('Failed to regenerate GRUB config' in msg for msg in mocked_logger.errmsg)


### PR DESCRIPTION
This is mainly a preventative action to make sure that the grub config
is compatible with the target grub.

The actor only runs grub2-mkconfig when BLS is enabled in
/etc/default/grub. When BLS is disabled, the regeneration is taken care
of by the grub kernel install scripts (in /usr/lib/kernel/install/),
which do call grub2-mkconfig as required.

On 9to10 conversions the kernel install scripts handle regeneration
whether the BLS is enabled or not.

Note that in some cases grub2-mkconfig might be ran twice, as there are
2 more actors that run it (ensurevalidgrubcfghybrid and
grub2mkconfigonppc64). This shouldn't be a problem since the generation
is quick. However a better solution could be designed in the future.

Jira: RHEL-110712