### PR TITLE
Ensure that greenboot rpms are removed during IPU

### DIFF
--- a/etc/leapp/transaction/to_remove
+++ b/etc/leapp/transaction/to_remove
@@ -1,3 +1,11 @@
 ### List of packages (each on new line) to be removed from the upgrade transaction
 # Removing initial-setup package to avoid it asking for EULA acceptance during upgrade - OAMG-1531
 initial-setup
+
+# greenboot packages have a value just for rpm-ostree based systems
+# however, if someone would install them anyway, they would damage
+# the upgraded systems (mainly in case IPU 8.10 -> 9.8+).
+# As there is not value for of these packages on systems upgraded by leapp
+# (rpm based only), let's just remove them to stay safe
+greenboot
+greenboot-default-health-checks


### PR DESCRIPTION
The greenboot packages have a value just for rpm-ostree based systems. However, if someone install them anyway (e.g. configuration mistake..), they would damage the upgraded systems - mainly in case IPU 8.10 -> 9.8+. Systemd fails with error:
    ```
    Failed to isolate the default target.
    ```

Due to bugs in greenboot scriptlets, that do not count with DNF execution inside container, nor with the update of greenboot packages from 0.14.x to 0.16.x and newer.

As there is not value to have these packages on rpm based system at all, just remove them during the upgrade to stay on a safe side.