### PR TITLE
fix(checkyumpluginsenabled): correctly create remediation command

### DIFF
--- a/repos/system_upgrade/common/actors/checkyumpluginsenabled/libraries/checkyumpluginsenabled.py
+++ b/repos/system_upgrade/common/actors/checkyumpluginsenabled/libraries/checkyumpluginsenabled.py
@@ -36,8 +36,8 @@ def check_required_dnf_plugins_enabled(pkg_manager_info):
         product_id_plugin_conf = os.path.join(plugin_configs_dir, 'product-id.conf')
 
         remediation_commands = [
-            f"sed -i 's/^plugins=0/plugins=1/' '{dnf_conf_path}'"
-            f"sed -i 's/^enabled=0/enabled=1/' '{rhsm_plugin_conf}'"
+            f"sed -i 's/^plugins=0/plugins=1/' '{dnf_conf_path}'",
+            f"sed -i 's/^enabled=0/enabled=1/' '{rhsm_plugin_conf}'",
             f"sed -i 's/^enabled=0/enabled=1/' '{product_id_plugin_conf}'"
         ]
 


### PR DESCRIPTION
The remediation command for the inhibitor triggered when required dnf plugins are not enabled was created incorrectly. This patch fixes the command creation.

This is a regression that was introduced during removal of 7to8 related code [here](https://github.com/oamg/leapp-repository/pull/1427/changes/84cefba4c2e03a261f46effe507cac1ae25ecc87#diff-8a05c97750aae910c79df435fed901fccc03458198b3de72545e9e0c2a52d02fL48-L50). It even slipped me when updating the commands recently ([PR#1510](https://github.com/oamg/leapp-repository/pull/1510)) since it is just a few missing commas.
