### PR TITLE
remove single quoting from remediation commands

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -120,7 +120,7 @@ Requires:       leapp-repository-dependencies = %{leapp_repo_deps}
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' instead of the real framework rpm version.
-Requires:       leapp-framework >= 6.4, leapp-framework < 7
+Requires:       leapp-framework >= 6.5, leapp-framework < 7
 
 # Since we provide sub-commands for the leapp utility, we expect the leapp
 # tool to be installed as well.

--- a/repos/system_upgrade/common/actors/checkrootsymlinks/actor.py
+++ b/repos/system_upgrade/common/actors/checkrootsymlinks/actor.py
@@ -1,8 +1,5 @@
-import os
-
-from leapp import reporting
 from leapp.actors import Actor
-from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import checkrootsymlinks
 from leapp.models import Report, RootDirectory
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
@@ -20,50 +17,4 @@ class CheckRootSymlinks(Actor):
     tags = (IPUWorkflowTag, ChecksPhaseTag)
 
     def process(self):
-        rootdir = next(self.consume(RootDirectory), None)
-        if not rootdir:
-            raise StopActorExecutionError('Cannot check root symlinks',
-                                          details={'Problem': 'Did not receive a message with '
-                                                              'root subdirectories'})
-        absolute_links = [item for item in rootdir.items if item.target and os.path.isabs(item.target)]
-        absolute_links_nonutf = [item for item in rootdir.invalid_items if item.target and os.path.isabs(item.target)]
-        if not absolute_links and not absolute_links_nonutf:
-            return
-
-        report_fields = [
-                reporting.Title('Upgrade requires links in root directory to be relative'),
-                reporting.Summary(
-                    'After rebooting, parts of the upgrade process can fail if symbolic links in / '
-                    'point to absolute paths.\n'
-                    'Please change these links to relative ones.'
-                    ),
-                reporting.ExternalLink(
-                    url='https://access.redhat.com/solutions/6989732',
-                    title='leapp upgrade stops with Inhibitor "Upgrade requires links in root '
-                          'directory to be relative"'
-                ),
-                reporting.Severity(reporting.Severity.HIGH),
-                reporting.Groups([reporting.Groups.INHIBITOR])]
-
-        # Generate reports about absolute links presence
-        rem_commands = []
-        if absolute_links:
-            commands = []
-            for item in absolute_links:
-                command = ' '.join(['ln',
-                                    '-snf',
-                                    f"'{os.path.relpath(item.target, '/')}'",
-                                    f"'{os.path.join('/', item.name)}'"])
-                commands.append(command)
-            rem_commands = [['bash', '-c', '{}'.format(' && '.join(commands))]]
-        # Generate reports about non-utf8 absolute links presence
-        nonutf_count = len(absolute_links_nonutf)
-        if nonutf_count > 0:
-            # for non-utf encoded filenames can't provide a remediation command, so will mention this fact in a hint
-            rem_hint = ("{} symbolic links point to absolute paths that have non-utf8 encoding and need to be"
-                        " fixed additionally".format(nonutf_count))
-            report_fields.append(reporting.Remediation(hint=rem_hint, commands=rem_commands))
-        else:
-            report_fields.append(reporting.Remediation(commands=rem_commands))
-
-        reporting.create_report(report_fields)
+        checkrootsymlinks.process()

--- a/repos/system_upgrade/common/actors/checkrootsymlinks/libraries/checkrootsymlinks.py
+++ b/repos/system_upgrade/common/actors/checkrootsymlinks/libraries/checkrootsymlinks.py
@@ -1,0 +1,65 @@
+import os
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.stdlib import api
+from leapp.models import RootDirectory
+
+
+def _dquote(s):
+    """Double-quote a string for use inside a non-interactive shell script."""
+    escaped = (s.replace('\\', '\\\\')
+                .replace('"', '\\"')
+                .replace('$', '\\$')
+                .replace('`', '\\`'))
+    return '"{}"'.format(escaped)
+
+
+def process():
+    rootdir = next(api.consume(RootDirectory), None)
+    if not rootdir:
+        raise StopActorExecutionError('Cannot check root symlinks',
+                                      details={'Problem': 'Did not receive a message with '
+                                                          'root subdirectories'})
+    absolute_links = [item for item in rootdir.items if item.target and os.path.isabs(item.target)]
+    absolute_links_nonutf = [item for item in rootdir.invalid_items if item.target and os.path.isabs(item.target)]
+    if not absolute_links and not absolute_links_nonutf:
+        return
+
+    report_fields = [
+            reporting.Title('Upgrade requires links in root directory to be relative'),
+            reporting.Summary(
+                'After rebooting, parts of the upgrade process can fail if symbolic links in / '
+                'point to absolute paths.\n'
+                'Please change these links to relative ones.'
+                ),
+            reporting.ExternalLink(
+                url='https://access.redhat.com/solutions/6989732',
+                title='leapp upgrade stops with Inhibitor "Upgrade requires links in root '
+                      'directory to be relative"'
+            ),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.INHIBITOR])]
+
+    # Generate reports about absolute links presence
+    rem_commands = []
+    if absolute_links:
+        commands = []
+        for item in absolute_links:
+            command = ' '.join(['ln',
+                                '-snf',
+                                _dquote(os.path.relpath(item.target, '/')),
+                                _dquote(os.path.join('/', item.name))])
+            commands.append(command)
+        rem_commands = [['bash', '-c', '{}'.format(' && '.join(commands))]]
+    # Generate reports about non-utf8 absolute links presence
+    nonutf_count = len(absolute_links_nonutf)
+    if nonutf_count > 0:
+        # for non-utf encoded filenames can't provide a remediation command, so will mention this fact in a hint
+        rem_hint = ("{} symbolic links point to absolute paths that have non-utf8 encoding and need to be"
+                    " fixed additionally".format(nonutf_count))
+        report_fields.append(reporting.Remediation(hint=rem_hint, commands=rem_commands))
+    else:
+        report_fields.append(reporting.Remediation(commands=rem_commands))
+
+    reporting.create_report(report_fields)

--- a/repos/system_upgrade/common/actors/checkyumpluginsenabled/libraries/checkyumpluginsenabled.py
+++ b/repos/system_upgrade/common/actors/checkyumpluginsenabled/libraries/checkyumpluginsenabled.py
@@ -36,9 +36,9 @@ def check_required_dnf_plugins_enabled(pkg_manager_info):
         product_id_plugin_conf = os.path.join(plugin_configs_dir, 'product-id.conf')
 
         remediation_commands = [
-            f"sed -i 's/^plugins=0/plugins=1/' '{dnf_conf_path}'",
-            f"sed -i 's/^enabled=0/enabled=1/' '{rhsm_plugin_conf}'",
-            f"sed -i 's/^enabled=0/enabled=1/' '{product_id_plugin_conf}'"
+            f'sed -i "s/^plugins=0/plugins=1/" "{dnf_conf_path}"',
+            f'sed -i "s/^enabled=0/enabled=1/" "{rhsm_plugin_conf}"',
+            f'sed -i "s/^enabled=0/enabled=1/" "{product_id_plugin_conf}"',
         ]
 
         reporting.create_report([


### PR DESCRIPTION
The framework now uses shlex.quote to always make literals out of remediation command arguments ([PR#921](https://github.com/oamg/leapp/pull/921)). Some of the existing commands used single quotes in them so the resulting command in leapp-report.txt used unintuitive escaping of single quotes.

The chackrootsymlinks can still end up with a single quote if the user has it in one of the symlinks that need to be adjusted. However, it is not possible to handle this differently without introducing side effects.

### Requires leapp framework PR#921

### Examples
#### Basic symlinks
```
bin -> /usr/bin
leapp-logs -> /var/log/leapp
lib -> /usr/lib
lib64 -> /usr/lib64
```
leapp-report.json
```
{
  "context": [
    "bash",
    "-c",
    "ln -snf \"usr/bin\" \"/bin\" && ln -snf \"usr/lib\" \"/lib\" && ln -snf \"usr/lib64\" \"/lib64\" && ln -snf \"var/log/leapp\" \"/leapp-logs\""
  ],
  "type": "command"
},
```
leapp-report.txt
```
bash -c 'ln -snf "usr/bin" "/bin" && ln -snf "usr/lib" "/lib" && ln -snf "usr/lib64" "/lib64" && ln -snf "var/log/leapp" "/leapp-logs"'
```
#### Problematic input
Symlinks in ``/``
```
'$USER' -> /var/log/leapp
'backslash\backslash' -> /var/log/leapp
bin -> /usr/bin
'escapedmark\!escapedmark' -> /var/log/leapp
'hex\xFFhex' -> /var/log/leapp
leapp-logs -> /var/log/leapp
lib -> /usr/lib
lib64 -> /usr/lib64
'mark!mark' -> /var/log/leapp
'newline\nnewline' -> /var/log/leapp
"quote'quote" -> /var/log/leapp
"quote'quote'quote" -> /var/log/leapp
'return\rreturn' -> /var/log/leapp
'space space' -> /var/log/leapp
'tab\ttab' -> /var/log/leapp
'`zsh`' -> /var/log/leapp
```
leapp-report.json
```
{
   "context": [
   "bash",
    "-c",
     "ln -snf \"usr/bin\" \"/bin\" && ln -snf \"usr/lib\" \"/lib\" && ln -snf \"usr/lib64\" \"/lib64\" && ln -snf \"var/log/leapp\" \"/leapp-logs\" && ln -snf \"var/log/leapp\" \"/quote'quote\" && ln -snf \"var/log/leapp\" \"/quote'quote'quote\" &
& ln -snf \"var/log/leapp\" \"/mark!mark\" && ln -snf \"var/log/leapp\" \"/space space\" && ln -snf \"var/log/leapp\" \"/\\$USER\" && ln -snf \"var/log/leapp\" \"/\\`zsh\\`\" && ln -snf \"var/log/leapp\" \"/backslash\\\\backslash\" && ln -snf \"var/log/lea
pp\" \"/escapedmark\\\\!escapedmark\" && ln -snf \"var/log/leapp\" \"/newline\\\\nnewline\" && ln -snf \"var/log/leapp\" \"/tab\\\\ttab\" && ln -snf \"var/log/leapp\" \"/return\\\\rreturn\" && ln -snf \"var/log/leapp\" \"/hex\\\\xFFhex\""
   ],
   "type": "command"
},
```

leapp-report.txt
```
bash -c 'ln -snf "usr/bin" "/bin" && ln -snf "usr/lib" "/lib" && ln -snf "usr/lib64" "/lib64" && ln -snf "var/log/leapp" "/leapp-logs" && ln -snf "var/log/leapp" "/quote'"'"'quote" && ln -snf "var/log/leapp" "/quote'"'"'quote'"'"'quote" && ln -snf "var/log/leapp" "/mark!mark" && ln -snf "var/log/leapp" "/space space" && ln -snf "var/log/leapp" "/\$USER" && ln -snf "var/log/leapp" "/\`zsh\`" && ln -snf "var/log/leapp" "/backslash\\backslash" && ln -snf "var/log/leapp" "/escapedmark\\!escapedmark" && ln -snf "var/log/leapp" "/newline\\nnewline" && ln -snf "var/log/leapp" "/tab\\ttab" && ln -snf "var/log/leapp" "/return\\rreturn" && ln -snf "var/log/leapp" "/hex\\xFFhex"'
```
Easier to read version:
```
bash -c '
ln -snf "usr/bin" "/bin" 
&& ln -snf "usr/lib" "/lib"
&& ln -snf "usr/lib64" "/lib64"
&& ln -snf "var/log/leapp" "/leapp-logs"
&& ln -snf "var/log/leapp" "/quote'"'"'quote"
&& ln -snf "var/log/leapp" "/quote'"'"'quote'"'"'quote"
&& ln -snf "var/log/leapp" "/mark!mark"
&& ln -snf "var/log/leapp" "/space space"
&& ln -snf "var/log/leapp" "/\$USER"
&& ln -snf "var/log/leapp" "/\`zsh\`"
&& ln -snf "var/log/leapp" "/backslash\\backslash"
&& ln -snf "var/log/leapp" "/escapedmark\\!escapedmark"
&& ln -snf "var/log/leapp" "/newline\\nnewline"
&& ln -snf "var/log/leapp" "/tab\\ttab"
&& ln -snf "var/log/leapp" "/return\\rreturn"
&& ln -snf "var/log/leapp" "/hex\\xFFhex"
'
```
As you can see, for those with ``'`` in the path there is the ugly quoting and for the ones with special symbols it is escaped and double quoted leaving the space for ugly output minimal. Notably the ! is not escaped due to the fact that bash -c is a non-interactive shell where it does not have any special meaning and the topmost shell uses the ``'`` so it is literal there. The other symbols that would lead to expansion are escaped so that we can use double quotes. It would be reasonable to drop the _dquote in favour of shlex, but that would lead to something similar we see in sed commands in following examples and would be further exaggerated by the user input having ``'`` in their path.


Tried the command and it worked resulting in all of the symlinks being changed:
```
'$USER' -> var/log/leapp
'backslash\backslash' -> var/log/leapp
bin -> usr/bin
'escapedmark\!escapedmark' -> var/log/leapp
'hex\xFFhex' -> var/log/leapp
leapp-logs -> var/log/leapp
lib -> usr/lib
lib64 -> usr/lib64
'mark!mark' -> var/log/leapp
'newline\nnewline' -> var/log/leapp
"quote'quote" -> var/log/leapp
"quote'quote'quote" -> var/log/leapp
'return\rreturn' -> var/log/leapp
'space space' -> var/log/leapp
'tab\ttab' -> var/log/leapp
'`zsh`' -> var/log/leapp
```


### The sed commands 
The command does not change - we know that the paths don't contain any symbols that would cause unexpected expansion and also the pattern is ok to be double quoted. Following showcases how important it is to not use `'` when not necessary. Here it is not needed to have single quoted arguments and so we can simply avoid the ugly command by using double quotes as shown in the next example.

#### With single quotes (original)
(With the framework PR#921 and **without** this PR)
leapp-report.json
```
{
  "context": [
    "bash",
    "-c",
    "sed -i 's/^plugins=0/plugins=1/' '/etc/dnf/dnf.conf'; sed -i 's/^enabled=0/enabled=1/' '/etc/dnf/plugins/subscription-manager.conf'; sed -i 's/^enabled=0/enabled=1/' '/etc/dnf/plugins/product-id.conf'"
  ],
  "type": "command"
}
```

leapp-report.txt
```
bash -c 'sed -i '"'"'s/^plugins=0/plugins=1/'"'"' '"'"'/etc/dnf/dnf.conf'"'"'; sed -i '"'"'s/^enabled=0/enabled=1/'"'"' '"'"'/etc/dnf/plugins/subscription-manager.conf'"'"'; sed -i '"'"'s/^enabled=0/enabled=1/'"'"' '"'"'/etc/dnf/plugins/product-i
d.conf'"'"''
```

#### Without single quotes (now)
(With the framework PR#921 and **with** this PR)
leapp-report.json
```
{
  "context": [
   "bash",
   "-c",
   "sed -i \"s/^plugins=0/plugins=1/\" \"/etc/dnf/dnf.conf\"; sed -i \"s/^enabled=0/enabled=1/\" \"/etc/dnf/plugins/subscription-manager.conf\"; sed -i \"s/^enabled=0/enabled=1/\" \"/etc/dnf/plugins/product-id.conf\""
   ],
   type": "command"
}
```

leapp-report.txt
```
bash -c 'sed -i "s/^plugins=0/plugins=1/" "/etc/dnf/dnf.conf"; sed -i "s/^enabled=0/enabled=1/" "/etc/dnf/plugins/subscription-manager.conf"; sed -i "s/^enabled=0/enabled=1/" "/etc/dnf/plugins/product-id.conf"'
```

---

### Without subcommand
This is a made up example showing how a path extracted from the users system could trigger the ugly quoting even without the subcommand nesting.

leapp-report.json
```
{
  "context": [
    "rm",
    "-rf",
    "/home/user/space 'quote"
  ],
  "type": "command"
},
```

leapp-report.txt
```
rm -rf '/home/user/space '"'"'quote'
```


Jira: RHEL-156521