### PR TITLE
python test deps: update required py packages per python

### DIFF
--- a/commands/tests/test_upgrade_paths.py
+++ b/commands/tests/test_upgrade_paths.py
@@ -1,7 +1,7 @@
 import os
 import resource
+import unittest.mock as mock
 
-import mock
 import pytest
 
 from leapp.cli.commands import command_utils

--- a/repos/system_upgrade/common/actors/biosdevname/tests/test_biosdevname.py
+++ b/repos/system_upgrade/common/actors/biosdevname/tests/test_biosdevname.py
@@ -1,7 +1,8 @@
+from unittest.mock import mock_open, patch
+
 import pytest
 import pyudev
 import six
-from mock import mock_open, patch
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import biosdevname

--- a/repos/system_upgrade/common/actors/cephvolumescan/tests/test_cephvolumescan.py
+++ b/repos/system_upgrade/common/actors/cephvolumescan/tests/test_cephvolumescan.py
@@ -1,9 +1,6 @@
-import pytest
-from mock import Mock, patch
+from unittest.mock import patch
 
 from leapp.libraries.actor import cephvolumescan
-from leapp.models import InstalledRPM, LsblkEntry, RPM, StorageInfo
-from leapp.reporting import Report
 
 CONT_PS_COMMAND_OUTPUT = {
     "stdout":

--- a/repos/system_upgrade/common/actors/distributionsignedrpmscanner/tests/test_distributionsignedrpmscanner.py
+++ b/repos/system_upgrade/common/actors/distributionsignedrpmscanner/tests/test_distributionsignedrpmscanner.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock as mock
 
 from leapp.libraries.common import rpms
 from leapp.libraries.common.config import mock_configs
@@ -8,7 +8,6 @@ from leapp.models import (
     fields,
     InstalledRPM,
     InstalledUnsignedRPM,
-    IPUConfig,
     Model,
     OSRelease,
     RPM,

--- a/repos/system_upgrade/common/actors/ifcfgscanner/tests/unit_test_ifcfgscanner.py
+++ b/repos/system_upgrade/common/actors/ifcfgscanner/tests/unit_test_ifcfgscanner.py
@@ -1,9 +1,9 @@
 import errno
 import textwrap
+import unittest.mock as mock
 from io import StringIO
 from os.path import basename
 
-import mock
 import six
 
 from leapp.libraries.actor import ifcfgscanner

--- a/repos/system_upgrade/common/actors/scanmemory/tests/test_scanmemory.py
+++ b/repos/system_upgrade/common/actors/scanmemory/tests/test_scanmemory.py
@@ -1,4 +1,5 @@
-import mock
+import unittest.mock as mock
+
 import six
 
 from leapp.libraries.actor import scanmemory

--- a/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/tests/component_test_selinuxcontentscanner.py
+++ b/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/tests/component_test_selinuxcontentscanner.py
@@ -4,9 +4,7 @@ import pytest
 
 from leapp.libraries.common.config import mock_configs
 from leapp.libraries.stdlib import api, CalledProcessError, run
-from leapp.models import SELinuxCustom, SELinuxFacts, SELinuxModule, SELinuxModules, SELinuxRequestRPMs
-from leapp.reporting import Report
-from leapp.snactor.fixture import current_actor_context
+from leapp.models import SELinuxCustom, SELinuxFacts, SELinuxModules, SELinuxRequestRPMs
 
 # compat module ensures compatibility with newer systems and is not part of testing
 TEST_MODULES = [

--- a/repos/system_upgrade/el8toel9/actors/nisscanner/tests/test_nisscan.py
+++ b/repos/system_upgrade/el8toel9/actors/nisscanner/tests/test_nisscan.py
@@ -1,4 +1,5 @@
-import mock
+import unittest.mock as mock
+
 import pytest
 import six
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,14 @@ isort
 funcsigs==1.0.2
 mock==2.0.0
 pylint
-pytest==4.6.11; python_version < '3.0'
-pytest==6.2.5; python_version >= '3.6'
-pyudev==0.22.0
-distro==1.5.0
+pytest==6.2.5; python_version >= '3.6' and python_version < '3.8'
+pytest==7.4.4; python_version >= '3.8' and python_version < '3.10'
+pytest==9.0.3; python_version >= '3.10'
+pyudev==0.22.0; python_version < '3.10'
+pyudev==0.24.1; python_version >= '3.10'
+distro==1.5.0; python_version < '3.10'
+distro==1.9.0; python_version >= '3.10'
 ipaddress==1.0.23
 git+https://github.com/oamg/leapp
 requests
-# pinning a py27 troublemaking transitive dependency
-lazy-object-proxy==1.5.2; python_version < '3'
 rpm

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 flake8
 isort
 funcsigs==1.0.2
-mock==2.0.0
 pylint
 pytest==6.2.5; python_version >= '3.6' and python_version < '3.8'
 pytest==7.4.4; python_version >= '3.8' and python_version < '3.10'


### PR DESCRIPTION
tl;dr; We haven't updated the requirements.txt file for a long time
(basically since IPU 7 -> 8; if we do not count some minor updates).
Let's update dependencies to use newer python modules for newer
versions of python.

* Pytest
  Originally we required pytest v6.2.5 for any python 3.6+. This is
  pretty old requirement coming from time of python ~ 3.8 and recently
  a https://github.com/advisories/GHSA-6w46-j5rx-g56g occuared, which is fix in pytest v9.0.3.
  So let's update ranges to actually allow use of newer pytest on newer
  systems:

        +----------------+---------------+
        | pytest version | python range  |
        +----------------+---------------+
        | 6.2.5          | 3.6.x - 3.7.x |
        | 8.3.5          | 3.8.x - 3.9.x |
        | 9.0.3          | 3.10+         |
        +----------------+---------------+

* Pyudev
  The original v0.22 is used up to CS 9 (pyton 3.9-). Use 0.24.1 for
  python 3.10+ (reflects CS 10 as well)

* Distro
  The original v1.5.0 can be used till CS 9 (python 3.9 included) safely
  as nowadays. Let's use version 1.9.0 for Python 3.10+

* Mock
   Drop the dependency + update imports in unit tests to use mock from std library.
   Covers https://github.com/oamg/leapp-repository/pull/1523

* Drop unsued dependencies (old python that is no longer supported
  in the project).

### TODO:
- [x] discover why unit tests for python3.9 el8toel9 are randomly failing on import
  - just when I decided that it was pebkac, I was able to reproduce it. it seems that there is a race condition when using newer python modules.
  - It seems to be problem between Python 3.9 and Pytest 8. Both have changes related to imports and mainly pytest is the source of problems for projects which have own handling of imports implemented. Seems that Pytest 7 works well on Python 3.9. I will give it several rounds before marking it ready for merge.
  - Confirmed. Pytest 7.x.x is safe to use with Python 3.9