### PR TITLE
Drop dependency on mock

### DIFF
--- a/commands/tests/test_upgrade_paths.py
+++ b/commands/tests/test_upgrade_paths.py
@@ -1,7 +1,7 @@
 import os
 import resource
+import unittest.mock as mock
 
-import mock
 import pytest
 
 from leapp.cli.commands import command_utils

--- a/repos/system_upgrade/common/actors/biosdevname/tests/test_biosdevname.py
+++ b/repos/system_upgrade/common/actors/biosdevname/tests/test_biosdevname.py
@@ -1,7 +1,8 @@
+from unittest.mock import mock_open, patch
+
 import pytest
 import pyudev
 import six
-from mock import mock_open, patch
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import biosdevname

--- a/repos/system_upgrade/common/actors/cephvolumescan/tests/test_cephvolumescan.py
+++ b/repos/system_upgrade/common/actors/cephvolumescan/tests/test_cephvolumescan.py
@@ -1,9 +1,6 @@
-import pytest
-from mock import Mock, patch
+from unittest.mock import patch
 
 from leapp.libraries.actor import cephvolumescan
-from leapp.models import InstalledRPM, LsblkEntry, RPM, StorageInfo
-from leapp.reporting import Report
 
 CONT_PS_COMMAND_OUTPUT = {
     "stdout":

--- a/repos/system_upgrade/common/actors/distributionsignedrpmscanner/tests/test_distributionsignedrpmscanner.py
+++ b/repos/system_upgrade/common/actors/distributionsignedrpmscanner/tests/test_distributionsignedrpmscanner.py
@@ -1,4 +1,4 @@
-import mock
+import unittest.mock as mock
 
 from leapp.libraries.common import rpms
 from leapp.libraries.common.config import mock_configs
@@ -8,7 +8,6 @@ from leapp.models import (
     fields,
     InstalledRPM,
     InstalledUnsignedRPM,
-    IPUConfig,
     Model,
     OSRelease,
     RPM,

--- a/repos/system_upgrade/common/actors/ifcfgscanner/tests/unit_test_ifcfgscanner.py
+++ b/repos/system_upgrade/common/actors/ifcfgscanner/tests/unit_test_ifcfgscanner.py
@@ -1,9 +1,9 @@
 import errno
 import textwrap
+import unittest.mock as mock
 from io import StringIO
 from os.path import basename
 
-import mock
 import six
 
 from leapp.libraries.actor import ifcfgscanner

--- a/repos/system_upgrade/common/actors/scanmemory/tests/test_scanmemory.py
+++ b/repos/system_upgrade/common/actors/scanmemory/tests/test_scanmemory.py
@@ -1,4 +1,5 @@
-import mock
+import unittest.mock as mock
+
 import six
 
 from leapp.libraries.actor import scanmemory

--- a/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/tests/component_test_selinuxcontentscanner.py
+++ b/repos/system_upgrade/common/actors/selinux/selinuxcontentscanner/tests/component_test_selinuxcontentscanner.py
@@ -4,9 +4,7 @@ import pytest
 
 from leapp.libraries.common.config import mock_configs
 from leapp.libraries.stdlib import api, CalledProcessError, run
-from leapp.models import SELinuxCustom, SELinuxFacts, SELinuxModule, SELinuxModules, SELinuxRequestRPMs
-from leapp.reporting import Report
-from leapp.snactor.fixture import current_actor_context
+from leapp.models import SELinuxCustom, SELinuxFacts, SELinuxModules, SELinuxRequestRPMs
 
 # compat module ensures compatibility with newer systems and is not part of testing
 TEST_MODULES = [

--- a/repos/system_upgrade/el8toel9/actors/nisscanner/tests/test_nisscan.py
+++ b/repos/system_upgrade/el8toel9/actors/nisscanner/tests/test_nisscan.py
@@ -1,4 +1,5 @@
-import mock
+import unittest.mock as mock
+
 import pytest
 import six
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 flake8
 isort
 funcsigs==1.0.2
-mock==2.0.0
 pylint
 pytest==4.6.11; python_version < '3.0'
 pytest==6.2.5; python_version >= '3.6'


### PR DESCRIPTION
The mock library is now a part of the Python standard library since Python 3.3 and is available as the unittest.mock. The 'mock' library is only a backport which is not needed anymore.

Also remove some unnecessary imports.