### PR TITLE
repofileutils: disable ConfigParser interpolation when parsing .repo files

### DIFF
--- a/repos/system_upgrade/common/libraries/repofileutils.py
+++ b/repos/system_upgrade/common/libraries/repofileutils.py
@@ -48,7 +48,7 @@ def parse_repofile(repofile):
     """
     data = []
     with open(repofile, mode='r') as fp:
-        cp = utils.parse_config(fp, strict=False)
+        cp = utils.parse_config(fp, strict=False, no_interpolation=True)
         for repoid in cp.sections():
             try:
                 data.append(_parse_repository(repoid, dict(cp.items(repoid))))

--- a/repos/system_upgrade/common/libraries/tests/test_repofileutils.py
+++ b/repos/system_upgrade/common/libraries/tests/test_repofileutils.py
@@ -75,3 +75,23 @@ def test_parse_repofile():
     repos_duplicate = [repo for repo in repofile.data if repo.repoid == 'duplicate']
     assert len(repos_duplicate) == 1  # only one instance got through
     assert repos_duplicate[0].name == 'Duplicate 2'  # and it's the latter one
+
+
+def test_parse_repofile_preserves_url_encoded_characters(tmp_path):
+    """Percent signs from URL encoding must not be treated as config interpolation."""
+    repo_path = tmp_path / 'urlencoded.repo'
+    expected_baseurl = (
+        'https://cdn.example.com/content/dist/rhel8/%24releasever/x86_64/os/'
+        '?token=foo%2Fbar%3Dbaz'
+    )
+    repo_path.write_text(
+        '[urlencoded]\n'
+        'name=URL-encoded baseurl\n'
+        'baseurl={}\n'
+        'enabled=0\n'.format(expected_baseurl),
+        encoding='utf-8',
+    )
+
+    repofile = repofileutils.parse_repofile(str(repo_path))
+    repo = next(r for r in repofile.data if r.repoid == 'urlencoded')
+    assert repo.baseurl == expected_baseurl

--- a/repos/system_upgrade/common/libraries/tests/test_utils_parse_config.py
+++ b/repos/system_upgrade/common/libraries/tests/test_utils_parse_config.py
@@ -1,0 +1,30 @@
+from configparser import InterpolationSyntaxError
+
+import pytest
+
+from leapp.libraries.common import utils
+
+
+def test_parse_config_no_interpolation_preserves_url_encoding():
+    """Values with URL-encoded sequences must be read literally (no % interpolation)."""
+    cfg_text = (
+        '[repo]\n'
+        'name=test\n'
+        'baseurl=https://example.com/path%20with%20spaces/repo%3Fquery=1\n'
+    )
+    parser = utils.parse_config(cfg_text, strict=False, no_interpolation=True)
+    assert parser.get('repo', 'baseurl') == (
+        'https://example.com/path%20with%20spaces/repo%3Fquery=1'
+    )
+
+
+def test_parse_config_interpolation_rejects_bare_percent_sequences():
+    """Default ConfigParser treats '%' as interpolation; invalid sequences must raise."""
+    cfg_text = (
+        '[repo]\n'
+        'name=test\n'
+        'baseurl=https://example.com/path%20with%20spaces/repo\n'
+    )
+    parser = utils.parse_config(cfg_text, strict=False, no_interpolation=False)
+    with pytest.raises(InterpolationSyntaxError):
+        parser.get('repo', 'baseurl')

--- a/repos/system_upgrade/common/libraries/utils.py
+++ b/repos/system_upgrade/common/libraries/utils.py
@@ -10,7 +10,7 @@ from leapp.libraries.stdlib import api, CalledProcessError, config, run, STDOUT
 from leapp.utils.deprecation import deprecated
 
 
-def parse_config(cfg=None, strict=True):
+def parse_config(cfg=None, strict=True, no_interpolation=False):
     """
     Applies a workaround to parse a config file using py3 AND py2
 
@@ -18,10 +18,20 @@ def parse_config(cfg=None, strict=True):
     the old ones (Py2) obsoletes, these function was created to use the
     ConfigParser on Py2 and Py3
 
+    When no_interpolation is True, values are read literally. Use this for
+    inputs that may contain percent-encoded URLs (e.g. yum .repo baseurl),
+    since default ConfigParser treats ``%`` as interpolation syntax.
+
     :type cfg: str
     :type strict: bool
+    :type no_interpolation: bool
     """
-    if six.PY3:
+    if no_interpolation:
+        if six.PY3:
+            parser = six.moves.configparser.RawConfigParser(strict=strict)  # pylint: disable=unexpected-keyword-arg
+        else:
+            parser = six.moves.configparser.RawConfigParser()
+    elif six.PY3:
         parser = six.moves.configparser.ConfigParser(strict=strict)  # pylint: disable=unexpected-keyword-arg
     else:
         parser = six.moves.configparser.ConfigParser()

--- a/repos/system_upgrade/common/libraries/utils.py
+++ b/repos/system_upgrade/common/libraries/utils.py
@@ -1,8 +1,7 @@
 import functools
 import os
 import sys
-
-import six
+from configparser import ConfigParser, RawConfigParser
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import mounting
@@ -12,44 +11,33 @@ from leapp.utils.deprecation import deprecated
 
 def parse_config(cfg=None, strict=True, no_interpolation=False):
     """
-    Applies a workaround to parse a config file using py3 AND py2
+    Parse a config input.
 
-    ConfigParser has a new def to read strings/files in Py3, making
-    the old ones (Py2) obsoletes, these function was created to use the
-    ConfigParser on Py2 and Py3
+    When ``no_interpolation`` is True, ``RawConfigParser`` is used to read
+    values literally. This is useful for inputs that may contain URLs with
+    '%' characters for URL encoding (e.g. yum .repo baseurl).
 
-    When no_interpolation is True, values are read literally. Use this for
-    inputs that may contain percent-encoded URLs (e.g. yum .repo baseurl),
-    since default ConfigParser treats ``%`` as interpolation syntax.
+    When set to False, the default ``ConfigParser`` is used, where '%' is treated
+    as interpolation syntax and must be escaped (%%) if used literally.
 
-    :type cfg: str
+    :param cfg: Config data as a string or a file-like object
+    :type cfg: str or file-like object
+    :param strict: Enable strict parsing (no duplicate sections/options)
     :type strict: bool
+    :param no_interpolation: Disable interpolation and read values literally
     :type no_interpolation: bool
     """
     if no_interpolation:
-        if six.PY3:
-            parser = six.moves.configparser.RawConfigParser(strict=strict)  # pylint: disable=unexpected-keyword-arg
-        else:
-            parser = six.moves.configparser.RawConfigParser()
-    elif six.PY3:
-        parser = six.moves.configparser.ConfigParser(strict=strict)  # pylint: disable=unexpected-keyword-arg
+        parser = RawConfigParser(strict=strict)
     else:
-        parser = six.moves.configparser.ConfigParser()
+        parser = ConfigParser(strict=strict)
 
     # we do not handle exception here, handle with it when these function is called
-    if cfg and six.PY3:
-        # Python 3
-        if isinstance(cfg, six.string_types):
+    if cfg:
+        if isinstance(cfg, str):
             parser.read_string(cfg)
         else:
             parser.read_file(cfg)
-    elif cfg:
-        # Python 2
-        from cStringIO import StringIO  # pylint: disable=import-outside-toplevel
-        if isinstance(cfg, six.string_types):
-            parser.readfp(StringIO(cfg))  # pylint: disable=deprecated-method
-        else:
-            parser.readfp(cfg)  # pylint: disable=deprecated-method
     return parser
 
 


### PR DESCRIPTION
repofileutils: disable ConfigParser interpolation when parsing .repo files

This occurs when parsing repository definitions containing percent encoded values (e.g. '%252B'in baseurls). Python's ConfigParser enables interpolation by default and treats '%' as a special token, which causes valid URLs to fail during parsing.

Disable interpolation by using parse_config(..., no_interpolation=True) so that repository values are handled literally, consistent with DNF  or YUM behavior.

Jira-ref: RHEL-162328, RHEL-148631