### PR TITLE
el8toel9: networkdeprecations: warn about ifcfg devices not controlled by NM

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/networkdeprecations/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/networkdeprecations/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import networkdeprecations
-from leapp.models import IfCfg, NetworkManagerConnection, Report
+from leapp.models import IfCfg, NetworkManagerConnection, Report, SystemdServicesInfoSource
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
@@ -16,7 +16,7 @@ class CheckNetworkDeprecations(Actor):
     """
 
     name = "network_deprecations"
-    consumes = (IfCfg, NetworkManagerConnection,)
+    consumes = (IfCfg, NetworkManagerConnection, SystemdServicesInfoSource,)
     produces = (Report,)
     tags = (ChecksPhaseTag, IPUWorkflowTag,)
 

--- a/repos/system_upgrade/el8toel9/actors/networkdeprecations/libraries/networkdeprecations.py
+++ b/repos/system_upgrade/el8toel9/actors/networkdeprecations/libraries/networkdeprecations.py
@@ -1,12 +1,13 @@
 from leapp import reporting
 from leapp.libraries.stdlib import api
-from leapp.models import IfCfg, NetworkManagerConnection
+from leapp.models import IfCfg, NetworkManagerConnection, SystemdServicesInfoSource
 
 FMT_LIST_SEPARATOR = '\n    - '
 
 
 def process():
     wep_files = []
+    nm_controlled_files = []
 
     # Scan NetworkManager native keyfile connections
     for nmconn in api.consume(NetworkManagerConnection):
@@ -26,6 +27,8 @@ def process():
         if ifcfg.secrets is not None:
             props = props + ifcfg.secrets
 
+        nm_controlled = True
+
         for prop in props:
             name = prop.name
             value = prop.value
@@ -39,6 +42,14 @@ def process():
             if name in ('KEY_PASSPHRASE1', 'KEY1', 'WEP_KEY_FLAGS'):
                 wep_files.append(ifcfg.filename)
                 continue
+
+            # NM_CONTROLLED
+            if name == 'NM_CONTROLLED' and value.lower() in ("no", "false", "f", "n", "0"):
+                nm_controlled = False
+                continue
+
+        if nm_controlled:
+            nm_controlled_files.append(ifcfg.filename)
 
     if wep_files:
         title = 'Wireless networks using unsupported WEP encryption detected'
@@ -65,3 +76,43 @@ def process():
             reporting.RelatedResource('file', fname)
             for fname in wep_files
         ])
+
+    if nm_controlled_files and _is_nm_service_disabled():
+        title = 'ifcfg files expect NetworkManager but the service is disabled'
+        summary = (
+            'NetworkManager is disabled on the system, but there are ifcfg'
+            ' configuration files that do not set NM_CONTROLLED=no. After the'
+            ' upgrade, legacy network scripts will no longer be available and'
+            ' NetworkManager will be the only way to manage networking. These'
+            ' connections will not be active unless NetworkManager is enabled.'
+            ' Files with the problematic configuration:{}'
+        ).format(
+            ''.join(['{}{}'.format(FMT_LIST_SEPARATOR, f) for f in nm_controlled_files])
+        )
+        remediation = (
+            'Either enable the NetworkManager service before upgrading, or add'
+            ' NM_CONTROLLED=no to the ifcfg files that should not be managed'
+            ' by NetworkManager.'
+        )
+        reporting.create_report([
+            reporting.Title(title),
+            reporting.Summary(summary),
+            reporting.Remediation(hint=remediation),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.NETWORK, reporting.Groups.SERVICES]),
+            reporting.Groups([reporting.Groups.INHIBITOR]),
+            reporting.RelatedResource('package', 'NetworkManager'),
+        ] + [
+            reporting.RelatedResource('file', fname)
+            for fname in nm_controlled_files
+        ])
+
+
+def _is_nm_service_disabled():
+    services_info = next(api.consume(SystemdServicesInfoSource), None)
+    if not services_info:
+        return True
+    for svc in services_info.service_files:
+        if svc.name == 'NetworkManager.service':
+            return svc.state == 'disabled'
+    return True

--- a/repos/system_upgrade/el8toel9/actors/networkdeprecations/tests/unit_test_networkdeprecations.py
+++ b/repos/system_upgrade/el8toel9/actors/networkdeprecations/tests/unit_test_networkdeprecations.py
@@ -3,7 +3,9 @@ from leapp.models import (
     IfCfgProperty,
     NetworkManagerConnection,
     NetworkManagerConnectionProperty,
-    NetworkManagerConnectionSetting
+    NetworkManagerConnectionSetting,
+    SystemdServiceFile,
+    SystemdServicesInfoSource
 )
 from leapp.reporting import Report
 from leapp.utils.report import is_inhibitor
@@ -122,3 +124,81 @@ def test_ifcfg_dynamic_wep(current_actor_context):
     current_actor_context.run()
     report_fields = current_actor_context.consume(Report)[0].report
     assert is_inhibitor(report_fields)
+
+
+def _nm_service_info(state):
+    return SystemdServicesInfoSource(service_files=[
+        SystemdServiceFile(name='NetworkManager.service', state=state),
+    ])
+
+
+def test_nm_disabled_ifcfg_no_nm_controlled(current_actor_context):
+    """
+    Report if NM is disabled and ifcfg files don't have NM_CONTROLLED=no.
+    """
+
+    current_actor_context.feed(_nm_service_info('disabled'))
+    current_actor_context.feed(IfCfg(filename='/NM/ifcfg-eth0', properties=(
+        IfCfgProperty(name='TYPE', value='Ethernet'),
+    )))
+    current_actor_context.run()
+    reports = current_actor_context.consume(Report)
+    assert len(reports) == 1
+    assert 'ifcfg files expect NetworkManager' in reports[0].report['title']
+
+
+def test_nm_disabled_ifcfg_nm_controlled_no(current_actor_context):
+    """
+    No report if NM is disabled but all ifcfg files have NM_CONTROLLED=no.
+    """
+
+    current_actor_context.feed(_nm_service_info('disabled'))
+    current_actor_context.feed(IfCfg(filename='/NM/ifcfg-eth0', properties=(
+        IfCfgProperty(name='TYPE', value='Ethernet'),
+        IfCfgProperty(name='NM_CONTROLLED', value='no'),
+    )))
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+
+
+def test_nm_enabled_ifcfg_no_nm_controlled(current_actor_context):
+    """
+    No report if NM is enabled, even if ifcfg files lack NM_CONTROLLED=no.
+    """
+
+    current_actor_context.feed(_nm_service_info('enabled'))
+    current_actor_context.feed(IfCfg(filename='/NM/ifcfg-eth0', properties=(
+        IfCfgProperty(name='TYPE', value='Ethernet'),
+    )))
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)
+
+
+def test_nm_disabled_mixed_ifcfg(current_actor_context):
+    """
+    Report only the ifcfg files that lack NM_CONTROLLED=no when NM is disabled.
+    """
+
+    current_actor_context.feed(_nm_service_info('disabled'))
+    current_actor_context.feed(IfCfg(filename='/NM/ifcfg-eth0', properties=(
+        IfCfgProperty(name='TYPE', value='Ethernet'),
+    )))
+    current_actor_context.feed(IfCfg(filename='/NM/ifcfg-eth1', properties=(
+        IfCfgProperty(name='TYPE', value='Ethernet'),
+        IfCfgProperty(name='NM_CONTROLLED', value='no'),
+    )))
+    current_actor_context.run()
+    reports = current_actor_context.consume(Report)
+    assert len(reports) == 1
+    assert '/NM/ifcfg-eth0' in reports[0].report['summary']
+    assert '/NM/ifcfg-eth1' not in reports[0].report['summary']
+
+
+def test_nm_disabled_no_ifcfg(current_actor_context):
+    """
+    No report if NM is disabled but there are no ifcfg files at all.
+    """
+
+    current_actor_context.feed(_nm_service_info('disabled'))
+    current_actor_context.run()
+    assert not current_actor_context.consume(Report)


### PR DESCRIPTION
Network devices currently configured via ifcfg have to be configured by NetworkManager in EL9. If NetworkManager is disabled, connectivity will be lost. Generate a report with HIGH severity in that case.

If devices are configured with NM_CONTROLLED=no, then ignore it, as they are being explicitly excluded from NetworkManager control.

Assisted-by: Claude 4.6 Opus

Jira: https://redhat.atlassian.net/browse/RHEL-133966