### PR TITLE
leapp_resume.service: use multi-user.target instead of default.target

### DIFF
--- a/repos/system_upgrade/common/actors/createresumeservice/actor.py
+++ b/repos/system_upgrade/common/actors/createresumeservice/actor.py
@@ -22,18 +22,21 @@ class CreateSystemdResumeService(Actor):
     tags = (FinalizationPhaseTag, IPUWorkflowTag)
 
     def process(self):
-        service_name = 'leapp_resume.service'
         systemd_dir = '/etc/systemd/system'
+        service_name = 'leapp_resume.service'
+        target_name = 'multi-user.target'
 
         service_templ_fpath = self.get_file_path(service_name)
         shutil.copyfile(service_templ_fpath, os.path.join(systemd_dir, service_name))
 
-        service_path = '/etc/systemd/system/{}'.format(service_name)
-        symlink_path = '/etc/systemd/system/default.target.wants/{}'.format(service_name)
+        target_wants_path = os.path.join(systemd_dir, '{}.wants'.format(target_name))
 
-        # in case nothing is enabled in the default target, the directory does not exist
+        service_path = os.path.join(systemd_dir, service_name)
+        symlink_path = os.path.join(target_wants_path, service_name)
+
+        # in case nothing is enabled in the target, the directory does not exist
         try:
-            os.mkdir(os.path.join(systemd_dir, 'default.target.wants'))
+            os.mkdir(target_wants_path)
         except OSError:
             pass
 

--- a/repos/system_upgrade/common/actors/createresumeservice/files/leapp_resume.service
+++ b/repos/system_upgrade/common/actors/createresumeservice/files/leapp_resume.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Temporary Leapp service which resumes execution after reboot
-After=default.target
+After=multi-user.target
 DefaultDependencies=no
 After=dbus.service
 After=network-online.target

--- a/repos/system_upgrade/common/actors/createresumeservice/tests/test_createresumeservice.py
+++ b/repos/system_upgrade/common/actors/createresumeservice/tests/test_createresumeservice.py
@@ -1,21 +1,18 @@
 import os
 
-import distro
 import pytest
 
 
 @pytest.mark.skipif(os.getuid() != 0, reason='User is not a root')
-@pytest.mark.skipif(
-    distro.id() == 'fedora',
-    reason='default.target.wants does not exists on Fedora distro',
-)
 def test_create_resume_service(current_actor_context):
-
     current_actor_context.run()
 
+    systemd_dir = '/etc/systemd/system'
     service_name = 'leapp_resume.service'
-    service_path = '/etc/systemd/system/{}'.format(service_name)
-    symlink_path = '/etc/systemd/system/default.target.wants/{}'.format(service_name)
+    target_name = 'multi-user.target'
+
+    service_path = os.path.join(systemd_dir, service_name)
+    symlink_path = os.path.join(systemd_dir, '{}.wants'.format(target_name), service_name)
 
     try:
         assert os.path.isfile(service_path)

--- a/repos/system_upgrade/common/actors/removeresumeservice/actor.py
+++ b/repos/system_upgrade/common/actors/removeresumeservice/actor.py
@@ -21,13 +21,16 @@ class RemoveSystemdResumeService(Actor):
     tags = (FirstBootPhaseTag.After, IPUWorkflowTag)
 
     def process(self):
+        systemd_dir = '/etc/systemd/system'
         service_name = 'leapp_resume.service'
-        if os.path.isfile('/etc/systemd/system/{}'.format(service_name)):
+        target_name = 'multi-user.target'
+
+        service_path = os.path.join(systemd_dir, service_name)
+        target_wants_path = os.path.join(systemd_dir, '{}.wants'.format(target_name), service_name)
+
+        if os.path.isfile(service_path):
             run(['systemctl', 'disable', service_name])
-            paths_to_unlink = [
-                '/etc/systemd/system/{}'.format(service_name),
-                '/etc/systemd/system/default.target.wants/{}'.format(service_name),
-            ]
+            paths_to_unlink = [service_path, target_wants_path]
             for path in paths_to_unlink:
                 try:
                     os.unlink(path)


### PR DESCRIPTION
When selinux autorelabel is triggered, the `selinux-autorelabel-generator` links `default.target` to `selinux-autorelabel.target`. During boot, the relabel is performed and then the system is rebooted, resulting in an intermediate reboot before the system fully starts.

Since `leapp_resume.service` was linked into `default.target.wants/` and ordered `After=default.target`, it was started during this intermediate autorelabel boot. When the relabel finished and the reboot was triggered, `leapp_resume.service` was terminated, preventing post-upgrade tasks from completing. The service was then rerun on the next boot.

This patch makes `leapp_resume.service` rely on `multi-user.target`, instead of the `default.target`, which is not reached during the autorelabel boot, ensuring `leapp_resume.service` only runs on the actual first boot into the upgraded OS.

Jira: RHEL-60060

---

### Steps to reproduce:
1. Make sure the [journal is persistent](https://access.redhat.com/solutions/696893)
2. Enable selinux if not enabled already (verify with `sestatus`)
3. Enable the relabeling `touch /.autorelabel`

Without the patch, the `leapp_resume.service` is started in both last boots (this is where the persistent journal is useful).
With the patch, the `leapp_resume.service` is started only in the last reboot and not in the relabeling boot.