### PR TITLE
Remove rd.luks.uuid cmdline args from upgrade boot entry

### DIFF
--- a/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
@@ -50,7 +50,9 @@ def collect_undesired_args(livemode_enabled):
         args = dict(zip(('ro', 'rhgb', 'quiet'), itertools.repeat(None)))
         args['rd.lvm.lv'] = _get_rdlvm_arg_values()
 
-    return set(args.items())
+    undesired = set(args.items())
+    undesired |= collect_set_of_kernel_args_from_msgs(UpgradeKernelCmdlineArgTasks, 'to_remove')
+    return undesired
 
 
 def format_grubby_args_from_args_set(args_dict):

--- a/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
@@ -18,7 +18,8 @@ from leapp.models import (
     LateTargetKernelCmdlineArgTasks,
     LiveModeArtifacts,
     LiveModeConfig,
-    TargetKernelCmdlineArgTasks
+    TargetKernelCmdlineArgTasks,
+    UpgradeKernelCmdlineArgTasks
 )
 
 CUR_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -395,3 +396,26 @@ def test_modify_grubenv_to_have_separate_blsdir(monkeypatch, has_separate_boot):
     monkeypatch.setattr(addupgradebootentry, 'run', run_mocked)
 
     addupgradebootentry.modify_our_grubenv_to_have_separate_blsdir(efi_info)
+
+
+def test_collect_undesired_args_includes_upgrade_to_remove(monkeypatch):
+    msgs = [
+        UpgradeKernelCmdlineArgTasks(to_remove=[
+            KernelCmdlineArg(key='rd.luks.uuid', value='luks-aaa'),
+            KernelCmdlineArg(key='rd.luks.uuid', value='luks-bbb'),
+        ]),
+    ]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+
+    undesired = addupgradebootentry.collect_undesired_args(livemode_enabled=False)
+
+    assert ('rd.luks.uuid', 'luks-aaa') in undesired
+    assert ('rd.luks.uuid', 'luks-bbb') in undesired
+
+
+def test_collect_undesired_args_no_upgrade_to_remove(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[]))
+
+    undesired = addupgradebootentry.collect_undesired_args(livemode_enabled=False)
+
+    assert undesired == set()

--- a/repos/system_upgrade/common/actors/checkluks/actor.py
+++ b/repos/system_upgrade/common/actors/checkluks/actor.py
@@ -1,6 +1,15 @@
 from leapp.actors import Actor
 from leapp.libraries.actor.checkluks import check_invalid_luks_devices
-from leapp.models import CephInfo, LuksDumps, StorageInfo, TargetUserSpaceUpgradeTasks, UpgradeInitramfsTasks
+from leapp.models import (
+    CephInfo,
+    KernelCmdline,
+    LuksDumps,
+    StorageInfo,
+    TargetKernelCmdlineArgTasks,
+    TargetUserSpaceUpgradeTasks,
+    UpgradeInitramfsTasks,
+    UpgradeKernelCmdlineArgTasks
+)
 from leapp.reporting import Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
@@ -15,8 +24,14 @@ class CheckLuks(Actor):
     """
 
     name = 'check_luks'
-    consumes = (CephInfo, LuksDumps, StorageInfo)
-    produces = (Report, TargetUserSpaceUpgradeTasks, UpgradeInitramfsTasks)
+    consumes = (CephInfo, KernelCmdline, LuksDumps, StorageInfo)
+    produces = (
+        Report,
+        TargetKernelCmdlineArgTasks,
+        TargetUserSpaceUpgradeTasks,
+        UpgradeInitramfsTasks,
+        UpgradeKernelCmdlineArgTasks
+    )
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 
     def process(self):

--- a/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
+++ b/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
@@ -6,9 +6,12 @@ from leapp.models import (
     CephInfo,
     CopyFile,
     DracutModule,
+    KernelCmdline,
     LuksDumps,
+    TargetKernelCmdlineArgTasks,
     TargetUserSpaceUpgradeTasks,
-    UpgradeInitramfsTasks
+    UpgradeInitramfsTasks,
+    UpgradeKernelCmdlineArgTasks
 )
 from leapp.reporting import create_report
 
@@ -103,6 +106,41 @@ def report_inhibitor(luks1_partitions, no_tpm2_partitions):
     ] + report_hints)
 
 
+def _emit_rdluks_undesired_for_upgrade_cmdline():
+    """
+    Identify rd.luks.uuid args on the source kernel cmdline and request their
+    removal from the upgrade boot entry.
+
+    The upgrade initramfs uses clevis-tpm2 to unlock LUKS devices. Dracut's
+    rd.luks.uuid mechanism is not needed and can cause problems if left in.
+    This mechanism  limits what devices will be unlocked during boot, i.e., only
+    devices named in the rd.luks.uuid args will be unlocked.  However, we want
+    to unlock all LUKS devices (at least those in /etc/crypttab). Therefore, we
+    request that rd.luks.uuid args be removed from the upgrade kernel cmdline.
+    """
+    cmdline = next(api.consume(KernelCmdline), None)
+    if not cmdline:
+        api.current_logger().debug('No KernelCmdline message received, nothing to do.')
+        return
+
+    rdluks_args = [arg for arg in cmdline.parameters if arg.key == 'rd.luks.uuid']
+
+    if not rdluks_args:
+        api.current_logger().debug('No rd.luks.uuid args found on the source kernel cmdline.')
+        return
+
+    api.current_logger().debug(
+        'Requesting removal of rd.luks.uuid args from the upgrade kernel cmdline: %s',
+        ['{}={}'.format(a.key, a.value) for a in rdluks_args]
+    )
+    api.produce(UpgradeKernelCmdlineArgTasks(to_remove=rdluks_args))
+
+    # When installing the target kernel RPM, the cmdline is copied from the booted system.
+    # As we remove the rd.luks.uuid args, we would accidentally remove them also from the
+    # target entry. Therefore, we add them back in here.
+    api.produce(TargetKernelCmdlineArgTasks(to_add=rdluks_args))
+
+
 def check_invalid_luks_devices():
     luks_dumps = next(api.consume(LuksDumps), None)
     if not luks_dumps:
@@ -123,9 +161,6 @@ def check_invalid_luks_devices():
             luks1_partitions.append(luks_dump.device_name)
         elif luks_dump.version == 2 and not _at_least_one_tpm_token(luks_dump):
             no_tpm2_partitions.append(luks_dump.device_name)
-
-        if luks1_partitions or no_tpm2_partitions:
-            report_inhibitor(luks1_partitions, no_tpm2_partitions)
         else:
             ok_partitions.append(luks_dump.device_name)
 
@@ -154,3 +189,4 @@ def check_invalid_luks_devices():
                 DracutModule(name='clevis-pin-tpm2')
             ])
         )
+        _emit_rdluks_undesired_for_upgrade_cmdline()

--- a/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
+++ b/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
@@ -111,6 +111,7 @@ def check_invalid_luks_devices():
 
     luks1_partitions = []
     no_tpm2_partitions = []
+    ok_partitions = []
     ceph_vol = _get_ceph_volumes()
     for luks_dump in luks_dumps.dumps:
         # if the device is managed by ceph, don't inhibit
@@ -126,25 +127,30 @@ def check_invalid_luks_devices():
         if luks1_partitions or no_tpm2_partitions:
             report_inhibitor(luks1_partitions, no_tpm2_partitions)
         else:
-            required_crypt_rpms = [
-                'clevis',
-                'clevis-dracut',
-                'clevis-systemd',
-                'clevis-udisks2',
-                'clevis-luks',
-                'cryptsetup',
-                'tpm2-tss',
-                'tpm2-tools',
-                'tpm2-abrmd'
-            ]
-            api.produce(TargetUserSpaceUpgradeTasks(
-                copy_files=[CopyFile(src="/etc/crypttab")],
-                install_rpms=required_crypt_rpms)
-            )
-            api.produce(UpgradeInitramfsTasks(
-                include_files=['/etc/crypttab'],
-                include_dracut_modules=[
-                    DracutModule(name='clevis'),
-                    DracutModule(name='clevis-pin-tpm2')
-                ])
-            )
+            ok_partitions.append(luks_dump.device_name)
+
+    if luks1_partitions or no_tpm2_partitions:
+        report_inhibitor(luks1_partitions, no_tpm2_partitions)
+    elif ok_partitions:
+        required_crypt_rpms = [
+            'clevis',
+            'clevis-dracut',
+            'clevis-systemd',
+            'clevis-udisks2',
+            'clevis-luks',
+            'cryptsetup',
+            'tpm2-tss',
+            'tpm2-tools',
+            'tpm2-abrmd'
+        ]
+        api.produce(TargetUserSpaceUpgradeTasks(
+            copy_files=[CopyFile(src="/etc/crypttab")],
+            install_rpms=required_crypt_rpms)
+        )
+        api.produce(UpgradeInitramfsTasks(
+            include_files=['/etc/crypttab'],
+            include_dracut_modules=[
+                DracutModule(name='clevis'),
+                DracutModule(name='clevis-pin-tpm2')
+            ])
+        )

--- a/repos/system_upgrade/common/actors/checkluks/tests/test_checkluks.py
+++ b/repos/system_upgrade/common/actors/checkluks/tests/test_checkluks.py
@@ -1,13 +1,19 @@
+from leapp.libraries.actor import checkluks
 from leapp.libraries.common import distro
-from leapp.libraries.common.config import version
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
 from leapp.models import (
     CephInfo,
+    KernelCmdline,
+    KernelCmdlineArg,
     LsblkEntry,
     LuksDump,
     LuksDumps,
     LuksToken,
+    TargetKernelCmdlineArgTasks,
     TargetUserSpaceUpgradeTasks,
-    UpgradeInitramfsTasks
+    UpgradeInitramfsTasks,
+    UpgradeKernelCmdlineArgTasks
 )
 from leapp.reporting import Report
 from leapp.snactor.fixture import current_actor_context
@@ -17,7 +23,7 @@ _REPORT_TITLE_UNSUITABLE = 'Detected LUKS devices unsuitable for in-place upgrad
 
 
 def test_actor_with_luks1_notpm(monkeypatch, current_actor_context):
-    monkeypatch.setattr(version, 'get_source_major_version', lambda: '8')
+    monkeypatch.setattr(checkluks, 'get_source_major_version', lambda: '8')
     monkeypatch.setattr(distro, 'get_source_distro_id', lambda: 'rhel')
     monkeypatch.setattr(distro, 'get_target_distro_id', lambda: 'rhel')
 
@@ -41,7 +47,7 @@ def test_actor_with_luks1_notpm(monkeypatch, current_actor_context):
 
 
 def test_actor_with_luks2_notpm(monkeypatch, current_actor_context):
-    monkeypatch.setattr(version, 'get_source_major_version', lambda: '8')
+    monkeypatch.setattr(checkluks, 'get_source_major_version', lambda: '8')
     luks_dump = LuksDump(
         version=2,
         uuid='27b57c75-9adf-4744-ab04-9eb99726a301',
@@ -62,7 +68,7 @@ def test_actor_with_luks2_notpm(monkeypatch, current_actor_context):
 
 
 def test_actor_with_luks2_invalid_token(monkeypatch, current_actor_context):
-    monkeypatch.setattr(version, 'get_source_major_version', lambda: '8')
+    monkeypatch.setattr(checkluks, 'get_source_major_version', lambda: '8')
     luks_dump = LuksDump(
         version=2,
         uuid='dc1dbe37-6644-4094-9839-8fc5dcbec0c6',
@@ -84,7 +90,7 @@ def test_actor_with_luks2_invalid_token(monkeypatch, current_actor_context):
 
 
 def test_actor_with_luks2_clevis_tpm_token(monkeypatch, current_actor_context):
-    monkeypatch.setattr(version, 'get_source_major_version', lambda: '8')
+    monkeypatch.setattr(checkluks, 'get_source_major_version', lambda: '8')
     luks_dump = LuksDump(
         version=2,
         uuid='83050bd9-61c6-4ff0-846f-bfd3ac9bfc67',
@@ -113,7 +119,7 @@ def test_actor_with_luks2_clevis_tpm_token(monkeypatch, current_actor_context):
 
 
 def test_actor_with_luks2_ceph(monkeypatch, current_actor_context):
-    monkeypatch.setattr(version, 'get_source_major_version', lambda: '8')
+    monkeypatch.setattr(checkluks, 'get_source_major_version', lambda: '8')
     ceph_volume = ['sda']
     current_actor_context.feed(CephInfo(encrypted_volumes=ceph_volume))
     luks_dump = LuksDump(
@@ -143,3 +149,50 @@ LSBLK_ENTRY = LsblkEntry(
     parent_name="",
     parent_path=""
 )
+
+
+def test_rdluks_uuid_args_removed_from_upgrade_cmdline(monkeypatch):
+    cmdline = KernelCmdline(parameters=[
+        KernelCmdlineArg(key='root', value='/dev/mapper/rhel-root'),
+        KernelCmdlineArg(key='rd.luks.uuid', value='luks-aaa-bbb'),
+        KernelCmdlineArg(key='rd.luks.uuid', value='luks-ccc-ddd'),
+        KernelCmdlineArg(key='ro', value=None),
+    ])
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[cmdline]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkluks._emit_rdluks_undesired_for_upgrade_cmdline()
+
+    upgrade_msgs = [m for m in api.produce.model_instances if isinstance(m, UpgradeKernelCmdlineArgTasks)]
+    assert len(upgrade_msgs) == 1
+
+    removed_keys_values = {(arg.key, arg.value) for arg in upgrade_msgs[0].to_remove}
+    assert removed_keys_values == {
+        ('rd.luks.uuid', 'luks-aaa-bbb'),
+        ('rd.luks.uuid', 'luks-ccc-ddd'),
+    }
+
+    target_msgs = [m for m in api.produce.model_instances if isinstance(m, TargetKernelCmdlineArgTasks)]
+    assert len(target_msgs) == 1
+
+    readded_keys_values = {(arg.key, arg.value) for arg in target_msgs[0].to_add}
+    assert readded_keys_values == {
+        ('rd.luks.uuid', 'luks-aaa-bbb'),
+        ('rd.luks.uuid', 'luks-ccc-ddd'),
+    }
+
+
+def test_no_rdluks_uuid_no_message(monkeypatch):
+    cmdline = KernelCmdline(parameters=[
+        KernelCmdlineArg(key='root', value='/dev/mapper/rhel-root'),
+        KernelCmdlineArg(key='ro', value=None),
+    ])
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[cmdline]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkluks._emit_rdluks_undesired_for_upgrade_cmdline()
+
+    upgrade_msgs = [m for m in api.produce.model_instances if isinstance(m, UpgradeKernelCmdlineArgTasks)]
+    assert not upgrade_msgs
+    target_msgs = [m for m in api.produce.model_instances if isinstance(m, TargetKernelCmdlineArgTasks)]
+    assert not target_msgs

--- a/repos/system_upgrade/common/models/kernelcmdlineargs.py
+++ b/repos/system_upgrade/common/models/kernelcmdlineargs.py
@@ -39,10 +39,14 @@ class LateTargetKernelCmdlineArgTasks(Model):
 class UpgradeKernelCmdlineArgTasks(Model):
     """
     Modifications of the upgrade kernel cmdline.
+
+    The arguments in to_remove have precedence over argument in to_add. That is, if 'ARG'
+    is in to_remove, it is guaranteed to be removed (even if it is also in to_add).
     """
     topic = SystemInfoTopic
 
     to_add = fields.List(fields.Model(KernelCmdlineArg), default=[])
+    to_remove = fields.List(fields.Model(KernelCmdlineArg), default=[])
 
 
 class KernelCmdline(Model):


### PR DESCRIPTION
Request removal of the rd.luks.uuid cmdline args from the upgrade boot entry. These args filter which devices in /etc/cryptab can be unlocked during early stages of the boot process. As we want to mount more devices (essentially everything in /etc/cryptab), presence of these args is undesired.

Jira-ref: RHEL-145136