### PR TITLE
Remove enforcing=1 from boot entries during IPU

### DIFF
--- a/repos/system_upgrade/common/actors/checkselinux/actor.py
+++ b/repos/system_upgrade/common/actors/checkselinux/actor.py
@@ -1,6 +1,15 @@
 from leapp.actors import Actor
 from leapp.libraries.actor import checkselinux
-from leapp.models import KernelCmdlineArg, Report, SELinuxFacts, SelinuxPermissiveDecision, SelinuxRelabelDecision
+from leapp.models import (
+    KernelCmdline,
+    KernelCmdlineArg,
+    Report,
+    SELinuxFacts,
+    SelinuxPermissiveDecision,
+    SelinuxRelabelDecision,
+    TargetKernelCmdlineArgTasks,
+    UpgradeKernelCmdlineArgTasks
+)
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
 
@@ -13,12 +22,14 @@ class CheckSelinux(Actor):
     """
 
     name = 'check_se_linux'
-    consumes = (SELinuxFacts,)
+    consumes = (SELinuxFacts, KernelCmdline)
     produces = (
         KernelCmdlineArg,
         Report,
         SelinuxPermissiveDecision,
         SelinuxRelabelDecision,
+        TargetKernelCmdlineArgTasks,
+        UpgradeKernelCmdlineArgTasks,
     )
     tags = (ChecksPhaseTag, IPUWorkflowTag)
 

--- a/repos/system_upgrade/common/actors/checkselinux/libraries/checkselinux.py
+++ b/repos/system_upgrade/common/actors/checkselinux/libraries/checkselinux.py
@@ -1,10 +1,84 @@
 from leapp import reporting
+from leapp.libraries.common.config import architecture
 from leapp.libraries.common.config.version import get_target_major_version
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.stdlib import api
-from leapp.models import KernelCmdlineArg, SELinuxFacts, SelinuxPermissiveDecision, SelinuxRelabelDecision
+from leapp.models import (
+    KernelCmdline,
+    KernelCmdlineArg,
+    SELinuxFacts,
+    SelinuxPermissiveDecision,
+    SelinuxRelabelDecision,
+    TargetKernelCmdlineArgTasks,
+    UpgradeKernelCmdlineArgTasks
+)
 
 DOC_URL = 'https://red.ht/rhel9-disabling-selinux'
+
+_ENFORCING_ONE_ARG = KernelCmdlineArg(key='enforcing', value='1')
+
+
+def _proc_cmdline_has_enforcing_one(kernel_cmdline):
+    """
+    Checks if the kernel command line contains enforcing=1.
+    """
+    if not kernel_cmdline:
+        return False
+    for param in kernel_cmdline.parameters:
+        if param.key == 'enforcing' and param.value == '1':
+            return True
+    return False
+
+
+def _request_removal_of_enforcing_one():
+    """
+    Schedule stripping of enforcing=1 from the upgrade and target boot entries.
+
+    The upgrade workflow runs with SELinux permissive, but if enforcing=1 is present on
+    the running kernel or in any bootloader entry it can override that. We produce:
+
+    * ``UpgradeKernelCmdlineArgTasks`` so the interim upgrade boot entry drops enforcing=1
+      (consumed by ``addupgradebootentry``).
+    * ``TargetKernelCmdlineArgTasks`` so the target kernel entry and the default kernel
+      command line configuration are updated during finalization (consumed by
+      ``kernelcmdlineconfig``), ensuring that future kernels also omit enforcing=1.
+
+    Original boot entries for existing (non-target) kernels are left untouched.
+
+    ``SELinuxFacts.enforcing_via_any_cmdline`` is populated earlier by the
+    ``systemfacts`` actor.
+    """
+    arch = api.current_actor().configuration.architecture
+    arch_msg = ' Then make sure to run zipl to update the boot menu.' if arch == architecture.ARCH_S390X else ''
+    doc_url = 'https://red.ht/rhel-{}-configure-kernel-cmdline'.format(get_target_major_version())
+    hint = (
+        'After the upgrade, add the `enforcing=1` kernel command line argument back if it is wanted.'
+        ' Run "grubby --update-kernel=ALL --args=enforcing=1" to enable enforcing on all boot entries'
+        f' and set it as default.{arch_msg}'
+        ' Follow the documentation in the attached link for more details.'
+    )
+
+    api.produce(UpgradeKernelCmdlineArgTasks(to_remove=[_ENFORCING_ONE_ARG]))
+    api.produce(TargetKernelCmdlineArgTasks(to_remove=[_ENFORCING_ONE_ARG]))
+    reporting.create_report([
+        reporting.Title('Kernel boot parameter enforcing=1 will be removed'),
+        reporting.Summary(
+            'The kernel parameter enforcing=1 forces SELinux enforcing mode at boot and overrides '
+            'the permissive configuration used during the upgrade. Leapp will remove enforcing=1 from '
+            'the upgrade and target kernel boot entries and update the default kernel command line '
+            'configuration so it does not persist after the upgrade. Existing boot entries for other '
+            'kernels will not be modified.'
+        ),
+        reporting.Remediation(hint=hint),
+        reporting.Severity(reporting.Severity.INFO),
+        reporting.Groups([
+            reporting.Groups.SELINUX,
+            reporting.Groups.BOOT,
+            reporting.Groups.KERNEL,
+            reporting.Groups.POST,
+        ]),
+        reporting.ExternalLink(url=doc_url, title='Configuring kernel command line parameters'),
+    ])
 
 
 def process():
@@ -48,6 +122,10 @@ def process():
             reporting.Groups([reporting.Groups.SELINUX, reporting.Groups.SECURITY])
         ])
         return
+
+    kernel_cmdline = next(api.consume(KernelCmdline), None)
+    if _proc_cmdline_has_enforcing_one(kernel_cmdline) or facts.enforcing_via_any_cmdline:
+        _request_removal_of_enforcing_one()
 
     if conf_status in ('enforcing', 'permissive'):
         api.produce(SelinuxRelabelDecision(set_relabel=True))

--- a/repos/system_upgrade/common/actors/checkselinux/tests/test_checkselinux.py
+++ b/repos/system_upgrade/common/actors/checkselinux/tests/test_checkselinux.py
@@ -4,11 +4,24 @@ from leapp import reporting
 from leapp.libraries.actor import checkselinux
 from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, produce_mocked
 from leapp.libraries.stdlib import api
-from leapp.models import Report, SELinuxFacts, SelinuxPermissiveDecision, SelinuxRelabelDecision
-from leapp.snactor.fixture import current_actor_context
+from leapp.models import (
+    KernelCmdline,
+    KernelCmdlineArg,
+    SELinuxFacts,
+    SelinuxPermissiveDecision,
+    SelinuxRelabelDecision,
+    TargetKernelCmdlineArgTasks,
+    UpgradeKernelCmdlineArgTasks
+)
 
 
-def create_selinuxfacts(static_mode, enabled, policy='targeted', mls_enabled=True):
+def create_selinuxfacts(
+    static_mode,
+    enabled,
+    policy='targeted',
+    mls_enabled=True,
+    enforcing_via_any_cmdline=False,
+):
     runtime_mode = static_mode if static_mode != 'disabled' else None
 
     return SELinuxFacts(
@@ -16,7 +29,8 @@ def create_selinuxfacts(static_mode, enabled, policy='targeted', mls_enabled=Tru
         static_mode=static_mode,
         enabled=enabled,
         policy=policy,
-        mls_enabled=mls_enabled
+        mls_enabled=mls_enabled,
+        enforcing_via_any_cmdline=enforcing_via_any_cmdline,
     )
 
 
@@ -25,7 +39,7 @@ def test_actor_schedule_relabelling(monkeypatch, mode):
 
     fact = create_selinuxfacts(static_mode=mode, enabled=True)
 
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[fact]))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[fact, KernelCmdline(parameters=[])]))
     monkeypatch.setattr(api, 'produce', produce_mocked())
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
 
@@ -38,7 +52,7 @@ def test_actor_schedule_relabelling(monkeypatch, mode):
 def test_actor_set_permissive(monkeypatch):
     relabel = create_selinuxfacts(static_mode='enforcing', enabled=True)
 
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[relabel]))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[relabel, KernelCmdline(parameters=[])]))
     monkeypatch.setattr(api, 'produce', produce_mocked())
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
 
@@ -56,7 +70,9 @@ def test_actor_selinux_disabled(monkeypatch, el8_to_el9):
     target_ver = '8' if not el8_to_el9 else '9'
 
     monkeypatch.setattr(checkselinux, 'get_target_major_version', lambda: target_ver)
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[disabled]))
+    monkeypatch.setattr(
+        api, 'current_actor', CurrentActorMocked(msgs=[disabled, KernelCmdline(parameters=[])])
+    )
     monkeypatch.setattr(api, 'produce', produce_mocked())
     monkeypatch.setattr(reporting, "create_report", create_report_mocked())
 
@@ -67,3 +83,41 @@ def test_actor_selinux_disabled(monkeypatch, el8_to_el9):
     else:
         assert not api.produce.model_instances
         assert reporting.create_report.called
+
+
+def test_enforcing_one_in_proc_cmdline_schedules_removal(monkeypatch):
+    fact = create_selinuxfacts(static_mode='permissive', enabled=True)
+    kcmd = KernelCmdline(parameters=[KernelCmdlineArg(key='enforcing', value='1')])
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[fact, kcmd]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+
+    checkselinux.process()
+
+    upgrade_produced = [m for m in api.produce.model_instances if isinstance(m, UpgradeKernelCmdlineArgTasks)]
+    assert upgrade_produced
+    assert upgrade_produced[0].to_remove == [KernelCmdlineArg(key='enforcing', value='1')]
+
+    target_produced = [m for m in api.produce.model_instances if isinstance(m, TargetKernelCmdlineArgTasks)]
+    assert target_produced
+    assert target_produced[0].to_remove == [KernelCmdlineArg(key='enforcing', value='1')]
+
+
+def test_enforcing_one_only_in_bootloader_schedules_removal(monkeypatch):
+    fact = create_selinuxfacts(
+        static_mode='permissive', enabled=True, enforcing_via_any_cmdline=True
+    )
+    kcmd = KernelCmdline(parameters=[KernelCmdlineArg(key='ro')])
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[fact, kcmd]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+
+    checkselinux.process()
+
+    upgrade_produced = [m for m in api.produce.model_instances if isinstance(m, UpgradeKernelCmdlineArgTasks)]
+    assert upgrade_produced
+    assert upgrade_produced[0].to_remove == [KernelCmdlineArg(key='enforcing', value='1')]
+
+    target_produced = [m for m in api.produce.model_instances if isinstance(m, TargetKernelCmdlineArgTasks)]
+    assert target_produced
+    assert target_produced[0].to_remove == [KernelCmdlineArg(key='enforcing', value='1')]

--- a/repos/system_upgrade/common/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/common/actors/systemfacts/libraries/systemfacts.py
@@ -230,6 +230,24 @@ def get_repositories_status():
             })
 
 
+def _bootloader_entries_contain_enforcing_one():
+    """
+    True if grubby reports enforcing=1 in any boot loader entry's kernel arguments.
+    """
+    try:
+        out = run(['/usr/sbin/grubby', '--info', 'ALL'], split=False)['stdout']
+    except (OSError, CalledProcessError):
+        api.current_logger().debug(
+            'grubby --info ALL failed; assuming no bootloader enforcing=1', exc_info=True
+        )
+        return False
+
+    for line in out.splitlines():
+        if line.startswith('args=') and 'enforcing=1' in line[len('args='):].strip('"').split():
+            return True
+    return False
+
+
 def get_selinux_status():
     """ Get SELinux status information """
     # will be None if something went wrong or contain SELinuxFacts otherwise
@@ -258,6 +276,8 @@ def get_selinux_status():
         outdata['runtime_mode'] = 'permissive'
         outdata['static_mode'] = 'disabled'
         outdata['policy'] = 'targeted'
+
+    outdata['enforcing_via_any_cmdline'] = _bootloader_entries_contain_enforcing_one()
 
     res = SELinuxFacts(**outdata)
     return res

--- a/repos/system_upgrade/common/actors/systemfacts/tests/test_systemfacts_selinux.py
+++ b/repos/system_upgrade/common/actors/systemfacts/tests/test_systemfacts_selinux.py
@@ -2,6 +2,7 @@ import warnings
 
 import pytest
 
+from leapp.libraries.actor import systemfacts
 from leapp.libraries.actor.systemfacts import get_selinux_status
 from leapp.models import SELinuxFacts
 
@@ -20,6 +21,23 @@ reason_to_skip_msg = "Selinux is not available"
 # FIXME: create valid tests...
 
 
+def _run_result(stdout):
+    return {'stdout': stdout, 'stderr': '', 'signal': None, 'exit_code': 0, 'pid': 1}
+
+
+@pytest.fixture(autouse=True)
+def stub_grubby_info_all_without_enforcing(monkeypatch):
+    """
+    Avoid invoking real grubby from get_selinux_status(); default: no enforcing=1 in boot entries.
+    """
+
+    def mocked_run(cmd, split=False, **dummy_kwargs):
+        assert cmd == ['/usr/sbin/grubby', '--info', 'ALL'], f"Unexpected grubby cmd: {cmd}"
+        return _run_result('index=0\nkernel="/boot/vmlinuz-1"\nargs="ro rhgb quiet"\nroot="UUID=xxx"\n')
+
+    monkeypatch.setattr(systemfacts, 'run', mocked_run)
+
+
 @pytest.mark.skipif(no_selinux, reason=reason_to_skip_msg)
 def test_selinux_enabled_enforcing(monkeypatch):
     """
@@ -34,7 +52,8 @@ def test_selinux_enabled_enforcing(monkeypatch):
                      'mls_enabled': True,
                      'enabled': True,
                      'runtime_mode': 'enforcing',
-                     'static_mode': 'enforcing'}
+                     'static_mode': 'enforcing',
+                     'enforcing_via_any_cmdline': False}
     assert SELinuxFacts(**expected_data) == get_selinux_status()
 
 
@@ -52,7 +71,8 @@ def test_selinux_enabled_permissive(monkeypatch):
                      'mls_enabled': True,
                      'enabled': True,
                      'runtime_mode': 'permissive',
-                     'static_mode': 'permissive'}
+                     'static_mode': 'permissive',
+                     'enforcing_via_any_cmdline': False}
     assert SELinuxFacts(**expected_data) == get_selinux_status()
 
 
@@ -70,7 +90,8 @@ def test_selinux_disabled(monkeypatch):
                      'mls_enabled': False,
                      'enabled': False,
                      'runtime_mode': 'permissive',
-                     'static_mode': 'permissive'}
+                     'static_mode': 'permissive',
+                     'enforcing_via_any_cmdline': False}
     assert SELinuxFacts(**expected_data) == get_selinux_status()
 
 
@@ -93,6 +114,38 @@ def test_selinux_disabled_no_config_file(monkeypatch):
                      'mls_enabled': False,
                      'enabled': False,
                      'runtime_mode': 'permissive',
-                     'static_mode': 'disabled'}
+                     'static_mode': 'disabled',
+                     'enforcing_via_any_cmdline': False}
 
     assert SELinuxFacts(**expected_data) == get_selinux_status()
+
+
+@pytest.mark.skipif(no_selinux, reason=reason_to_skip_msg)
+@pytest.mark.parametrize('grubby_stdout,expected', [
+    ('index=0\nargs="ro enforcing=1"\n', True),
+    ('index=0\nargs="ro enforcing=1 rhgb quiet"\n', True),
+    ('index=0\nargs="enforcing=1"\n', True),
+    ('index=0\nargs="ro enforcing=1"\nindex=1\nargs="ro rhgb quiet"\n', True),
+    ('index=0\nargs="ro rhgb quiet"\nindex=1\nargs="ro enforcing=1"\n', True),
+    ('index=0\nargs="ro enforcing=0"\n', False),
+    ('index=0\nargs="ro rhgb quiet"\n', False),
+    ('index=0\nargs="ro fooenforcing=1"\n', False),
+    ('index=0\nargs="ro enforcing=1bar"\n', False),
+    ('index=0\nargs="ro"\n', False),
+    ('index=0\nargs=""\n', False),
+])
+def test_bootloader_enforcing_one_detected(monkeypatch, grubby_stdout, expected):
+    monkeypatch.setattr(selinux, 'is_selinux_mls_enabled', lambda: 1)
+    monkeypatch.setattr(selinux, 'security_getenforce', lambda: 1)
+    monkeypatch.setattr(selinux, 'selinux_getenforcemode', lambda: [0, 1])
+    monkeypatch.setattr(selinux, 'is_selinux_enabled', lambda: 1)
+    monkeypatch.setattr(selinux, 'selinux_getpolicytype', lambda: [0, 'targeted'])
+
+    def mocked_run(cmd, split=False, **dummy_kwargs):
+        assert cmd == ['/usr/sbin/grubby', '--info', 'ALL'], f"Unexpected grubby cmd: {cmd}"
+        return _run_result(grubby_stdout)
+
+    monkeypatch.setattr(systemfacts, 'run', mocked_run)
+
+    fact = get_selinux_status()
+    assert fact.enforcing_via_any_cmdline is expected

--- a/repos/system_upgrade/common/models/selinuxfacts.py
+++ b/repos/system_upgrade/common/models/selinuxfacts.py
@@ -10,3 +10,7 @@ class SELinuxFacts(Model):
     enabled = fields.Boolean()
     policy = fields.StringEnum(['targeted', 'minimum', 'mls'])
     mls_enabled = fields.Boolean()
+    enforcing_via_any_cmdline = fields.Boolean(default=False)
+    """
+    True when any bootloader entries have set enforcing=1.
+    """


### PR DESCRIPTION
Detect enforcing=1 on the running kernel (KernelCmdline) or in any bootloader
entry. Bootloader detection is collected by systemfacts via `grubby --info ALL`
and exposed as SELinuxFacts.enforcing_via_any_cmdline.

When enforcing=1 is present, checkselinux (Checks phase) emits
UpgradeKernelCmdlineArgTasks to remove enforcing=1 from the interim upgrade
boot entry, and TargetKernelCmdlineArgTasks to remove it from the target kernel
entry and update the default kernel command line during finalization.

An INFO report with remediation guidance to restore enforcing=1 after upgrade is also
produced. Original boot entries for existing kernels are not modified.

JIRA-ref: RHEL-162192