### PR TITLE
Add AI assistant harness with AGENTS.md and task skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md
+
+## Project objective
+
+[Leapp-repository](https://github.com/oamg/leapp-repository) contains the actors, models, and libraries for RHEL in-place upgrades (IPU). It runs on top of the [Leapp framework](https://github.com/oamg/leapp), which provides the actor runtime, workflow execution, messaging, and core CLI behavior. It's important to notice, that framework-level mechanics belong to leapp, while upgrade-path logic belong to leapp-repository.
+
+## Architecture
+
+Leapp IPU content is actor-based and message-driven:
+- Actors exchange typed messages (`consumes` / `produces`) through workflow phases.
+- Messages only flow forward: a producer must run before its consumer. Within the same phase, the framework resolves ordering automatically.
+- Prefer scanner/checker design: collect facts in one actor, evaluate in another.
+- Keep actor `process()` thin; place implementation logic in actor libraries for testability.
+
+### Phase workflow (always apply)
+- `FactsCollectionPhase`: collect system facts and produce messages
+- `ChecksPhase`: consume previously collected facts, report/inhibit compatibility issues
+- If modification is required, do it in later phases (`ApplicationsPhase` or `ThirdPartyApplicationsPhase`).
+- `FinalPhase`: to perform actions after the upgraded system is booted.
+
+For full phase details if ambiguous :
+- [Phases of the Upgrade Workflow](https://leapp-repository.readthedocs.io/latest/upgrade-architecture-and-workflow/phases-overview.html#phases-overview)
+
+### Repository Layout
+
+```
+├── system_upgrade/
+    ├── common/                      # common repository/content used and accessible for all system upgrades
+    │   ├── actors/<name>/
+    │   │   ├── actor.py             # Actor class definition
+    │   │   ├── libraries/           # Actor-private logic
+    │   │   └── tests/               # Actor tests (unit_test_*.py, test_*.py)
+    │   ├── models/                  # Data models (consumed/produced by actors)
+    │   ├── topics/                  # Message topics
+    │   └── libraries/               # Shared libraries (importable via leapp.libraries.common)
+    ├── el8toel9/                     # content specific only for  RHEL 8 -> 9 upgrades
+    └── el9toel10/                    # content specific only for  RHEL 9 -> 10 upgrades
+```
+
+
+## General rules (always apply)
+
+- Follow leapp specific guidelines: docs/source/contributing/coding-guidelines.md and project conventions first.
+- Follow Python coding guidelines: https://leapp.readthedocs.io/en/stable/contributing.html
+- Analyze and plan before introducing code.
+- Ask, don't assume. Be verbose when user input is unclear or can be interpreted in many ways.
+- Explain your decisions briefly; expand detail only when requested.
+- If multiple approaches or solution exists, pick simpler one.
+- Be ready to undo your changes.
+- Before introducing new code, check if it's not already solved in codebase. Avoid code duplication.
+- Try to write as simple code as possible. New code should easy to read and understand even for non-experienced developers.
+- Don't change code, which is not directly involved in given task. Don't try to improve unrelated code.
+- Don't perform git commit, git push, or create PRs without explicit user request.
+
+
+
+## Common Commands
+
+Quick reference (details in skills below):
+
+```bash
+make lint                                    # pylint + flake8 + isort
+TEST_CONTAINER=el9 make test_container       # full CI-equivalent test
+ACTOR=<name> make dev_test_no_lint           # single-actor fast test
+```
+
+## Skills
+
+Load the relevant skill for the task at hand:
+
+- **Run tests / lint** → `skills/leapp-test-runner/`
+- **Write or fix unit tests** → `skills/leapp-unit-tests/`
+- **Develop or modify actors** → `skills/leapp-actor-dev/`
+
+
+## Definition of Done
+
+- Scope is clear and limited to the requested change.
+- New or changed code is covered by unit tests.
+- Relevant checks were run (`make lint` and/or targeted tests) and results are reported.
+- Risks, assumptions, and follow-up work are explicitly called out

--- a/skills/leapp-actor-dev/SKILL.md
+++ b/skills/leapp-actor-dev/SKILL.md
@@ -1,0 +1,95 @@
+# Developing Leapp Actors
+
+## Actor structure
+
+Every actor follows layout:
+
+```
+repos/system_upgrade/<leapp_repo_dir>/actors/<actor_name>/
+├── actor.py              # Actor class (thin wrapper)
+├── libraries/
+│   └── <actor_name>.py   # Implementation logic
+└── tests/
+    └── test_<actor_name>.py
+```
+
+Keep `actor.py` minimal — delegate the real implementation to the library for testability:
+
+```python
+from leapp.actors import Actor
+from leapp.libraries.actor import <actor_name>
+from leapp.models import <ConsumedModel>, <ProducedModel>
+from leapp.tags import <PhaseTag>, IPUWorkflowTag
+
+
+class MyActor(Actor):
+    """Brief description of what this actor does."""
+
+    name = '<actor_name>'
+    consumes = (<ConsumedModel>,)
+    produces = (<ProducedModel>,)
+    tags = (IPUWorkflowTag, <PhaseTag>)
+
+    def process(self):
+        <actor_name>.process()
+```
+
+## Phase selection
+
+| Intent | Phase tag | Rules |
+|--------|-----------|-------|
+| Collect system facts | `FactsPhaseTag` | Produce messages only, no decisions |
+| Check compatibility / inhibit | `ChecksPhaseTag` | Consume facts, no direct system interaction |
+| Modify application config | `ApplicationsPhaseTag` | Only after RPM upgrade is complete |
+| Modify third-party config | `ThirdPartyApplicationsPhaseTag` | Same as above, for non-Red Hat apps |
+
+### Common multi-actor patterns
+
+**Inhibiting an incompatible system** (2 actors):
+1. Scanner in `FactsCollectionPhase` — produces a facts message.
+2. Checker in `ChecksPhase` — consumes facts, creates report / inhibits.
+
+**Modifying incompatible config** (3 actors):
+1. Scanner in `FactsCollectionPhase` — collects info.
+2. Checker in `ChecksPhase` — decides and reports planned change.
+3. Modifier in `ApplicationsPhase` — performs the change.
+
+## Placement rules
+
+- Reusable across upgrade paths → `repos/system_upgrade/common/`
+- Specific to one path → `repos/system_upgrade/el8toel9/` or `el9toel10/`
+- Same rule applies to models and shared libraries.
+
+
+## Before writing new code
+
+- Search existing actors/models/libraries — reuse before creating.
+- Check if a model already provides the message you need (search model class names in `repos/`).
+- Discover `repos/system_upgrade/common/libraries/` for shared utilities.
+- Prefer using stdlib functions over shell commands.
+- If introduce envars, use LEAPP and LEAPP_DEVEL.
+- Write unit-testable code (see `skills/leapp-unit-tests/`).
+
+
+## Key constraints
+
+- Avoid running code on a module level to avoid slow downs during this load phase
+- Never use `subprocess` — use `leapp.libraries.stdlib.run()` instead.
+- Never interact with the system during `ChecksPhase`.
+- Do not introduce new dependencies, unless it's strongly justified.
+
+
+## Python compatibility
+
+| Repository | Required Python versions |
+|------------|--------------------------|
+| `common`   | 3.6, 3.9, 3.12 |
+| `el8toel9` | 3.6, 3.9 |
+| `el9toel10`| 3.9, 3.12 |
+
+## Reference
+
+- [How to write an Actor for Leapp Upgrade](https://leapp-repository.readthedocs.io/latest/tutorials/howto-first-actor-upgrade.html)
+- [Phases of the Upgrade Workflow](https://leapp-repository.readthedocs.io/latest/upgrade-architecture-and-workflow/phases-overview.html)
+- [Coding guidelines](https://leapp-repository.readthedocs.io/latest/contributing/coding-guidelines.html)
+- [Best Practices for actor development](https://leapp.readthedocs.io/en/stable/best-practices.html)

--- a/skills/leapp-test-runner/SKILL.md
+++ b/skills/leapp-test-runner/SKILL.md
@@ -1,0 +1,68 @@
+# Running Tests and Linters
+
+All non-container commands (`make lint`, `make test_no_lint`, `make fast_lint`, `make dev_test_no_lint`) require a local virtualenv and `REPOSITORIES` envar (e.g. `REPOSITORIES=common,el9toel10`). Create the virtualenv with `make install-deps` (RHEL/CentOS) or `make install-deps-fedora` (Fedora) — the Makefile handles activation internally, don't source the venv manually. Set `PYTHON_VENV=pythonX.X` to choose the Python version (default: `python3.6`). Container commands are self-contained and recommended as the default.
+
+## Container-based testing (CI-equivalent, no venv needed)
+
+Three container options, each matching a target Python version:
+
+| Container | Python | Used for |
+|-----------|--------|----------|
+| `el8`     | 3.6    | `common`, `el8toel9` |
+| `el9`     | 3.9    | `common`, `el8toel9`, `el9toel10` |
+| `f42`     | 3.13   | lint-only (latest tooling) |
+
+Pick container(s) based on which repositories your change touches:
+- `common` actors: test on `el8` **and** `el9` (both Python versions must pass).
+- `el8toel9` only: `el8` is sufficient, `el9` is a bonus.
+- `el9toel10` only: `el9`.
+
+```bash
+# Full test (lint + unit tests) in container — recommended
+TEST_CONTAINER=el9 make test_container
+
+# Tests only, skip lint — faster iteration
+TEST_CONTAINER=el9 make test_container_no_lint
+
+# All containers at once
+make test_container_all
+```
+
+## Single-actor testing (fastest feedback, requires venv)
+
+Use during development when iterating on one actor:
+
+```bash
+ACTOR=checkmemory make dev_test_no_lint
+```
+
+## Linting
+
+```bash
+# Lint in container (recommended, no venv needed)
+make lint_container
+
+# Full lint locally (requires venv): pylint + flake8 + isort
+make lint
+
+# Lint only local changes relative to main branch (requires venv)
+make fast_lint
+
+# Auto-fix isort violations locally (requires venv)
+make lint_fix
+```
+
+## Choosing what to run
+
+| Situation | Command |
+|-----------|---------|
+| Quick check during development | `ACTOR=<name> make dev_test_no_lint` |
+| Before pushing | `TEST_CONTAINER=elX make test_container` |
+| Full CI confidence | `make test_container_all` |
+| Only lint issues | `make fast_lint` or `TEST_CONTAINER=elX make lint_container` |
+
+## Interpreting failures
+
+- **pylint / flake8**: fix the reported file and line.
+- **isort**: run `make lint_fix` to auto-sort imports, then verify.
+- **pytest**: read the traceback; check if the test uses `monkeypatch.setattr` correctly and if mocked models match current schema.

--- a/skills/leapp-unit-tests/SKILL.md
+++ b/skills/leapp-unit-tests/SKILL.md
@@ -1,0 +1,94 @@
+# Writing Unit Tests
+
+
+## File placement
+
+### Tests for actors
+
+Tests live in the tests directory under an actor:
+
+```
+repos/system_upgrade/<leapp_repo_dir>/actors/<actor_name>/
+├── actor.py
+├── libraries/<actor_name>.py
+└── tests/test_<actor_name>.py      # <-- tests go here
+```
+
+### Tests for shared libraries
+
+Tests for shared libraries are in the `tests` sub-directory next to the shared library, like:
+
+```
+repos/system_upgrade/<leapp_repo_dir>/
+├── <libA>.py
+├── tests/test_<libA>.py      # <-- tests for libA go here
+├── <pathB>/<libB>.py
+└── <pathB>/tests/test_<libB>.py      # <-- tests for libB go here
+```
+
+## Key testing utilities
+
+As mocked objects, use functions and classes present in `leapp.libraries.common.testutils` - especially:
+
+| Utility                   | Purpose                                                    |
+| ------------------------- | ---------------------------------------------------------- |
+| `CurrentActorMocked(...)` | Mock `api.current_actor` with configuration, version, etc. |
+| `produce_mocked()`        | Capture `api.produce(...)` calls for assertions            |
+| `create_report_mocked()`  | Capture `reporting.create_report(...)` calls               |
+| `logger_mocked()`         | Capture log output                                         |
+
+
+## Standard test pattern
+
+Test the **library**, not the actor class directly:
+
+```python
+from leapp.libraries.actor import <actor_lib>
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import <ConsumedModel>, <ProducedModel>
+
+
+def test_<scenario>(monkeypatch):
+    # 1. Mock current_actor context
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+
+    # 2. Mock consumed messages
+    monkeypatch.setattr(api, 'consume', lambda x: iter([<ConsumedModel>(...)]))
+
+    # 3. Mock produce
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    # 4. Call library function
+    <actor_lib>.process()
+
+    # 5. Assert on produced messages
+    assert api.produce.called
+    assert isinstance(api.produce.model_instances[0], <ProducedModel>)
+```
+
+## Rules
+
+
+- Test the library, not `actor.py` — the `process()` method should be a thin wrapper.
+- Pass consumed messages via `CurrentActorMocked(msgs=[...])`.
+- Mock file I/O instead of creating temp files when possible. Use the `leapp_tmpdir` fixture when tempfiles are needed.
+- Use `monkeypatch.setattr` over `unittest.mock.patch` — monkeypatch is the project convention.
+- Cover at least: happy path, edge/error cases, and inhibitor conditions if applicable.
+- If you intentionally skip a test scenario, add a comment explaining why.
+- Use consistent string quoting within a file.
+- Use pytest.mark.parametrize where possible.
+- Never use type() when creating mock classes.
+- Use module-level constants with "_" prefix.
+
+- Name test functions clearly after the behavior: `test_inhibits_when_fips_enabled` not `test_fips_1`.
+- Look at existing tests in `repos/system_upgrade/common/actors/` for project conventions before writing new ones.
+
+## Running tests
+
+See `skills/leapp-test-runner/` for full commands. Quick single-actor run:
+
+```bash
+ACTOR=<actor_name> make dev_test_no_lint
+```
+


### PR DESCRIPTION
Introduce an AI assistant harness to guide agents and human developers when working with coding tools with this repo. AGENTS.md serves as a compact always-loaded entrypoint with project boundaries, architecture, phases,  eneral rules and a definition of  done. Detailed procedure guidance is split into skill files to minimize token consumption.                                           
Skills added:                                                         
- leapp-test-runner: container-based testing, linting, failure triage 
- leapp-unit-tests: test patterns, testutils API, mocking conventions 
- leapp-actor-dev: actor structure, phase selection, placement rules 