### PR TITLE
pulseaudiocheck: fix for users with "None" home directory

### DIFF
--- a/repos/system_upgrade/el9toel10/actors/pulseaudiocheck/scanpulseaudio/libraries/scanpulseaudio.py
+++ b/repos/system_upgrade/el9toel10/actors/pulseaudiocheck/scanpulseaudio/libraries/scanpulseaudio.py
@@ -2,6 +2,7 @@ import os
 import pwd
 
 from leapp.libraries.common.rpms import check_file_modification
+from leapp.libraries.stdlib import api
 from leapp.models import PulseAudioConfiguration
 
 # System-wide PulseAudio configuration directory
@@ -54,6 +55,9 @@ def _get_user_config_dirs():
     """
     found = []
     for user in pwd.getpwall():
+        if not user.pw_dir:
+            api.current_logger().debug('User "{}" has no valid home entry, skipping.'.format(user.pw_name))
+            continue
         pulse_dir = os.path.join(user.pw_dir, _USER_CONFIG_SUBDIR)
         if os.path.isdir(pulse_dir) and os.listdir(pulse_dir):
             found.append(pulse_dir)

--- a/repos/system_upgrade/el9toel10/actors/pulseaudiocheck/scanpulseaudio/tests/test_scanpulseaudio.py
+++ b/repos/system_upgrade/el9toel10/actors/pulseaudiocheck/scanpulseaudio/tests/test_scanpulseaudio.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from leapp.libraries.actor import scanpulseaudio
 from leapp.libraries.actor.scanpulseaudio import _get_dropin_dirs_with_content, _get_user_config_dirs, scan_pulseaudio
 
@@ -36,16 +38,24 @@ class TestGetUserConfigDirs:
         monkeypatch.setattr(os.path, 'isdir', lambda _: False)
         assert _get_user_config_dirs() == []
 
-    def test_user_config_found(self, monkeypatch):
+    @pytest.mark.parametrize(
+        'home_dir, expect',
+        [
+            ('/home/testuser', ['/home/testuser/.config/pulse']),
+            ('', []),
+        ],
+    )
+    def test_user_config_found(self, monkeypatch, home_dir, expect):
         monkeypatch.setattr(os.path, 'isdir', lambda path: path == '/home/testuser/.config/pulse')
         monkeypatch.setattr(os, 'listdir', lambda _: ['default.pa'])
 
         class FakeUser:
-            pw_dir = '/home/testuser'
+            pw_name = 'testuser'
+            pw_dir = home_dir
 
-        monkeypatch.setattr(scanpulseaudio.pwd, 'getpwall', lambda: [FakeUser()])
+        monkeypatch.setattr(scanpulseaudio.pwd, 'getpwall', lambda: [FakeUser])
         result = _get_user_config_dirs()
-        assert result == ['/home/testuser/.config/pulse']
+        assert result == expect
 
 
 class TestScanPulseaudio:


### PR DESCRIPTION
If the user has single entry in /etc/passwd without any colons, the reported pw_dir is NoneType. This makes the os.path.join() crash as NoneType is unexpected.
While technically, entry without the colons is considered invalid and not POSIX compliant, it has been seen that some customers are using such entries and leapp is already taking this possibility into account.
This commit modifies the behaviour of the scanpulseaudio actor, so such entries are logged and skipped.

Jira: RHEL-174874