### PR TITLE
conftest: exit actor context when switching repos

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,24 +12,42 @@ logging.getLogger("parso").setLevel(logging.INFO)
 
 
 def _load_and_add_repo(manager, repo_path):
-    repo = find_and_scan_repositories(
+    manager_with_new_repos = find_and_scan_repositories(
         repo_path,
         include_locals=True
     )
-    unloaded = set()
-    loaded = {r.repo_id for r in manager.repos}
-    if hasattr(repo, 'repos'):
-        for repo in repo.repos:
+
+    newly_discovered_repo_ids = set()
+    already_known_repoids = {r.repo_id for r in manager.repos}
+    if hasattr(manager_with_new_repos, 'repos'):
+        for repo in manager_with_new_repos.repos:
             if not manager.repo_by_id(repo.repo_id):
                 manager.add_repo(repo)
-                unloaded.add(repo.repo_id)
+                newly_discovered_repo_ids.add(repo.repo_id)
     else:
         manager.add_repo(repo)
-    if not loaded:
+    if not already_known_repoids:
         manager.load(skip_actors_discovery=True)
     else:
-        for repo_id in unloaded:
+        for repo_id in newly_discovered_repo_ids:
             manager.repo_by_id(repo_id).load(skip_actors_discovery=True)
+
+
+def _cleanup_actor_context_from_session(collector):
+    is_actor_context_attached = hasattr(collector.session, "current_actor_path")
+
+    if not is_actor_context_attached:
+        return  # Nothing to clean
+
+    try:
+        collector.session.current_actor_context.__exit__(
+            None, None, None
+        )
+        delattr(collector.session, 'current_actor_path')
+        collector.session.current_actor_context = None
+        collector.session.current_actor = None
+    except AttributeError:
+        pass
 
 
 def pytest_collectstart(collector):
@@ -38,14 +56,21 @@ def pytest_collectstart(collector):
         if not current_repo_basedir:
             # This is not a repository
             return
+
         if not hasattr(collector.session, "leapp_repository"):
             collector.session.leapp_repository = RepositoryManager()
             collector.session.repo_base_dir = current_repo_basedir
             _load_and_add_repo(collector.session.leapp_repository, current_repo_basedir)
         else:
-            if not collector.session.leapp_repository.repo_by_id(
-                get_repository_id(current_repo_basedir)
-            ):
+            repo_id = get_repository_id(current_repo_basedir)
+            repo = collector.session.leapp_repository.repo_by_id(repo_id)
+            if not repo:
+                # We are about to load a new repository, which will append module loaders
+                # to sys.meta_path. Cleaning actor context will restore the meta_path used
+                # when the context was entered, so if we did the cleanup later we would
+                # undo appends to the meta_path.
+                _cleanup_actor_context_from_session(collector)
+
                 _load_and_add_repo(collector.session.leapp_repository, current_repo_basedir)
 
         # we're forcing the actor context switch only when traversing new


### PR DESCRIPTION
Prior to this patch, the current_actor_context fixture was always exited when executing a new actor. Exiting the fixture causes sys.meta_path to be restored to a state when the fixture was first entered. Therefore, if we are running tests across multiple repositories, say common and el9toel10, then when we are executing the first actor from el9toel10 we execute `__exit__ `of the last executed actor from the common repository. So the following would happen:
1) Finish running the last actor named 'X' from the common repository.
2) Load el9toel10 repository, appending to sys.meta_path loaders for leapp.libraries.common, etc.
3) Discovery of the tests of the first actor from el9toel10.
4) Detect that we are executing a different actor than 'X', so call
   cleanup, which restores the state of sys.meta_path. Therefore, this effectively removes all loaders for el9toel10 repository from  sys.meta_path.
5) Execute tests for the first actor from el9toel10.

This patch ensures that we call `current_actor_context.__exit__` whenever we are about to start loading a new repository, preventing us from unwanted removal of the loaders in sys.meta_path (added by the loaded repository).