### PR TITLE
fix(target_initramfs): always regenerate initramfs

### DIFF
--- a/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/libraries/targetinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/libraries/targetinitramfsgenerator.py
@@ -97,13 +97,15 @@ def _get_modules():
 
 
 def process():
+    """
+    Regenerate target system initramfs.
+
+    The initramfs is regenerated unconditionally always as there might be new configs
+    necessary for boot which are written by us after the RPM transaction installs
+    the target kernel (and generates the target initramfs for the first time).
+    """
     files = _get_files()
     modules = _get_modules()
-
-    if not files and not modules['kernel'] and not modules['dracut']:
-        api.current_logger().debug(
-            'No additional files or modules required to add into the target initramfs.')
-        return
 
     target_kernel_info = next(api.consume(InstalledTargetKernelInfo), None)
     if not target_kernel_info:

--- a/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/tests/test_targetinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/tests/test_targetinitramfsgenerator.py
@@ -71,13 +71,12 @@ def gen_InitrdIncludes(files):
 
 def test_no_includes(monkeypatch):
     run_mocked = RunMocked()
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[]))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[mk_kernel_info(KERNEL_VERSION)]))
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(targetinitramfsgenerator, 'run', run_mocked)
 
     targetinitramfsgenerator.process()
-    assert NO_INCLUDE_MSG in api.current_logger.dbgmsg
-    assert not run_mocked.called
+    assert run_mocked.called
 
 
 TEST_CASES = [


### PR DESCRIPTION
Remove conditions that would skip target initramfs regeneration if there are no dracut or kernel modules to be included. Instead, regenerate the target initramfs always, as there might be new configs written by us after the upgrade RPM transaction installs the target kernel and generates a corresponding initramfs. The initramfs generated during RPM transaction, therefore lacks or contains invalid config files.

Jira: RHEL-151509