### PR TITLE
fix(breadcrumbs): use os-release pretty name for source_os

### DIFF
--- a/commands/command_utils.py
+++ b/commands/command_utils.py
@@ -39,6 +39,20 @@ class DistroIDs(str, Enum):
     ALMALINUX = 'almalinux'
 
 
+DISTRO_NAMES = {
+    DistroIDs.RHEL: 'Red Hat Enterprise Linux',
+    DistroIDs.CENTOS: 'CentOS Stream',
+    DistroIDs.ALMALINUX: 'AlmaLinux',
+}
+"""
+Maps distro IDs to their user-facing display names (matching NAME in /etc/os-release).
+
+NOTE: keep in sync with distro_id_to_pretty_name() in
+repos/system_upgrade/common/libraries/distro.py the repo library
+is not importable from the CLI layer.
+"""
+
+
 _DISTRO_VERSION_FORMATS = {
     DistroIDs.RHEL: VersionFormats.MAJOR_MINOR,
     DistroIDs.CENTOS: VersionFormats.MAJOR_ONLY,

--- a/commands/upgrade/breadcrumbs.py
+++ b/commands/upgrade/breadcrumbs.py
@@ -6,6 +6,7 @@ from functools import wraps
 from itertools import chain
 
 from leapp import FULL_VERSION
+from leapp.cli.commands.command_utils import DISTRO_NAMES
 from leapp.libraries.stdlib.call import _call
 from leapp.utils.audit import get_messages
 
@@ -13,6 +14,20 @@ try:
     from json.decoder import JSONDecodeError  # pylint: disable=ungrouped-imports
 except ImportError:
     JSONDecodeError = ValueError
+
+
+def _get_os_name(ipu_cfg, direction):
+    """
+    Determine the OS display name from IPUConfig data.
+
+    :param direction: 'source' or 'target'
+    """
+    distro = (ipu_cfg.get('distro') or {}).get(direction, '')
+    version = (ipu_cfg.get('version') or {}).get(direction, '')
+    if not distro:
+        return 'N/A'
+    distro_name = DISTRO_NAMES.get(distro, 'unknown')
+    return '{} {}'.format(distro_name, version or 'N/A')
 
 
 def runs_in_container():
@@ -95,10 +110,9 @@ class _BreadCrumbs:
         self._crumbs['run_id'] = os.environ.get('LEAPP_EXECUTION_ID', 'N/A')
         self._crumbs['leapp_file_changes'].extend(self._verify_leapp_pkgs())
         messages = get_messages(('IPUConfig',), self._crumbs['run_id'])
-        versions = json.loads((messages or [{}])[0].get('message', {}).get(
-            'data', '{}')).get('version', {'target': 'N/A', 'source': 'N/A'})
-        self._crumbs['target_os'] = 'Red Hat Enterprise Linux {target}'.format(**versions)
-        self._crumbs['source_os'] = 'Red Hat Enterprise Linux {source}'.format(**versions)
+        ipu_cfg = json.loads((messages or [{}])[0].get('message', {}).get('data', '{}'))
+        self._crumbs['source_os'] = _get_os_name(ipu_cfg, 'source')
+        self._crumbs['target_os'] = _get_os_name(ipu_cfg, 'target')
         self._crumbs['activity_ended'] = datetime.datetime.utcnow().isoformat() + 'Z'
         self._crumbs['env'] = {k: v for k, v in os.environ.items() if k.startswith('LEAPP_')}
         try:

--- a/repos/system_upgrade/common/libraries/distro.py
+++ b/repos/system_upgrade/common/libraries/distro.py
@@ -227,6 +227,10 @@ def distro_id_to_pretty_name(distro_id):
     Get pretty name for the given distro id.
 
     The pretty name is what is found in the NAME field of /etc/os-release.
+
+    NOTE: a parallel mapping exists in commands/command_utils.py
+    (DISTRO_NAMES) for use in the CLI layer which cannot import
+    repo libraries. Keep both in sync when adding a new distro.
     """
     return {
         "rhel": "Red Hat Enterprise Linux",


### PR DESCRIPTION
source_os was always formatted as RHEL plus version.source, so non-RHEL sources (e.g. CentOS Stream 9) appeared as "Red Hat Enterprise Linux 9".

Set source_os from IPUConfig.os_release.pretty_name when set, with the previous RHEL-style string as fallback. target_os unchanged.

Migration results and RHSM leapp facts pick up the same source_os value.

JIRA: RHEL-156580