### PR TITLE
config(rhui): Add config for setting rpm gpg keys to remove

### DIFF
--- a/repos/system_upgrade/common/actors/removeobsoletegpgkeys/actor.py
+++ b/repos/system_upgrade/common/actors/removeobsoletegpgkeys/actor.py
@@ -1,4 +1,5 @@
 from leapp.actors import Actor
+from leapp.configs.common.rhui import all_rhui_cfg
 from leapp.libraries.actor import removeobsoleterpmgpgkeys
 from leapp.models import DNFWorkaround, InstalledRPM
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
@@ -17,10 +18,14 @@ class RemoveObsoleteGpgKeys(Actor):
     - If converting, the obsolete keys are all of the keys provided by the
       vendor of the source distribution.
 
+    Additionally, if RHUI configuration is active (use_config=True), GPG keys
+    specified in the RHUI obsolete_gpg_keys configuration will also be removed.
+
     A DNFWorkaround is registered to actually remove the keys.
     """
 
     name = "remove_obsolete_gpg_keys"
+    config_schemas = all_rhui_cfg
     consumes = (InstalledRPM,)
     produces = (DNFWorkaround,)
     tags = (FactsPhaseTag, IPUWorkflowTag)

--- a/repos/system_upgrade/common/actors/removeobsoletegpgkeys/libraries/removeobsoleterpmgpgkeys.py
+++ b/repos/system_upgrade/common/actors/removeobsoletegpgkeys/libraries/removeobsoleterpmgpgkeys.py
@@ -1,11 +1,23 @@
 import itertools
+import re
 
+from leapp.configs.common.rhui import RhuiObsoleteGpgKeys, RhuiUseConfig, RHUI_CONFIG_SECTION
+from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.config import get_source_distro_id, get_target_distro_id
 from leapp.libraries.common.config.version import get_target_major_version
 from leapp.libraries.common.distro import get_distribution_data
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import DNFWorkaround, InstalledRPM
+
+_GPG_PUBKEY_NVR_FORMAT = re.compile(r"^gpg-pubkey-[0-9a-f]{8}-[0-9a-f]{8}$")
+
+
+def _is_valid_pubkey_nvr(name):
+    """
+    Validate if a string is a valid gpg key RPM NVR
+    """
+    return _GPG_PUBKEY_NVR_FORMAT.match(name) is not None
 
 
 def _is_key_installed(key):
@@ -50,17 +62,47 @@ def _get_source_distro_keys():
     ]
 
 
+def _get_rhui_configured_keys():
+    """
+    Get obsolete cloud vendor keys specified in RHUI configuration.
+
+    Returns keys only when RHUI use_config is True, ensuring this is opt-in behavior.
+    Only returns keys that are actually installed on the system.
+    """
+    rhui_config = api.current_actor().config[RHUI_CONFIG_SECTION]
+
+    # Only apply RHUI keys when user explicitly configures RHUI
+    if not rhui_config[RhuiUseConfig.name]:
+        api.current_logger().debug("RHUI config disabled, ignoring obsolete RPM GPG keys")
+        return []
+
+    configured_keys = rhui_config[RhuiObsoleteGpgKeys.name]
+
+    for key in configured_keys:
+        if not _is_valid_pubkey_nvr(key):
+            raise StopActorExecutionError(
+                "Provided RHUI config contains invalid value for setting {}".format(
+                    RhuiObsoleteGpgKeys.name
+                ),
+                details={
+                    "details": "Entry {} is not a in valid RPM GPG name".format(key)
+                },
+            )
+
+    return [key for key in configured_keys if _is_key_installed(key)]
+
+
 def register_dnfworkaround(keys):
     api.produce(
         DNFWorkaround(
             display_name="remove obsolete RPM GPG keys from RPM DB",
             script_path=api.current_actor().get_common_tool_path("removerpmgpgkeys"),
-            script_args=keys,
+            script_args=list(keys),
         )
     )
 
 
-def process():
+def _get_all_obsolete_keys():
     if get_source_distro_id() == get_target_distro_id():
         # only upgrading - remove keys obsoleted in previous versions
         keys = _get_obsolete_keys()
@@ -68,5 +110,11 @@ def process():
         # also converting - we need to remove all keys from the source distro
         keys = _get_source_distro_keys()
 
+    keys.extend(_get_rhui_configured_keys())
+    return set(keys)
+
+
+def process():
+    keys = _get_all_obsolete_keys()
     if keys:
         register_dnfworkaround(keys)

--- a/repos/system_upgrade/common/actors/removeobsoletegpgkeys/libraries/removeobsoleterpmgpgkeys.py
+++ b/repos/system_upgrade/common/actors/removeobsoletegpgkeys/libraries/removeobsoleterpmgpgkeys.py
@@ -1,11 +1,23 @@
 import itertools
+import re
 
+from leapp.configs.common.rhui import RHUI_CONFIG_SECTION, RhuiObsoleteGpgKeys, RhuiUseConfig
+from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.config import get_source_distro_id, get_target_distro_id
 from leapp.libraries.common.config.version import get_target_major_version
 from leapp.libraries.common.distro import get_distribution_data
 from leapp.libraries.common.rpms import has_package
 from leapp.libraries.stdlib import api
 from leapp.models import DNFWorkaround, InstalledRPM
+
+_GPG_PUBKEY_NVR_FORMAT = re.compile(r"^gpg-pubkey-[0-9a-f]{8}-[0-9a-f]{8}$")
+
+
+def _is_valid_pubkey_nvr(name):
+    """
+    Validate if a string is a valid gpg key RPM NVR
+    """
+    return _GPG_PUBKEY_NVR_FORMAT.match(name) is not None
 
 
 def _is_key_installed(key):
@@ -50,17 +62,51 @@ def _get_source_distro_keys():
     ]
 
 
+def _get_rhui_configured_keys():
+    """
+    Get obsolete cloud vendor keys specified in RHUI configuration.
+
+    Returns keys only when RHUI use_config is True, ensuring this is opt-in behavior.
+    Only returns keys that are actually installed on the system.
+    """
+    rhui_config = api.current_actor().config[RHUI_CONFIG_SECTION]
+
+    # Only apply RHUI keys when the leapp RHUI configuration is set
+    if not rhui_config[RhuiUseConfig.name]:
+        api.current_logger().debug("RHUI config disabled, ignoring obsolete RPM GPG keys")
+        return []
+
+    configured_keys = rhui_config[RhuiObsoleteGpgKeys.name]
+
+    for key in configured_keys:
+        if not _is_valid_pubkey_nvr(key):
+            raise StopActorExecutionError(
+                "Provided RHUI config contains invalid value for setting {}".format(
+                    RhuiObsoleteGpgKeys.name
+                ),
+                details={
+                    "details": "Entry {} is not a in valid RPM GPG name".format(key),
+                    "hint": (
+                        "The expected format is: gpg-pubkey-<version>-<release>,"
+                        " for example: gpg-pubkey-d4082792-5b32db75"
+                    ),
+                },
+            )
+
+    return [key for key in configured_keys if _is_key_installed(key)]
+
+
 def register_dnfworkaround(keys):
     api.produce(
         DNFWorkaround(
             display_name="remove obsolete RPM GPG keys from RPM DB",
             script_path=api.current_actor().get_common_tool_path("removerpmgpgkeys"),
-            script_args=keys,
+            script_args=list(keys),
         )
     )
 
 
-def process():
+def _get_all_obsolete_keys():
     if get_source_distro_id() == get_target_distro_id():
         # only upgrading - remove keys obsoleted in previous versions
         keys = _get_obsolete_keys()
@@ -68,5 +114,11 @@ def process():
         # also converting - we need to remove all keys from the source distro
         keys = _get_source_distro_keys()
 
+    keys.extend(_get_rhui_configured_keys())
+    return set(keys)
+
+
+def process():
+    keys = _get_all_obsolete_keys()
     if keys:
         register_dnfworkaround(keys)

--- a/repos/system_upgrade/common/actors/removeobsoletegpgkeys/tests/test_removeobsoleterpmgpgkeys.py
+++ b/repos/system_upgrade/common/actors/removeobsoletegpgkeys/tests/test_removeobsoleterpmgpgkeys.py
@@ -1,18 +1,54 @@
 import os
 import unittest.mock as mock
 
+from leapp.exceptions import StopActorExecutionError
 import pytest
 
+from leapp.configs.common.rhui import RhuiObsoleteGpgKeys, RhuiUseConfig
 from leapp.libraries.actor import removeobsoleterpmgpgkeys
 from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
 from leapp.libraries.stdlib import api
-from leapp.models import InstalledRPM, RPM
+from leapp.models import DNFWorkaround, InstalledRPM, RPM
 
 _CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def common_folder_path_mocked(folder):
     return os.path.join(_CUR_DIR, "../../../files/", folder)
+
+
+@pytest.mark.parametrize(
+    "key, is_valid",
+    [
+        # too short
+        ("gpg-pubkey-10-10", False),
+        ("gpg-pubkey-888-abc", False),
+        ("gpg-d4082792-5b32db75j", False),
+        # too long ver
+        ("gpg-pubkey-1234456789-b32db75j8", False),
+        # end bound
+        ("gpg-pubkey-12345678-123456789", False),
+        # start bound
+        ("aaagpg-pubkey-12345678-12345678", False),
+        # invalid format
+        ("gpg-12345678-12345678", False),
+        ("pubkey-12345678-12345678", False),
+        ("gpg-pubkey-5b32db75j", False),
+        ("gpg-pubkey-d40827925b32db75j", False),
+        # non hex
+        ("gpg-pubkey-abcdefgh-aaaaaaaa", False),
+        ("gpg-pubkey-12345678-hhhhhhhh", False),
+        # uppercase
+        ("gpg-pubkey-DEADBEEF-12345678", False),
+        ("gpg-pubkey-12345678-DEADBEEF", False),
+        # Ok
+        ("gpg-pubkey-12345678-deadbeef", True),
+        ("gpg-pubkey-d4082792-5b32db75", True),
+        ("gpg-pubkey-2fa658e0-45700c69", True),
+    ],
+)
+def test_is_valid_pubkey_nvr(key, is_valid):
+    assert removeobsoleterpmgpgkeys._is_valid_pubkey_nvr(key) == is_valid
 
 
 def test_is_key_installed(monkeypatch):
@@ -170,27 +206,47 @@ def test_get_source_distro_keys(monkeypatch, distro, expected):
 )
 def test_workaround_should_register(monkeypatch, keys, should_register):
     monkeypatch.setattr(
-        removeobsoleterpmgpgkeys, "_get_obsolete_keys", lambda: keys
+        removeobsoleterpmgpgkeys, "_get_all_obsolete_keys", lambda: keys
     )
     monkeypatch.setattr(api, "produce", produce_mocked())
     monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
 
     removeobsoleterpmgpgkeys.process()
     assert api.produce.called == should_register
+    if should_register:
+        inst = api.produce.model_instances[0]
+        assert isinstance(inst, DNFWorkaround)
+        assert inst.script_args == keys
 
 
-def test_process(monkeypatch):
+@pytest.mark.parametrize(
+    "obsolete_keys, src_distro_keys, rhui_keys",
+    [
+        (
+            ["gpg-pubkey-12345678-abcdefgh"],
+            ["gpg-pubkey-87654321-hgfedcba"],
+            ["gpg-pubkey-12344321-abecedaa"],
+        ),
+        # test if the keys are deduplicated
+        (
+            ["gpg-pubkey-12345678-abcdefgh"],
+            ["gpg-pubkey-12345678-abcdefgh"],
+            ["gpg-pubkey-12345678-abcdefgh"],
+        ),
+    ],
+)
+def test_process(monkeypatch, obsolete_keys, src_distro_keys, rhui_keys):
     """
     Test that the correct path is taken depending on whether also converting
     """
-    obsolete = ["gpg-pubkey-12345678-abcdefgh"]
-    source_distro = ["gpg-pubkey-87654321-hgfedcba"]
-
     monkeypatch.setattr(
-        removeobsoleterpmgpgkeys, "_get_obsolete_keys", lambda: obsolete
+        removeobsoleterpmgpgkeys, "_get_obsolete_keys", lambda: obsolete_keys
     )
     monkeypatch.setattr(
-        removeobsoleterpmgpgkeys, "_get_source_distro_keys", lambda: source_distro,
+        removeobsoleterpmgpgkeys, "_get_source_distro_keys", lambda: src_distro_keys,
+    )
+    monkeypatch.setattr(
+        removeobsoleterpmgpgkeys, "_get_rhui_configured_keys", lambda: rhui_keys
     )
 
     # upgrade only path
@@ -202,7 +258,7 @@ def test_process(monkeypatch):
     ):
         removeobsoleterpmgpgkeys.process()
         removeobsoleterpmgpgkeys.register_dnfworkaround.assert_called_once_with(
-            obsolete
+            set(obsolete_keys + rhui_keys)
         )
 
     # upgrade + conversion paths
@@ -214,7 +270,7 @@ def test_process(monkeypatch):
     ):
         removeobsoleterpmgpgkeys.process()
         removeobsoleterpmgpgkeys.register_dnfworkaround.assert_called_once_with(
-            source_distro
+            set(src_distro_keys + rhui_keys)
         )
 
     monkeypatch.setattr(
@@ -225,5 +281,57 @@ def test_process(monkeypatch):
     ):
         removeobsoleterpmgpgkeys.process()
         removeobsoleterpmgpgkeys.register_dnfworkaround.assert_called_once_with(
-            source_distro
+            set(src_distro_keys + rhui_keys)
         )
+
+
+@pytest.mark.parametrize(
+    "use_config, configured_keys, expected_in_result",
+    [
+        # RHUI config enabled with keys
+        (True, ["gpg-pubkey-aaaaaaaa-11111111", "gpg-pubkey-bbbbbbbb-22222222"], True),
+        # RHUI config disabled (keys should NOT be included)
+        (False, ["gpg-pubkey-12345678-abcdefgh"], False),
+        # Empty key list
+        (True, [], False),
+    ]
+)
+def test_get_rhui_configured_keys(monkeypatch, use_config, configured_keys, expected_in_result):
+    """Test that RHUI configured keys are returned only when use_config=True"""
+    rhui_config = {}
+    if use_config is not None:
+        rhui_config[RhuiUseConfig.name] = use_config
+    if configured_keys is not None:
+        rhui_config[RhuiObsoleteGpgKeys.name] = configured_keys
+
+    all_config = {'rhui': rhui_config}
+
+    monkeypatch.setattr(
+        api, "current_actor", CurrentActorMocked(config=all_config)
+    )
+    monkeypatch.setattr(
+        removeobsoleterpmgpgkeys, "_is_key_installed", lambda key: key in configured_keys
+    )
+
+    result = removeobsoleterpmgpgkeys._get_rhui_configured_keys()
+
+    if expected_in_result:
+        assert set(result) == set(configured_keys)
+    else:
+        assert result == []
+
+
+def test_get_rhui_configured_keys_raises_on_invalid(monkeypatch):
+    """Test that RHUI configured keys are returned only when use_config=True"""
+    rhui_config = {
+        RhuiUseConfig.name: True,
+        RhuiObsoleteGpgKeys.name: ["gpg-pubkey-10-10"],
+    }
+    all_config = {'rhui': rhui_config}
+
+    monkeypatch.setattr(
+        api, "current_actor", CurrentActorMocked(config=all_config)
+    )
+
+    with pytest.raises(StopActorExecutionError):
+        removeobsoleterpmgpgkeys._get_rhui_configured_keys()

--- a/repos/system_upgrade/common/actors/removeobsoletegpgkeys/tests/test_removeobsoleterpmgpgkeys.py
+++ b/repos/system_upgrade/common/actors/removeobsoletegpgkeys/tests/test_removeobsoleterpmgpgkeys.py
@@ -3,16 +3,52 @@ import unittest.mock as mock
 
 import pytest
 
+from leapp.configs.common.rhui import RhuiObsoleteGpgKeys, RhuiUseConfig
+from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import removeobsoleterpmgpgkeys
 from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
 from leapp.libraries.stdlib import api
-from leapp.models import InstalledRPM, RPM
+from leapp.models import DNFWorkaround, InstalledRPM, RPM
 
 _CUR_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def common_folder_path_mocked(folder):
     return os.path.join(_CUR_DIR, "../../../files/", folder)
+
+
+@pytest.mark.parametrize(
+    "key, is_valid",
+    [
+        # too short
+        ("gpg-pubkey-10-10", False),
+        ("gpg-pubkey-888-abc", False),
+        ("gpg-d4082792-5b32db75j", False),
+        # too long ver
+        ("gpg-pubkey-1234456789-b32db75j8", False),
+        # end bound
+        ("gpg-pubkey-12345678-123456789", False),
+        # start bound
+        ("aaagpg-pubkey-12345678-12345678", False),
+        # invalid format
+        ("gpg-12345678-12345678", False),
+        ("pubkey-12345678-12345678", False),
+        ("gpg-pubkey-5b32db75j", False),
+        ("gpg-pubkey-d40827925b32db75j", False),
+        # non hex
+        ("gpg-pubkey-abcdefgh-aaaaaaaa", False),
+        ("gpg-pubkey-12345678-hhhhhhhh", False),
+        # uppercase
+        ("gpg-pubkey-DEADBEEF-12345678", False),
+        ("gpg-pubkey-12345678-DEADBEEF", False),
+        # Ok
+        ("gpg-pubkey-12345678-deadbeef", True),
+        ("gpg-pubkey-d4082792-5b32db75", True),
+        ("gpg-pubkey-2fa658e0-45700c69", True),
+    ],
+)
+def test_is_valid_pubkey_nvr(key, is_valid):
+    assert removeobsoleterpmgpgkeys._is_valid_pubkey_nvr(key) == is_valid
 
 
 def test_is_key_installed(monkeypatch):
@@ -170,27 +206,47 @@ def test_get_source_distro_keys(monkeypatch, distro, expected):
 )
 def test_workaround_should_register(monkeypatch, keys, should_register):
     monkeypatch.setattr(
-        removeobsoleterpmgpgkeys, "_get_obsolete_keys", lambda: keys
+        removeobsoleterpmgpgkeys, "_get_all_obsolete_keys", lambda: keys
     )
     monkeypatch.setattr(api, "produce", produce_mocked())
     monkeypatch.setattr(api, "current_actor", CurrentActorMocked())
 
     removeobsoleterpmgpgkeys.process()
     assert api.produce.called == should_register
+    if should_register:
+        inst = api.produce.model_instances[0]
+        assert isinstance(inst, DNFWorkaround)
+        assert inst.script_args == keys
 
 
-def test_process(monkeypatch):
+@pytest.mark.parametrize(
+    "obsolete_keys, src_distro_keys, rhui_keys",
+    [
+        (
+            ["gpg-pubkey-12345678-abcdefgh"],
+            ["gpg-pubkey-87654321-hgfedcba"],
+            ["gpg-pubkey-12344321-abecedaa"],
+        ),
+        # test if the keys are deduplicated
+        (
+            ["gpg-pubkey-12345678-abcdefgh"],
+            ["gpg-pubkey-12345678-abcdefgh"],
+            ["gpg-pubkey-12345678-abcdefgh"],
+        ),
+    ],
+)
+def test_process(monkeypatch, obsolete_keys, src_distro_keys, rhui_keys):
     """
     Test that the correct path is taken depending on whether also converting
     """
-    obsolete = ["gpg-pubkey-12345678-abcdefgh"]
-    source_distro = ["gpg-pubkey-87654321-hgfedcba"]
-
     monkeypatch.setattr(
-        removeobsoleterpmgpgkeys, "_get_obsolete_keys", lambda: obsolete
+        removeobsoleterpmgpgkeys, "_get_obsolete_keys", lambda: obsolete_keys
     )
     monkeypatch.setattr(
-        removeobsoleterpmgpgkeys, "_get_source_distro_keys", lambda: source_distro,
+        removeobsoleterpmgpgkeys, "_get_source_distro_keys", lambda: src_distro_keys,
+    )
+    monkeypatch.setattr(
+        removeobsoleterpmgpgkeys, "_get_rhui_configured_keys", lambda: rhui_keys
     )
 
     # upgrade only path
@@ -202,7 +258,7 @@ def test_process(monkeypatch):
     ):
         removeobsoleterpmgpgkeys.process()
         removeobsoleterpmgpgkeys.register_dnfworkaround.assert_called_once_with(
-            obsolete
+            set(obsolete_keys + rhui_keys)
         )
 
     # upgrade + conversion paths
@@ -214,7 +270,7 @@ def test_process(monkeypatch):
     ):
         removeobsoleterpmgpgkeys.process()
         removeobsoleterpmgpgkeys.register_dnfworkaround.assert_called_once_with(
-            source_distro
+            set(src_distro_keys + rhui_keys)
         )
 
     monkeypatch.setattr(
@@ -225,5 +281,57 @@ def test_process(monkeypatch):
     ):
         removeobsoleterpmgpgkeys.process()
         removeobsoleterpmgpgkeys.register_dnfworkaround.assert_called_once_with(
-            source_distro
+            set(src_distro_keys + rhui_keys)
         )
+
+
+@pytest.mark.parametrize(
+    "use_config, configured_keys, expected_in_result",
+    [
+        # RHUI config enabled with keys
+        (True, ["gpg-pubkey-aaaaaaaa-11111111", "gpg-pubkey-bbbbbbbb-22222222"], True),
+        # RHUI config disabled (keys should NOT be included)
+        (False, ["gpg-pubkey-12345678-abcdefgh"], False),
+        # Empty key list
+        (True, [], False),
+    ]
+)
+def test_get_rhui_configured_keys(monkeypatch, use_config, configured_keys, expected_in_result):
+    """Test that RHUI configured keys are returned only when use_config=True"""
+    rhui_config = {}
+    if use_config is not None:
+        rhui_config[RhuiUseConfig.name] = use_config
+    if configured_keys is not None:
+        rhui_config[RhuiObsoleteGpgKeys.name] = configured_keys
+
+    all_config = {'rhui': rhui_config}
+
+    monkeypatch.setattr(
+        api, "current_actor", CurrentActorMocked(config=all_config)
+    )
+    monkeypatch.setattr(
+        removeobsoleterpmgpgkeys, "_is_key_installed", lambda key: key in configured_keys
+    )
+
+    result = removeobsoleterpmgpgkeys._get_rhui_configured_keys()
+
+    if expected_in_result:
+        assert set(result) == set(configured_keys)
+    else:
+        assert result == []
+
+
+def test_get_rhui_configured_keys_raises_on_invalid(monkeypatch):
+    """Test that RHUI configured keys are returned only when use_config=True"""
+    rhui_config = {
+        RhuiUseConfig.name: True,
+        RhuiObsoleteGpgKeys.name: ["gpg-pubkey-10-10"],
+    }
+    all_config = {'rhui': rhui_config}
+
+    monkeypatch.setattr(
+        api, "current_actor", CurrentActorMocked(config=all_config)
+    )
+
+    with pytest.raises(StopActorExecutionError):
+        removeobsoleterpmgpgkeys._get_rhui_configured_keys()

--- a/repos/system_upgrade/common/configs/rhui.py
+++ b/repos/system_upgrade/common/configs/rhui.py
@@ -116,6 +116,30 @@ class RhuiTargetRepositoriesToUse(Config):
     default = list()
 
 
+class RhuiObsoleteGpgKeys(Config):
+    section = RHUI_CONFIG_SECTION
+    name = "obsolete_gpg_keys"
+    type_ = fields.List(fields.String())
+    description = """
+        List of obsolete cloud vendor GPG keys to remove from the RPM database during the upgrade.
+
+        These are GPG keys used by cloud providers to sign RHUI client packages. These are NOT
+        Red Hat distribution keys.
+
+        Each key should be specified in the format of an NVR of the RPM metapackage for the given key after
+        it's imported to rpmdb:
+            gpg-pubkey-<version>-<release>
+        For example: "gpg-pubkey-d4082792-5b32db75"
+
+        These keys will be removed in addition to any keys marked as obsolete in the
+        distribution-specific configuration. Only keys that are actually installed
+        will be removed.
+
+        Note: This setting only takes effect when use_config is set to True.
+    """
+    default = list()
+
+
 all_rhui_cfg = (
     RhuiTargetPkgs,
     RhuiUpgradeFiles,
@@ -123,5 +147,6 @@ all_rhui_cfg = (
     RhuiCloudProvider,
     RhuiCloudVariant,
     RhuiSourcePkgs,
-    RhuiUseConfig
+    RhuiUseConfig,
+    RhuiObsoleteGpgKeys
 )

--- a/repos/system_upgrade/common/configs/rhui.py
+++ b/repos/system_upgrade/common/configs/rhui.py
@@ -116,6 +116,30 @@ class RhuiTargetRepositoriesToUse(Config):
     default = list()
 
 
+class RhuiObsoleteGpgKeys(Config):
+    section = RHUI_CONFIG_SECTION
+    name = "obsolete_gpg_keys"
+    type_ = fields.List(fields.String())
+    description = """
+        List of obsolete cloud vendor GPG keys to remove from the RPM database during the upgrade.
+
+        These are GPG keys used by cloud providers to sign RHUI client packages. These are NOT
+        Red Hat distribution keys.
+
+        Each key should be specified in the format of an NVR of the RPM metapackage for the given key after 
+        it's imported to rpmdb:
+            gpg-pubkey-<version>-<release>
+        For example: "gpg-pubkey-d4082792-5b32db75"
+
+        These keys will be removed in addition to any keys marked as obsolete in the
+        distribution-specific configuration. Only keys that are actually installed
+        will be removed.
+
+        Note: This setting only takes effect when use_config is set to True.
+    """
+    default = list()
+
+
 all_rhui_cfg = (
     RhuiTargetPkgs,
     RhuiUpgradeFiles,
@@ -123,5 +147,6 @@ all_rhui_cfg = (
     RhuiCloudProvider,
     RhuiCloudVariant,
     RhuiSourcePkgs,
-    RhuiUseConfig
+    RhuiUseConfig,
+    RhuiObsoleteGpgKeys
 )


### PR DESCRIPTION
Add a config option obsolete_gpg_keys to allow users to specify obsolete
rpm gpg keys to be removed during the upgrade. The removeobsoletegpgkeys
then checks the config and produces the appropriate DNFWorkaround
messages to remove them, similar to distro keys.

This can be prefilled in the config shipped by leapp-rhui-* packages to
remove RPM GPG keys for cloud vendor keys, such as those which are used
to sign the RHUI client rpm.

Jira: RHEL-121205