### PR TITLE
Fix utils/actor_path.py crash on invalid repo paths

### DIFF
--- a/utils/actor_path.py
+++ b/utils/actor_path.py
@@ -30,7 +30,17 @@ def main():
         # the scanning and resolving done below
         manager = RepositoryManager()
         for repo in repos:
-            manager.add_repo(scan_repo(os.path.join(SYSUPG_REPO, repo)))
+            repo_path = os.path.join(SYSUPG_REPO, repo)
+            try:
+                repo_obj = scan_repo(repo_path)
+            except KeyError:  # this is not a nice API, should handle this better in the framework
+                sys.stderr.write(
+                    "ERROR: Failed to scan repository at {}, make sure there"
+                    " is a valid leapp repository at the path.\n".format(repo_path)
+                )
+                return
+
+            manager.add_repo(repo_obj)
         _resolve_repository_links(manager=manager, include_locals=True)
         manager.load()
     else:


### PR DESCRIPTION
When a scan of a path which does not contain a valid leapp repository is attempted in utils/actor.py, it crashes. For example, run with REPOSITORIES=common,invalid:
```
$ ACTOR=mysql_check REPOSITORIES=common,invalid make test ERROR: Unknown error: 'name'
ERROR: Possibly you need newer version of the leapp framework
ERROR:   e.g.: rm -rf .tut && make install-deps-fedora
Traceback (most recent call last):
  File "utils/actor_path.py", line 50, in <module>
    main()
  File "utils/actor_path.py", line 33, in main
    manager.add_repo(scan_repo(os.path.join(SYSUPG_REPO, repo)))
  File "/home/user/leapp-repository/tut/lib/python3.6/site-packages/leapp/repository/scan.py", line 70, in scan_repo
    return scan(Repository(path), path)
  File "/home/user/leapp-repository/tut/lib/python3.6/site-packages/leapp/repository/__init__.py", line 40, in __init__
    self.name = get_repository_name(directory)
  File "/home/user/leapp-repository/tut/lib/python3.6/site-packages/leapp/utils/repository.py", line 96, in get_repository_name
    return get_repository_metadata(path)['name']
KeyError: 'name'
```
With this patch, there is an error with suggestion: $ ACTOR=mysql_check 
```
REPOSITORIES=common,invalid make test ERROR: Failed to scan repository at repos/system_upgrade/invalid, make sure there is a valid leapp repository at the path. . tut/bin/activate; \
echo "--- Linting ... ---" && \
SEARCH_PATH="" && \
echo "Using search path '${SEARCH_PATH}'" && \
echo "--- Running pylint ---" && \
bash -c "[[ ! -z '${SEARCH_PATH}' ]] && find ${SEARCH_PATH} -name '*.py' | sort -u | xargs pylint -j0 " && \ echo "--- Running flake8 ---" && \
bash -c "[[ ! -z '${SEARCH_PATH}' ]] && flake8 ${SEARCH_PATH} " --- Linting ... ---
Using search path ''
--- Running pylint ---
make: *** [Makefile:343: lint] Error 1
```
### This was found by a user trying to develop actors, let's make the problem more obvious