### PR TITLE
Fix rt kernel detection on Centos Stream

### DIFF
--- a/repos/system_upgrade/common/libraries/config/tests/test_version.py
+++ b/repos/system_upgrade/common/libraries/config/tests/test_version.py
@@ -132,19 +132,6 @@ def test_is_supported_version(monkeypatch, result, src_ver, is_saphana):
     assert version.is_supported_version() == result
 
 
-@pytest.mark.parametrize('result,kernel,release_id', [
-    (False, '3.10.0-790.el7.x86_64', 'rhel'),
-    (False, '3.10.0-790.el7.x86_64', 'fedora'),
-    (False, '3.10.0-790.35.2.rt666.1133.el7.x86_64', 'fedora'),
-    (True, '3.10.0-790.35.2.rt666.1133.el7.x86_64', 'rhel'),
-])
-@suppress_deprecation(version.is_rhel_realtime)
-def test_is_rhel_realtime(monkeypatch, result, kernel, release_id):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver='7.9', kernel=kernel,
-                                                                 release_id=release_id))
-    assert version.is_rhel_realtime() == result
-
-
 @pytest.mark.parametrize('result,sys_version', [
     ('7', '7.1.0'),
     ('7', '7.9'),

--- a/repos/system_upgrade/common/libraries/config/version.py
+++ b/repos/system_upgrade/common/libraries/config/version.py
@@ -171,6 +171,19 @@ def matches_version(match_list, detected):
     """
     Check if the `detected` version meets the criteria specified in `match_list`.
 
+    For CentOS Stream (which natively uses only major versions), the match list
+    and the detected version are automatically adjusted to ensure intuitive evaluation:
+
+    - If `match_list` contains only major versions, the comparison is restricted
+      to the major version component:
+        version.matches_version(['> 8', '<= 9'], '9.5')  # True
+
+    - If `match_list` contains major.minor versions but `detected` is a major-only
+      version, the function resolves the input to its defined "virtual version"
+      before evaluation:
+        # e.g., if the virtual version for '9' is defined as '9.5'
+        version.matches_version(['> 8.10', '<= 9.7'], '9')  # True
+
     :param match_list: specification of versions to check against
     :type match_list: list or tuple of strings in one of the two following forms:
                       ``['>'|'>='|'<'|'<='] <integer>.<integer>`` form, where elements are ANDed,

--- a/repos/system_upgrade/common/libraries/config/version.py
+++ b/repos/system_upgrade/common/libraries/config/version.py
@@ -3,7 +3,6 @@ import re
 
 import six
 
-from leapp.libraries.common import kernel as kernel_lib
 from leapp.libraries.stdlib import api
 from leapp.utils.deprecation import deprecated
 
@@ -333,28 +332,6 @@ def is_rhel_alt():
     conf = api.current_actor().configuration
     # rhel-alt is rhel 7 with kernel 4.x - there is not better detection...
     return conf.os_release.release_id == 'rhel' and conf.kernel[0] == '4'
-
-
-@deprecated(since='2023-08-15', message='This information is now provided by KernelInfo message.')
-def is_rhel_realtime():
-    """
-    Check whether the original system is RHEL Real Time.
-
-    Currently the check is based on the release of the original booted kernel.
-    In case of RHEL, we are sure the release contains the ".rt" string and
-    non-realtime kernels don't. Let's use this minimalistic check for now.
-    In future, we could detect whether the system is preemptive or not based
-    on properties of the kernel (e.g. uname -a tells that information).
-
-    :return: `True` if the orig system is RHEL RT and `False` otherwise.
-    :rtype: bool
-    """
-    conf = api.current_actor().configuration
-    if conf.os_release.release_id != 'rhel':
-        return False
-
-    kernel_type = kernel_lib.determine_kernel_type_from_uname(get_source_version(), conf.kernel)
-    return kernel_type == kernel_lib.KernelType.REALTIME
 
 
 def is_supported_version():

--- a/repos/system_upgrade/common/libraries/kernel.py
+++ b/repos/system_upgrade/common/libraries/kernel.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config.version import matches_version
 from leapp.libraries.stdlib import api, CalledProcessError, run
 
 KernelPkgInfo = namedtuple('KernelPkgInfo', ('name', 'version', 'release', 'arch', 'nevra'))
@@ -14,6 +15,8 @@ class KernelType:
     REALTIME = 'realtime'
 
 
+# TODO: rename rhel_version to something distro agnostic in the new function
+# when this is deprecated
 def determine_kernel_type_from_uname(rhel_version, kernel_uname_r):
     """
     Determine kernel type from given kernel release (uname-r).
@@ -23,12 +26,7 @@ def determine_kernel_type_from_uname(rhel_version, kernel_uname_r):
     :returns: Kernel type based on a given uname_r
     :rtype: KernelType
     """
-    version_fragments = rhel_version.split('.')
-    major_ver = version_fragments[0]
-    minor_ver = version_fragments[1] if len(version_fragments) > 1 else '0'
-    rhel_version = (major_ver, minor_ver)
-
-    if rhel_version <= ('9', '2'):
+    if matches_version(['<= 9.2'], rhel_version):
         uname_r_infixes = {
             '.rt': KernelType.REALTIME
         }

--- a/repos/system_upgrade/common/libraries/tests/test_kernel_lib.py
+++ b/repos/system_upgrade/common/libraries/tests/test_kernel_lib.py
@@ -5,23 +5,44 @@ import pytest
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import kernel as kernel_lib
 from leapp.libraries.common.kernel import KernelType
+from leapp.libraries.common.testutils import CurrentActorMocked
+from leapp.libraries.stdlib import api
 
 
 @pytest.mark.parametrize(
-    ('rhel_version', 'uname_r', 'expected_kernel_type'),
+    ('version', 'uname_r', 'expected_kernel_type'),
     (
-        ('7.9', '3.10.0-1160.el7.x86_64', KernelType.ORDINARY),
-        ('7.9', '3.10.0-1160.rt56.1131.el7.x86_64', KernelType.REALTIME),
-        ('8.7', '4.18.0-425.3.1.el8.x86_64', KernelType.ORDINARY),
-        ('8.7', '4.18.0-425.3.1.rt7.213.el8.x86_64', KernelType.REALTIME),
-        ('9.2', '5.14.0-284.11.1.el9_2.x86_64', KernelType.ORDINARY),
-        ('9.2', '5.14.0-284.11.1.rt14.296.el9_2.x86_64', KernelType.REALTIME),
-        ('9.3', '5.14.0-354.el9.x86_64', KernelType.ORDINARY),
-        ('9.3', '5.14.0-354.el9.x86_64+rt', KernelType.REALTIME),
+        # (version, virtual_version)
+        (('7.9', None), '3.10.0-1160.el7.x86_64', KernelType.ORDINARY),
+        (('7.9', None), '3.10.0-1160.rt56.1131.el7.x86_64', KernelType.REALTIME),
+        (('8.7', None), '4.18.0-425.3.1.el8.x86_64', KernelType.ORDINARY),
+        (('8.7', None), '4.18.0-425.3.1.rt7.213.el8.x86_64', KernelType.REALTIME),
+        (('9.2', None), '5.14.0-284.11.1.el9_2.x86_64', KernelType.ORDINARY),
+        (('9.2', None), '5.14.0-284.11.1.rt14.296.el9_2.x86_64', KernelType.REALTIME),
+        (('9.3', None), '5.14.0-354.el9.x86_64', KernelType.ORDINARY),
+        (('9.3', None), '5.14.0-354.el9.x86_64+rt', KernelType.REALTIME),
+        # centos
+        (('8', '8.7'), '4.18.0-425.3.1.el8.x86_64', KernelType.ORDINARY),
+        (('8', '8.7'), '4.18.0-425.3.1.rt7.213.el8.x86_64', KernelType.REALTIME),
+        (('9', '9.2'), '5.14.0-284.11.1.el9_2.x86_64', KernelType.ORDINARY),
+        (('9', '9.2'), '5.14.0-284.11.1.rt14.296.el9_2.x86_64', KernelType.REALTIME),
+        (('9', '9.3'), '5.14.0-354.el9.x86_64', KernelType.ORDINARY),
+        (('9', '9.3'), '5.14.0-354.el9.x86_64+rt', KernelType.REALTIME),
     )
 )
-def test_determine_kernel_type_from_uname(rhel_version, uname_r, expected_kernel_type):
-    kernel_type = kernel_lib.determine_kernel_type_from_uname(rhel_version, uname_r)
+def test_determine_kernel_type_from_uname(monkeypatch, version, uname_r, expected_kernel_type):
+    real_ver, virtual_ver = version
+    # needed to for lookups of virtual versions in matches_version
+    actor_mock = CurrentActorMocked(
+        release_id='centos' if '.' not in real_ver else 'rhel',
+        src_ver=real_ver,
+        dst_ver="irrelevant",
+        virtual_source_version=virtual_ver or real_ver,
+        virtual_target_version="irrelevant",
+    )
+    monkeypatch.setattr(api, 'current_actor', actor_mock)
+
+    kernel_type = kernel_lib.determine_kernel_type_from_uname(real_ver, uname_r)
     assert kernel_type == expected_kernel_type
 
 


### PR DESCRIPTION
The kernel detection function didn't take into account major-only versions as used for CentOS Stream and therefore it misidentified rt kernels as "ordinary" as can be seen in the KernelInfo models "type" field which is populated with the output from the function:
```
Actor: scan_source_kernel
Phase: FactsCollection
Type: KernelInfo
Message_data:
{
    "pkg": {
        "arch": "x86_64",
        "epoch": "0",
        "module": null,
        "name": "kernel-rt-core",
        "packager": "builder@centos.org",
        "pgpsig": "RSA/SHA256, Thu 21 May 2026 02:15:40 AM CEST, Key ID 05b555b38483c65d",
        "release": "708.el9",
        "repository": "rt",
        "stream": null,
        "version": "5.14.0"
    },
    "type": "ordinary",
    "uname_r": "5.14.0-708.el9.x86_64+rt"
}
```
Which caused the target system to default to a non-rt kernel.

With this PR the kernel is correctly identified as "realtime":
```
Actor: scan_source_kernel
Phase: FactsCollection
Type: KernelInfo
Message_data:
{
    "pkg": {
        "arch": "x86_64",
        "epoch": "0",
        "module": null,
        "name": "kernel-rt-core",
        "packager": "builder@centos.org",
        "pgpsig": "RSA/SHA256, Thu 21 May 2026 02:15:40 AM CEST, Key ID 05b555b38483c65d",
        "release": "708.el9",
        "repository": "rt",
        "stream": null,
        "version": "5.14.0"
    },
    "type": "realtime",
    "uname_r": "5.14.0-708.el9.x86_64+rt"
}
```
and the target system correctly defaults to rt kernel:
```
[root@localhost ~]# uname -r
6.12.0-231.el10.x86_64+rt
```
```
# cat /etc/sysconfig/kernel
# UPDATEDEFAULT specifies if kernel-install should make
# new kernels the default
UPDATEDEFAULT=yes

# DEFAULTKERNEL specifies the default kernel package type
DEFAULTKERNEL=kernel-rt-core
```
---
I also removed the deprecated `is_rhel_realtime()` function because it caused circular imports between version and kernel libs. It was also deprecated long enough. 

Jira: RHEL-161560