### PR TITLE
Add inhibitor for incorrect /var/run symlink configuration

### DIFF
--- a/repos/system_upgrade/common/actors/checkvarrunsymlink/actor.py
+++ b/repos/system_upgrade/common/actors/checkvarrunsymlink/actor.py
@@ -1,0 +1,25 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkvarrunsymlink
+from leapp.models import TrackedFilesInfoSource
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckVarRunSymlink(Actor):
+    """
+    Check that /var/run is a symlink pointing to /run.
+
+    In modern Linux systems that use systemd, /run is a tmpfs filesystem
+    managed by systemd and /var/run must be a symbolic link pointing to
+    ../run for compatibility. Inhibit the upgrade if /var/run is not
+    configured as expected, as this can cause boot failures, service
+    startup failures, or login issues.
+    """
+
+    name = 'check_var_run_symlink'
+    consumes = (TrackedFilesInfoSource,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        checkvarrunsymlink.process()

--- a/repos/system_upgrade/common/actors/checkvarrunsymlink/libraries/checkvarrunsymlink.py
+++ b/repos/system_upgrade/common/actors/checkvarrunsymlink/libraries/checkvarrunsymlink.py
@@ -1,0 +1,49 @@
+from leapp import reporting
+from leapp.libraries.stdlib import api
+from leapp.models import TrackedFilesInfoSource
+
+VAR_RUN_PATH = '/var/run'
+
+
+def _get_real_path(tracked_files):
+    for finfo in tracked_files.files:
+        if finfo.path == VAR_RUN_PATH:
+            return finfo.real_path
+    return None
+
+
+def process():
+    tracked_files = next(api.consume(TrackedFilesInfoSource), None)
+    if not tracked_files:
+        api.current_logger().warning(
+            'The TrackedFilesInfoSource message is missing. Skipping the check of /var/run symlink.'
+        )
+        return
+
+    real_path = _get_real_path(tracked_files)
+    if real_path is None or real_path == '/run':
+        return
+
+    reporting.create_report([
+        reporting.Title('/var/run is not correctly configured'),
+        reporting.Summary(
+            'In modern Linux systems that use systemd, /run is a tmpfs filesystem'
+            ' managed by systemd and /var/run must be a symbolic link pointing to'
+            ' ../run for compatibility. The current system does not have /var/run'
+            ' configured as expected. This can cause boot failures, service startup'
+            ' failures, or login issues both on the current system and after an'
+            ' in-place upgrade.'
+        ),
+        reporting.Remediation(
+            hint=(
+                'Back up current /var/run directory if needed and replace it by'
+                ' symbolic link pointing to "../run".'
+            ),
+            commands=[
+                ['bash', '-c', 'mv /var/run /tmp/var_run.bak && ln -s ../run /var/run'],
+            ]
+        ),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.FILESYSTEM, reporting.Groups.INHIBITOR]),
+        reporting.RelatedResource('directory', VAR_RUN_PATH),
+    ])

--- a/repos/system_upgrade/common/actors/checkvarrunsymlink/tests/test_checkvarrunsymlink.py
+++ b/repos/system_upgrade/common/actors/checkvarrunsymlink/tests/test_checkvarrunsymlink.py
@@ -1,0 +1,41 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import checkvarrunsymlink
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import FileInfo, TrackedFilesInfoSource
+from leapp.utils.report import is_inhibitor
+
+
+def _msg_varrun(real_path):
+    return TrackedFilesInfoSource(files=[
+        FileInfo(path='/var/run', exists=True, is_modified=False, real_path=real_path)
+    ])
+
+
+@pytest.mark.parametrize('real_path, should_inhibit', [
+    ('/run', False),
+    ('/var/run', True),
+    ('/tmp/foo', True),
+])
+def test_check_var_run_symlink(monkeypatch, real_path, should_inhibit):
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        msgs=[_msg_varrun(real_path)]
+    ))
+
+    checkvarrunsymlink.process()
+
+    assert bool(reporting.create_report.called) == should_inhibit
+    if should_inhibit:
+        assert is_inhibitor(reporting.create_report.report_fields)
+
+
+def test_check_var_run_missing_message(monkeypatch):
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[]))
+
+    checkvarrunsymlink.process()
+
+    assert not reporting.create_report.called

--- a/repos/system_upgrade/common/actors/scansourcefiles/libraries/scansourcefiles.py
+++ b/repos/system_upgrade/common/actors/scansourcefiles/libraries/scansourcefiles.py
@@ -10,6 +10,7 @@ from leapp.models import FileInfo, TrackedFilesInfoSource
 TRACKED_FILES = {
     'common': [
         '/etc/pki/tls/openssl.cnf',
+        '/var/run',
     ],
     '8': [
     ],
@@ -56,10 +57,12 @@ def is_modified(input_file):
 
 
 def scan_file(input_file):
+    exists = os.path.exists(input_file)
     data = {
         'path': input_file,
-        'exists': os.path.exists(input_file),
+        'exists': exists,
         'rpm_name': _get_rpm_name(input_file),
+        'real_path': os.path.realpath(input_file) if exists else '',
     }
 
     if data['rpm_name']:

--- a/repos/system_upgrade/common/actors/scansourcefiles/tests/unit_test_scansourcefiles.py
+++ b/repos/system_upgrade/common/actors/scansourcefiles/tests/unit_test_scansourcefiles.py
@@ -66,22 +66,27 @@ def test_get_rpm_name_error(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ('input_file', 'exists', 'rpm_name', 'is_modified'),
+    ('input_file', 'exists', 'rpm_name', 'is_modified', 'real_path'),
     (
-        ('/not_existing_file', False, '', False),
-        ('/not_existing_file_rpm_owned', False, 'rpm', False),
-        ('/not_existing_file_rpm_owned_modified', False, 'rpm', True),
-        ('/existing_file_not_modified', True, '', False),
-        ('/existing_file_owned_by_rpm_not_modified', True, 'rpm', False),
-        ('/existing_file_owned_by_rpm_modified', True, 'rpm', True),
+        ('/not_existing_file', False, '', False, ''),
+        ('/not_existing_file_rpm_owned', False, 'rpm', False, ''),
+        ('/not_existing_file_rpm_owned_modified', False, 'rpm', True, ''),
+        ('/existing_file_not_modified', True, '', False, '/existing_file_not_modified'),
+        ('/existing_file_owned_by_rpm_not_modified', True, 'rpm', False, '/existing_file_owned_by_rpm_not_modified'),
+        ('/existing_file_owned_by_rpm_modified', True, 'rpm', True, '/existing_file_owned_by_rpm_modified'),
+        ('/existing_symlink', True, '', False, '/target'),
     )
 )
-def test_scan_file(monkeypatch, input_file, exists, rpm_name, is_modified):
+def test_scan_file(monkeypatch, input_file, exists, rpm_name, is_modified, real_path):
     monkeypatch.setattr(scansourcefiles, 'is_modified', lambda _: is_modified)
     monkeypatch.setattr(scansourcefiles, '_get_rpm_name', lambda _: rpm_name)
     monkeypatch.setattr(os.path, 'exists', lambda _: exists)
+    monkeypatch.setattr(os.path, 'realpath', lambda _: real_path)
 
-    expected_model_output = FileInfo(path=input_file, exists=exists, rpm_name=rpm_name, is_modified=is_modified)
+    expected_model_output = FileInfo(
+        path=input_file, exists=exists, rpm_name=rpm_name,
+        is_modified=is_modified, real_path=real_path
+    )
     assert scansourcefiles.scan_file(input_file) == expected_model_output
 
 

--- a/repos/system_upgrade/common/models/trackedfiles.py
+++ b/repos/system_upgrade/common/models/trackedfiles.py
@@ -40,6 +40,11 @@ class FileInfo(Model):
     In such a case the value is always false.
     """
 
+    real_path = fields.String(default="")
+    """
+    The resolved (real) path of the file. Empty string if path does not exist.
+    """
+
 
 class TrackedFilesInfoSource(Model):
     """


### PR DESCRIPTION
If /var/run is not correctly configured as a symbolic link to /run, the in-place upgrade can lead to boot failures, service startup failures, or login issues. A new ChecksPhase actor detects this unsupported configuration and inhibits the upgrade.

JIRA: RHEL-76846