### PR TITLE
Adjust repomapping for multi-distro mappings

### DIFF
--- a/etc/leapp/files/repomap.json
+++ b/etc/leapp/files/repomap.json
@@ -1,6 +1,6 @@
 {
-    "datetime": "202604161146Z",
-    "version_format": "1.3.0",
+    "datetime": "202607211604Z",
+    "version_format": "2.0.0",
     "provided_data_streams": [
         "4.3"
     ],
@@ -11,165 +11,219 @@
             "entries": [
                 {
                     "source": "rhel8-BaseOS",
-                    "target": [
-                        "rhel9-BaseOS"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-BaseOS"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-AppStream",
-                    "target": [
-                        "rhel9-AppStream"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-AppStream"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-CRB",
-                    "target": [
-                        "rhel9-CRB"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-CRB"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-rhui-client-config-server-8-ha",
-                    "target": [
-                        "rhel9-rhui-client-config-server-9"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-rhui-client-config-server-9"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-rhui-client-config-server-8",
-                    "target": [
-                        "rhel9-rhui-client-config-server-9"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-rhui-client-config-server-9"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-Supplementary",
-                    "target": [
-                        "rhel9-Supplementary"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-Supplementary"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-RT",
-                    "target": [
-                        "rhel9-RT"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-RT"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-NFV",
-                    "target": [
-                        "rhel9-NFV"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-NFV"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-SAP-NetWeaver",
-                    "target": [
-                        "rhel9-SAP-NetWeaver"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-SAP-NetWeaver"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-SAP-Solutions",
-                    "target": [
-                        "rhel9-SAP-Solutions"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-SAP-Solutions"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-HighAvailability",
-                    "target": [
-                        "rhel9-HighAvailability"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-HighAvailability"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-Advanced-Virt",
-                    "target": [
-                        "rhel9-AppStream"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-AppStream"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-Advanced-Virt-CRB",
-                    "target": [
-                        "rhel9-CRB"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-CRB"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-jbeap-7.4",
-                    "target": [
-                        "rhel9-jbeap-7.4"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-jbeap-7.4"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-jbeap-8.0",
-                    "target": [
-                        "rhel9-jbeap-8.0"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-jbeap-8.0"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-jbeap-8.1",
-                    "target": [
-                        "rhel9-jbeap-8.1"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-jbeap-8.1"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-satellite-6.16",
-                    "target": [
-                        "rhel9-satellite-6.16"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-satellite-6.16"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-satellite-capsule-6.16",
-                    "target": [
-                        "rhel9-satellite-capsule-6.16"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-satellite-capsule-6.16"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-satellite-maintenance-6.16",
-                    "target": [
-                        "rhel9-satellite-maintenance-6.16"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-satellite-maintenance-6.16"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-satellite-utils-6.16",
-                    "target": [
-                        "rhel9-satellite-utils-6.16"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-satellite-utils-6.16"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-satellite-client-6",
-                    "target": [
-                        "rhel9-satellite-client-6"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-satellite-client-6"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-rhui-client-config-server-8-sap",
-                    "target": [
-                        "rhel9-rhui-client-config-server-9-sap"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-rhui-client-config-server-9-sap"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-rhui-microsoft-azure-rhel8",
-                    "target": [
-                        "rhel9-rhui-microsoft-azure-rhel9"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-rhui-microsoft-azure-rhel9"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-rhui-microsoft-azure-sap-apps",
-                    "target": [
-                        "rhel9-rhui-microsoft-azure-sap-apps"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-rhui-microsoft-azure-sap-apps"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-rhui-microsoft-sap-ha",
-                    "target": [
-                        "rhel9-rhui-microsoft-sap-ha"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-rhui-microsoft-sap-ha"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-rhui-google-compute-engine",
-                    "target": [
-                        "rhel9-rhui-google-compute-engine-leapp"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-rhui-google-compute-engine-leapp"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel8-rhui-custom-client-at-alibaba",
-                    "target": [
-                        "rhel9-rhui-custom-client-at-alibaba"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel9-rhui-custom-client-at-alibaba"
+                        ]
+                    }
                 }
             ]
         },
@@ -179,105 +233,139 @@
             "entries": [
                 {
                     "source": "rhel9-BaseOS",
-                    "target": [
-                        "rhel10-BaseOS"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-BaseOS"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-AppStream",
-                    "target": [
-                        "rhel10-AppStream"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-AppStream"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-CRB",
-                    "target": [
-                        "rhel10-CRB"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-CRB"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-Supplementary",
-                    "target": [
-                        "rhel10-Supplementary"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-Supplementary"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-RT",
-                    "target": [
-                        "rhel10-RT"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-RT"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-NFV",
-                    "target": [
-                        "rhel10-NFV"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-NFV"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-SAP-NetWeaver",
-                    "target": [
-                        "rhel10-SAP-NetWeaver"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-SAP-NetWeaver"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-SAP-Solutions",
-                    "target": [
-                        "rhel10-SAP-Solutions"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-SAP-Solutions"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-HighAvailability",
-                    "target": [
-                        "rhel10-HighAvailability"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-HighAvailability"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-satellite-client-6",
-                    "target": [
-                        "rhel10-satellite-client-6"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-satellite-client-6"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-rhui-client-config-server-9",
-                    "target": [
-                        "rhel10-rhui-client-config-server-10"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-rhui-client-config-server-10"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-rhui-microsoft-azure-rhel9",
-                    "target": [
-                        "rhel10-rhui-microsoft-azure-rhel10"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-rhui-microsoft-azure-rhel10"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-rhui-custom-client-at-alibaba",
-                    "target": [
-                        "rhel10-rhui-custom-client-at-alibaba"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-rhui-custom-client-at-alibaba"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-rhui-client-config-server-9-sap",
-                    "target": [
-                        "rhel10-rhui-client-config-server-10-sap"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-rhui-client-config-server-10-sap"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-rhui-microsoft-azure-sap-apps",
-                    "target": [
-                        "rhel10-rhui-microsoft-azure-sap-apps"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-rhui-microsoft-azure-sap-apps"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-rhui-microsoft-sap-ha",
-                    "target": [
-                        "rhel10-rhui-microsoft-sap-ha"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-rhui-microsoft-sap-ha"
+                        ]
+                    }
                 },
                 {
                     "source": "rhel9-rhui-google-compute-engine",
-                    "target": [
-                        "rhel10-rhui-google-compute-engine-leapp"
-                    ]
+                    "target": {
+                        "default": [
+                            "rhel10-rhui-google-compute-engine-leapp"
+                        ]
+                    }
                 }
             ]
         }

--- a/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repomap_calc.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repomap_calc.py
@@ -118,14 +118,6 @@ class RepoMapDataHandler:
         """
         matching_pesid_repos = []
         for pesid_repo in self.repositories:
-            # FIXME(pstodulk): Why we do not check actually architecture here?
-            # It seems obvious we should check it, but it's not clear why we
-            # don't and investigation might be required.
-            # For the investigation:
-            # # check repoids matching various architectures
-            # # check repoids without $arch in substring on how many architectures they are present
-            # Investigate and: add a comment with an explanation or fix the
-            # condition.
             if (
                 pesid_repo.repoid == repoid
                 and pesid_repo.major_version == major_version
@@ -133,9 +125,6 @@ class RepoMapDataHandler:
             ):
                 matching_pesid_repos.append(pesid_repo)
 
-        # FIXME: when a PESID is present for multiple architectures, there
-        # are multiple matching repos even though there should really be just
-        # one, the condition below fails even though it shouldn't
         if len(matching_pesid_repos) == 1:
             # Perform no heuristics if only a single pesid repository with matching repoid found
             return matching_pesid_repos[0]
@@ -233,10 +222,9 @@ class RepoMapDataHandler:
         for candidate in self.get_target_pesid_repos(target_pesid):
             matches_rhui = candidate.rhui == src_pesidrepo.rhui
             matches_repo_type = candidate.repo_type == 'rpm'
-            matches_arch = candidate.arch == api.current_actor().configuration.architecture
             matches_distro = candidate.distro == self.target_distro
 
-            if matches_rhui and matches_arch and matches_distro and matches_repo_type:
+            if matches_rhui and matches_distro and matches_repo_type:
                 # user can specify in future the specific channel should be
                 # prioritized always (e.g. want to go to EUS...).
                 channel = self.prio_channel or src_pesidrepo.channel

--- a/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repomap_loader.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repomap_loader.py
@@ -2,7 +2,7 @@ import os
 from collections import defaultdict
 
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.common.config import get_target_distro_id
+from leapp.libraries.common.config import get_source_distro_id, get_target_distro_id
 from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
 from leapp.libraries.common.fetch import load_data_asset
 from leapp.libraries.common.rpms import get_leapp_packages, LeappComponents
@@ -42,11 +42,18 @@ class RepoMapData:
             distro=data['distro'],
         ))
 
-    def get_repositories(self, valid_major_versions):
+    def get_repositories(self, valid_major_versions, valid_distros):
         """
-        Return the list of PESIDRepositoryEntry object matching the specified major versions.
+        Get repository entries for the specified major versions and distros
+
+        :return: PESIDRepositoryEntry objects matching the specified major versions and distros
+        :rtype: list[PESIDRepositoryEntry]
         """
-        return [repo for repo in self.repositories if repo.major_version in valid_major_versions]
+        return [
+            repo
+            for repo in self.repositories
+            if repo.major_version in valid_major_versions and repo.distro in valid_distros
+        ]
 
     def _add_mapping(
         self,
@@ -197,7 +204,7 @@ def load_repositories_mapping(read_repofile_func=_read_repofile):
     Load the mapping of DNF repositories related to the current upgrade path.
 
     Read the mapping from the repomap.json file and filter out data irrelevant
-    for the current and target system major version.
+    for the current and target system major version and distribution.
 
     Produce and return the RepositoriesMapping message.
 
@@ -211,9 +218,11 @@ def load_repositories_mapping(read_repofile_func=_read_repofile):
     json_data = read_repofile_func(REPOMAP_FILE)
     try:
         repomap_data = RepoMapData.load_from_dict(json_data)
+
+        src_distro, dst_distro = get_source_distro_id(), get_target_distro_id()
         src_ver, dst_ver = get_source_major_version(), get_target_major_version()
 
-        mapping = repomap_data.get_mappings(src_ver, dst_ver, get_target_distro_id())
+        mapping = repomap_data.get_mappings(src_ver, dst_ver, dst_distro)
         if mapping is None:
             # don't really expect this to happen because before it was not
             # handled at all and I am not aware of any crashes
@@ -223,11 +232,8 @@ def load_repositories_mapping(read_repofile_func=_read_repofile):
             )
             _inhibit_upgrade(err_message.format(src_ver, dst_ver))
 
-        valid_major_versions = [get_source_major_version(), get_target_major_version()]
-        repositories_mapping = RepositoriesMapping(
-            mapping=mapping,
-            repositories=repomap_data.get_repositories(valid_major_versions)
-        )
+        repos = repomap_data.get_repositories([src_ver, dst_ver], [src_distro, dst_distro])
+        repositories_mapping = RepositoriesMapping(mapping=mapping, repositories=repos)
         api.produce(repositories_mapping)
     except ModelViolationError as err:
         err_message = (

--- a/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repomap_loader.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repomap_loader.py
@@ -42,17 +42,19 @@ class RepoMapData:
             distro=data['distro'],
         ))
 
-    def get_repositories(self, valid_major_versions, valid_distros):
+    def get_repositories(self, major_versions, distros, arches):
         """
         Get repository entries for the specified major versions and distros
 
-        :return: PESIDRepositoryEntry objects matching the specified major versions and distros
+        :return: PESIDRepositoryEntry objects matching the specified major versions, distros and arches
         :rtype: list[PESIDRepositoryEntry]
         """
         return [
             repo
             for repo in self.repositories
-            if repo.major_version in valid_major_versions and repo.distro in valid_distros
+            if repo.major_version in major_versions
+            and repo.distro in distros
+            and repo.arch in arches
         ]
 
     def _add_mapping(
@@ -213,7 +215,6 @@ def load_repositories_mapping(read_repofile_func=_read_repofile):
     :rtype: RepositoriesMapping
     :raises StopActorExecutionError: When cannot produce valid RepositoriesMapping
     """
-    # TODO: add filter based on the current arch
 
     json_data = read_repofile_func(REPOMAP_FILE)
     try:
@@ -232,7 +233,12 @@ def load_repositories_mapping(read_repofile_func=_read_repofile):
             )
             _inhibit_upgrade(err_message.format(src_ver, dst_ver))
 
-        repos = repomap_data.get_repositories([src_ver, dst_ver], [src_distro, dst_distro])
+        repos = repomap_data.get_repositories(
+            [src_ver, dst_ver],
+            [src_distro, dst_distro],
+            [api.current_actor().configuration.architecture],
+        )
+
         repositories_mapping = RepositoriesMapping(mapping=mapping, repositories=repos)
         api.produce(repositories_mapping)
     except ModelViolationError as err:

--- a/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repomap_loader.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repomap_loader.py
@@ -2,6 +2,7 @@ import os
 from collections import defaultdict
 
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.config import get_target_distro_id
 from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
 from leapp.libraries.common.fetch import load_data_asset
 from leapp.libraries.common.rpms import get_leapp_packages, LeappComponents
@@ -14,13 +15,13 @@ REPOMAP_FILE = 'repomap.json'
 
 
 class RepoMapData:
-    VERSION_FORMAT = '1.3.0'
+    VERSION_FORMAT = '2.0.0'
 
     def __init__(self):
         self.repositories = []
         self.mapping = {}
 
-    def add_repository(self, data, pesid):
+    def _add_repository(self, data, pesid):
         """
         Add new PESIDRepositoryEntry with given pesid from the provided dictionary.
 
@@ -47,7 +48,13 @@ class RepoMapData:
         """
         return [repo for repo in self.repositories if repo.major_version in valid_major_versions]
 
-    def add_mapping(self, source_major_version, target_major_version, source_pesid, target_pesid):
+    def _add_mapping(
+        self,
+        source_major_version,
+        target_major_version,
+        source_pesid,
+        target_pesids,
+    ):
         """
         Add a new mapping entry that is mapping the source pesid to the destination pesid(s),
         relevant in an IPU from the supplied source major version to the supplied target
@@ -58,32 +65,36 @@ class RepoMapData:
         :param str target_major_version: Specifies the major version of the target system
                                          for which the added mapping applies.
         :param str source_pesid: PESID of the source repository.
-        :param Union[str|List[str]] target_pesid: A single target PESID or a list of target
-                                                  PESIDs of the added mapping.
+        :param dict[str, list[str]] target_pesids: A dict mapping distro to a list of PESIDS
         """
         # NOTE: it could be more simple, but I prefer to be sure the input data
         # contains just one map per source PESID.
         key = '{}:{}'.format(source_major_version, target_major_version)
-        rmap = self.mapping.get(key, defaultdict(set))
-        self.mapping[key] = rmap
-        if isinstance(target_pesid, list):
-            rmap[source_pesid].update(target_pesid)
-        else:
-            rmap[source_pesid].add(target_pesid)
+        # source -> distro -> targets
+        pesids_map = self.mapping.setdefault(key, defaultdict(lambda: defaultdict(set)))
 
-    def get_mappings(self, src_major_version, dst_major_version):
+        for distro, pesids in target_pesids.items():
+            pesids_map[source_pesid][distro].update(pesids)
+
+    def get_mappings(self, src_major_version, dst_major_version, dst_distro):
         """
         Return the list of RepoMapEntry objects for the specified upgrade path.
 
         IOW, the whole mapping for specified IPU.
         """
         key = '{}:{}'.format(src_major_version, dst_major_version)
-        rmap = self.mapping.get(key, None)
-        if not rmap:
+        pesids_map = self.mapping.get(key, None)
+        if not pesids_map:
             return None
+
         map_list = []
-        for src_pesid in sorted(rmap.keys()):
-            map_list.append(RepoMapEntry(source=src_pesid, target=sorted(rmap[src_pesid])))
+        for src_pesid in sorted(pesids_map.keys()):
+            target_pesids_by_distro = pesids_map[src_pesid]
+            default = target_pesids_by_distro['default']
+            targets = target_pesids_by_distro.get(dst_distro, default)
+
+            map_list.append(RepoMapEntry(source=src_pesid, target=sorted(targets)))
+
         return map_list
 
     @staticmethod
@@ -97,33 +108,58 @@ class RepoMapData:
 
         repomap = RepoMapData()
 
-        # Load reposiories
+        # Load repositories
         existing_pesids = set()
         for repo_family in data['repositories']:
             existing_pesids.add(repo_family['pesid'])
             for repo in repo_family['entries']:
-                repomap.add_repository(repo, repo_family['pesid'])
+                repomap._add_repository(repo, repo_family['pesid'])
 
         # Load mappings
         for mapping in data['mapping']:
             for entry in mapping['entries']:
-                if not isinstance(entry['target'], list):
+                source_pesid = entry['source']
+                target_pesids_by_distro = entry['target']
+
+                if not isinstance(target_pesids_by_distro, dict):
                     raise ValueError(
-                        'The target field of a mapping entry is not a list: {}'
-                        .format(entry)
+                        "The 'target' of a mapping entry for PESID {} is {}, must be a dict".format(
+                            source_pesid, type(target_pesids_by_distro)
+                        )
                     )
 
-                for pesid in [entry['source']] + entry['target']:
+                if 'default' not in target_pesids_by_distro:
+                    raise ValueError(
+                        "The 'target' of a mapping entry for PESID {} does not contain 'default'".format(
+                            source_pesid
+                        )
+                    )
+
+                for _distro, pesids in target_pesids_by_distro.items():
+                    if not isinstance(pesids, list):
+                        raise ValueError(
+                            "Values of the 'target' dict of a mapping entry for PESID {} must be lists".format(
+                                source_pesid
+                            )
+                        )
+
+                for pesid in [entry['source']] + [id for ids in entry['target'].values() for id in ids]:
+                    # FIXME: this check isn't complete since the distro field was
+                    # introduced for repositories, because the PESID might be
+                    # associated with just repositories for a particular
+                    # distro(s) and therefore might not be for the source or
+                    # target distro.
+                    # However this is better than nothing.
                     if pesid not in existing_pesids:
                         raise ValueError(
-                            'The {} pesid is not related to any repository.'
-                            .format(pesid)
+                            'The {} pesid is not related to any repository.'.format(pesid)
                         )
-                repomap.add_mapping(
+
+                repomap._add_mapping(
                     source_major_version=mapping['source_major_version'],
                     target_major_version=mapping['target_major_version'],
-                    source_pesid=entry['source'],
-                    target_pesid=entry['target'],
+                    source_pesid=source_pesid,
+                    target_pesids=target_pesids_by_distro,
                 )
         return repomap
 
@@ -175,7 +211,17 @@ def load_repositories_mapping(read_repofile_func=_read_repofile):
     json_data = read_repofile_func(REPOMAP_FILE)
     try:
         repomap_data = RepoMapData.load_from_dict(json_data)
-        mapping = repomap_data.get_mappings(get_source_major_version(), get_target_major_version())
+        src_ver, dst_ver = get_source_major_version(), get_target_major_version()
+
+        mapping = repomap_data.get_mappings(src_ver, dst_ver, get_target_distro_id())
+        if mapping is None:
+            # don't really expect this to happen because before it was not
+            # handled at all and I am not aware of any crashes
+            err_message = (
+                'The repository mapping file is invalid: '
+                'no mappings found for IPU {}:{}'
+            )
+            _inhibit_upgrade(err_message.format(src_ver, dst_ver))
 
         valid_major_versions = [get_source_major_version(), get_target_major_version()]
         repositories_mapping = RepositoriesMapping(

--- a/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repomap_loader.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repomap_loader.py
@@ -106,6 +106,52 @@ class RepoMapData:
 
         return map_list
 
+    def validate_target_pesids_for_ipu(self, source_distro, target_distro, arch):
+        """
+        Validate that all PESIDs are associated with a repository
+
+        If a PESID is mapped as a target PESID in the mapping section, check
+        that the PESID is associated with some repository for the given IPU
+        i.e. a repository matching the given source and target distro and
+        architecture and the target major version exists in the repositories
+        section.
+
+        The check doesn't really make sense for a PESID mapped as a source,
+        because it not being present in repositories section for the given IPU
+        can be intentional and is valid.
+        """
+        # TODO maybe take into account just the current source/target version?
+        # But we can check them without further input unlike the distro and
+        # arch.
+        repo_lookup = set()
+        for repo in self.repositories:
+            repo_lookup.add((repo.pesid, repo.major_version, repo.distro, repo.arch))
+
+        for upg_path, mappings in self.mapping.items():
+            source_ver, target_ver = upg_path.split(':', 1)
+
+            for source_pesid, target_pesids_by_distro in mappings.items():
+                default = target_pesids_by_distro['default']
+                pesids_for_distro = target_pesids_by_distro.get(target_distro, default)
+
+                # There is no repository for the source system that would belong to the pesid
+                # that is the source of the mapping. Therefore, the mapping will never be used
+                # and we can skip checking its target pesids. This avoids raising ValueErrors,
+                # for example, for on RHUI-mappings that will be always defined only for RHEL.
+                if (source_pesid, source_ver, source_distro, arch) not in repo_lookup:
+                    continue
+
+                for pesid in pesids_for_distro:
+                    if (pesid, target_ver, target_distro, arch) not in repo_lookup:
+                        raise ValueError(
+                            "Target PESID {} does not have any associated repository"
+                            " for major version {} and distro {}.".format(
+                                pesid,
+                                target_ver,
+                                target_distro,
+                            )
+                        )
+
     @staticmethod
     def load_from_dict(data):
         if data['version_format'] != RepoMapData.VERSION_FORMAT:
@@ -153,12 +199,14 @@ class RepoMapData:
                         )
 
                 for pesid in [entry['source']] + [id for ids in entry['target'].values() for id in ids]:
-                    # FIXME: this check isn't complete since the distro field was
-                    # introduced for repositories, because the PESID might be
-                    # associated with just repositories for a particular
-                    # distro(s) and therefore might not be for the source or
-                    # target distro.
-                    # However this is better than nothing.
+                    # NOTE: this check isn't complete for target repositories,
+                    # since the distro field was introduced for repositories,
+                    # because the PESID might be associated with just
+                    # repositories for a particular distro(s) and therefore
+                    # might not be for the target distro.
+                    # This is therefore a very simple check, for a proper one
+                    # the :py:func:`validate_target_pesids_for_ipu` can be
+                    # used.
                     if pesid not in existing_pesids:
                         raise ValueError(
                             'The {} pesid is not related to any repository.'.format(pesid)
@@ -222,6 +270,9 @@ def load_repositories_mapping(read_repofile_func=_read_repofile):
 
         src_distro, dst_distro = get_source_distro_id(), get_target_distro_id()
         src_ver, dst_ver = get_source_major_version(), get_target_major_version()
+        arch = api.current_actor().configuration.architecture
+
+        repomap_data.validate_target_pesids_for_ipu(src_distro, dst_distro, arch)
 
         mapping = repomap_data.get_mappings(src_ver, dst_ver, dst_distro)
         if mapping is None:
@@ -236,7 +287,7 @@ def load_repositories_mapping(read_repofile_func=_read_repofile):
         repos = repomap_data.get_repositories(
             [src_ver, dst_ver],
             [src_distro, dst_distro],
-            [api.current_actor().configuration.architecture],
+            [arch],
         )
 
         repositories_mapping = RepositoriesMapping(mapping=mapping, repositories=repos)

--- a/repos/system_upgrade/common/actors/targetcontentresolver/tests/files/repomap_example.json
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/tests/files/repomap_example.json
@@ -10,7 +10,7 @@
           "source": "pesid1",
           "target": {
             "default": ["pesid2", "pesid3"],
-            "centos": ["pesid6", "pesid7"]
+            "centos": ["pesid7"]
           }
         }
       ]
@@ -22,8 +22,9 @@
         {
           "source": "pesid3",
           "target": {
-            "default": ["pesid4", "pesid5"],
-            "almalinux": ["pesid6"]
+            "default": ["pesid4"],
+            "centos": ["pesid4"],
+            "almalinux": ["pesid9"]
           }
         }
       ]
@@ -70,11 +71,50 @@
       ]
     },
     {
+      "pesid": "pesid2",
+      "entries": [
+        {
+          "major_version": "8",
+          "repoid": "some-rhel-8-repoid1",
+          "arch": "x86_64",
+          "repo_type": "rpm",
+          "channel": "eus",
+          "distro": "almalinux"
+        }
+      ]
+    },
+    {
       "pesid": "pesid3",
       "entries": [
         {
           "major_version": "8",
           "repoid": "some-rhel-8-repoid2",
+          "arch": "x86_64",
+          "repo_type": "rpm",
+          "channel": "eus",
+          "distro": "rhel"
+        }
+      ]
+    },
+    {
+      "pesid": "pesid3",
+      "entries": [
+        {
+          "major_version": "8",
+          "repoid": "some-rhel-8-repoid2",
+          "arch": "x86_64",
+          "repo_type": "rpm",
+          "channel": "eus",
+          "distro": "almalinux"
+        }
+      ]
+    },
+    {
+      "pesid": "pesid4",
+      "entries": [
+        {
+          "major_version": "9",
+          "repoid": "some-rhel-9-repo1",
           "arch": "x86_64",
           "repo_type": "rpm",
           "channel": "eus",
@@ -91,7 +131,7 @@
           "arch": "x86_64",
           "repo_type": "rpm",
           "channel": "eus",
-          "distro": "rhel"
+          "distro": "centos"
         }
       ]
     },

--- a/repos/system_upgrade/common/actors/targetcontentresolver/tests/files/repomap_example.json
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/tests/files/repomap_example.json
@@ -1,6 +1,6 @@
 {
   "datetime": "202107141655Z",
-  "version_format": "1.3.0",
+  "version_format": "2.0.0",
   "mapping": [
     {
       "source_major_version": "7",
@@ -8,10 +8,10 @@
       "entries": [
         {
           "source": "pesid1",
-          "target": [
-            "pesid2",
-            "pesid3"
-          ]
+          "target": {
+            "default": ["pesid2", "pesid3"],
+            "centos": ["pesid6", "pesid7"]
+          }
         }
       ]
     },
@@ -21,10 +21,10 @@
       "entries": [
         {
           "source": "pesid3",
-          "target": [
-            "pesid4",
-            "pesid5"
-          ]
+          "target": {
+            "default": ["pesid4", "pesid5"],
+            "almalinux": ["pesid6"]
+          }
         }
       ]
     }

--- a/repos/system_upgrade/common/actors/targetcontentresolver/tests/files/repomap_example.json
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/tests/files/repomap_example.json
@@ -44,6 +44,19 @@
       ]
     },
     {
+      "pesid": "pesid1",
+      "entries": [
+        {
+          "major_version": "7",
+          "repoid": "some-rhel-7-repoid",
+          "arch": "aarch64",
+          "repo_type": "rpm",
+          "channel": "eus",
+          "distro": "rhel"
+        }
+      ]
+    },
+    {
       "pesid": "pesid2",
       "entries": [
         {

--- a/repos/system_upgrade/common/actors/targetcontentresolver/tests/test_repomap_operations.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/tests/test_repomap_operations.py
@@ -256,10 +256,9 @@ def mapping_data_for_find_repository_equiv():
         make_pesid_repo('pesid1', '7', 'pesid1-repoid', channel='e4s', rhui='aws'),
         make_pesid_repo('pesid2', '8', 'pesid2-repoid1-centos', distro='centos'),
         make_pesid_repo('pesid2', '8', 'pesid2-repoid1'),
-        make_pesid_repo('pesid2', '8', 'pesid2-repoid2-s390x', arch='s390x'),
         # This repository is a better candidate than the full match equivalent, but _find_repository_target_equivalent
         # should not take into account channel priorities
-        make_pesid_repo('pesid2', '8', 'pesid2-repoid2', arch='x86_64', channel='eus'),
+        make_pesid_repo('pesid2', '8', 'pesid2-repoid2', channel='eus'),
         make_pesid_repo('pesid2', '8', 'pesid2-repoid3-srpm', repo_type='srpm'),
         make_pesid_repo('pesid2', '8', 'pesid2-repoid4.1', rhui='aws'),
         make_pesid_repo('pesid2', '8', 'pesid2-repoid4.2', channel='eus', rhui='aws'),
@@ -323,13 +322,13 @@ def test_find_repository_target_equivalent_fallback_to_default(monkeypatch,
 
     fail_description = (
         'The _find_repository_target_equivalent failed to find repository with some of the fallback channels.')
-    expected_target_equivalent = repositories[7]
+    expected_target_equivalent = repositories[6]
     actual_target_equivalent = handler._find_repository_target_equivalent(repositories[1], 'pesid2')
     assert expected_target_equivalent == actual_target_equivalent, fail_description
 
     handler.set_default_channels(['eus', 'ga'])
 
-    expected_target_equivalent = repositories[8]
+    expected_target_equivalent = repositories[7]
     actual_target_equivalent = handler._find_repository_target_equivalent(repositories[1], 'pesid2')
     assert expected_target_equivalent == actual_target_equivalent, fail_description
 
@@ -342,12 +341,12 @@ def test_find_repository_target_equivalent_no_target_equivalent(monkeypatch,
     Verifies that the  does not crash when there is no target repository that is equivalent to the
     source repository.
     """
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch='s390x', src_ver='7.9', dst_ver='8.4'))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch='x86_64', src_ver='7.9', dst_ver='8.4'))
     handler = RepoMapDataHandler(mapping_data_for_find_repository_equiv)
 
     fail_description = 'The _find_repository_target_equivalent found target equivalent when there are none.'
 
-    repository_with_no_equivalent = make_pesid_repo('pesid1', '7', 'pesid1-some-repoid', arch='s390x', rhui='aws')
+    repository_with_no_equivalent = make_pesid_repo('pesid1', '7', 'pesid1-some-repoid', rhui='azure')
     target_equivalent = handler._find_repository_target_equivalent(repository_with_no_equivalent, 'pesid2')
     assert target_equivalent is None, fail_description
 
@@ -371,14 +370,14 @@ def test_get_mapped_target_pesid_repos(monkeypatch, mapping_data_for_find_reposi
     target_pesid_repos_map = handler.get_mapped_target_pesid_repos(repositories[0])
     expected_pesid_to_best_candidate_map = {
         'pesid2': repositories[3],
-        'pesid3': repositories[9]
+        'pesid3': repositories[8]
     }
     assert target_pesid_repos_map == expected_pesid_to_best_candidate_map, fail_description
 
     # The pesid3 does not have an equivalent for provided source pesid repository (due to not having any rhui repos)
     target_pesid_repos_map = handler.get_mapped_target_pesid_repos(repositories[1])
     expected_pesid_to_best_candidate_map = {
-        'pesid2': repositories[7],
+        'pesid2': repositories[6],
         'pesid3': None
     }
     assert target_pesid_repos_map == expected_pesid_to_best_candidate_map, fail_description
@@ -404,7 +403,7 @@ def test_get_mapped_target_repoids(monkeypatch, mapping_data_for_find_repository
         'to be enabled on the target system.')
     # Both pesid2 and pesid3 have an equivalent for provided source pesid repository
     actual_target_repoids = handler.get_mapped_target_repoids(repositories[0])
-    expected_target_repoids = {repositories[3].repoid, repositories[9].repoid}
+    expected_target_repoids = {repositories[3].repoid, repositories[8].repoid}
     assert len(actual_target_repoids) == len(expected_target_repoids), fail_description
     assert set(actual_target_repoids) == expected_target_repoids, fail_description
 

--- a/repos/system_upgrade/common/actors/targetcontentresolver/tests/test_repomap_operations.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/tests/test_repomap_operations.py
@@ -59,28 +59,31 @@ def repomap_data_for_pesid_repo_retrieval():
     return repomap_data
 
 
+@pytest.fixture(params=[
+    ('rhel', 'rhel'),
+    ('centos', 'rhel'),
+    ('centos', 'centos'),
+])
+def distro_pair(request):
+    return request.param
+
+
 @pytest.fixture
-def repomap_data_multiple_distros():
-    repomap_data = RepositoriesMapping(
+def conversion_repomap_data(distro_pair):
+    src_distro, dst_distro = distro_pair
+    return RepositoriesMapping(
         mapping=[
             RepoMapEntry(source="pesid1", target=["pesid3", "pesid2"]),
         ],
         repositories=[
-            make_pesid_repo("pesid1", "9", "pesid1-repoid"),
-            make_pesid_repo("pesid1", "9", "pesid1-repoid-eus", channel="eus"),
-            make_pesid_repo("pesid1", "9", "pesid1-repoid-centos", distro="centos"),
-            make_pesid_repo("pesid2", "10", "pesid2-repoid"),
-            make_pesid_repo("pesid2", "10", "pesid2-repoid-centos", distro="centos"),
-            make_pesid_repo("pesid3", "10", "pesid3-repoid"),
-            make_pesid_repo("pesid3", "10", "pesid3-repoid-eus", channel="eus"),
-            make_pesid_repo("pesid3", "10", "pesid3-repoid-aws", rhui="aws"),
-            make_pesid_repo("pesid3", "10", "pesid3-repoid-centos", distro="centos"),
-            make_pesid_repo("pesid1", "9", "pesid1-repoid-almalinux", distro="almalinux"),
-            make_pesid_repo("pesid2", "10", "pesid2-repoid-almalinux", distro="almalinux"),
-            make_pesid_repo("pesid3", "10", "pesid3-repoid-almalinux", distro="almalinux"),
+            make_pesid_repo("pesid1", "9", "pesid1-repoid", distro=src_distro),
+            make_pesid_repo("pesid1", "9", "pesid1-repoid-eus", channel="eus", distro=src_distro),
+            make_pesid_repo("pesid2", "10", "pesid2-repoid", distro=dst_distro),
+            make_pesid_repo("pesid3", "10", "pesid3-repoid", distro=dst_distro),
+            make_pesid_repo("pesid3", "10", "pesid3-repoid-eus", channel="eus", distro=dst_distro),
+            make_pesid_repo("pesid3", "10", "pesid3-repoid-aws", rhui="aws", distro=dst_distro),
         ],
     )
-    return repomap_data
 
 
 def test_get_pesid_repo_entry(monkeypatch, repomap_data_for_pesid_repo_retrieval):
@@ -109,45 +112,6 @@ def test_get_pesid_repo_entry(monkeypatch, repomap_data_for_pesid_repo_retrieval
     assert handler.get_pesid_repo_entry('nonexisting-repo', '7', 'rhel') is None, fail_description
 
 
-@pytest.mark.parametrize('distro', ('rhel', 'centos', 'almalinux'))
-def test_get_pesid_repo_entry_distro(
-    monkeypatch, repomap_data_multiple_distros, distro
-):
-    """
-    Test for the RepoMapDataHandler.get_pesid_repo_entry method.
-
-    Verifies that the method correctly retrieves PESIDRepositoryEntry that are
-    matching the OS major version, repoid and the distro, regardless of the
-    actual distro.
-    """
-    monkeypatch.setattr(
-        api,
-        "current_actor",
-        CurrentActorMocked(
-            arch="x86_64",
-            src_ver="9.6",
-            dst_ver="10.2",
-            src_distro=distro,
-            dst_distro=distro,
-        ),
-    )
-    handler = RepoMapDataHandler(repomap_data_multiple_distros)
-    repositories = [
-        repo
-        for repo in repomap_data_multiple_distros.repositories
-        if repo.distro == distro
-    ]
-
-    fail_description = (
-        "get_pesid_repo_entry method failed to find correct pesid repository that matches given parameters."
-    )
-    for exp_repo in repositories:
-        result_repo = handler.get_pesid_repo_entry(
-            exp_repo.repoid, exp_repo.major_version, exp_repo.distro
-        )
-        assert result_repo == exp_repo, fail_description
-
-
 def test_get_target_pesids(monkeypatch, repomap_data_for_pesid_repo_retrieval):
     """
     Test for the RepoMapDataHandler.get_target_pesids method.
@@ -171,47 +135,8 @@ def test_get_target_pesids(monkeypatch, repomap_data_for_pesid_repo_retrieval):
     assert [] == handler.get_target_pesids('pesid_no_mapping'), fail_description
 
 
-@pytest.mark.parametrize('distro', ('rhel', 'centos', 'almalinux'))
-def test_get_target_pesids_distro(
-    monkeypatch, repomap_data_multiple_distros, distro
-):
-    """
-    Test for the RepoMapDataHandler.get_target_pesids method.
-
-    Verifies that the method correctly tells what target pesids is the given source pesid mapped to.
-    """
-    monkeypatch.setattr(
-        api,
-        "current_actor",
-        CurrentActorMocked(
-            arch="x86_64", src_ver="7.9", dst_ver="8.4", release_id=distro
-        ),
-    )
-    handler = RepoMapDataHandler(repomap_data_multiple_distros)
-
-    expected_target_pesids = ['pesid2', 'pesid3']
-    actual_target_pesids = handler.get_target_pesids('pesid1')
-
-    fail_description = (
-        'The get_target_pesids method did not correctly identify what is the given source pesid mapped to.')
-    assert expected_target_pesids == actual_target_pesids, fail_description
-
-    fail_description = (
-        'The get_target_pesids method found target pesids even if the source repository is not mapped.')
-    assert [] == handler.get_target_pesids('pesid2'), fail_description
-    assert [] == handler.get_target_pesids('pesid_no_mapping'), fail_description
-
-
-@pytest.mark.parametrize(
-    'distro,expect_pesid3,expect_pesid1',
-    [
-        ('rhel', [5, 6, 7], [0, 1]),
-        ('centos', [8], [2]),
-        ('almalinux', [11], [9]),
-    ]
-)
 def test_get_pesid_repos(
-    monkeypatch, repomap_data_multiple_distros, distro, expect_pesid3, expect_pesid1
+    monkeypatch, distro_pair, conversion_repomap_data
 ):
     """
     Test for the RepoMapDataHandler.get_pesid_repos method.
@@ -222,28 +147,27 @@ def test_get_pesid_repos(
       * the given pesid,
       * and the given distro.
     """
+    src_distro, dst_distro = distro_pair
     monkeypatch.setattr(
         api,
         "current_actor",
         CurrentActorMocked(
-            arch="x86_64", src_ver="9.6", dst_ver="10.4", release_id=distro
+            arch="x86_64", src_ver="9.6", dst_ver="10.4",
+            src_distro=src_distro, dst_distro=dst_distro,
         ),
     )
-    handler = RepoMapDataHandler(repomap_data_multiple_distros)
+    handler = RepoMapDataHandler(conversion_repomap_data)
+    repositories = conversion_repomap_data.repositories
 
-    actual_pesid_repos = handler.get_pesid_repos('pesid3', '10', distro)
-    expected_pesid_repos = [
-        repomap_data_multiple_distros.repositories[repo] for repo in expect_pesid3
-    ]
     fail_description = 'The get_pesid_repos failed to find pesid repos matching the given criteria.'
+    actual_pesid_repos = handler.get_pesid_repos('pesid3', '10', dst_distro)
+    expected_pesid_repos = [repositories[i] for i in (3, 4, 5)]
     assert len(expected_pesid_repos) == len(actual_pesid_repos), fail_description
     for actual_pesid_repo in actual_pesid_repos:
         assert actual_pesid_repo in expected_pesid_repos, fail_description
 
-    actual_pesid_repos = handler.get_pesid_repos('pesid1', '9', distro)
-    expected_pesid_repos = [
-        repomap_data_multiple_distros.repositories[repo] for repo in expect_pesid1
-    ]
+    actual_pesid_repos = handler.get_pesid_repos('pesid1', '9', src_distro)
+    expected_pesid_repos = [repositories[i] for i in (0, 1)]
     assert len(expected_pesid_repos) == len(actual_pesid_repos), fail_description
     for actual_pesid_repo in actual_pesid_repos:
         assert actual_pesid_repo in expected_pesid_repos, fail_description
@@ -255,30 +179,24 @@ def test_get_pesid_repos(
     assert [] == handler.get_pesid_repos('nonexisting_pesid', '7', 'rhel'), fail_description
 
 
-@pytest.mark.parametrize(
-    'distro,expected_repos_index',
-    [
-        ('rhel', [0, 1]),
-        ('centos', []),
-        ('almalinux', []),
-    ]
-)
-def test_get_source_pesid_repos(monkeypatch, repomap_data_for_pesid_repo_retrieval, distro, expected_repos_index):
+def test_get_source_pesid_repos(monkeypatch, distro_pair, conversion_repomap_data):
     """
     Test for the RepoMapDataHandler.get_source_pesid_repos method.
 
     Verifies that the method is able to collect all PESIDRepositoryEntry that match the given PES ID and
     have the same major version and distro as the source system.
     """
+    src_distro, dst_distro = distro_pair
     monkeypatch.setattr(api, 'current_actor',
-                        CurrentActorMocked(arch='x86_64', src_ver='7.9', dst_ver='8.4', release_id=distro))
-    handler = RepoMapDataHandler(repomap_data_for_pesid_repo_retrieval)
-    repositories = repomap_data_for_pesid_repo_retrieval.repositories
+                        CurrentActorMocked(arch='x86_64', src_ver='9.6', dst_ver='10.4',
+                                           src_distro=src_distro, dst_distro=dst_distro))
+    handler = RepoMapDataHandler(conversion_repomap_data)
+    repositories = conversion_repomap_data.repositories
 
     fail_description = (
         'The get_source_pesid_repos method failed to retrieve all pesid repos that match given pesid '
         'and have the same major version and distro as the source system.')
-    expected_pesid_repos = [repositories[i] for i in expected_repos_index]
+    expected_pesid_repos = [repositories[i] for i in (0, 1)]
     actual_pesid_repos = handler.get_source_pesid_repos('pesid1')
     assert len(expected_pesid_repos) == len(actual_pesid_repos), fail_description
     for actual_pesid_repo in actual_pesid_repos:
@@ -287,39 +205,32 @@ def test_get_source_pesid_repos(monkeypatch, repomap_data_for_pesid_repo_retriev
     fail_description = (
         'The get_source_pesid_repos method does not take into account the source system version correctly.'
     )
-    monkeypatch.setattr(repomap_calc, 'get_source_major_version', lambda: '10')
+    monkeypatch.setattr(repomap_calc, 'get_source_major_version', lambda: '8')
 
-    # Repeat the same test as above to make sure it respects the source OS major version
     assert [] == handler.get_source_pesid_repos('pesid1'), fail_description
 
     assert [] == handler.get_source_pesid_repos('pesid2'), fail_description
     assert [] == handler.get_source_pesid_repos('nonexisting_pesid'), fail_description
 
 
-@pytest.mark.parametrize(
-    'distro,expected_repos_index',
-    [
-        ('rhel', [3, 4, 5]),
-        ('centos', []),
-        ('almalinux', []),
-    ]
-)
-def test_get_target_pesid_repos(monkeypatch, repomap_data_for_pesid_repo_retrieval, distro, expected_repos_index):
+def test_get_target_pesid_repos(monkeypatch, distro_pair, conversion_repomap_data):
     """
     Test for the RepoMapDataHandler.get_target_pesid_repos method.
 
     Verifies that the method is able to collect all PESIDRepositoryEntry that match the given PES ID and
-    have the same major version and distro as the source system.
+    have the same major version and distro as the target system.
     """
+    src_distro, dst_distro = distro_pair
     monkeypatch.setattr(api, 'current_actor',
-                        CurrentActorMocked(arch='x86_64', src_ver='7.9', dst_ver='8.4', dst_distro=distro))
-    handler = RepoMapDataHandler(repomap_data_for_pesid_repo_retrieval)
-    repositories = repomap_data_for_pesid_repo_retrieval.repositories
+                        CurrentActorMocked(arch='x86_64', src_ver='9.6', dst_ver='10.4',
+                                           src_distro=src_distro, dst_distro=dst_distro))
+    handler = RepoMapDataHandler(conversion_repomap_data)
+    repositories = conversion_repomap_data.repositories
 
     fail_description = (
         'The get_target_pesid_repos method failed to retrieve all pesid repos that match given pesid '
         'and have the same major version and distro as the target system.')
-    expected_pesid_repos = [repositories[i] for i in expected_repos_index]
+    expected_pesid_repos = [repositories[i] for i in (3, 4, 5)]
     actual_pesid_repos = handler.get_target_pesid_repos('pesid3')
     assert len(expected_pesid_repos) == len(actual_pesid_repos), fail_description
     for actual_pesid_repo in actual_pesid_repos:
@@ -329,9 +240,9 @@ def test_get_target_pesid_repos(monkeypatch, repomap_data_for_pesid_repo_retriev
         'The get_target_pesid_repos method doesn\'t take into account the target system version correctly.'
     )
     monkeypatch.setattr(api, 'current_actor',
-                        CurrentActorMocked(arch='x86_64', src_ver='9.4', dst_ver='10.0', dst_distro=distro))
+                        CurrentActorMocked(arch='x86_64', src_ver='7.6', dst_ver='8.0',
+                                           src_distro=src_distro, dst_distro=dst_distro))
 
-    # Repeat the same test as above to make sure it respects the target OS major version
     assert [] == handler.get_target_pesid_repos('pesid3'), fail_description
 
     assert [] == handler.get_target_pesid_repos('pesid1'), fail_description

--- a/repos/system_upgrade/common/actors/targetcontentresolver/tests/unit_test_repomap_loader.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/tests/unit_test_repomap_loader.py
@@ -79,6 +79,26 @@ CENTOS_REPOS = [
 
 ALMA_REPOS = [
     PESIDRepositoryEntry(
+        pesid='pesid2',
+        major_version='8',
+        repoid='some-rhel-8-repoid1',
+        arch='x86_64',
+        repo_type='rpm',
+        channel='eus',
+        rhui='',
+        distro='almalinux',
+    ),
+    PESIDRepositoryEntry(
+        pesid='pesid3',
+        major_version='8',
+        repoid='some-rhel-8-repoid2',
+        arch='x86_64',
+        repo_type='rpm',
+        channel='eus',
+        rhui='',
+        distro='almalinux',
+    ),
+    PESIDRepositoryEntry(
         pesid='pesid8',
         major_version='8',
         repoid='some-almalinux-8-repoid1',
@@ -96,12 +116,12 @@ ALMA_REPOS = [
     [
         ('rhel', 'rhel', {'pesid2', 'pesid3'}, RHEL_REPOS),
         # has specific mapping
-        ('centos', 'centos', {'pesid6', 'pesid7'}, CENTOS_REPOS),
+        ('centos', 'centos', {'pesid7'}, CENTOS_REPOS),
         # no specific mapping, should use default, same as rhel
         ('almalinux', 'almalinux', {'pesid2', 'pesid3'}, ALMA_REPOS),
         # conversions
         ('centos', 'rhel', {'pesid2', 'pesid3'}, RHEL_REPOS + CENTOS_REPOS),
-        ('rhel', 'centos', {'pesid6', 'pesid7'}, RHEL_REPOS + CENTOS_REPOS),
+        ('rhel', 'centos', {'pesid7'}, RHEL_REPOS + CENTOS_REPOS),
         ('almalinux', 'rhel', {'pesid2', 'pesid3'}, RHEL_REPOS + ALMA_REPOS),
     ]
 )
@@ -389,3 +409,104 @@ def test_load_repositories_mapping_raises_on_invalid_data(monkeypatch):
 
     with pytest.raises(StopActorExecutionError):
         repomap_loader.load_repositories_mapping(lambda dummy: {})
+
+
+@pytest.mark.parametrize(
+    "target_repo",
+    [
+        # mapped for a different version
+        {
+            "pesid": "target_pesid1",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "some-rhel-9-repo1",
+                    "arch": "x86_64",
+                    "repo_type": "rpm",
+                    "channel": "eus",
+                    "distro": "rhel",
+                }
+            ],
+        },
+        # mapped for a different distro
+        {
+            "pesid": "target_pesid2",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "some-rhel-9-repo1",
+                    "arch": "x86_64",
+                    "repo_type": "rpm",
+                    "channel": "eus",
+                    "distro": "rhel",
+                }
+            ],
+        },
+        # mapped for a different arch
+        {
+            "pesid": "target_pesid3",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repoid": "some-rhel-9-repo1",
+                    "arch": "aarch64",
+                    "repo_type": "rpm",
+                    "channel": "eus",
+                    "distro": "rhel",
+                }
+            ],
+        },
+    ],
+)
+def test_scan_repositories_with_non_existing_pesids_mapped(monkeypatch, target_repo):
+    """
+    Tests whether a PESID present in mapping as a target, but not present in
+    repositories with the given target distro and architecture is detected.
+    """
+
+    json_data = {
+        'datetime': '202107141655Z',
+        'version_format': repomap_loader.RepoMapData.VERSION_FORMAT,
+        'mapping': [
+            {
+                'source_major_version': '7',
+                'target_major_version': '8',
+                'entries': [
+                    {
+                        'source': 'source_pesid',
+                        'target': {
+                            'default': [target_repo['pesid']]
+                        },
+                    }
+                ],
+            }
+        ],
+        'repositories': [
+            {
+                'pesid': 'source_pesid',
+                'entries': [
+                    {
+                        'major_version': '7',
+                        'repoid': 'some-rhel-9-repo1',
+                        'arch': 'x86_64',
+                        "repo_type": "rpm",
+                        "channel": "eus",
+                        "distro": "rhel",
+                    }
+                ],
+            },
+            target_repo,
+        ],
+    }
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver='7.9', dst_ver='8.4'))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    with pytest.raises(StopActorExecutionError) as error_info:
+        repomap_loader.load_repositories_mapping(lambda dummy: json_data)
+
+    msg = (
+        "Target PESID {} does not have any associated repository"
+        " for major version 8 and distro rhel"
+    ).format(target_repo["pesid"])
+    assert msg in error_info.value.message

--- a/repos/system_upgrade/common/actors/targetcontentresolver/tests/unit_test_repomap_loader.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/tests/unit_test_repomap_loader.py
@@ -21,17 +21,93 @@ def adjust_cwd():
     os.chdir(previous_cwd)
 
 
+RHEL_REPOS = [
+    PESIDRepositoryEntry(
+        pesid='pesid1',
+        major_version='7',
+        repoid='some-rhel-7-repoid',
+        arch='x86_64',
+        repo_type='rpm',
+        channel='eus',
+        rhui='',
+        distro='rhel',
+    ),
+    PESIDRepositoryEntry(
+        pesid='pesid2',
+        major_version='8',
+        repoid='some-rhel-8-repoid1',
+        arch='x86_64',
+        repo_type='rpm',
+        channel='eus',
+        rhui='',
+        distro='rhel',
+    ),
+    PESIDRepositoryEntry(
+        pesid='pesid3',
+        major_version='8',
+        repoid='some-rhel-8-repoid2',
+        arch='x86_64',
+        repo_type='rpm',
+        channel='eus',
+        rhui='',
+        distro='rhel',
+    ),
+]
+
+CENTOS_REPOS = [
+    PESIDRepositoryEntry(
+        pesid='pesid6',
+        major_version='7',
+        repoid='some-centos-9-repoid1',
+        arch='x86_64',
+        repo_type='rpm',
+        channel='ga',
+        rhui='',
+        distro='centos',
+        ),
+    PESIDRepositoryEntry(
+        pesid='pesid7',
+        major_version='8',
+        repoid='some-centos-10-repoid1',
+        arch='x86_64',
+        repo_type='rpm',
+        channel='ga',
+        rhui='',
+        distro='centos',
+    ),
+]
+
+ALMA_REPOS = [
+    PESIDRepositoryEntry(
+        pesid='pesid8',
+        major_version='8',
+        repoid='some-almalinux-8-repoid1',
+        arch='x86_64',
+        repo_type='rpm',
+        channel='ga',
+        rhui='',
+        distro='almalinux',
+    ),
+]
+
+
 @pytest.mark.parametrize(
-    'target_distro, expect',
+    'src_distro, dst_distro, expect_mapping, expect_repos',
     [
-        ('rhel', {'pesid2', 'pesid3'}),
+        ('rhel', 'rhel', {'pesid2', 'pesid3'}, RHEL_REPOS),
         # has specific mapping
-        ('centos', {'pesid6', 'pesid7'}),
+        ('centos', 'centos', {'pesid6', 'pesid7'}, CENTOS_REPOS),
         # no specific mapping, should use default, same as rhel
-        ('almalinux', {'pesid2', 'pesid3'}),
+        ('almalinux', 'almalinux', {'pesid2', 'pesid3'}, ALMA_REPOS),
+        # conversions
+        ('centos', 'rhel', {'pesid2', 'pesid3'}, RHEL_REPOS + CENTOS_REPOS),
+        ('rhel', 'centos', {'pesid6', 'pesid7'}, RHEL_REPOS + CENTOS_REPOS),
+        ('almalinux', 'rhel', {'pesid2', 'pesid3'}, RHEL_REPOS + ALMA_REPOS),
     ]
 )
-def test_scan_existing_valid_data(monkeypatch, adjust_cwd, target_distro, expect):
+def test_scan_existing_valid_data(
+    monkeypatch, adjust_cwd, src_distro, dst_distro, expect_mapping, expect_repos
+):
     """
     Tests whether an existing valid repomap file is loaded correctly.
     """
@@ -41,7 +117,9 @@ def test_scan_existing_valid_data(monkeypatch, adjust_cwd, target_distro, expect
     monkeypatch.setattr(
         api,
         "current_actor",
-        CurrentActorMocked(src_ver="7.9", dst_ver="8.4", dst_distro=target_distro),
+        CurrentActorMocked(
+            src_ver="7.9", dst_ver="8.4", src_distro=src_distro, dst_distro=dst_distro
+        ),
     )
     monkeypatch.setattr(api, 'produce', produce_mocked())
 
@@ -64,78 +142,15 @@ def test_scan_existing_valid_data(monkeypatch, adjust_cwd, target_distro, expect
     assert len(repo_mapping.mapping) == 1, fail_description
     fail_description = 'Actor failed to load IPU-relevant mapping data correctly.'
     assert repo_mapping.mapping[0].source == 'pesid1', fail_description
-    assert set(repo_mapping.mapping[0].target) == expect, fail_description
+    assert set(repo_mapping.mapping[0].target) == expect_mapping, fail_description
 
     # 2. Verify that only repositories valid for the current IPU are produced
     pesid_repos = repo_mapping.repositories
     fail_description = 'Actor produced incorrect number of IPU-relevant pesid repos.'
-    assert len(pesid_repos) == 6, fail_description
-
-    expected_pesid_repos = [
-        PESIDRepositoryEntry(
-            pesid='pesid1',
-            major_version='7',
-            repoid='some-rhel-7-repoid',
-            arch='x86_64',
-            repo_type='rpm',
-            channel='eus',
-            rhui='',
-            distro='rhel',
-        ),
-        PESIDRepositoryEntry(
-            pesid='pesid2',
-            major_version='8',
-            repoid='some-rhel-8-repoid1',
-            arch='x86_64',
-            repo_type='rpm',
-            channel='eus',
-            rhui='',
-            distro='rhel',
-        ),
-        PESIDRepositoryEntry(
-            pesid='pesid3',
-            major_version='8',
-            repoid='some-rhel-8-repoid2',
-            arch='x86_64',
-            repo_type='rpm',
-            channel='eus',
-            rhui='',
-            distro='rhel',
-        ),
-        PESIDRepositoryEntry(
-            pesid='pesid6',
-            major_version='7',
-            repoid='some-centos-9-repoid1',
-            arch='x86_64',
-            repo_type='rpm',
-            channel='ga',
-            rhui='',
-            distro='centos',
-        ),
-        PESIDRepositoryEntry(
-            pesid='pesid7',
-            major_version='8',
-            repoid='some-centos-10-repoid1',
-            arch='x86_64',
-            repo_type='rpm',
-            channel='ga',
-            rhui='',
-            distro='centos',
-        ),
-        PESIDRepositoryEntry(
-            pesid='pesid8',
-            major_version='8',
-            repoid='some-almalinux-8-repoid1',
-            arch='x86_64',
-            repo_type='rpm',
-            channel='ga',
-            rhui='',
-            distro='almalinux',
-        ),
-    ]
+    assert len(pesid_repos) == len(expect_repos), fail_description
 
     fail_description = 'Expected pesid repo is not present in the deserialization output.'
-    for expected_pesid_repo in expected_pesid_repos:
+    for expected_pesid_repo in expect_repos:
         assert expected_pesid_repo in pesid_repos, fail_description
 
 

--- a/repos/system_upgrade/common/actors/targetcontentresolver/tests/unit_test_repomap_loader.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/tests/unit_test_repomap_loader.py
@@ -2,7 +2,6 @@ import json
 import os
 
 import pytest
-import requests
 
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import repomap_loader
@@ -22,14 +21,28 @@ def adjust_cwd():
     os.chdir(previous_cwd)
 
 
-def test_scan_existing_valid_data(monkeypatch, adjust_cwd):
+@pytest.mark.parametrize(
+    'target_distro, expect',
+    [
+        ('rhel', {'pesid2', 'pesid3'}),
+        # has specific mapping
+        ('centos', {'pesid6', 'pesid7'}),
+        # no specific mapping, should use default, same as rhel
+        ('almalinux', {'pesid2', 'pesid3'}),
+    ]
+)
+def test_scan_existing_valid_data(monkeypatch, adjust_cwd, target_distro, expect):
     """
     Tests whether an existing valid repomap file is loaded correctly.
     """
 
     with open('files/repomap_example.json') as repomap_file:
         data = json.load(repomap_file)
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver='7.9', dst_ver='8.4'))
+    monkeypatch.setattr(
+        api,
+        "current_actor",
+        CurrentActorMocked(src_ver="7.9", dst_ver="8.4", dst_distro=target_distro),
+    )
     monkeypatch.setattr(api, 'produce', produce_mocked())
 
     result = repomap_loader.load_repositories_mapping(lambda dummy: data)
@@ -51,7 +64,7 @@ def test_scan_existing_valid_data(monkeypatch, adjust_cwd):
     assert len(repo_mapping.mapping) == 1, fail_description
     fail_description = 'Actor failed to load IPU-relevant mapping data correctly.'
     assert repo_mapping.mapping[0].source == 'pesid1', fail_description
-    assert set(repo_mapping.mapping[0].target) == {'pesid2', 'pesid3'}, fail_description
+    assert set(repo_mapping.mapping[0].target) == expect, fail_description
 
     # 2. Verify that only repositories valid for the current IPU are produced
     pesid_repos = repo_mapping.repositories
@@ -199,7 +212,9 @@ def test_load_repositories_mapping_with_mapping_to_pesid_without_repos(monkeypat
                 'entries':  [
                     {
                         'source': 'source_pesid',
-                        'target': ['nonexisting_pesid']
+                        'target': {
+                            "default": ['nonexisting_pesid']
+                        }
                     }
                 ]
             }
@@ -246,7 +261,9 @@ def test_load_repositories_mapping_with_repo_entry_missing_required_fields(monke
                 'entries':  [
                     {
                         'source': 'source_pesid',
-                        'target': ['target_pesid']
+                        'target': {
+                            "default": ['target_pesid']
+                        }
                     }
                 ]
             }
@@ -284,7 +301,7 @@ def test_load_repositories_mapping_with_repo_entry_missing_required_fields(monke
     assert 'the JSON is missing a required field' in error_info.value.message
 
 
-def test_load_repositories_mapping_with_repo_entry_mapping_target_not_a_list(monkeypatch):
+def test_scan_repositories_with_repo_entry_mapping_target_not_a_list(monkeypatch):
     """
     Tests whether deserialization of a mapping entry that has its target field set to a string
     is handled internally and StopActorExecutionError is propagated to the user.
@@ -300,7 +317,7 @@ def test_load_repositories_mapping_with_repo_entry_mapping_target_not_a_list(mon
                 'entries':  [
                     {
                         'source': 'source_pesid',
-                        'target': 'target_pesid'
+                        'target': ['target_pesid']
                     }
                 ]
             }
@@ -313,6 +330,9 @@ def test_load_repositories_mapping_with_repo_entry_mapping_target_not_a_list(mon
                         'major_version': '7',
                         'repoid': 'some-rhel-9-repo1',
                         'arch': 'x86_64',
+                        'repo_type': 'rpm',
+                        'channel': 'eus',
+                        'distro': 'rhel',
                     }
                 ]
             },
@@ -323,6 +343,9 @@ def test_load_repositories_mapping_with_repo_entry_mapping_target_not_a_list(mon
                         'major_version': '7',
                         'repoid': 'some-rhel-9-repo1',
                         'arch': 'x86_64',
+                        'repo_type': 'rpm',
+                        'channel': 'eus',
+                        'distro': 'rhel',
                     }
                 ]
             }
@@ -335,7 +358,10 @@ def test_load_repositories_mapping_with_repo_entry_mapping_target_not_a_list(mon
     with pytest.raises(StopActorExecutionError) as error_info:
         repomap_loader.load_repositories_mapping(lambda dummy: json_data)
 
-    assert 'repository mapping file is invalid' in error_info.value.message
+    assert (
+        "The 'target' of a mapping entry for PESID source_pesid is <class 'list'>, must be a dict"
+        in error_info.value.message
+    )
 
 
 def test_load_repositories_mapping_raises_on_invalid_data(monkeypatch):


### PR DESCRIPTION
## Gist of the changes:
Different distributions come with different sets of repositories, i.e., a repository with the PESID `source_pesid` might need to be mapped to `target_pesid1` on RHEL, while on CentOS the target PESIDs should be `target_pesid2, target_pesid3`. Therefore, the format is changed from: 
```
"mapping": [
            {
              "source_major_version": "7",
              "target_major_version": "8",
              "entries": [
                {
                  "source": "pesid1",
                  "target":  ["pesid2", "pesid3"],
                  }
                }
              ]
            }
          ],
```
to
```
"mapping": [
            {
              "source_major_version": "7",
              "target_major_version": "8",
              "entries": [
                {
                  "source": "pesid1",
                  "target": {
                    "default": ["pesid2", "pesid3"],
                    "centos": ["pesid4"]
                  }
                }
              ]
            }
          ],
```

## Cross-repository dependencies - preparation checklist
The following work items need to be addressed (essentially immediately) after this PR is merged:
- [x] schema update is prepared: [PR17](https://github.com/oamg/schema-test/pull/17)
- [x] repomap generator is updated
- [x] Repositories mapping (`/etc/leapp/files/repomap.json`) needs to be updated

Jira: RHEL-151413