### PR TITLE
fix upgrades using kernel with 64k page size

### DIFF
--- a/docs/source/libraries-and-api/deprecations-list.md
+++ b/docs/source/libraries-and-api/deprecations-list.md
@@ -20,6 +20,7 @@ Only the versions in which a deprecation has been made are listed.
   - **`CurrentKernel`** - The model is not used by any actor and provides incomplete information. Use the `KernelInfo` model instead for information about the source distribution kernel.
   - **`RenamedInterfaces`** - Information provided in this message is not always complete and it's not used since the `net.naming-scheme` kernel command line argument is set during the upgrade.
 - Shared libraries
+  - **`leapp.libraries.common.kernel.KERNEL_UNAME_R_PROVIDES`** - The constant is no longer used.
   - **`leapp.libraries.common.dnfconfig`** - Moved to `leapp.libraries.common.dnflibs.dnfconfig`. Original library is deprecated.
   - **`leapp.libraries.common.dnfplugin`** - Moved to `leapp.libraries.common.dnflibs.dnfplugin`. Original library is deprecated.
   - **`leapp.libraries.common.module`** - Replaced by `leapp.libraries.common.dnflibs.dnfmodule` (renamed for clarity). Original library is deprecated.

--- a/docs/source/libraries-and-api/deprecations-list.md
+++ b/docs/source/libraries-and-api/deprecations-list.md
@@ -17,6 +17,7 @@ Only the versions in which a deprecation has been made are listed.
   - **`LEAPP_DISABLE_NET_NAMING_SCHEMES`** - The `net.naming-scheme` kernel argument provides much better alternative to the legacy solution enabled using this variable. Hence the legacy solution is deprecated together with this environment variable.
   - **`LEAPP_NO_NETWORK_RENAMING`** - It becomes obsoleted by the solution based on `net.naming-scheme` which replaces the legacy solution based on created udev link files correcting NIC names during the upgrade.
 - Models:
+  - **`CurrentKernel`** - The model is not used by any actor and provides incomplete information. Use the `KernelInfo` model instead for information about the source distribution kernel.
   - **`RenamedInterfaces`** - Information provided in this message is not always complete and it's not used since the `net.naming-scheme` kernel command line argument is set during the upgrade.
 - Shared libraries
   - **`leapp.libraries.common.dnfconfig`** - Moved to `leapp.libraries.common.dnflibs.dnfconfig`. Original library is deprecated.

--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/actor.py
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/actor.py
@@ -4,6 +4,7 @@ from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
 from leapp.utils.deprecation import suppress_deprecation
 
 from leapp.models import (  # isort:skip
+    KernelInfo,
     LiveModeConfig,
     RequiredUpgradeInitramPackages,  # deprecated
     UpgradeDracutModule,  # deprecated
@@ -21,10 +22,11 @@ class CommonLeappDracutModules(Actor):
     required to be installed in the target userspace so required fields can be included.
     Modules to be added are specified via the UpgradeDracutModule message.
     Packages to install on the target userspace are specified by the RequiredUpgradeInitramPackages message.
+    Kernel packages are selected based on the source system's kernel page size (e.g. kernel vs kernel-64k).
     """
 
     name = 'common_leapp_dracut_modules'
-    consumes = (LiveModeConfig,)
+    consumes = (KernelInfo, LiveModeConfig,)
     produces = (
         RequiredUpgradeInitramPackages,  # deprecated
         TargetUserSpaceUpgradeTasks,

--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/libraries/modscan.py
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/libraries/modscan.py
@@ -1,12 +1,15 @@
 import os
 import re
 
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import kernel as kernel_lib
 from leapp.libraries.common.config import architecture, version
 from leapp.libraries.stdlib import api
 from leapp.utils.deprecation import suppress_deprecation
 
 from leapp.models import (  # isort:skip
     CopyFile,
+    KernelInfo,
     LiveModeConfig,
     RequiredUpgradeInitramPackages,  # deprecated
     UpgradeDracutModule,  # deprecated
@@ -28,9 +31,6 @@ _REQUIRED_PACKAGES = [
     'hostname',
     'iscsi-initiator-utils',
     'kbd',
-    'kernel',
-    'kernel-core',
-    'kernel-modules',
     'keyutils',
     'kmod',
     'lldpad',
@@ -95,6 +95,18 @@ def _create_initram_packages():
         required_pkgs.append('NetworkManager')
     if version.get_target_major_version() == '9':
         required_pkgs += ['policycoreutils', 'rng-tools']
+
+    kernel_info = next(api.consume(KernelInfo), None)
+    if not kernel_info:
+        raise StopActorExecutionError('Could not retrieve KernelInfo message.')
+    page_size = kernel_info.page_size
+    kernel_packages = kernel_lib.get_target_kernel_pkg_names(
+        kernel_lib.KernelType.ORDINARY,
+        page_size,
+        api.current_actor().configuration.architecture
+    )
+    required_pkgs.extend(kernel_packages)
+
     return (
         RequiredUpgradeInitramPackages(packages=required_pkgs),
         TargetUserSpaceUpgradeTasks(install_rpms=required_pkgs)

--- a/repos/system_upgrade/common/actors/commonleappdracutmodules/tests/test_modscan_commonleappdracutmodules.py
+++ b/repos/system_upgrade/common/actors/commonleappdracutmodules/tests/test_modscan_commonleappdracutmodules.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 
 import pytest
 
+from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.actor import modscan
 from leapp.libraries.common.config import architecture
 from leapp.libraries.common.testutils import CurrentActorMocked
@@ -11,10 +12,36 @@ from leapp.libraries.stdlib import api
 from leapp.utils.deprecation import suppress_deprecation
 
 from leapp.models import (  # isort:skip
+    KernelInfo,
+    RPM,
     RequiredUpgradeInitramPackages,  # deprecated
     UpgradeDracutModule,  # deprecated
     TargetUserSpaceUpgradeTasks,
     UpgradeInitramfsTasks
+)
+
+_KERNEL_INFO_4K = KernelInfo(
+    pkg=RPM(name='kernel-core', arch='x86_64', version='5.14.0', release='100.el9',
+            epoch='0', packager='', pgpsig='SIG'),
+    type='ordinary',
+    uname_r='5.14.0-100.el9.x86_64',
+    page_size='4k',
+)
+
+_KERNEL_INFO_64K = KernelInfo(
+    pkg=RPM(name='kernel-64k-core', arch='aarch64', version='5.14.0', release='100.el9',
+            epoch='0', packager='', pgpsig='SIG'),
+    type='ordinary',
+    uname_r='5.14.0-100.el9.aarch64+64k',
+    page_size='64k',
+)
+
+_KERNEL_INFO_64K_PPC = KernelInfo(
+    pkg=RPM(name='kernel-core', arch='ppc64le', version='5.14.0', release='100.el9',
+            epoch='0', packager='', pgpsig='SIG'),
+    type='ordinary',
+    uname_r='5.14.0-100.el9.ppc64le',
+    page_size='64k',
 )
 
 
@@ -74,8 +101,7 @@ def test_created_modules(monkeypatch):
     ('8.4', '9.0', architecture.ARCH_S390X),
 ))
 def test_required_packages(monkeypatch, src_ver, dst_ver, arch):
-    # the default set of required rpms should not contain biosdevname
-    for pkg in ['biosdevname', 'policycoreutils', 'rng-tools']:
+    for pkg in ['biosdevname', 'policycoreutils', 'rng-tools', 'kernel', 'kernel-core', 'kernel-modules']:
         assert pkg not in modscan._REQUIRED_PACKAGES
 
     required_packages = modscan._REQUIRED_PACKAGES[:]
@@ -83,17 +109,59 @@ def test_required_packages(monkeypatch, src_ver, dst_ver, arch):
         required_packages += ['policycoreutils', 'rng-tools']
     if arch == architecture.ARCH_X86_64:
         required_packages += ['biosdevname']
+    required_packages += ['kernel', 'kernel-core', 'kernel-modules']
 
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver=src_ver, dst_ver=dst_ver, arch=arch))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        src_ver=src_ver, dst_ver=dst_ver, arch=arch, msgs=[_KERNEL_INFO_4K]
+    ))
     old_initram, new_initram = modscan._create_initram_packages()
     assert (set(required_packages)
             == set(old_initram.packages)
             == set(new_initram.install_rpms))
 
 
+def test_required_packages_no_kernel_info(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(src_ver='9.8', dst_ver='10.2'))
+    with pytest.raises(StopActorExecutionError):
+        modscan._create_initram_packages()
+
+
+@pytest.mark.parametrize('kernel_info,arch,expected_kernel_pkgs,unexpected_kernel_pkgs', (
+    (_KERNEL_INFO_4K, architecture.ARCH_ARM64,
+     ['kernel', 'kernel-core', 'kernel-modules'],
+     ['kernel-64k', 'kernel-64k-core', 'kernel-64k-modules']),
+    (_KERNEL_INFO_64K, architecture.ARCH_ARM64,
+     ['kernel-64k', 'kernel-64k-core', 'kernel-64k-modules'],
+     ['kernel', 'kernel-core', 'kernel-modules']),
+    # ppc64le: 64k page size but standard kernel packages (no kernel-64k RPMs)
+    (_KERNEL_INFO_64K_PPC, architecture.ARCH_PPC64LE,
+     ['kernel', 'kernel-core', 'kernel-modules'],
+     ['kernel-64k', 'kernel-64k-core', 'kernel-64k-modules']),
+    # x86_64: 4k page size, standard kernel packages
+    (_KERNEL_INFO_4K, architecture.ARCH_X86_64,
+     ['kernel', 'kernel-core', 'kernel-modules'],
+     ['kernel-64k', 'kernel-64k-core', 'kernel-64k-modules']),
+    # s390x: 4k page size, standard kernel packages
+    (_KERNEL_INFO_4K, architecture.ARCH_S390X,
+     ['kernel', 'kernel-core', 'kernel-modules'],
+     ['kernel-64k', 'kernel-64k-core', 'kernel-64k-modules']),
+))
+def test_required_packages_page_size(monkeypatch, kernel_info, arch, expected_kernel_pkgs, unexpected_kernel_pkgs):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        src_ver='9.6', dst_ver='10.0', arch=arch, msgs=[kernel_info]
+    ))
+    old_initram, new_initram = modscan._create_initram_packages()
+    for pkg in expected_kernel_pkgs:
+        assert pkg in new_initram.install_rpms
+        assert pkg in old_initram.packages
+    for pkg in unexpected_kernel_pkgs:
+        assert pkg not in new_initram.install_rpms
+        assert pkg not in old_initram.packages
+
+
 @suppress_deprecation(UpgradeDracutModule)
 def test_process_produces_modules(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[_KERNEL_INFO_4K]))
     messages = []
     monkeypatch.setattr(api, 'produce', lambda *x: messages.extend(x))
     monkeypatch.setattr(api, 'get_actor_folder_path', _files_get_folder_path)

--- a/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/libraries/targetinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/libraries/targetinitramfsgenerator.py
@@ -110,8 +110,8 @@ def process():
     target_kernel_info = next(api.consume(InstalledTargetKernelInfo), None)
     if not target_kernel_info:
         raise StopActorExecutionError(
-            'Cannot get version of the installed RHEL-8 kernel',
-            details={'Problem': 'Did not receive a message with installed RHEL-8 kernel version'
+            'Cannot get version of the installed target OS kernel',
+            details={'Problem': 'Did not receive a message with installed target OS kernel version'
                                 ' (InstalledTargetKernelVersion)'})
 
     _copy_modules(modules['dracut'], DRACUT_DIR, 'dracut')

--- a/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/tests/test_targetinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/targetinitramfsgenerator/tests/test_targetinitramfsgenerator.py
@@ -105,7 +105,7 @@ def test_no_kernel_version(monkeypatch, msgs):
 
     with pytest.raises(StopActorExecutionError) as e:
         targetinitramfsgenerator.process()
-    assert 'Cannot get version of the installed RHEL-8 kernel' in str(e)
+    assert 'Cannot get version of the installed target OS kernel' in str(e)
     assert not run_mocked.called
 
 

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/actor.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/actor.py
@@ -5,6 +5,7 @@ from leapp.models import UpgradeDracutModule  # deprecated
 from leapp.models import (
     BootContent,
     FIPSInfo,
+    KernelInfo,
     LiveModeConfig,
     LVMConfig,
     RAIDInfo,
@@ -22,9 +23,10 @@ class UpgradeInitramfsGenerator(Actor):
     Creates the upgrade initramfs
 
     Creates an initram disk within a systemd-nspawn container using the target
-    system userspace, including new kernel. The creation of the initram disk
-    can be influenced with the UpgradeInitramfsTasks message (e.g. specifying
-    what files or dracut modules should be installed in the upgrade initramfs)
+    system userspace, including the appropriate kernel variant based on the
+    source system's page size. The creation of the initram disk can be
+    influenced with the UpgradeInitramfsTasks message (e.g. specifying what
+    files or dracut modules should be installed in the upgrade initramfs).
 
     See the UpgradeInitramfsTasks model for more details.
     """
@@ -32,6 +34,7 @@ class UpgradeInitramfsGenerator(Actor):
     name = 'upgrade_initramfs_generator'
     consumes = (
         FIPSInfo,
+        KernelInfo,
         LiveModeConfig,
         LVMConfig,
         RAIDInfo,

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/files/generate-initram.sh
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/files/generate-initram.sh
@@ -7,7 +7,10 @@ stage() {
 }
 
 get_kernel_version() {
-    rpm -qa kernel --qf '%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort --version-sort | tail --lines=1
+    # The actor should always provide the version via LEAPP_KERNEL_VERSION and ensure
+    # only one kernel is installed in the container. This is simple fallback in case
+    # the version is not provided.
+    rpm -q --whatprovides kernel --qf '%{VERSION}-%{RELEASE}.%{ARCH}\n' | sort --version-sort | tail --lines=1
 }
 
 dracut_install_modules()

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/libraries/upgradeinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/libraries/upgradeinitramfsgenerator.py
@@ -4,6 +4,7 @@ import shutil
 from collections import namedtuple
 
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import kernel as kernel_lib
 from leapp.libraries.common import mounting
 from leapp.libraries.common.config.version import get_target_major_version
 from leapp.libraries.common.dnflibs import dnfplugin
@@ -12,6 +13,7 @@ from leapp.models import RequiredUpgradeInitramPackages  # deprecated
 from leapp.models import UpgradeDracutModule  # deprecated
 from leapp.models import (
     BootContent,
+    KernelInfo,
     LiveModeConfig,
     LVMConfig,
     RAIDInfo,
@@ -33,51 +35,40 @@ def _get_target_kernel_version(context):
     """
     Get the version of the most recent kernel version within the container.
     """
+    kernel_info = next(api.consume(KernelInfo), None)
+    if not kernel_info:
+        raise StopActorExecutionError('Could not retrieve KernelInfo message.')
+    page_size = kernel_info.page_size
+    arch = api.current_actor().configuration.architecture
+    kernel_pkg_names = kernel_lib.get_target_kernel_pkg_names(kernel_lib.KernelType.ORDINARY, page_size, arch)
+    kernel_core_pkg = kernel_pkg_names.core
 
-    kernel_version = None
     try:
-        # NOTE: Currently we install/use always kernel-core in the upgrade
-        # initramfs. We do not use currently any different kernel package
-        # in the container. Note this could change in future e.g. on aarch64
-        # for IPU 9 -> 10.
-        # TODO(pstodulk): Investigate situation on ARM systems. OAMG-11433
-        results = context.call(['rpm', '-qa', 'kernel-core'], split=True)['stdout']
+        results = context.call(['rpm', '-qa', kernel_core_pkg], split=True)['stdout']
     except CalledProcessError:
         raise StopActorExecutionError(
             'Cannot get version of the installed kernel inside container.',
             details={'Problem': 'Could not query the currently installed kernel inside container using rpm.'})
 
+    if not results:
+        raise StopActorExecutionError(
+            'Cannot get version of the installed kernel inside container.',
+            details={'Problem': 'An rpm query for the available kernels did not produce any results.'})
+
     if len(results) > 1:
-        # this is should not happen. It's hypothetic situation, which alone it's
-        # already error. So skipping more sophisticated implementation.
-        # The container is always created during the upgrade and as that we expect
-        # always one-and-only kernel installed.
         raise StopActorExecutionError(
             'Cannot get version of the installed kernel inside container.',
             details={'Problem': 'Detected unexpectedly multiple kernels inside target userspace container.'}
         )
 
-    # kernel version == version-release from package
-    kernel_version = '-'.join(results[0].rsplit("-", 2)[-2:])
-    api.current_logger().debug('Detected kernel version inside container: {}.'.format(kernel_version))
-
+    kernel_version = kernel_lib.get_uname_r_provided_by_kernel_pkg(results[0], context=context)
     if not kernel_version:
         raise StopActorExecutionError(
             'Cannot get version of the installed kernel inside container.',
-            details={'Problem': 'An rpm query for the available kernels did not produce any results.'})
+            details={'Problem': 'Failed to determine uname-r provided by {}.'.format(results[0])})
 
+    api.current_logger().debug('Detected kernel version inside container: {}.'.format(kernel_version))
     return kernel_version
-
-
-def _get_target_kernel_modules_dir(context):
-    """
-    Return the path where the custom kernel modules should be copied.
-    """
-
-    kernel_version = _get_target_kernel_version(context)
-    modules_dir = os.path.join('/', 'lib', 'modules', kernel_version, 'extra', 'leapp')
-
-    return modules_dir
 
 
 def _reinstall_leapp_repository_hint():
@@ -153,7 +144,7 @@ def copy_dracut_modules(context, modules):
     _copy_modules(context, modules, DRACUT_DIR, 'dracut')
 
 
-def copy_kernel_modules(context, modules):
+def copy_kernel_modules(context, modules, kernel_version):
     """
     Copy kernel modules into the target userspace.
 
@@ -161,7 +152,7 @@ def copy_kernel_modules(context, modules):
     StopActorExecutionError exception is raised.
     """
 
-    dst_dir = _get_target_kernel_modules_dir(context)
+    dst_dir = os.path.join('/', 'lib', 'modules', kernel_version, 'extra', 'leapp')
     _copy_modules(context, modules, dst_dir, 'kernel')
 
 
@@ -396,8 +387,10 @@ def generate_initram_disk(context):
     # Issue #645
     initramfs_includes = collect_initramfs_includes()
 
+    kernel_version = _get_target_kernel_version(context)
+
     copy_dracut_modules(context, initramfs_includes.dracut_modules)
-    copy_kernel_modules(context, initramfs_includes.kernel_modules)
+    copy_kernel_modules(context, initramfs_includes.kernel_modules, kernel_version)
 
     def fmt_module_list(module_list):
         return ','.join(mod.name for mod in module_list)
@@ -422,7 +415,7 @@ def generate_initram_disk(context):
 
     env_variables = ' '.join(env_variables)
     env_variables = env_variables.format(
-        kernel_version=_get_target_kernel_version(context),
+        kernel_version=kernel_version,
         dracut_modules=fmt_module_list(initramfs_includes.dracut_modules),
         kernel_modules=fmt_module_list(initramfs_includes.kernel_modules),
         arch=api.current_actor().configuration.architecture,
@@ -481,7 +474,7 @@ def _generate_livemode_initramfs(context, userspace_initramfs_dest, target_kerne
     initramfs_includes = collect_initramfs_includes()
 
     copy_dracut_modules(context, initramfs_includes.dracut_modules)
-    copy_kernel_modules(context, initramfs_includes.kernel_modules)
+    copy_kernel_modules(context, initramfs_includes.kernel_modules, target_kernel_ver)
 
     md_cmdline_conf = write_md_uuid_cmdline_conf(context)
     if md_cmdline_conf:

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/tests/unit_test_upgradeinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/tests/unit_test_upgradeinitramfsgenerator.py
@@ -600,8 +600,8 @@ def test_get_target_kernel_version_page_size(monkeypatch, page_size, arch, expec
         queried_cmds.append(cmd)
         if cmd[:2] == ['rpm', '-qa']:
             return {'stdout': [target_nevra]}
-        if cmd[:3] == ['rpm', '-q', '--provides']:
-            return {'stdout': ['kernel-uname-r = {}'.format(expected_uname_r)]}
+        if cmd[:3] == ['rpm', '-q', '-l']:
+            return {'stdout': ['/lib/modules/{}/vmlinuz'.format(expected_uname_r)]}
         return {'stdout': []}
 
     context.call = mock_call
@@ -609,7 +609,7 @@ def test_get_target_kernel_version_page_size(monkeypatch, page_size, arch, expec
     version = upgradeinitramfsgenerator._get_target_kernel_version(context)
     assert version == expected_uname_r
     assert queried_cmds[0] == ['rpm', '-qa', expected_pkg]
-    assert queried_cmds[1] == ['rpm', '-q', '--provides', target_nevra]
+    assert queried_cmds[1] == ['rpm', '-q', '-l', target_nevra]
 
 
 def test_get_target_kernel_version_no_kernel_info(monkeypatch):
@@ -644,8 +644,8 @@ def test_get_target_kernel_version_empty_uname_r(monkeypatch):
     def mock_call(cmd, *args, **kwargs):
         if cmd[:2] == ['rpm', '-qa']:
             return {'stdout': ['kernel-core-5.14.0-100.el9.x86_64']}
-        if cmd[:3] == ['rpm', '-q', '--provides']:
-            return {'stdout': ['some-other-provide = foo']}
+        if cmd[:3] == ['rpm', '-q', '-l']:
+            return {'stdout': ['/boot/vmlinuz-5.14.0-100.el9.x86_64']}
         return {'stdout': []}
 
     context.call = mock_call

--- a/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/tests/unit_test_upgradeinitramfsgenerator.py
+++ b/repos/system_upgrade/common/actors/initramfs/upgradeinitramfsgenerator/tests/unit_test_upgradeinitramfsgenerator.py
@@ -11,6 +11,8 @@ from leapp.utils.deprecation import suppress_deprecation
 
 from leapp.models import (  # isort:skip
     FIPSInfo,
+    KernelInfo,
+    RPM,
     RequiredUpgradeInitramPackages,  # deprecated
     UpgradeDracutModule,  # deprecated
     BootContent,
@@ -356,7 +358,7 @@ def test_generate_initram_disk(monkeypatch, input_msgs, dracut_modules, kernel_m
     curr_actor = CurrentActorMocked(msgs=input_msgs, arch=architecture.ARCH_X86_64)
     monkeypatch.setattr(upgradeinitramfsgenerator.api, 'current_actor', curr_actor)
     monkeypatch.setattr(upgradeinitramfsgenerator, 'copy_dracut_modules', MockedCopyArgs())
-    monkeypatch.setattr(upgradeinitramfsgenerator, '_get_target_kernel_version', lambda _: '')
+    monkeypatch.setattr(upgradeinitramfsgenerator, '_get_target_kernel_version', lambda _: '5.14.0-100.el9.x86_64')
     monkeypatch.setattr(upgradeinitramfsgenerator, 'copy_kernel_modules', MockedCopyArgs())
     monkeypatch.setattr(upgradeinitramfsgenerator, 'copy_boot_files', lambda dummy: None)
     monkeypatch.setattr(upgradeinitramfsgenerator, '_get_fspace', MockedGetFspace(2*2**30))
@@ -381,6 +383,8 @@ def test_generate_initram_disk(monkeypatch, input_msgs, dracut_modules, kernel_m
         assert module in _kernel_modules
         detected_kernel_modules.add(module)
     assert detected_kernel_modules == _kernel_modules
+
+    assert upgradeinitramfsgenerator.copy_kernel_modules.args[2] == '5.14.0-100.el9.x86_64'
 
     # TODO(pstodulk): this test is not created properly, as context.call check
     # is skipped completely. Testing will more convenient with fixed #376
@@ -423,26 +427,28 @@ def test_copy_modules_fail(monkeypatch, kind):
     context.copytree_to = copytree_to_error
     monkeypatch.setattr(os.path, 'exists', mock_context_path_exists)
     monkeypatch.setattr(upgradeinitramfsgenerator.api, 'current_logger', MockedLogger())
-    monkeypatch.setattr(upgradeinitramfsgenerator, '_get_target_kernel_modules_dir', lambda _: '/kernel_modules')
 
     module_class = None
     copy_fn = None
-    dst_path = None
+    dst_dir = None
     if kind == 'dracut':
         module_class = DracutModule
         copy_fn = upgradeinitramfsgenerator.copy_dracut_modules
-        dst_path = 'dracut'
+        dst_dir = 'dracut'
     elif kind == 'kernel':
         module_class = KernelModule
         copy_fn = upgradeinitramfsgenerator.copy_kernel_modules
-        dst_path = 'kernel_modules'
+        dst_dir = 'lib/modules/dummy/extra/leapp'
 
     modules = [module_class(name='foo', module_path='/path/foo')]
     with pytest.raises(StopActorExecutionError) as err:
-        copy_fn(context, modules)
+        if kind == 'dracut':
+            copy_fn(context, modules)
+        else:
+            copy_fn(context, modules, 'dummy')
     assert err.value.message.startswith('Failed to install {kind} modules'.format(kind=kind))
-    expected_err_log = 'Failed to copy {kind} module "foo" from "/path/foo" to "/base/dir/{dst_path}"'.format(
-            kind=kind, dst_path=dst_path)
+    expected_err_log = 'Failed to copy {kind} module "foo" from "/path/foo" to "/base/dir/{dst_dir}"'.format(
+            kind=kind, dst_dir=dst_dir)
     assert expected_err_log in upgradeinitramfsgenerator.api.current_logger.errmsg
 
 
@@ -456,7 +462,6 @@ def test_copy_modules_duplicate_skip(monkeypatch, kind):
 
     monkeypatch.setattr(os.path, 'exists', mock_context_path_exists)
     monkeypatch.setattr(upgradeinitramfsgenerator.api, 'current_logger', MockedLogger())
-    monkeypatch.setattr(upgradeinitramfsgenerator, '_get_target_kernel_modules_dir', lambda _: '/kernel_modules')
 
     module_class = None
     copy_fn = None
@@ -470,7 +475,10 @@ def test_copy_modules_duplicate_skip(monkeypatch, kind):
     module = module_class(name='foo', module_path='/path/foo')
     modules = [module, module]
 
-    copy_fn(context, modules)
+    if kind == 'dracut':
+        copy_fn(context, modules)
+    else:
+        copy_fn(context, modules, 'dummy')
 
     debugmsg = 'The foo {kind} module has been already installed. Skipping.'.format(kind=kind)
     assert context.content
@@ -558,3 +566,89 @@ def test_prepare_boot_files_for_livemode(monkeypatch):
     assert boot_content.kernel_path == '/boot/vmlinuz-upgrade.x86_64'
     assert boot_content.initram_path == '/boot/initramfs-upgrade.x86_64.img'
     assert boot_content.kernel_hmac_path == '/boot/.vmlinuz-upgrade.x86_64.hmac'
+
+
+def _make_kernel_info(page_size='4k', arch='aarch64'):
+    return KernelInfo(
+        pkg=RPM(name='kernel-core', arch=arch, version='5.14.0', release='100.el9',
+                epoch='0', packager='', pgpsig='SIG'),
+        type='ordinary',
+        uname_r='5.14.0-100.el9.{}'.format(arch),
+        page_size=page_size,
+    )
+
+
+@pytest.mark.parametrize('page_size,arch,expected_pkg,expected_uname_r', [
+    ('4k', 'aarch64', 'kernel-core', '5.14.0-100.el9.aarch64'),
+    ('4k', 'x86_64', 'kernel-core', '5.14.0-100.el9.x86_64'),
+    ('4k', 's390x', 'kernel-core', '5.14.0-100.el9.s390x'),
+    # aarch64: 64k page size and special kernel packages
+    ('64k', 'aarch64', 'kernel-64k-core', '5.14.0-100.el9.aarch64+64k'),
+    # ppc64le: 64k page size but standard kernel packages
+    ('64k', 'ppc64le', 'kernel-core', '5.14.0-100.el9.ppc64le'),
+])
+def test_get_target_kernel_version_page_size(monkeypatch, page_size, arch, expected_pkg, expected_uname_r):
+    kernel_info = _make_kernel_info(page_size, arch)
+    monkeypatch.setattr(upgradeinitramfsgenerator.api, 'current_actor',
+                        CurrentActorMocked(arch=arch, msgs=[kernel_info]))
+
+    context = MockedContext()
+    target_nevra = '{}-5.14.0-100.el9.{}'.format(expected_pkg, arch)
+    queried_cmds = []
+
+    def mock_call(cmd, *args, **kwargs):
+        queried_cmds.append(cmd)
+        if cmd[:2] == ['rpm', '-qa']:
+            return {'stdout': [target_nevra]}
+        if cmd[:3] == ['rpm', '-q', '--provides']:
+            return {'stdout': ['kernel-uname-r = {}'.format(expected_uname_r)]}
+        return {'stdout': []}
+
+    context.call = mock_call
+
+    version = upgradeinitramfsgenerator._get_target_kernel_version(context)
+    assert version == expected_uname_r
+    assert queried_cmds[0] == ['rpm', '-qa', expected_pkg]
+    assert queried_cmds[1] == ['rpm', '-q', '--provides', target_nevra]
+
+
+def test_get_target_kernel_version_no_kernel_info(monkeypatch):
+    monkeypatch.setattr(upgradeinitramfsgenerator.api, 'current_actor',
+                        CurrentActorMocked(msgs=[]))
+
+    context = MockedContext()
+
+    with pytest.raises(StopActorExecutionError, match='Could not retrieve KernelInfo message'):
+        upgradeinitramfsgenerator._get_target_kernel_version(context)
+
+
+def test_get_target_kernel_version_empty_results(monkeypatch):
+    kernel_info = _make_kernel_info(page_size='4k', arch='x86_64')
+    monkeypatch.setattr(upgradeinitramfsgenerator.api, 'current_actor',
+                        CurrentActorMocked(arch='x86_64', msgs=[kernel_info]))
+
+    context = MockedContext()
+    context.call = lambda cmd, *args, **kwargs: {'stdout': []}
+
+    with pytest.raises(StopActorExecutionError, match='Cannot get version of the installed kernel'):
+        upgradeinitramfsgenerator._get_target_kernel_version(context)
+
+
+def test_get_target_kernel_version_empty_uname_r(monkeypatch):
+    kernel_info = _make_kernel_info(page_size='4k', arch='x86_64')
+    monkeypatch.setattr(upgradeinitramfsgenerator.api, 'current_actor',
+                        CurrentActorMocked(arch='x86_64', msgs=[kernel_info]))
+
+    context = MockedContext()
+
+    def mock_call(cmd, *args, **kwargs):
+        if cmd[:2] == ['rpm', '-qa']:
+            return {'stdout': ['kernel-core-5.14.0-100.el9.x86_64']}
+        if cmd[:3] == ['rpm', '-q', '--provides']:
+            return {'stdout': ['some-other-provide = foo']}
+        return {'stdout': []}
+
+    context.call = mock_call
+
+    with pytest.raises(StopActorExecutionError, match='Cannot get version of the installed kernel'):
+        upgradeinitramfsgenerator._get_target_kernel_version(context)

--- a/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/actor.py
+++ b/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/actor.py
@@ -8,10 +8,19 @@ class ScanInstalledTargetKernelVersion(Actor):
     """
     Scan for the version of the newly installed kernel
 
-    This actor will query rpm for all kernel-core packages and reports the
-    first matching target system kernel RPM. In case the RHEL Real Time has
-    been detected on the original system, the kernel-rt-core rpm is searched.
-    If the rpm is missing, fallback for standard kernel RPM.
+    Based on the source kernel type and page size, this actor determines the
+    appropriate target kernel package (e.g. kernel-core, kernel-64k-core,
+    kernel-rt-core) and produces InstalledTargetKernelInfo containing the installed target kernel RPM. If the
+    expected variant is missing, it falls back to the ordinary kernel for
+    the same page size. Note that a fallback from a realtime to an ordinary
+    kernel may occur when the target realtime kernel package is not
+    available. This can happen if the user does not have a repository
+    providing the realtime kernel enabled, and there is currently no way
+    to verify package availability beforehand (the dnf plugin does not
+    propagate this information back to the actor). In such cases, the user
+    must enable the appropriate repository and install the realtime kernel
+    after the upgrade manually, which is preferred to ending up with an
+    unbootable system.
     """
 
     name = 'scan_installed_target_kernel_version'

--- a/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/libraries/scankernel.py
+++ b/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/libraries/scankernel.py
@@ -11,23 +11,15 @@ from leapp.utils.deprecation import suppress_deprecation
 KernelBootFiles = namedtuple('KernelBootFiles', ('vmlinuz_path', 'initramfs_path'))
 
 
-def get_kernel_pkg_name(rhel_major_version, kernel_type):
+def get_target_kernel_package_nevra(kernel_pkg_name: str) -> str:
     """
-    Get the name of the package providing kernel binaries.
+    Get the NEVRA of the installed target kernel package.
 
-    :param str rhel_major_version: RHEL major version
-    :param KernelType kernel_type: Type of the kernel
-    :returns: Kernel package name
+    :param kernel_pkg_name: Name of the kernel package (e.g. ``kernel-core``)
+    :type kernel_pkg_name: str
+    :returns: NEVRA of the target kernel package, or empty string if not found
     :rtype: str
     """
-    kernel_pkg_name_table = {
-        kernel_lib.KernelType.ORDINARY: 'kernel-core',
-        kernel_lib.KernelType.REALTIME: 'kernel-rt-core'
-    }
-    return kernel_pkg_name_table[kernel_type]
-
-
-def get_target_kernel_package_nevra(kernel_pkg_name):
     try:
         kernel_nevras = run(['rpm', '-q', kernel_pkg_name], split=True)['stdout']
     except CalledProcessError:
@@ -40,10 +32,19 @@ def get_target_kernel_package_nevra(kernel_pkg_name):
     return ''
 
 
-def get_boot_files_provided_by_kernel_pkg(kernel_nevra):
+def get_boot_files_provided_by_kernel_pkg(kernel_nevra: str) -> KernelBootFiles:
+    """
+    Get paths to the vmlinuz and initramfs files provided by a given kernel package.
+
+    :param kernel_nevra: NEVRA of the kernel package
+    :type kernel_nevra: str
+    :returns: Paths to vmlinuz and initramfs in ``/boot``
+    :rtype: KernelBootFiles
+    :raises StopActorExecutionError: If the boot files cannot be determined
+    """
     initramfs_path = ''
     vmlinuz_path = ''
-    err_msg = 'Cannot determine location of the target kernel boot image and corresponding initramfs .'
+    err_msg = 'Cannot determine location of the target kernel boot image and corresponding initramfs.'
     try:
         kernel_pkg_files = run(['rpm', '-q', '-l', kernel_nevra], split=True)['stdout']
         for kernel_file_path in kernel_pkg_files:
@@ -63,7 +64,13 @@ def get_boot_files_provided_by_kernel_pkg(kernel_nevra):
 
 
 @suppress_deprecation(InstalledTargetKernelVersion)
-def process():
+def process() -> None:
+    """
+    Identify the target kernel package and produce ``InstalledTargetKernelInfo``.
+
+    Selects the target kernel package based on the source kernel type and page size.
+    Falls back to a non-realtime kernel if the matching realtime variant is not available.
+    """
     # pylint: disable=no-else-return  # false positive
     # TODO: should we take care about stuff of kernel-rt and kernel in the same
     # time when both are present? or just one? currently, handle only one
@@ -73,19 +80,33 @@ def process():
     if not src_kernel_info:
         return  # Will not happen, other actors would inhibit the upgrade
 
-    target_ver = get_target_major_version()
-    target_kernel_pkg_name = get_kernel_pkg_name(target_ver, src_kernel_info.type)
-    target_kernel_nevra = get_target_kernel_package_nevra(target_kernel_pkg_name)
+    arch = api.current_actor().configuration.architecture
+    target_kernel_pkg_names = kernel_lib.get_target_kernel_pkg_names(
+        src_kernel_info.type,
+        src_kernel_info.page_size,
+        arch
+    )
+    target_kernel_core_pkg = target_kernel_pkg_names.core
+    target_kernel_nevra = get_target_kernel_package_nevra(target_kernel_core_pkg)
 
     if src_kernel_info.type != kernel_lib.KernelType.ORDINARY and not target_kernel_nevra:
-        api.current_logger().warning('The kernel-rt-core rpm from the target RHEL has not been detected. Switching '
-                                     'to non-preemptive kernel.')
-        target_kernel_pkg_name = get_kernel_pkg_name(target_ver, kernel_lib.KernelType.ORDINARY)
-        target_kernel_nevra = get_target_kernel_package_nevra(target_kernel_pkg_name)
+        # Fallback to ordinary kernel if target kernel nevra could not be determined
+        api.current_logger().warning('The %s rpm from the target RHEL has not been detected. Switching '
+                                     'to non-preemptive kernel.', target_kernel_core_pkg)
+        target_kernel_pkg_names = kernel_lib.get_target_kernel_pkg_names(
+            kernel_lib.KernelType.ORDINARY,
+            src_kernel_info.page_size,
+            arch
+        )
+        target_kernel_core_pkg = target_kernel_pkg_names.core
+        target_kernel_nevra = get_target_kernel_package_nevra(target_kernel_core_pkg)
 
     if target_kernel_nevra:
         boot_files = get_boot_files_provided_by_kernel_pkg(target_kernel_nevra)
         target_kernel_version = kernel_lib.get_uname_r_provided_by_kernel_pkg(target_kernel_nevra)
+        if not target_kernel_version:
+            api.current_logger().warning('Failed to determine uname-r provided by %s.', target_kernel_nevra)
+            return
         installed_kernel_info = InstalledTargetKernelInfo(pkg_nevra=target_kernel_nevra,
                                                           uname_r=target_kernel_version,
                                                           kernel_img_path=boot_files.vmlinuz_path,

--- a/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/tests/test_scaninstalledkernel_scaninstalledtargetkernelversion.py
+++ b/repos/system_upgrade/common/actors/scaninstalledtargetkernelversion/tests/test_scaninstalledkernel_scaninstalledtargetkernelversion.py
@@ -4,6 +4,9 @@ from leapp.exceptions import StopActorExecutionError
 from leapp.libraries import stdlib
 from leapp.libraries.actor import scankernel
 from leapp.libraries.common import kernel as kernel_lib
+from leapp.libraries.common.config import architecture
+from leapp.libraries.common.config.architecture import ARCH_ARM64, ARCH_PPC64LE, ARCH_X86_64
+from leapp.libraries.common.kernel import KernelPageSize, KernelType
 from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
 from leapp.libraries.stdlib import api
 from leapp.models import InstalledTargetKernelInfo, InstalledTargetKernelVersion, KernelInfo, RPM
@@ -11,8 +14,14 @@ from leapp.utils.deprecation import suppress_deprecation
 
 TARGET_KERNEL_NEVRA = 'kernel-core-1.2.3-4.el9.x86_64'
 TARGET_RT_KERNEL_NEVRA = 'kernel-rt-core-1.2.3-4.rt56.7.el9.x86_64'
+TARGET_64K_KERNEL_NEVRA = 'kernel-64k-core-1.2.3-4.el10.aarch64'
+TARGET_RT_64K_KERNEL_NEVRA = 'kernel-rt-64k-core-1.2.3-4.el10.aarch64'
+TARGET_PPC_KERNEL_NEVRA = 'kernel-core-1.2.3-4.el10.ppc64le'
 OLD_KERNEL_NEVRA = 'kernel-core-0.1.2-3.el8.x86_64'
 OLD_RT_KERNEL_NEVRA = 'kernel-rt-core-0.1.2-3.rt4.5.el8.x86_64'
+OLD_64K_KERNEL_NEVRA = 'kernel-64k-core-0.1.2-3.el9.aarch64'
+OLD_RT_64K_KERNEL_NEVRA = 'kernel-rt-64k-core-0.1.2-3.el9.aarch64'
+OLD_PPC_KERNEL_NEVRA = 'kernel-core-0.1.2-3.el9.ppc64le'
 
 
 class MockedRun:
@@ -22,7 +31,7 @@ class MockedRun:
         self._stdouts = stdouts
 
     def __call__(self, *args, **kwargs):
-        for key in ('kernel-core', 'kernel-rt-core'):
+        for key in ('kernel-rt-64k-core', 'kernel-64k-core', 'kernel-rt-core', 'kernel-core'):
             if key in args[0]:
                 return {'stdout': self._stdouts.get(key, [])}
         return {'stdout': []}
@@ -30,7 +39,9 @@ class MockedRun:
 
 @suppress_deprecation(InstalledTargetKernelVersion)
 def assert_produced_messages_are_correct(produced_messages, expected_target_nevra, initramfs_path, kernel_img_path):
-    target_evra = expected_target_nevra.replace('kernel-core-', '').replace('kernel-rt-core-', '')
+    target_evra = expected_target_nevra
+    for prefix in ('kernel-rt-64k-core-', 'kernel-64k-core-', 'kernel-rt-core-', 'kernel-core-'):
+        target_evra = target_evra.replace(prefix, '')
     installed_kernel_ver = [msg for msg in produced_messages if isinstance(msg, InstalledTargetKernelVersion)]
     assert len(installed_kernel_ver) == 1, 'Actor should produce InstalledTargetKernelVersion (backwards compat.)'
     assert installed_kernel_ver[0].version == target_evra
@@ -44,38 +55,112 @@ def assert_produced_messages_are_correct(produced_messages, expected_target_nevr
 
 
 @pytest.mark.parametrize(
-    ('is_rt', 'expected_target_nevra', 'stdouts'),
+    ('kernel_type', 'page_size', 'arch', 'expected_target_nevra', 'stdouts', 'dst_ver'),
     [
-        (False, TARGET_KERNEL_NEVRA, {'kernel-core': [OLD_KERNEL_NEVRA, TARGET_KERNEL_NEVRA]}),
-        (False, TARGET_KERNEL_NEVRA, {'kernel-core': [TARGET_KERNEL_NEVRA, OLD_KERNEL_NEVRA]}),
-        (False, TARGET_KERNEL_NEVRA, {
-            'kernel-core': [TARGET_KERNEL_NEVRA, OLD_KERNEL_NEVRA],
-            'kernel-rt-core': [TARGET_RT_KERNEL_NEVRA, OLD_RT_KERNEL_NEVRA],
-        }),
-        (True, TARGET_RT_KERNEL_NEVRA, {
-            'kernel-rt-core': [OLD_RT_KERNEL_NEVRA, TARGET_RT_KERNEL_NEVRA]
-        }),
-        (True, TARGET_RT_KERNEL_NEVRA, {
-            'kernel-rt-core': [TARGET_RT_KERNEL_NEVRA, OLD_RT_KERNEL_NEVRA]
-        }),
-        (True, TARGET_RT_KERNEL_NEVRA, {
-            'kernel-core': [TARGET_KERNEL_NEVRA, OLD_KERNEL_NEVRA],
-            'kernel-rt-core': [TARGET_RT_KERNEL_NEVRA, OLD_RT_KERNEL_NEVRA],
-        }),
+        (
+            KernelType.ORDINARY,
+            KernelPageSize.PAGE_SIZE_4K,
+            ARCH_X86_64,
+            TARGET_KERNEL_NEVRA,
+            {'kernel-core': [OLD_KERNEL_NEVRA, TARGET_KERNEL_NEVRA]},
+            '9.0',
+        ),
+        (
+            KernelType.ORDINARY,
+            KernelPageSize.PAGE_SIZE_4K,
+            ARCH_X86_64,
+            TARGET_KERNEL_NEVRA,
+            {'kernel-core': [TARGET_KERNEL_NEVRA, OLD_KERNEL_NEVRA]},
+            '9.0',
+        ),
+        (
+            KernelType.ORDINARY,
+            KernelPageSize.PAGE_SIZE_4K,
+            ARCH_X86_64,
+            TARGET_KERNEL_NEVRA,
+            {
+                'kernel-core': [TARGET_KERNEL_NEVRA, OLD_KERNEL_NEVRA],
+                'kernel-rt-core': [TARGET_RT_KERNEL_NEVRA, OLD_RT_KERNEL_NEVRA],
+            },
+            '9.0',
+        ),
+        (
+            KernelType.REALTIME,
+            KernelPageSize.PAGE_SIZE_4K,
+            ARCH_X86_64,
+            TARGET_RT_KERNEL_NEVRA,
+            {'kernel-rt-core': [OLD_RT_KERNEL_NEVRA, TARGET_RT_KERNEL_NEVRA]},
+            '9.0',
+        ),
+        (
+            KernelType.REALTIME,
+            KernelPageSize.PAGE_SIZE_4K,
+            ARCH_X86_64,
+            TARGET_RT_KERNEL_NEVRA,
+            {'kernel-rt-core': [TARGET_RT_KERNEL_NEVRA, OLD_RT_KERNEL_NEVRA]},
+            '9.0',
+        ),
+        (
+            KernelType.REALTIME,
+            KernelPageSize.PAGE_SIZE_4K,
+            ARCH_X86_64,
+            TARGET_RT_KERNEL_NEVRA,
+            {
+                'kernel-core': [TARGET_KERNEL_NEVRA, OLD_KERNEL_NEVRA],
+                'kernel-rt-core': [TARGET_RT_KERNEL_NEVRA, OLD_RT_KERNEL_NEVRA],
+            },
+            '9.0',
+        ),
+        # 64k kernel variants on aarch64
+        (
+            KernelType.ORDINARY,
+            KernelPageSize.PAGE_SIZE_64K,
+            ARCH_ARM64,
+            TARGET_64K_KERNEL_NEVRA,
+            {'kernel-64k-core': [OLD_64K_KERNEL_NEVRA, TARGET_64K_KERNEL_NEVRA]},
+            '10.0',
+        ),
+        (
+            KernelType.REALTIME,
+            KernelPageSize.PAGE_SIZE_64K,
+            ARCH_ARM64,
+            TARGET_RT_64K_KERNEL_NEVRA,
+            {'kernel-rt-64k-core': [OLD_RT_64K_KERNEL_NEVRA, TARGET_RT_64K_KERNEL_NEVRA]},
+            '10.0',
+        ),
+        (
+            KernelType.REALTIME,
+            KernelPageSize.PAGE_SIZE_64K,
+            ARCH_ARM64,
+            TARGET_RT_64K_KERNEL_NEVRA,
+            {
+                'kernel-64k-core': [TARGET_64K_KERNEL_NEVRA, OLD_64K_KERNEL_NEVRA],
+                'kernel-rt-64k-core': [TARGET_RT_64K_KERNEL_NEVRA, OLD_RT_64K_KERNEL_NEVRA],
+            },
+            '10.0',
+        ),
+        # 64k page size on ppc64le: standard kernel packages (no kernel-64k RPMs)
+        (
+            KernelType.ORDINARY,
+            KernelPageSize.PAGE_SIZE_64K,
+            ARCH_PPC64LE,
+            TARGET_PPC_KERNEL_NEVRA,
+            {'kernel-core': [OLD_PPC_KERNEL_NEVRA, TARGET_PPC_KERNEL_NEVRA]},
+            '10.0',
+        ),
     ]
 )
-def test_scaninstalledkernel(monkeypatch, is_rt, expected_target_nevra, stdouts):
+def test_scaninstalledkernel(monkeypatch, kernel_type, page_size, arch, expected_target_nevra, stdouts, dst_ver):
     src_kernel_pkg = RPM(name='kernel-core', arch='x86_64', version='0.1.2', release='3',
                          epoch='0', packager='', pgpsig='SOME_OTHER_SIG_X')
-    src_kernel_type = kernel_lib.KernelType.REALTIME if is_rt else kernel_lib.KernelType.ORDINARY
-    src_kernel_info = KernelInfo(pkg=src_kernel_pkg, type=src_kernel_type, uname_r='X')
+    src_kernel_info = KernelInfo(pkg=src_kernel_pkg, type=kernel_type, page_size=page_size, uname_r='X')
 
     def patched_get_boot_files(nevra):
         assert nevra == expected_target_nevra
         return scankernel.KernelBootFiles(vmlinuz_path='/boot/vmlinuz-X', initramfs_path='/boot/initramfs-X')
 
     result = []
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(dst_ver='9.0', msgs=[src_kernel_info]))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=arch, dst_ver=dst_ver, msgs=[src_kernel_info]))
     monkeypatch.setattr(api, 'produce', result.append)
     monkeypatch.setattr(scankernel, 'run', MockedRun(stdouts))
     monkeypatch.setattr(scankernel, 'get_boot_files_provided_by_kernel_pkg', patched_get_boot_files)
@@ -120,19 +205,43 @@ def test_get_boot_files_provided_by_kernel_pkg(monkeypatch, vmlinuz_path, initra
         assert result.initramfs_path == initramfs_path
 
 
-def test_scaninstalledkernel_missing_rt(monkeypatch):
+@pytest.mark.parametrize(
+    ('page_size', 'arch', 'expected_fallback_nevra', 'stdouts', 'dst_ver'),
+    [
+        (
+            KernelPageSize.PAGE_SIZE_4K,
+            ARCH_X86_64,
+            TARGET_KERNEL_NEVRA,
+            {
+                'kernel-core': [TARGET_KERNEL_NEVRA],
+                'kernel-rt-core': [OLD_RT_KERNEL_NEVRA],
+            },
+            '9.0',
+        ),
+        (
+            KernelPageSize.PAGE_SIZE_64K,
+            ARCH_ARM64,
+            TARGET_64K_KERNEL_NEVRA,
+            {
+                'kernel-64k-core': [TARGET_64K_KERNEL_NEVRA],
+                'kernel-rt-64k-core': [OLD_RT_64K_KERNEL_NEVRA],
+            },
+            '10.0',
+        ),
+    ]
+)
+def test_scaninstalledkernel_missing_rt(monkeypatch, page_size, arch, expected_fallback_nevra, stdouts, dst_ver):
     src_kernel_pkg = RPM(name='kernel-rt-core', arch='x86_64', version='0.1.2', release='3',
                          epoch='0', packager='', pgpsig='SOME_OTHER_SIG_X')
-    src_kernel_type = kernel_lib.KernelType.REALTIME
-    src_kernel_info = KernelInfo(pkg=src_kernel_pkg, type=src_kernel_type, uname_r='X')
+    src_kernel_info = KernelInfo(pkg=src_kernel_pkg, type=KernelType.REALTIME,
+                                 page_size=page_size, uname_r='X')
 
     result = []
-    stdouts = {'kernel-core': [TARGET_KERNEL_NEVRA], 'kernel-rt-core': [OLD_RT_KERNEL_NEVRA]}
 
     def patched_get_boot_content(target_nevra):
         return scankernel.KernelBootFiles(vmlinuz_path='/boot/vmlinuz-X', initramfs_path='/boot/initramfs-X')
 
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(dst_ver='9.0', msgs=[src_kernel_info]))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=arch, dst_ver=dst_ver, msgs=[src_kernel_info]))
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
     monkeypatch.setattr(api, 'produce', result.append)
     monkeypatch.setattr(scankernel, 'run', MockedRun(stdouts))
@@ -143,13 +252,13 @@ def test_scaninstalledkernel_missing_rt(monkeypatch):
 
     assert api.current_logger.warnmsg
 
-    assert_produced_messages_are_correct(result, TARGET_KERNEL_NEVRA, '/boot/initramfs-X', '/boot/vmlinuz-X')
+    assert_produced_messages_are_correct(result, expected_fallback_nevra, '/boot/initramfs-X', '/boot/vmlinuz-X')
 
 
 def test_scaninstalledkernel_missing(monkeypatch):
     src_kernel_pkg = RPM(name='kernel-rt-core', arch='x86_64', version='0.1.2', release='3',
                          epoch='0', packager='', pgpsig='SOME_OTHER_SIG_X')
-    src_kernel_type = kernel_lib.KernelType.REALTIME
+    src_kernel_type = KernelType.REALTIME
     src_kernel_info = KernelInfo(pkg=src_kernel_pkg, type=src_kernel_type, uname_r='X')
 
     result = []

--- a/repos/system_upgrade/common/actors/scansourcekernel/libraries/scan_source_kernel.py
+++ b/repos/system_upgrade/common/actors/scansourcekernel/libraries/scan_source_kernel.py
@@ -7,12 +7,14 @@ from leapp.libraries.stdlib import api
 from leapp.models import DistributionSignedRPM, KernelInfo
 
 
-def scan_source_kernel():
+def scan_source_kernel() -> None:
+    """Identify the booted kernel package and produce ``KernelInfo``."""
     uname_r = api.current_actor().configuration.kernel
     installed_rpms = [msg.items for msg in api.consume(DistributionSignedRPM)]
     installed_rpms = list(itertools.chain(*installed_rpms))
 
     kernel_type = kernel_lib.determine_kernel_type_from_uname(get_source_version(), uname_r)
+    kernel_page_size = kernel_lib.determine_kernel_page_size()
     kernel_pkg_info = kernel_lib.get_kernel_pkg_info_for_uname_r(uname_r)
 
     kernel_pkg_id = (kernel_pkg_info.name, kernel_pkg_info.version, kernel_pkg_info.release, kernel_pkg_info.arch)
@@ -26,5 +28,5 @@ def scan_source_kernel():
     if not kernel_pkg:
         raise StopActorExecutionError(message='Unable to identify package providing the booted kernel.')
 
-    kernel_info = KernelInfo(pkg=kernel_pkg, type=kernel_type, uname_r=uname_r)
+    kernel_info = KernelInfo(pkg=kernel_pkg, type=kernel_type, uname_r=uname_r, page_size=kernel_page_size)
     api.produce(kernel_info)

--- a/repos/system_upgrade/common/libraries/kernel.py
+++ b/repos/system_upgrade/common/libraries/kernel.py
@@ -1,10 +1,19 @@
 from collections import namedtuple
 
 from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import mounting
+from leapp.libraries.common.config import architecture as arch_config
 from leapp.libraries.common.config.version import matches_version
 from leapp.libraries.stdlib import api, CalledProcessError, run
 
 KernelPkgInfo = namedtuple('KernelPkgInfo', ('name', 'version', 'release', 'arch', 'nevra'))
+KernelPkgNames = namedtuple('KernelPkgNames', ('base', 'core', 'modules'))
+
+
+class KernelPackageInfoError(StopActorExecutionError):
+    """
+    Raised when kernel package information cannot be determined.
+    """
 
 
 KERNEL_UNAME_R_PROVIDES = ['kernel-uname-r', 'kernel-rt-uname-r']
@@ -15,18 +24,32 @@ class KernelType:
     REALTIME = 'realtime'
 
 
+class KernelPageSize:
+    PAGE_SIZE_4K = '4k'
+    PAGE_SIZE_64K = '64k'
+
+
+def _normalize_rt64k_suffix(uname_r):
+    # TODO(pmocary): Remove when the kernel-rt-64k RPM provides match the actual uname -r output.
+    return uname_r.replace('+rt_64k', '+rt-64k')
+
+
 # TODO: rename rhel_version to something distro agnostic in the new function
 # when this is deprecated
-def determine_kernel_type_from_uname(rhel_version, kernel_uname_r):
+def determine_kernel_type_from_uname(rhel_version: str, kernel_uname_r: str) -> str:
     """
     Determine kernel type from given kernel release (uname-r).
 
-    :param str rhel_version: Version of RHEL for which the kernel with the uname-r is targeted.
-    :param str kernel_uname_r: Kernel release (uname-r)
-    :returns: Kernel type based on a given uname_r
-    :rtype: KernelType
+    :param rhel_version: Version of RHEL for which the kernel with the uname-r is targeted.
+    :type rhel_version: str
+    :param kernel_uname_r: Kernel release (uname-r)
+    :type kernel_uname_r: str
+    :returns: Kernel type based on a given uname_r (values come exclusively from the KernelType class)
+    :rtype: str
     """
     if matches_version(['<= 9.2'], rhel_version):
+        # NOTE: 64k page size kernel was introduced in 9.2 for aarch64 only. However,
+        # the 64k realtime kernel was introduced in 9.6, thus no special infix exists.
         uname_r_infixes = {
             '.rt': KernelType.REALTIME
         }
@@ -35,9 +58,11 @@ def determine_kernel_type_from_uname(rhel_version, kernel_uname_r):
                 return kernel_type
     else:
         uname_r_suffixes = {
-            '+rt': KernelType.REALTIME
+            '+rt': KernelType.REALTIME,
+            '+rt-64k': KernelType.REALTIME,
         }
 
+        kernel_uname_r = _normalize_rt64k_suffix(kernel_uname_r)
         for suffix, kernel_type in uname_r_suffixes.items():
             if kernel_uname_r.endswith(suffix):
                 return kernel_type
@@ -45,20 +70,45 @@ def determine_kernel_type_from_uname(rhel_version, kernel_uname_r):
     return KernelType.ORDINARY
 
 
-def get_uname_r_provided_by_kernel_pkg(kernel_pkg_nevra):
+def determine_kernel_page_size() -> str:
+    """
+    Determine kernel page size for the running kernel using ``getconf PAGE_SIZE``.
+
+    :returns: Kernel page size (values come exclusively from the KernelPageSize class)
+    :rtype: str
+    """
+    try:
+        result = run(['getconf', 'PAGE_SIZE'])['stdout'].strip()
+        if result == '65536':
+            return KernelPageSize.PAGE_SIZE_64K
+    except CalledProcessError:
+        api.current_logger().warning('Failed to determine kernel page size via getconf, defaulting to 4k.')
+    return KernelPageSize.PAGE_SIZE_4K
+
+
+def get_uname_r_provided_by_kernel_pkg(kernel_pkg_nevra: str, context: mounting.IsolatedActions = None) -> str:
     """
     Get kernel release (uname-r) provided by a given kernel package.
 
-    Calls the ``rpm`` command internally and might raise CalledProcessError if the rpm query fails.
+    Calls the ``rpm`` command internally. Returns an empty string if the rpm query fails or no
+    matching provide is found.
 
-    :param str kernel_pkg_nevra: NEVRA of an installed kernel package
-    :returns: uname-r provided by the given package
+    :param kernel_pkg_nevra: NEVRA of an installed kernel package
+    :type kernel_pkg_nevra: str
+    :param context: An isolation context for running commands (e.g. inside a target userspace container).
+                    If ``None``, commands run on the host.
+    :type context: mounting.IsolatedActions or None
+    :returns: uname-r provided by the given package, or empty string on failure
     :rtype: str
     """
-    provides = run(['rpm', '-q', '--provides', kernel_pkg_nevra],
-                   split=True,
-                   callback_raw=lambda fd, value: None,
-                   callback_linebuffered=lambda fd, value: None)['stdout']
+    context = context or mounting.NotIsolatedActions(base_dir='/')
+    try:
+        provides = context.call(['rpm', '-q', '--provides', kernel_pkg_nevra],
+                                split=True,
+                                callback_raw=lambda fd, value: None,
+                                callback_linebuffered=lambda fd, value: None)['stdout']
+    except CalledProcessError:
+        return ''
     for provide_line in provides:
         if '=' not in provide_line:
             continue
@@ -69,30 +119,36 @@ def get_uname_r_provided_by_kernel_pkg(kernel_pkg_nevra):
     return ''
 
 
-def get_kernel_pkg_info(kernel_pkg_nevra):
+def get_kernel_pkg_info(kernel_pkg_nevra: str) -> KernelPkgInfo:
     """
     Query the RPM database for information about the given kernel package.
 
-    Calls the ``rpm`` command internally and might raise CalledProcessError if the rpm query fails.
-
-    :param str kernel_pkg_nevra: NEVRA of an installed kernel package
+    :param kernel_pkg_nevra: NEVRA of an installed kernel package
+    :type kernel_pkg_nevra: str
     :returns: Information about the given kernel package
     :rtype: KernelPkgInfo
+    :raises KernelPackageInfoError: If the rpm query fails
     """
     query_format = '%{NAME}|%{VERSION}|%{RELEASE}|%{ARCH}|'
-    pkg_info = run(['rpm', '-q', '--queryformat', query_format, kernel_pkg_nevra])['stdout'].strip().split('|')
+    try:
+        pkg_info = run(['rpm', '-q', '--queryformat', query_format, kernel_pkg_nevra])['stdout'].strip().split('|')
+    except CalledProcessError as err:
+        raise KernelPackageInfoError(
+            message='Unable to obtain kernel package information.',
+            details={'Problem': 'Failed to query RPM info for {}: {}'.format(kernel_pkg_nevra, err)})
     return KernelPkgInfo(name=pkg_info[0], version=pkg_info[1], release=pkg_info[2], arch=pkg_info[3],
                          nevra=kernel_pkg_nevra)
 
 
-def get_kernel_pkg_info_for_uname_r(uname_r):
+def get_kernel_pkg_info_for_uname_r(uname_r: str) -> KernelPkgInfo:
     """
     Identify the kernel package providing a kernel with the given kernel release (uname-r).
 
-    Raises ``StopActorExecutionError`` if no package provides given uname_r or if the internal rpm query fails.
-    :param str uname_r: NEVRA of an installed kernel package
+    :param uname_r: Kernel release (uname-r)
+    :type uname_r: str
     :returns: Information about the kernel package providing given uname_r
     :rtype: KernelPkgInfo
+    :raises KernelPackageInfoError: If no package provides given uname_r or if the internal rpm query fails
     """
     kernel_pkg_nevras = []
     for kernel_uname_r_provide in KERNEL_UNAME_R_PROVIDES:
@@ -103,12 +159,40 @@ def get_kernel_pkg_info_for_uname_r(uname_r):
 
     kernel_pkg_nevras = set(kernel_pkg_nevras)
 
+    uname_r = _normalize_rt64k_suffix(uname_r)
     for kernel_pkg_nevra in kernel_pkg_nevras:
         provided_uname = get_uname_r_provided_by_kernel_pkg(kernel_pkg_nevra)  # We know all packages provide a uname
         if not provided_uname:
             api.current_logger().warning('Failed to obtain uname-r provided by %s', kernel_pkg_nevra)
+            continue
+        provided_uname = _normalize_rt64k_suffix(provided_uname)
         if provided_uname == uname_r:
             return get_kernel_pkg_info(kernel_pkg_nevra)
 
-    raise StopActorExecutionError(message='Unable to obtain kernel information of the booted kernel: no package is '
-                                          'providing the booted kernel release returned by uname.')
+    raise KernelPackageInfoError(message='Unable to obtain kernel information of the booted kernel: no package is '
+                                         'providing the booted kernel release returned by uname.')
+
+
+def get_target_kernel_pkg_names(kernel_type: str, kernel_page_size: str, arch: str) -> KernelPkgNames:
+    """
+    Get the base, ``-core``, and ``-modules`` package names for the given kernel variant.
+
+    The ``kernel-64k`` RPM variant only exists on aarch64. On all other architectures the standard
+    kernel packages are used regardless of page size.
+
+    :param kernel_type: Type of the kernel
+    :type kernel_type: str
+    :param kernel_page_size: Page size of the kernel
+    :type kernel_page_size: str
+    :param arch: System architecture (e.g. ``x86_64``, ``aarch64``, ``ppc64le``)
+    :type arch: str
+    :returns: Kernel package names
+    :rtype: KernelPkgNames
+    """
+    parts = ['kernel']
+    if kernel_type == KernelType.REALTIME:
+        parts.append('rt')
+    if kernel_page_size == KernelPageSize.PAGE_SIZE_64K and arch == arch_config.ARCH_ARM64:
+        parts.append('64k')
+    base = '-'.join(parts)
+    return KernelPkgNames(base=base, core='{}-core'.format(base), modules='{}-modules'.format(base))

--- a/repos/system_upgrade/common/libraries/kernel.py
+++ b/repos/system_upgrade/common/libraries/kernel.py
@@ -16,6 +16,7 @@ class KernelPackageInfoError(StopActorExecutionError):
     """
 
 
+# Deprecated: KERNEL_UNAME_R_PROVIDES is no longer used.
 KERNEL_UNAME_R_PROVIDES = ['kernel-uname-r', 'kernel-rt-uname-r']
 
 
@@ -27,11 +28,6 @@ class KernelType:
 class KernelPageSize:
     PAGE_SIZE_4K = '4k'
     PAGE_SIZE_64K = '64k'
-
-
-def _normalize_rt64k_suffix(uname_r):
-    # TODO(pmocary): Remove when the kernel-rt-64k RPM provides match the actual uname -r output.
-    return uname_r.replace('+rt_64k', '+rt-64k')
 
 
 # TODO: rename rhel_version to something distro agnostic in the new function
@@ -62,7 +58,6 @@ def determine_kernel_type_from_uname(rhel_version: str, kernel_uname_r: str) -> 
             '+rt-64k': KernelType.REALTIME,
         }
 
-        kernel_uname_r = _normalize_rt64k_suffix(kernel_uname_r)
         for suffix, kernel_type in uname_r_suffixes.items():
             if kernel_uname_r.endswith(suffix):
                 return kernel_type
@@ -90,8 +85,8 @@ def get_uname_r_provided_by_kernel_pkg(kernel_pkg_nevra: str, context: mounting.
     """
     Get kernel release (uname-r) provided by a given kernel package.
 
-    Calls the ``rpm`` command internally. Returns an empty string if the rpm query fails or no
-    matching provide is found.
+    Extracts the kernel version from the package's ``/lib/modules/<version>`` file paths.
+    Returns an empty string if the rpm query fails or no matching path is found.
 
     :param kernel_pkg_nevra: NEVRA of an installed kernel package
     :type kernel_pkg_nevra: str
@@ -103,19 +98,20 @@ def get_uname_r_provided_by_kernel_pkg(kernel_pkg_nevra: str, context: mounting.
     """
     context = context or mounting.NotIsolatedActions(base_dir='/')
     try:
-        provides = context.call(['rpm', '-q', '--provides', kernel_pkg_nevra],
-                                split=True,
-                                callback_raw=lambda fd, value: None,
-                                callback_linebuffered=lambda fd, value: None)['stdout']
+        file_list = context.call(['rpm', '-q', '-l', kernel_pkg_nevra],
+                                 split=True,
+                                 callback_raw=lambda fd, value: None,
+                                 callback_linebuffered=lambda fd, value: None)['stdout']
     except CalledProcessError:
         return ''
-    for provide_line in provides:
-        if '=' not in provide_line:
+    modules_prefix = '/lib/modules/'
+    for file_path in file_list:
+        if not file_path.startswith(modules_prefix):
             continue
-        provide, value = provide_line.split('=', 1)
-        provide = provide.strip()
-        if provide in KERNEL_UNAME_R_PROVIDES:
-            return value.strip()
+        # Strip the /lib/modules/ prefix and take the first path component (the kernel version)
+        version = file_path[len(modules_prefix):].split('/', 1)[0]
+        if version:
+            return version
     return ''
 
 
@@ -144,33 +140,34 @@ def get_kernel_pkg_info_for_uname_r(uname_r: str) -> KernelPkgInfo:
     """
     Identify the kernel package providing a kernel with the given kernel release (uname-r).
 
+    Queries RPM for packages owning ``/lib/modules/<uname_r>`` and returns info about the ``-core``
+    kernel package among the results.
+
     :param uname_r: Kernel release (uname-r)
     :type uname_r: str
     :returns: Information about the kernel package providing given uname_r
     :rtype: KernelPkgInfo
     :raises KernelPackageInfoError: If no package provides given uname_r or if the internal rpm query fails
     """
-    kernel_pkg_nevras = []
-    for kernel_uname_r_provide in KERNEL_UNAME_R_PROVIDES:
-        try:
-            kernel_pkg_nevras += run(['rpm', '-q', '--whatprovides', kernel_uname_r_provide], split=True)['stdout']
-        except CalledProcessError:  # There is nothing providing a particular provide, e.g, kernel-rt-uname-r
-            continue  # Nothing bad happened, continue
+    try:
+        pkg_nevras = run(['rpm', '-q', '--whatprovides', '/lib/modules/{}'.format(uname_r)],
+                         split=True)['stdout']
+    except CalledProcessError as err:
+        raise KernelPackageInfoError(
+            message='Unable to obtain kernel information of the booted kernel.',
+            details={'Problem': 'No package owns /lib/modules/{}: {}'.format(uname_r, err)})
 
-    kernel_pkg_nevras = set(kernel_pkg_nevras)
-
-    uname_r = _normalize_rt64k_suffix(uname_r)
-    for kernel_pkg_nevra in kernel_pkg_nevras:
-        provided_uname = get_uname_r_provided_by_kernel_pkg(kernel_pkg_nevra)  # We know all packages provide a uname
-        if not provided_uname:
-            api.current_logger().warning('Failed to obtain uname-r provided by %s', kernel_pkg_nevra)
+    for pkg_nevra in pkg_nevras:
+        # Skip packages that are clearly not kernel core packages to avoid unnecessary rpm queries
+        if '-core' not in pkg_nevra or '-modules' in pkg_nevra:
             continue
-        provided_uname = _normalize_rt64k_suffix(provided_uname)
-        if provided_uname == uname_r:
-            return get_kernel_pkg_info(kernel_pkg_nevra)
+        pkg_info = get_kernel_pkg_info(pkg_nevra)
+        if pkg_info.name.endswith('-core'):
+            return pkg_info
 
-    raise KernelPackageInfoError(message='Unable to obtain kernel information of the booted kernel: no package is '
-                                         'providing the booted kernel release returned by uname.')
+    raise KernelPackageInfoError(
+        message='Unable to obtain kernel information of the booted kernel.',
+        details={'Problem': 'No installed package owning /lib/modules/{} is a kernel core package.'.format(uname_r)})
 
 
 def get_target_kernel_pkg_names(kernel_type: str, kernel_page_size: str, arch: str) -> KernelPkgNames:

--- a/repos/system_upgrade/common/libraries/tests/test_kernel_lib.py
+++ b/repos/system_upgrade/common/libraries/tests/test_kernel_lib.py
@@ -2,11 +2,10 @@ import functools
 
 import pytest
 
-from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import kernel as kernel_lib
-from leapp.libraries.common.kernel import KernelType
-from leapp.libraries.common.testutils import CurrentActorMocked
-from leapp.libraries.stdlib import api
+from leapp.libraries.common.kernel import KernelPageSize, KernelType
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
+from leapp.libraries.stdlib import api, CalledProcessError
 
 
 @pytest.mark.parametrize(
@@ -21,6 +20,9 @@ from leapp.libraries.stdlib import api
         (('9.2', None), '5.14.0-284.11.1.rt14.296.el9_2.x86_64', KernelType.REALTIME),
         (('9.3', None), '5.14.0-354.el9.x86_64', KernelType.ORDINARY),
         (('9.3', None), '5.14.0-354.el9.x86_64+rt', KernelType.REALTIME),
+        (('9.3', None), '5.14.0-354.el9.aarch64+64k', KernelType.ORDINARY),
+        (('9.3', None), '5.14.0-354.el9.aarch64+rt-64k', KernelType.REALTIME),
+        (('9.3', None), '5.14.0-354.el9.aarch64+rt_64k', KernelType.REALTIME),
         # centos
         (('8', '8.7'), '4.18.0-425.3.1.el8.x86_64', KernelType.ORDINARY),
         (('8', '8.7'), '4.18.0-425.3.1.rt7.213.el8.x86_64', KernelType.REALTIME),
@@ -28,6 +30,9 @@ from leapp.libraries.stdlib import api
         (('9', '9.2'), '5.14.0-284.11.1.rt14.296.el9_2.x86_64', KernelType.REALTIME),
         (('9', '9.3'), '5.14.0-354.el9.x86_64', KernelType.ORDINARY),
         (('9', '9.3'), '5.14.0-354.el9.x86_64+rt', KernelType.REALTIME),
+        (('9', '9.3'), '5.14.0-354.el9.aarch64+64k', KernelType.ORDINARY),
+        (('9', '9.3'), '5.14.0-354.el9.aarch64+rt-64k', KernelType.REALTIME),
+        (('9', '9.3'), '5.14.0-354.el9.aarch64+rt_64k', KernelType.REALTIME),
     )
 )
 def test_determine_kernel_type_from_uname(monkeypatch, version, uname_r, expected_kernel_type):
@@ -36,9 +41,9 @@ def test_determine_kernel_type_from_uname(monkeypatch, version, uname_r, expecte
     actor_mock = CurrentActorMocked(
         release_id='centos' if '.' not in real_ver else 'rhel',
         src_ver=real_ver,
-        dst_ver="irrelevant",
+        dst_ver='irrelevant',
         virtual_source_version=virtual_ver or real_ver,
-        virtual_target_version="irrelevant",
+        virtual_target_version='irrelevant',
     )
     monkeypatch.setattr(api, 'current_actor', actor_mock)
 
@@ -46,42 +51,104 @@ def test_determine_kernel_type_from_uname(monkeypatch, version, uname_r, expecte
     assert kernel_type == expected_kernel_type
 
 
-def test_get_uname_r_provided_by_kernel_pkg(monkeypatch):
+@pytest.mark.parametrize(
+    ('getconf_output', 'expected_page_size'),
+    (
+        ('4096', KernelPageSize.PAGE_SIZE_4K),
+        ('65536', KernelPageSize.PAGE_SIZE_64K),
+    )
+)
+def test_determine_kernel_page_size(monkeypatch, getconf_output, expected_page_size):
+    def run_mocked(cmd, *args, **kwargs):
+        assert cmd == ['getconf', 'PAGE_SIZE']
+        return {'stdout': getconf_output}
+
+    monkeypatch.setattr(kernel_lib, 'run', run_mocked)
+    page_size = kernel_lib.determine_kernel_page_size()
+    assert page_size == expected_page_size
+
+
+def test_determine_kernel_page_size_getconf_failure(monkeypatch):
+    def run_mocked(cmd, *args, **kwargs):
+        raise CalledProcessError(message='Command getconf PAGE_SIZE failed with exit code 1.', command=cmd,
+                                 result={'exit_code': 1, 'stdout': '', 'stderr': ''})
+
+    monkeypatch.setattr(kernel_lib, 'run', run_mocked)
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    page_size = kernel_lib.determine_kernel_page_size()
+    assert page_size == KernelPageSize.PAGE_SIZE_4K
+    assert api.current_logger.warnmsg
+
+
+def _mock_context_for_provides(kernel_nevra, provides_lines):
+    class _MockContext:
+        def call(self, cmd, *args, **kwargs):
+            assert cmd == ['rpm', '-q', '--provides', kernel_nevra]
+            return {'stdout': provides_lines}
+    return _MockContext()
+
+
+def test_get_uname_r_provided_by_kernel_pkg():
+    kernel_nevra = 'kernel-core-5.14.0-354.el9.x86_64'
+    provides_lines = [
+        'kmod(virtio_ring.ko)',
+        'kernel(zlib_inflate_blob) = 0x65408378',
+        'kernel-uname-r = 5.14.0-354.el9.x86_64'
+    ]
+
+    uname_r = kernel_lib.get_uname_r_provided_by_kernel_pkg(
+        kernel_nevra, context=_mock_context_for_provides(kernel_nevra, provides_lines)
+    )
+    assert uname_r == '5.14.0-354.el9.x86_64'
+
+
+def test_get_uname_r_provided_by_kernel_pkg_default_context(monkeypatch):
     kernel_nevra = 'kernel-core-5.14.0-354.el9.x86_64'
 
     def run_mocked(cmd, *args, **kwargs):
         assert cmd == ['rpm', '-q', '--provides', kernel_nevra]
-        output_lines = [
-            'kmod(virtio_ring.ko)',
-            'kernel(zlib_inflate_blob) = 0x65408378',
+        return {'stdout': [
             'kernel-uname-r = 5.14.0-354.el9.x86_64'
-        ]
-        return {'stdout': output_lines}
+        ]}
 
-    monkeypatch.setattr(kernel_lib, 'run', run_mocked)
+    monkeypatch.setattr(kernel_lib.mounting, 'run', run_mocked)
 
     uname_r = kernel_lib.get_uname_r_provided_by_kernel_pkg(kernel_nevra)
     assert uname_r == '5.14.0-354.el9.x86_64'
 
 
-@pytest.mark.parametrize('kernel_pkg_with_uname_installed', (True, False))
-def test_get_kernel_pkg_info_for_uname_r(monkeypatch, kernel_pkg_with_uname_installed):
-    uname_r = '5.14.0-354.el9.x86_64' if kernel_pkg_with_uname_installed else 'other-uname'
-
+@pytest.mark.parametrize(
+    ('uname_r', 'expected_nevra'),
+    (
+        ('5.14.0-354.el9.x86_64', 'kernel-core-5.14.0-354.el9.x86_64.rpm'),
+        ('5.14.0-354.el9.x86_64+rt', 'kernel-rt-core-5.14.0-354.el9.x86_64.rpm'),
+        ('5.14.0-687.el9.aarch64+64k', 'kernel-64k-core-5.14.0-687.el9.aarch64.rpm'),
+        # RPM provides +rt_64k (underscore), uname -r reports +rt-64k (hyphen)
+        ('5.14.0-687.el9.aarch64+rt-64k', 'kernel-rt-64k-core-5.14.0-687.el9.aarch64.rpm'),
+        # Reversed: uname -r reports +rt_64k (underscore)
+        ('5.14.0-687.el9.aarch64+rt_64k', 'kernel-rt-64k-core-5.14.0-687.el9.aarch64.rpm'),
+        ('unknown', None),
+    )
+)
+def test_get_kernel_pkg_info_for_uname_r(monkeypatch, uname_r, expected_nevra):
     def run_mocked(cmd, *args, **kwargs):
         assert cmd[0:3] == ['rpm', '-q', '--whatprovides']
         output_lines = [
             'kernel-core-5.14.0-354.el9.x86_64.rpm',
             'kernel-rt-core-5.14.0-354.el9.x86_64.rpm',
+            'kernel-64k-core-5.14.0-687.el9.aarch64.rpm',
+            'kernel-rt-64k-core-5.14.0-687.el9.aarch64.rpm',
         ]
         return {'stdout': output_lines}
 
     def get_uname_provided_by_pkg_mocked(pkg_nevra):
         nevra_uname_table = {
             'kernel-core-5.14.0-354.el9.x86_64.rpm': '5.14.0-354.el9.x86_64',
-            'kernel-rt-core-5.14.0-354.el9.x86_64.rpm': '5.14.0-354.el9.x86_64+rt'
+            'kernel-rt-core-5.14.0-354.el9.x86_64.rpm': '5.14.0-354.el9.x86_64+rt',
+            'kernel-64k-core-5.14.0-687.el9.aarch64.rpm': '5.14.0-687.el9.aarch64+64k',
+            'kernel-rt-64k-core-5.14.0-687.el9.aarch64.rpm': '5.14.0-687.el9.aarch64+rt_64k',
         }
-        return nevra_uname_table[pkg_nevra]  # Will raise if a different nevra is used than ones from run_mocked
+        return nevra_uname_table[pkg_nevra]
 
     monkeypatch.setattr(kernel_lib, 'run', run_mocked)
     monkeypatch.setattr(kernel_lib, 'get_uname_r_provided_by_kernel_pkg', get_uname_provided_by_pkg_mocked)
@@ -91,9 +158,39 @@ def test_get_kernel_pkg_info_for_uname_r(monkeypatch, kernel_pkg_with_uname_inst
                         'get_kernel_pkg_info',
                         lambda dummy_nevra: mk_pkg_info(nevra=dummy_nevra))
 
-    if kernel_pkg_with_uname_installed:
+    if expected_nevra:
         pkg_info = kernel_lib.get_kernel_pkg_info_for_uname_r(uname_r)
-        assert pkg_info == mk_pkg_info(nevra='kernel-core-5.14.0-354.el9.x86_64.rpm')
+        assert pkg_info == mk_pkg_info(nevra=expected_nevra)
     else:
-        with pytest.raises(StopActorExecutionError):
-            pkg_info = kernel_lib.get_kernel_pkg_info_for_uname_r(uname_r)
+        with pytest.raises(kernel_lib.KernelPackageInfoError):
+            kernel_lib.get_kernel_pkg_info_for_uname_r(uname_r)
+
+
+@pytest.mark.parametrize(
+    ('kernel_type', 'page_size', 'arch', 'expected'),
+    (
+        # 4k page size: standard packages on all architectures
+        (KernelType.ORDINARY, KernelPageSize.PAGE_SIZE_4K, 'x86_64',
+         ('kernel', 'kernel-core', 'kernel-modules')),
+        (KernelType.ORDINARY, KernelPageSize.PAGE_SIZE_4K, 'aarch64',
+         ('kernel', 'kernel-core', 'kernel-modules')),
+        (KernelType.ORDINARY, KernelPageSize.PAGE_SIZE_4K, 'ppc64le',
+         ('kernel', 'kernel-core', 'kernel-modules')),
+        (KernelType.REALTIME, KernelPageSize.PAGE_SIZE_4K, 'x86_64',
+         ('kernel-rt', 'kernel-rt-core', 'kernel-rt-modules')),
+        # 64k page size on aarch64: 64k variant packages
+        (KernelType.ORDINARY, KernelPageSize.PAGE_SIZE_64K, 'aarch64',
+         ('kernel-64k', 'kernel-64k-core', 'kernel-64k-modules')),
+        (KernelType.REALTIME, KernelPageSize.PAGE_SIZE_64K, 'aarch64',
+         ('kernel-rt-64k', 'kernel-rt-64k-core', 'kernel-rt-64k-modules')),
+        # 64k page size on non-aarch64: standard packages (no kernel-64k RPMs exist)
+        (KernelType.ORDINARY, KernelPageSize.PAGE_SIZE_64K, 'ppc64le',
+         ('kernel', 'kernel-core', 'kernel-modules')),
+        (KernelType.ORDINARY, KernelPageSize.PAGE_SIZE_64K, 'x86_64',
+         ('kernel', 'kernel-core', 'kernel-modules')),
+        (KernelType.ORDINARY, KernelPageSize.PAGE_SIZE_64K, 's390x',
+         ('kernel', 'kernel-core', 'kernel-modules')),
+    )
+)
+def test_get_target_kernel_pkg_names(kernel_type, page_size, arch, expected):
+    assert kernel_lib.get_target_kernel_pkg_names(kernel_type, page_size, arch) == expected

--- a/repos/system_upgrade/common/libraries/tests/test_kernel_lib.py
+++ b/repos/system_upgrade/common/libraries/tests/test_kernel_lib.py
@@ -1,5 +1,3 @@
-import functools
-
 import pytest
 
 from leapp.libraries.common import kernel as kernel_lib
@@ -22,7 +20,6 @@ from leapp.libraries.stdlib import api, CalledProcessError
         (('9.3', None), '5.14.0-354.el9.x86_64+rt', KernelType.REALTIME),
         (('9.3', None), '5.14.0-354.el9.aarch64+64k', KernelType.ORDINARY),
         (('9.3', None), '5.14.0-354.el9.aarch64+rt-64k', KernelType.REALTIME),
-        (('9.3', None), '5.14.0-354.el9.aarch64+rt_64k', KernelType.REALTIME),
         # centos
         (('8', '8.7'), '4.18.0-425.3.1.el8.x86_64', KernelType.ORDINARY),
         (('8', '8.7'), '4.18.0-425.3.1.rt7.213.el8.x86_64', KernelType.REALTIME),
@@ -32,7 +29,6 @@ from leapp.libraries.stdlib import api, CalledProcessError
         (('9', '9.3'), '5.14.0-354.el9.x86_64+rt', KernelType.REALTIME),
         (('9', '9.3'), '5.14.0-354.el9.aarch64+64k', KernelType.ORDINARY),
         (('9', '9.3'), '5.14.0-354.el9.aarch64+rt-64k', KernelType.REALTIME),
-        (('9', '9.3'), '5.14.0-354.el9.aarch64+rt_64k', KernelType.REALTIME),
     )
 )
 def test_determine_kernel_type_from_uname(monkeypatch, version, uname_r, expected_kernel_type):
@@ -80,24 +76,26 @@ def test_determine_kernel_page_size_getconf_failure(monkeypatch):
     assert api.current_logger.warnmsg
 
 
-def _mock_context_for_provides(kernel_nevra, provides_lines):
+def _mock_context_for_file_list(kernel_nevra, file_lines):
     class _MockContext:
-        def call(self, cmd, *args, **kwargs):
-            assert cmd == ['rpm', '-q', '--provides', kernel_nevra]
-            return {'stdout': provides_lines}
+        def call(self, cmd, *args, **kwargs):  # pylint: disable=no-self-use
+            assert cmd == ['rpm', '-q', '-l', kernel_nevra]
+            return {'stdout': file_lines}
     return _MockContext()
 
 
 def test_get_uname_r_provided_by_kernel_pkg():
     kernel_nevra = 'kernel-core-5.14.0-354.el9.x86_64'
-    provides_lines = [
-        'kmod(virtio_ring.ko)',
-        'kernel(zlib_inflate_blob) = 0x65408378',
-        'kernel-uname-r = 5.14.0-354.el9.x86_64'
+    file_lines = [
+        '/lib/modules',
+        '/lib/modules/5.14.0-354.el9.x86_64',
+        '/lib/modules/5.14.0-354.el9.x86_64/.vmlinuz.hmac',
+        '/lib/modules/5.14.0-354.el9.x86_64/vmlinuz',
+        '/boot/vmlinuz-5.14.0-354.el9.x86_64',
     ]
 
     uname_r = kernel_lib.get_uname_r_provided_by_kernel_pkg(
-        kernel_nevra, context=_mock_context_for_provides(kernel_nevra, provides_lines)
+        kernel_nevra, context=_mock_context_for_file_list(kernel_nevra, file_lines)
     )
     assert uname_r == '5.14.0-354.el9.x86_64'
 
@@ -106,9 +104,9 @@ def test_get_uname_r_provided_by_kernel_pkg_default_context(monkeypatch):
     kernel_nevra = 'kernel-core-5.14.0-354.el9.x86_64'
 
     def run_mocked(cmd, *args, **kwargs):
-        assert cmd == ['rpm', '-q', '--provides', kernel_nevra]
+        assert cmd == ['rpm', '-q', '-l', kernel_nevra]
         return {'stdout': [
-            'kernel-uname-r = 5.14.0-354.el9.x86_64'
+            '/lib/modules/5.14.0-354.el9.x86_64/vmlinuz'
         ]}
 
     monkeypatch.setattr(kernel_lib.mounting, 'run', run_mocked)
@@ -118,49 +116,45 @@ def test_get_uname_r_provided_by_kernel_pkg_default_context(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    ('uname_r', 'expected_nevra'),
+    ('uname_r', 'whatprovides_nevras', 'expected_nevra'),
     (
-        ('5.14.0-354.el9.x86_64', 'kernel-core-5.14.0-354.el9.x86_64.rpm'),
-        ('5.14.0-354.el9.x86_64+rt', 'kernel-rt-core-5.14.0-354.el9.x86_64.rpm'),
-        ('5.14.0-687.el9.aarch64+64k', 'kernel-64k-core-5.14.0-687.el9.aarch64.rpm'),
-        # RPM provides +rt_64k (underscore), uname -r reports +rt-64k (hyphen)
-        ('5.14.0-687.el9.aarch64+rt-64k', 'kernel-rt-64k-core-5.14.0-687.el9.aarch64.rpm'),
-        # Reversed: uname -r reports +rt_64k (underscore)
-        ('5.14.0-687.el9.aarch64+rt_64k', 'kernel-rt-64k-core-5.14.0-687.el9.aarch64.rpm'),
-        ('unknown', None),
+        ('5.14.0-354.el9.x86_64',
+         ['kernel-modules-core-5.14.0-354.el9.x86_64', 'kernel-core-5.14.0-354.el9.x86_64'],
+         'kernel-core-5.14.0-354.el9.x86_64'),
+        ('5.14.0-354.el9.x86_64+rt',
+         ['kernel-rt-modules-core-5.14.0-354.el9.x86_64', 'kernel-rt-core-5.14.0-354.el9.x86_64'],
+         'kernel-rt-core-5.14.0-354.el9.x86_64'),
+        ('5.14.0-687.el9.aarch64+64k',
+         ['kernel-64k-modules-core-5.14.0-687.el9.aarch64', 'kernel-64k-core-5.14.0-687.el9.aarch64'],
+         'kernel-64k-core-5.14.0-687.el9.aarch64'),
+        ('5.14.0-687.el9.aarch64+rt-64k',
+         ['kernel-rt-64k-modules-core-5.14.0-687.el9.aarch64', 'kernel-rt-64k-core-5.14.0-687.el9.aarch64'],
+         'kernel-rt-64k-core-5.14.0-687.el9.aarch64'),
+        ('unknown', None, None),
     )
 )
-def test_get_kernel_pkg_info_for_uname_r(monkeypatch, uname_r, expected_nevra):
+def test_get_kernel_pkg_info_for_uname_r(monkeypatch, uname_r, whatprovides_nevras, expected_nevra):
     def run_mocked(cmd, *args, **kwargs):
-        assert cmd[0:3] == ['rpm', '-q', '--whatprovides']
-        output_lines = [
-            'kernel-core-5.14.0-354.el9.x86_64.rpm',
-            'kernel-rt-core-5.14.0-354.el9.x86_64.rpm',
-            'kernel-64k-core-5.14.0-687.el9.aarch64.rpm',
-            'kernel-rt-64k-core-5.14.0-687.el9.aarch64.rpm',
-        ]
-        return {'stdout': output_lines}
+        assert cmd[:3] == ['rpm', '-q', '--whatprovides']
+        assert cmd[3] == '/lib/modules/{}'.format(uname_r)
+        if whatprovides_nevras is None:
+            raise CalledProcessError(
+                message='rpm query failed', command=cmd,
+                result={'exit_code': 1, 'stdout': '', 'stderr': ''})
+        return {'stdout': whatprovides_nevras}
 
-    def get_uname_provided_by_pkg_mocked(pkg_nevra):
-        nevra_uname_table = {
-            'kernel-core-5.14.0-354.el9.x86_64.rpm': '5.14.0-354.el9.x86_64',
-            'kernel-rt-core-5.14.0-354.el9.x86_64.rpm': '5.14.0-354.el9.x86_64+rt',
-            'kernel-64k-core-5.14.0-687.el9.aarch64.rpm': '5.14.0-687.el9.aarch64+64k',
-            'kernel-rt-64k-core-5.14.0-687.el9.aarch64.rpm': '5.14.0-687.el9.aarch64+rt_64k',
-        }
-        return nevra_uname_table[pkg_nevra]
+    def get_kernel_pkg_info_mocked(nevra):
+        name = nevra.rsplit('-', 2)[0]
+        return kernel_lib.KernelPkgInfo(name=name, version='', release='', arch='', nevra=nevra)
 
     monkeypatch.setattr(kernel_lib, 'run', run_mocked)
-    monkeypatch.setattr(kernel_lib, 'get_uname_r_provided_by_kernel_pkg', get_uname_provided_by_pkg_mocked)
-
-    mk_pkg_info = functools.partial(kernel_lib.KernelPkgInfo, name='', version='', release='', arch='')
-    monkeypatch.setattr(kernel_lib,
-                        'get_kernel_pkg_info',
-                        lambda dummy_nevra: mk_pkg_info(nevra=dummy_nevra))
+    monkeypatch.setattr(kernel_lib, 'get_kernel_pkg_info', get_kernel_pkg_info_mocked)
 
     if expected_nevra:
         pkg_info = kernel_lib.get_kernel_pkg_info_for_uname_r(uname_r)
-        assert pkg_info == mk_pkg_info(nevra=expected_nevra)
+        assert pkg_info.nevra == expected_nevra
+        assert pkg_info.name.endswith('-core')
+        assert '-modules' not in pkg_info.name
     else:
         with pytest.raises(kernel_lib.KernelPackageInfoError):
             kernel_lib.get_kernel_pkg_info_for_uname_r(uname_r)

--- a/repos/system_upgrade/common/models/installedkernelversion.py
+++ b/repos/system_upgrade/common/models/installedkernelversion.py
@@ -1,7 +1,12 @@
 from leapp.models import fields, Model
 from leapp.topics import SystemInfoTopic
+from leapp.utils.deprecation import deprecated
 
 
+@deprecated(
+    since='2026-06-04',
+    message='This model has been deprecated! Use KernelInfo model for information about source distribution kernel.'
+)
 class CurrentKernel(Model):
     topic = SystemInfoTopic
     version = fields.String()

--- a/repos/system_upgrade/common/models/installedtargetkernelversion.py
+++ b/repos/system_upgrade/common/models/installedtargetkernelversion.py
@@ -18,17 +18,27 @@ class KernelInfo(Model):
     """
     Information about the booted kernel.
     """
+
     topic = SystemInfoTopic
 
     pkg = fields.Model(RPM)
-    """ Package providing the booted kernel. """
+    """
+    Package providing the booted kernel.
+    """
 
     uname_r = fields.String()
-    """``uname -r`` of the booted kernel."""
+    """
+    ``uname -r`` of the booted kernel.
+    """
 
     type = fields.StringEnum(['ordinary', 'realtime'], default='ordinary')
     # @FixMe(mhecko): I want to use kernel_lib.KernelType here, but I cannot import any library code (yet).
     # #               Figure out how to do it.
+
+    page_size = fields.StringEnum(['4k', '64k'], default='4k')
+    """
+    Memory page size of the kernel.
+    """
 
 
 class InstalledTargetKernelInfo(Model):

--- a/repos/system_upgrade/el8toel9/actors/checkkernelarm/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/checkkernelarm/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkkernelarm
+from leapp.models import KernelInfo, RpmTransactionTasks
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckKernelARM(Actor):
+    """
+    Instruct the installation of 64k kernel on ARM machines.
+
+    On RHEL 8 all ARM machines use kernel with the 64k pagesize.
+    However, in case of RHEL 9 the default ARM kernel has 4k pagesize instead.
+    Ensure that 64k kernel is installed on the target system for ARM.
+    """
+
+    name = 'check_kernel_arm'
+    consumes = (KernelInfo,)
+    produces = (RpmTransactionTasks,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        checkkernelarm.process()

--- a/repos/system_upgrade/el8toel9/actors/checkkernelarm/libraries/checkkernelarm.py
+++ b/repos/system_upgrade/el8toel9/actors/checkkernelarm/libraries/checkkernelarm.py
@@ -1,0 +1,28 @@
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common import kernel as kernel_lib
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+from leapp.models import KernelInfo, RpmTransactionTasks
+
+
+def process():
+    if not architecture.matches_architecture(architecture.ARCH_ARM64):
+        # Nothing to do.
+        return
+
+    kernel_info = next(api.consume(KernelInfo), None)
+    if not kernel_info:
+        raise StopActorExecutionError('Could not retrieve KernelInfo message.')
+
+    target_pkgs = kernel_lib.get_target_kernel_pkg_names(
+        kernel_info.type,
+        kernel_info.page_size,
+        api.current_actor().configuration.architecture
+    )
+
+    api.current_logger().debug(
+        "Register expected target kernel RPMs for installation on ARM."
+    )
+    api.produce(RpmTransactionTasks(
+        to_install=sorted(list(target_pkgs)))
+    )

--- a/repos/system_upgrade/el8toel9/actors/checkkernelarm/tests/unit_test_checkkernelarm.py
+++ b/repos/system_upgrade/el8toel9/actors/checkkernelarm/tests/unit_test_checkkernelarm.py
@@ -1,0 +1,72 @@
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import checkkernelarm
+from leapp.libraries.common.config.architecture import ARCH_ARM64, ARCH_X86_64
+from leapp.libraries.common.kernel import KernelPageSize, KernelType
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import KernelInfo, RPM, RpmTransactionTasks
+
+_KERNEL_PKG = RPM(name='kernel-core', arch='aarch64', version='4.18.0', release='1.el8',
+                  epoch='0', packager='', pgpsig='SIG')
+
+
+def _make_kernel_info(kernel_type=KernelType.ORDINARY, page_size=KernelPageSize.PAGE_SIZE_64K):
+    return KernelInfo(
+        pkg=_KERNEL_PKG, type=kernel_type, page_size=page_size, uname_r='4.18.0-1.el8.aarch64'
+    )
+
+
+def test_skip_non_arm_architecture(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=ARCH_X86_64))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkkernelarm.process()
+
+    assert not api.produce.called
+
+
+def test_raises_when_no_kernel_info(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=ARCH_ARM64))
+
+    with pytest.raises(StopActorExecutionError, match='Could not retrieve KernelInfo'):
+        checkkernelarm.process()
+
+
+@pytest.mark.parametrize(
+    ('kernel_type', 'page_size', 'expected_pkgs'),
+    [
+        (
+            KernelType.ORDINARY,
+            KernelPageSize.PAGE_SIZE_64K,
+            ['kernel-64k', 'kernel-64k-core', 'kernel-64k-modules'],
+        ),
+        (
+            KernelType.ORDINARY,
+            KernelPageSize.PAGE_SIZE_4K,
+            ['kernel', 'kernel-core', 'kernel-modules'],
+        ),
+        (
+            KernelType.REALTIME,
+            KernelPageSize.PAGE_SIZE_64K,
+            ['kernel-rt-64k', 'kernel-rt-64k-core', 'kernel-rt-64k-modules'],
+        ),
+        (
+            KernelType.REALTIME,
+            KernelPageSize.PAGE_SIZE_4K,
+            ['kernel-rt', 'kernel-rt-core', 'kernel-rt-modules'],
+        ),
+    ]
+)
+def test_produces_rpm_transaction_tasks(monkeypatch, kernel_type, page_size, expected_pkgs):
+    kernel_info = _make_kernel_info(kernel_type=kernel_type, page_size=page_size)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(arch=ARCH_ARM64, msgs=[kernel_info]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkkernelarm.process()
+
+    assert api.produce.called == 1
+    produced = api.produce.model_instances[0]
+    assert isinstance(produced, RpmTransactionTasks)
+    assert sorted(produced.to_install) == sorted(expected_pkgs)


### PR DESCRIPTION
### fix support for kernels with 64k page size
On aarch64, dedicated kernel packages for systems using 64k memory pages
(kernel-64k and kernel-rt-64k) exist. However, for ppc64le the standard
kernel packages are used despite having 64k page size. The upgrade now
detects the kernel page size and selects the correct kernel packages for
both the target OS and the internal upgrade environment.

The kernel-rt-64k RPM's kernel-uname-r provide uses a different suffix
(+rt_64k) than what uname -r returns (+rt-64k). A normalization
workaround is included to handle both variants until the RPM metadata
or uname -r output is fixed.

- Add ``page_size`` field to the ``KernelInfo`` model
- Add ``KernelPageSize`` enum and ``determine_kernel_page_size()`` using
  ``getconf PAGE_SIZE`` to the kernel shared library
- Update ``scansourcekernel`` to detect and produce the ``page_size``
- Recognize ``+rt-64k`` uname-r suffix as realtime kernel type
- Add ``get_kernel_pkg_names()`` to resolve kernel package names based
  on type (ordinary/rt), page size (4k/64k), and architecture (special
  64k kernel RPMs only exist on aarch64)
- Add ``KernelPackageInfoError`` exception and update
  ``get_target_kernel_pkg_info()`` to raise it instead of letting
  ``CalledProcessError`` propagate
- Update ``commonleappdracutmodules`` to dynamically select kernel
  packages instead of hardcoding kernel/kernel-core/kernel-modules
- Update ``scaninstalledtargetkernelversion`` to use
  ``get_target_kernel_pkg_names()`` with fallback from rt to ordinary
  preserving page size
- Update ``upgradeinitramfsgenerator`` to query the correct kernel
  variant inside the target userspace container
- Update ``generate-initram.sh`` fallback to query all kernel variants
- Deprecate the unused ``CurrentKernel`` model in favor of ``KernelInfo``

### rework kernel package identification to use /lib/modules paths

The ``kernel-uname-r`` rpm provide uses a different suffix format than
the actual ``uname -r`` output for RT kernels with 64k page size:
``uname -r`` returns ``+rt-64k``  while the provide has ``+rt_64k``.
This mismatch causes the existing provide-based lookup to fail to
identify the running kernel's package and resulted in a normalization
fix that mitigates it.

This patch switches a different file-based approach which is more
reliable:
- ``get_kernel_pkg_info_for_uname_r()`` now queries
  ``rpm --whatprovides /lib/modules/<uname_r>`` to directly find the
  owning packages, then selects the ``-core`` package from the results
- ``get_uname_r_provided_by_kernel_pkg()`` now extracts the version
  from the package's ``/lib/modules/<version>/`` file listing instead
  of parsing provides, and accepts an optional context parameter for
  in-container queries
- Deprecate ``KERNEL_UNAME_R_PROVIDES`` and remove ``_normalize_rt64k_suffix``
  as they are no longer needed 


## Summary on what changed in kernel library (to form the changelog easier)
- added `determine_kernel_page_size` function
- added `get_target_kernel_pkg_names` function
- added `KernelPackageInfoError` that inherits from `StopExecutionError`
- deprecated `KERNEL_UNAME_R_PROVIDES` constant
- ` get_uname_r_provided_by_kernel_pkg`
  - uname_r is now retrieved from packages `/lib/modules/<uname_r>` instead of the RPM provides 
  - now returns empty string instead of propagating `CalledProcessError`
  - now takes an optional argument context
- `get_kernel_pkg_info`
  - now raises `KernelPackageInfoError` instead of propagating `CalledProcessError`
- `get_kernel_pkg_info_for_uname_r`
  - now raises `KernelPackageInfoError` instead of `StopActorExecutionError` and when rpm query fails
  - now matches the kernel pkg to uname_r base on the `/lib/modules/<uname_r>` instead of using RPM whatprovides

Jira: RHEL-111860