### PR TITLE
Add scandnfcomps actor to scan installed DNF comps

### DIFF
--- a/repos/system_upgrade/common/actors/scandnfcomps/actor.py
+++ b/repos/system_upgrade/common/actors/scandnfcomps/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scandnfcomps
+from leapp.models import InstalledDNFComps
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanDNFComps(Actor):
+    """
+    Scan installed DNF comps (environments and groups).
+
+    Collects information about DNF package environments and groups that are
+    currently installed on the source system and produce InstalledDNFComps
+    message.
+    """
+
+    name = 'scan_dnf_comps'
+    consumes = ()
+    produces = (InstalledDNFComps,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        scandnfcomps.process()

--- a/repos/system_upgrade/common/actors/scandnfcomps/libraries/scandnfcomps.py
+++ b/repos/system_upgrade/common/actors/scandnfcomps/libraries/scandnfcomps.py
@@ -1,0 +1,87 @@
+import warnings
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.dnflibs import create_dnf_base, DNFRepoError
+from leapp.libraries.stdlib import api
+from leapp.models import DNFEnvironment, DNFGroup, InstalledDNFComps
+
+try:
+    import dnf
+except ImportError:
+    # NOTE(pstodulk): To stay consistent with other DNF related actors, but
+    # I guess we can get rid of it nowadays.
+    dnf = None
+    warnings.warn('Could not import the `dnf` python module.', ImportWarning)
+
+
+def _get_installed_groups(base):
+    """
+    Query installed DNF comps groups via the DNF base object.
+
+    Iterates over all available comps groups and filters to those recorded
+    as installed in the DNF history.
+
+    :param base: Initialized dnf.Base object with filled sack
+    :type base: dnf.Base
+    :returns: List of DNFGroup model instances sorted by group id
+    :rtype: List[DNFGroup]
+    """
+    groups = []
+    for grp in base.comps.groups_iter():
+        if not base.history.group.get(grp.id):
+            # not installed
+            continue
+        groups.append(DNFGroup(
+            id=grp.id,
+            name=grp.ui_name,
+        ))
+    return sorted(groups, key=lambda x: x.id)
+
+
+def _get_installed_environments(base):
+    """
+    Query installed DNF comps environments via the DNF base object.
+
+    Iterates over all available comps environments and filters to those
+    recorded as installed in the DNF history.
+
+    :param base: Initialized dnf.Base object with filled sack
+    :type base: dnf.Base
+    :returns: List of DNFEnvironment model instances sorted by environment id
+    :rtype: List[DNFEnvironment]
+    """
+    environments = []
+    for env in base.comps.environments_iter():
+        if not base.history.env.get(env.id):
+            continue
+        environments.append(DNFEnvironment(
+            id=env.id,
+            name=env.ui_name,
+        ))
+    return sorted(environments, key=lambda x: x.id)
+
+
+def process():
+    """
+    Scan installed DNF comps and produce InstalledDNFComps message.
+
+    .. seealso::
+        :func:`create_dnf_base` for exceptions raised when creating dnf.Base
+    """
+    if not dnf:
+        api.current_logger().debug('DNF is not available, skipping DNF comps scan.')
+        return
+
+    try:
+        base = create_dnf_base()
+    except DNFRepoError as e:
+        e.details['details'] = e.message
+        raise StopActorExecutionError(
+            message='Cannot obtain information about DNF Groups and Environments',
+            details=e.details
+        )
+
+    api.produce(InstalledDNFComps(
+        environments=_get_installed_environments(base),
+        groups=_get_installed_groups(base),
+    ))

--- a/repos/system_upgrade/common/actors/scandnfcomps/tests/test_scandnfcomps.py
+++ b/repos/system_upgrade/common/actors/scandnfcomps/tests/test_scandnfcomps.py
@@ -1,0 +1,175 @@
+import pytest
+
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import scandnfcomps
+from leapp.libraries.common.dnflibs import DNFRepoError
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import DNFEnvironment, DNFGroup, InstalledDNFComps
+
+
+class MockCompsGroup():
+    def __init__(self, gid, ui_name):
+        self.id = gid
+        self.ui_name = ui_name
+
+
+class MockCompsEnvironment():
+    def __init__(self, env_id, ui_name):
+        self.id = env_id
+        self.ui_name = ui_name
+
+
+class MockComps():
+    def __init__(self, groups=None, environments=None):
+        self._groups = groups or []
+        self._environments = environments or []
+
+    def groups_iter(self):
+        return iter(self._groups)
+
+    def environments_iter(self):
+        return iter(self._environments)
+
+
+class MockHistory():
+
+    class _Lookup():
+        """
+        Simulates base.history.group or base.history.env
+
+        group & env have have same "API" that we use, so no need to create
+        a different class for each one.
+        """
+
+        def __init__(self, installed_ids):
+            self._installed = set(installed_ids)
+
+        def get(self, item_id):
+            return item_id in self._installed
+
+    def __init__(self, installed_group_ids=None, installed_env_ids=None):
+        self.group = MockHistory._Lookup(installed_group_ids or [])
+        self.env = MockHistory._Lookup(installed_env_ids or [])
+
+
+class MockDNFBase():
+    def __init__(self, comps=None, history=None):
+        self.comps = comps or MockComps()
+        self.history = history or MockHistory()
+
+
+def test_process_with_groups_and_environments(monkeypatch):
+    comps = MockComps(
+        groups=[
+            MockCompsGroup('core', 'Core'),
+            MockCompsGroup('base', 'Base'),
+        ],
+        environments=[
+            MockCompsEnvironment('minimal-environment', 'Minimal Install'),
+        ],
+    )
+    history = MockHistory(
+        installed_group_ids=['core', 'base'],
+        installed_env_ids=['minimal-environment'],
+    )
+    base = MockDNFBase(comps=comps, history=history)
+
+    mocked_producer = produce_mocked()
+    monkeypatch.setattr(scandnfcomps, 'create_dnf_base', lambda: base)
+    monkeypatch.setattr(scandnfcomps, 'dnf', True)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', mocked_producer)
+
+    scandnfcomps.process()
+
+    assert mocked_producer.called == 1
+    msg = mocked_producer.model_instances[0]
+    assert isinstance(msg, InstalledDNFComps)
+    assert len(msg.groups) == 2
+    assert msg.groups[0].id == 'base'
+    assert msg.groups[0].name == 'Base'
+    assert msg.groups[1].id == 'core'
+    assert msg.groups[1].name == 'Core'
+    assert len(msg.environments) == 1
+    assert msg.environments[0].id == 'minimal-environment'
+    assert msg.environments[0].name == 'Minimal Install'
+
+
+def test_process_filters_not_installed(monkeypatch):
+    """Only groups/environments recorded as installed in history are returned."""
+    comps = MockComps(
+        groups=[
+            MockCompsGroup('core', 'Core'),
+            MockCompsGroup('base', 'Base'),
+            MockCompsGroup('extra', 'Extra'),
+        ],
+        environments=[
+            MockCompsEnvironment('minimal-environment', 'Minimal Install'),
+            MockCompsEnvironment('server-product-environment', 'Server'),
+        ],
+    )
+    history = MockHistory(
+        installed_group_ids=['core'],
+        installed_env_ids=['server-product-environment'],
+    )
+    base = MockDNFBase(comps=comps, history=history)
+
+    mocked_producer = produce_mocked()
+    monkeypatch.setattr(scandnfcomps, 'create_dnf_base', lambda: base)
+    monkeypatch.setattr(scandnfcomps, 'dnf', True)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', mocked_producer)
+
+    scandnfcomps.process()
+
+    assert mocked_producer.called == 1
+    msg = mocked_producer.model_instances[0]
+    assert len(msg.groups) == 1
+    assert msg.groups[0].id == 'core'
+    assert len(msg.environments) == 1
+    assert msg.environments[0].id == 'server-product-environment'
+
+
+def test_process_empty_comps(monkeypatch):
+    base = MockDNFBase()
+
+    mocked_producer = produce_mocked()
+    monkeypatch.setattr(scandnfcomps, 'create_dnf_base', lambda: base)
+    monkeypatch.setattr(scandnfcomps, 'dnf', True)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', mocked_producer)
+
+    scandnfcomps.process()
+
+    assert mocked_producer.called == 1
+    msg = mocked_producer.model_instances[0]
+    assert isinstance(msg, InstalledDNFComps)
+    assert msg.groups == []
+    assert msg.environments == []
+
+
+def test_process_no_dnf(monkeypatch):
+    mocked_producer = produce_mocked()
+    monkeypatch.setattr(scandnfcomps, 'dnf', None)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', mocked_producer)
+
+    scandnfcomps.process()
+    assert mocked_producer.called == 0
+
+
+def test_process_dnf_repo_error(monkeypatch):
+    def raise_repo_error():
+        raise DNFRepoError(
+            message='DNF failed to load repositories: repo error',
+            details={'hint': 'Ensure the myrepo repository definition is correct.'}
+        )
+
+    monkeypatch.setattr(scandnfcomps, 'create_dnf_base', raise_repo_error)
+    monkeypatch.setattr(scandnfcomps, 'dnf', True)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    with pytest.raises(StopActorExecutionError, match='Cannot obtain information about DNF Groups and Environments'):
+        scandnfcomps.process()

--- a/repos/system_upgrade/common/models/dnfcomps.py
+++ b/repos/system_upgrade/common/models/dnfcomps.py
@@ -1,0 +1,76 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemFactsTopic
+
+
+class DNFGroup(Model):
+    """
+    Provide information about a single installed DNF comps group.
+
+    This model is not expected to be produced or consumed by any actors as
+    a standalone message. It is always part of InstalledDNFComps message.
+    """
+
+    topic = SystemFactsTopic
+
+    id = fields.String()
+    """
+    The DNF comps group identifier (e.g. "core", "base").
+    """
+
+    name = fields.String()
+    """
+    Human-readable display name of the group.
+    """
+
+    # NOTE(pstodulk): possible extension if needed in future, but not implemented now:
+    # (( to list installed packages, split by various groups ))
+    # mandatory_packages = fields.List(fields.String, default=[])
+    # default_packages = fields.List(fields.String, default=[])
+    # conditional_packages = fields.List(fields.String, default=[])
+    # optional_packages = fields.List(fields.String, default=[])
+
+
+class DNFEnvironment(Model):
+    """
+    Provide information about a single installed DNF comps environment.
+
+    This model is not expected to be produced or consumed by any actors as
+    a standalone message. It is always part of InstalledDNFComps message.
+    """
+
+    topic = SystemFactsTopic
+
+    id = fields.String()
+    """
+    The DNF comps environment identifier (e.g. "minimal-environment").
+    """
+
+    name = fields.String()
+    """
+    Human-readable display name of the environment.
+    """
+
+    # NOTE(pstodulk): possible extension if needed in future, but not implemented now:
+    # mandatory_groups = fields.List(fields.String(), default=[])
+    # optional_groups = fields.List(fields.String(), default=[])
+
+
+class InstalledDNFComps(Model):
+    """
+    Provide information about installed DNF comps on the source system.
+
+    Contains lists of installed DNF package environments and groups as
+    tracked by the DNF history database.
+    """
+
+    topic = SystemFactsTopic
+
+    environments = fields.List(fields.Model(DNFEnvironment), default=[])
+    """
+    List of installed DNF comps environments.
+    """
+
+    groups = fields.List(fields.Model(DNFGroup), default=[])
+    """
+    List of installed DNF comps groups.
+    """


### PR DESCRIPTION
The actor scan installed DNF environments and groups (DNF comps)
which are represented by new InstalledDNFComps model.

The scan is performed using initialized dnf.Base to load all
available groups and envs and then it checks what is installed based
on the history.

About each group and environment, only ID and and (pretty) name
are collected. Skipping the scan of other data as we do not have a
use for that at this moment.

Unit-tests and part of docstrings are assisted by AI. All the other
code had to be manually updated unfortunately.

Related to jira: RHEL-148697