### PR TITLE
checkvarrunsymlink: Log warning when /var/run is missing from tracked files

### DIFF
--- a/repos/system_upgrade/common/actors/checkvarrunsymlink/libraries/checkvarrunsymlink.py
+++ b/repos/system_upgrade/common/actors/checkvarrunsymlink/libraries/checkvarrunsymlink.py
@@ -21,7 +21,12 @@ def process():
         return
 
     real_path = _get_real_path(tracked_files)
-    if real_path is None or real_path == '/run':
+    if real_path is None:
+        api.current_logger().warning(
+            '/var/run not found in TrackedFilesInfoSource. Skipping the symlink check.'
+        )
+        return
+    if real_path == '/run':
         return
 
     reporting.create_report([


### PR DESCRIPTION
Address review feedback from #1546: emit a warning when /var/run is unexpectedly absent from TrackedFilesInfoSource instead of silently skipping the check.