### PR TITLE
Bump leapp-framework

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -120,7 +120,7 @@ Requires:       leapp-repository-dependencies = %{leapp_repo_deps}
 
 # IMPORTANT: this is capability provided by the leapp framework rpm.
 # Check that 'version' instead of the real framework rpm version.
-Requires:       leapp-framework >= 6.5, leapp-framework < 7
+Requires:       leapp-framework >= 6.6, leapp-framework < 7
 
 # Since we provide sub-commands for the leapp utility, we expect the leapp
 # tool to be installed as well.


### PR DESCRIPTION
I forgot to bump it here and also in the framework with b70ff3.

Requires https://github.com/oamg/leapp/pull/929.