### PR TITLE
Add machine-id validation actors for in-place upgrade

### DIFF
--- a/repos/system_upgrade/common/actors/checkmachineid/actor.py
+++ b/repos/system_upgrade/common/actors/checkmachineid/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkmachineid
+from leapp.models import MachineIdInfo
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckMachineId(Actor):
+    """
+    Check that /etc/machine-id contains a valid machine ID.
+
+    The /etc/machine-id file must contain exactly 32 lowercase hexadecimal
+    characters that may not be all zeros. If the file is missing or contains an
+    invalid ID, the system is in an unsupported state and the upgrade is inhibited.
+    """
+
+    name = 'check_machine_id'
+    consumes = (MachineIdInfo,)
+    produces = (Report,)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        checkmachineid.process()

--- a/repos/system_upgrade/common/actors/checkmachineid/libraries/checkmachineid.py
+++ b/repos/system_upgrade/common/actors/checkmachineid/libraries/checkmachineid.py
@@ -1,0 +1,46 @@
+import re
+
+from leapp import reporting
+from leapp.libraries.stdlib import api
+from leapp.models import MachineIdInfo
+
+_VALID_MACHINE_ID_RE = re.compile(r'^[0-9a-f]{32}$')
+_ALL_ZEROS = '0' * 32
+
+
+def process():
+    machine_id_info = next(api.consume(MachineIdInfo), None)
+    if not machine_id_info:
+        api.current_logger().warning(
+            'The MachineIdInfo message is missing. Skipping the check of /etc/machine-id.'
+        )
+        return
+
+    if (machine_id_info.machine_id
+            and _VALID_MACHINE_ID_RE.match(machine_id_info.machine_id)
+            and machine_id_info.machine_id != _ALL_ZEROS):
+        return
+
+    reporting.create_report([
+        reporting.Title('Missing or invalid /etc/machine-id file'),
+        reporting.Summary(
+            'The /etc/machine-id file is missing or does not contain a valid'
+            ' machine ID. A valid machine ID is a 32-character lowercase'
+            ' hexadecimal string that is not all zeros. Various system'
+            ' components rely on a valid machine ID and the upgrade cannot'
+            ' proceed without one.'
+        ),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.SANITY, reporting.Groups.INHIBITOR]),
+        reporting.Remediation(
+            hint=(
+                'Generate a valid machine ID by running `systemd-machine-id-setup`.'
+                ' See `man machine-id` and `man systemd-machine-id-setup` for details.'
+            )
+        ),
+        reporting.ExternalLink(
+            url='https://access.redhat.com/solutions/3600401',
+            title='How to reconfigure the machine-id?'
+        ),
+        reporting.RelatedResource('file', '/etc/machine-id'),
+    ])

--- a/repos/system_upgrade/common/actors/checkmachineid/tests/test_checkmachineid.py
+++ b/repos/system_upgrade/common/actors/checkmachineid/tests/test_checkmachineid.py
@@ -1,0 +1,39 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import checkmachineid
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import MachineIdInfo
+from leapp.utils.report import is_inhibitor
+
+_VALID_MACHINE_ID = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4'
+
+
+@pytest.mark.parametrize('machine_id,should_inhibit', [
+    (None, True),
+    ('', True),
+    ('abc123', True),
+    ('a' * 33, True),
+    ('z' * 32, True),
+    ('A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4', True),
+    ('0' * 32, True),
+    ('a' * 31 + ' ', True),
+    (_VALID_MACHINE_ID, False),
+])
+def test_check_machine_id(monkeypatch, machine_id, should_inhibit):
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(
+        msgs=[MachineIdInfo(machine_id=machine_id)]
+    ))
+    checkmachineid.process()
+    assert bool(reporting.create_report.called) == should_inhibit
+    if should_inhibit:
+        assert is_inhibitor(reporting.create_report.report_fields)
+
+
+def test_check_machine_id_missing_message(monkeypatch):
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[]))
+    checkmachineid.process()
+    assert not reporting.create_report.called

--- a/repos/system_upgrade/common/actors/scanmachineid/actor.py
+++ b/repos/system_upgrade/common/actors/scanmachineid/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scanmachineid
+from leapp.models import MachineIdInfo
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanMachineId(Actor):
+    """
+    Scan /etc/machine-id and produce machine ID facts for the source system.
+    """
+
+    name = 'scan_machine_id'
+    consumes = ()
+    produces = (MachineIdInfo,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        scanmachineid.process()

--- a/repos/system_upgrade/common/actors/scanmachineid/libraries/scanmachineid.py
+++ b/repos/system_upgrade/common/actors/scanmachineid/libraries/scanmachineid.py
@@ -1,0 +1,14 @@
+from leapp.libraries.stdlib import api
+from leapp.models import MachineIdInfo
+
+_MACHINE_ID_PATH = '/etc/machine-id'
+
+
+def process():
+    machine_id = None
+    try:
+        with open(_MACHINE_ID_PATH, 'r') as f:
+            machine_id = f.read().rstrip('\n')
+    except OSError as e:
+        api.current_logger().warning('Failed to read {}: {}'.format(_MACHINE_ID_PATH, e))
+    api.produce(MachineIdInfo(machine_id=machine_id))

--- a/repos/system_upgrade/common/actors/scanmachineid/tests/test_scanmachineid.py
+++ b/repos/system_upgrade/common/actors/scanmachineid/tests/test_scanmachineid.py
@@ -1,0 +1,59 @@
+from io import StringIO
+
+import pytest
+
+from leapp.libraries.actor import scanmachineid
+from leapp.libraries.common.testutils import logger_mocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import MachineIdInfo
+
+_VALID_MACHINE_ID = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4'
+
+
+@pytest.mark.parametrize('content,expected_id', [
+    (_VALID_MACHINE_ID + '\n', _VALID_MACHINE_ID),
+    (_VALID_MACHINE_ID, _VALID_MACHINE_ID),
+    ('', ''),
+    (_VALID_MACHINE_ID + ' \n', _VALID_MACHINE_ID + ' '),
+    (' ' + _VALID_MACHINE_ID + '\n', ' ' + _VALID_MACHINE_ID),
+])
+def test_scan_machine_id(monkeypatch, content, expected_id):
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(scanmachineid, 'open', lambda *a, **kw: StringIO(content), raising=False)
+    scanmachineid.process()
+    assert api.produce.called == 1
+    msg = api.produce.model_instances[0]
+    assert isinstance(msg, MachineIdInfo)
+    assert msg.machine_id == expected_id
+
+
+def test_scan_machine_id_missing(monkeypatch):
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    def _raise_file_not_found(*args, **kwargs):
+        raise FileNotFoundError('No such file or directory')
+
+    monkeypatch.setattr(scanmachineid, 'open', _raise_file_not_found, raising=False)
+    scanmachineid.process()
+    assert api.produce.called == 1
+    msg = api.produce.model_instances[0]
+    assert isinstance(msg, MachineIdInfo)
+    assert msg.machine_id is None
+    assert api.current_logger.warnmsg
+
+
+def test_scan_machine_id_unreadable(monkeypatch):
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    def _raise_os_error(*args, **kwargs):
+        raise OSError('Permission denied')
+
+    monkeypatch.setattr(scanmachineid, 'open', _raise_os_error, raising=False)
+    scanmachineid.process()
+    assert api.produce.called == 1
+    msg = api.produce.model_instances[0]
+    assert isinstance(msg, MachineIdInfo)
+    assert msg.machine_id is None
+    assert api.current_logger.warnmsg

--- a/repos/system_upgrade/common/models/machineid.py
+++ b/repos/system_upgrade/common/models/machineid.py
@@ -1,0 +1,14 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class MachineIdInfo(Model):
+    """
+    Information about /etc/machine-id on the source system.
+    """
+    topic = SystemInfoTopic
+
+    machine_id = fields.Nullable(fields.String())
+    """
+    Content of /etc/machine-id (trailing newline stripped), or None if missing/unreadable.
+    """


### PR DESCRIPTION
Introduced a scanner/checker actor pair that verifies /etc/machine-id exists and contains a valid 32-character hexadecimal identifier. The upgrade is inhibited if the file is missing or malformed, as a valid machine-id is required by systemd and the target userspace container creation.

Jira: RHEL-50161