### PR TITLE
feat(eap_repo_blocklist): blocklist conflicting EAP repos 

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/eaprepoblocklist/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/eaprepoblocklist/actor.py
@@ -1,0 +1,26 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import eaprepoblocklist
+from leapp.models import DistributionSignedRPM, RepositoriesSetupTasks
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class EapRepoBlocklist(Actor):
+    """
+    Check and handle EAP repos during RHEL in-place upgrade.
+
+    Detects the installed EAP version (7.4, 8.0, 8.1) from DistributionSignedRPM
+    and produces RepositoriesSetupTasks to enable matching EAP repos and block
+    conflicting ones on the target RHEL 9.
+    EAP 7.4 enables both jb-eap-7.4-for-rhel-9 and jb-eap-7.4-els-for-rhel-9 repos.
+    EAP 8.0 is not supported for leapp upgrade and will produce an inhibitor.
+    EAP 8.1 enables jb-eap-8.1-for-rhel-9-x86_64-rpms.
+    """
+
+    name = 'eaprepoblocklist'
+    consumes = (DistributionSignedRPM,)
+    produces = (RepositoriesSetupTasks, Report)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        eaprepoblocklist.process()

--- a/repos/system_upgrade/el8toel9/actors/eaprepoblocklist/libraries/eaprepoblocklist.py
+++ b/repos/system_upgrade/el8toel9/actors/eaprepoblocklist/libraries/eaprepoblocklist.py
@@ -1,0 +1,71 @@
+from leapp.libraries.common.config import get_source_distro_id, get_target_distro_id
+from leapp.libraries.stdlib import api
+from leapp.models import DistributionSignedRPM, RepositoriesSetupTasks
+from leapp.reporting import create_report, Groups, Remediation, Severity, Summary, Title
+
+EAP_RHEL9_REPOS = {
+    '7.4': [
+        'jb-eap-7.4-for-rhel-9-x86_64-rpms',
+        'jb-eap-7.4-els-for-rhel-9-x86_64-rpms',
+    ],
+    '8.0': [
+        'jb-eap-8.0-for-rhel-9-x86_64-rpms',
+    ],
+    '8.1': [
+        'jb-eap-8.1-for-rhel-9-x86_64-rpms',
+    ],
+}
+
+
+def detect_installed_eap():
+    for rpm_msg in api.consume(DistributionSignedRPM):
+        for rpm in rpm_msg.items:
+            if rpm.name == 'eap7-wildfly':
+                return '7.4'
+            if rpm.name == 'eap8-wildfly':
+                if '8.0.' in rpm.version:
+                    return '8.0'
+                if '8.1.' in rpm.version:
+                    return '8.1'
+                # This is hypothetical, it cannot happen, but if so, let's at least create a log
+                api.current_logger().warning('Detected unexpected EAP version: %s', rpm.version)
+    return None
+
+
+def process():
+    if get_source_distro_id() != 'rhel' or get_target_distro_id() != 'rhel':
+        api.current_logger().info('Skipping EAP repo check - not a RHEL to RHEL upgrade')
+        return
+
+    installed_eap = detect_installed_eap()
+
+    if not installed_eap:
+        api.current_logger().info('No EAP installation detected, skipping repo blocklist')
+        return
+
+    api.current_logger().info('Detected installed EAP version: {}'.format(installed_eap))
+
+    if installed_eap == '8.0':
+        create_report([
+            Title('JBoss EAP 8.0 upgrade via leapp is not supported'),
+            Summary(
+                'JBoss EAP 8.0 is not in the leapp upgrade scope. '
+                'Upgrade JBoss EAP to 8.1 before performing the upgrade.'
+            ),
+            Severity(Severity.HIGH),
+            Groups([Groups.INHIBITOR]),
+            Remediation(hint='Upgrade JBoss EAP to version 8.1 prior to running leapp upgrade.'),
+        ])
+        return
+
+    to_enable = EAP_RHEL9_REPOS[installed_eap]
+    to_block = [
+        repo
+        for version, repos in EAP_RHEL9_REPOS.items()
+        if version != installed_eap
+        for repo in repos
+    ]
+
+    api.current_logger().debug('Enabling repos: {}'.format(to_enable))
+    api.current_logger().debug('Blocking repos: {}'.format(to_block))
+    api.produce(RepositoriesSetupTasks(to_enable=to_enable, to_block=to_block))

--- a/repos/system_upgrade/el8toel9/actors/eaprepoblocklist/tests/unit_test_eaprepoblocklist.py
+++ b/repos/system_upgrade/el8toel9/actors/eaprepoblocklist/tests/unit_test_eaprepoblocklist.py
@@ -1,0 +1,94 @@
+from leapp.libraries.actor import eaprepoblocklist
+from leapp.models import DistributionSignedRPM, RepositoriesSetupTasks, RPM
+from leapp.reporting import Report
+from leapp.snactor.fixture import current_actor_context
+from leapp.utils.report import is_inhibitor
+
+RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
+RH_PGPSIG = 'RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51'
+
+
+def make_rpm(name, version):
+    return RPM(
+        name=name,
+        version=version,
+        release='1.el8',
+        epoch='0',
+        arch='noarch',
+        packager=RH_PACKAGER,
+        pgpsig=RH_PGPSIG,
+    )
+
+
+EAP74_RPM = make_rpm('eap7-wildfly', '7.4.0')
+EAP80_RPM = make_rpm('eap8-wildfly', '8.0.0')
+EAP81_RPM = make_rpm('eap8-wildfly', '8.1.0')
+
+
+def test_no_eap_installed(monkeypatch, current_actor_context):
+    monkeypatch.setattr(eaprepoblocklist, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(eaprepoblocklist, 'get_target_distro_id', lambda: 'rhel')
+
+    current_actor_context.feed(DistributionSignedRPM(items=[]))
+    current_actor_context.run()
+
+    assert not current_actor_context.consume(RepositoriesSetupTasks)
+    assert not current_actor_context.consume(Report)
+
+
+def test_eap74_installed(monkeypatch, current_actor_context):
+    monkeypatch.setattr(eaprepoblocklist, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(eaprepoblocklist, 'get_target_distro_id', lambda: 'rhel')
+
+    current_actor_context.feed(DistributionSignedRPM(items=[EAP74_RPM]))
+    current_actor_context.run()
+
+    tasks = current_actor_context.consume(RepositoriesSetupTasks)
+    assert tasks
+    task = tasks[0]
+    assert 'jb-eap-7.4-for-rhel-9-x86_64-rpms' in task.to_enable
+    assert 'jb-eap-7.4-els-for-rhel-9-x86_64-rpms' in task.to_enable
+    assert 'jb-eap-8.0-for-rhel-9-x86_64-rpms' in task.to_block
+    assert 'jb-eap-8.1-for-rhel-9-x86_64-rpms' in task.to_block
+    assert not current_actor_context.consume(Report)
+
+
+def test_eap80_installed(monkeypatch, current_actor_context):
+    monkeypatch.setattr(eaprepoblocklist, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(eaprepoblocklist, 'get_target_distro_id', lambda: 'rhel')
+
+    current_actor_context.feed(DistributionSignedRPM(items=[EAP80_RPM]))
+    current_actor_context.run()
+
+    reports = current_actor_context.consume(Report)
+    assert reports
+    assert is_inhibitor(reports[0].report)
+    assert not current_actor_context.consume(RepositoriesSetupTasks)
+
+
+def test_eap81_installed(monkeypatch, current_actor_context):
+    monkeypatch.setattr(eaprepoblocklist, 'get_source_distro_id', lambda: 'rhel')
+    monkeypatch.setattr(eaprepoblocklist, 'get_target_distro_id', lambda: 'rhel')
+
+    current_actor_context.feed(DistributionSignedRPM(items=[EAP81_RPM]))
+    current_actor_context.run()
+
+    tasks = current_actor_context.consume(RepositoriesSetupTasks)
+    assert tasks
+    task = tasks[0]
+    assert 'jb-eap-8.1-for-rhel-9-x86_64-rpms' in task.to_enable
+    assert 'jb-eap-7.4-for-rhel-9-x86_64-rpms' in task.to_block
+    assert 'jb-eap-7.4-els-for-rhel-9-x86_64-rpms' in task.to_block
+    assert 'jb-eap-8.0-for-rhel-9-x86_64-rpms' in task.to_block
+    assert not current_actor_context.consume(Report)
+
+
+def test_non_rhel_distro(monkeypatch, current_actor_context):
+    monkeypatch.setattr(eaprepoblocklist, 'get_source_distro_id', lambda: 'centos')
+    monkeypatch.setattr(eaprepoblocklist, 'get_target_distro_id', lambda: 'rhel')
+
+    current_actor_context.feed(DistributionSignedRPM(items=[EAP81_RPM]))
+    current_actor_context.run()
+
+    assert not current_actor_context.consume(RepositoriesSetupTasks)
+    assert not current_actor_context.consume(Report)

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,8 @@ max-line-length = 119
     # 'leapp.snactor.fixture.current_actor_context' imported but unused
     # 'leapp.snactor.fixture.current_actor_libraries' imported but unused
 per-file-ignores =
-    repos/system_upgrade/el7toel8/actors/*/tests/*.py:F811,F401
+    repos/system_upgrade/el8toel9/actors/*/tests/*.py:F811,F401
+    repos/system_upgrade/el9toel10/actors/*/tests/*.py:F811,F401
     repos/system_upgrade/common/actors/*/tests/*.py:F811,F401
 application-import-names = leapp
 # check only for correct group type and abc sorting without group


### PR DESCRIPTION
The upgrade with EAP 8.x was not performed correctly previously
as it could be processed with a different target EAP repository
than expected. The problem is that EAP 8.0 & 8.1 repository contains
some packages of the same name (e.g. "eap8-wildfly-openssl-el8-x86_64")
and PES scanner does not recognize correctly which PES event should
be evaluated for this specific package. So usually for EAP 8.1 the
upgrade has been finished with EAP 8.0.

To resolve this problem, the actor detects correctly which EAP version
is installed on the system (7.4, 8.0, or 8.1) and explicitly enable
requested repositories for the correct EAP version and block the others.
Also, EAP 8.0 is not allowed for the upgrade so it inhibits
the upgrade process if detected, suggesting users to update
to EAP 8.1 before they in-place upgrade to RHEL 9.x system.

This is applied just on RHEL distro we are not aware off Jboss EAP
on other distributions.

Jira: https://redhat.atlassian.net/browse/JBEAP-32869, https://redhat.atlassian.net/browse/EAPPROD-1305
