### PR TITLE
feat(livemode, stratis): support stratis storage in live mode

### DIFF
--- a/repos/system_upgrade/common/actors/livemode/emit_livemode_userspace_requirements/libraries/emit_livemode_userspace_requirements.py
+++ b/repos/system_upgrade/common/actors/livemode/emit_livemode_userspace_requirements/libraries/emit_livemode_userspace_requirements.py
@@ -29,6 +29,8 @@ def emit_livemode_userspace_requirements():
 
     if livemode_config.capture_upgrade_strace_into:
         packages += ['strace']
+    # TODO: Make this conditional depending on whether we detect stratis on the source system
+    packages += ['stratisd']
 
     packages = sorted(set(packages))
 


### PR DESCRIPTION
Add support for mounting stratis storage which requires the stratisd.service to be running in order to mount the filesystems. It is sufficient to make sure that the stratisd daemon is available in the squashfs image - fstab entries will request its start.