### PR TITLE
Add rpmtoflatpak actor to help with RPMs -> Flatpak migrations

### DIFF
--- a/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/checkreportflatpak/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/checkreportflatpak/actor.py
@@ -1,0 +1,28 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkreportflatpak
+from leapp.models import RpmToFlatpakFacts, RpmTransactionTasks
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckReportFlatpak(Actor):
+    """
+    Report RPM-to-Flatpak migrations and schedule required packages for installation.
+
+    Consumes facts produced by ScanRpmToFlatpak. When RHSM is in use
+    (the default), produces RpmTransactionTasks to install the
+    redhat-flatpak-preinstall-* packages and flatpak itself as part of the
+    main upgrade transaction, and creates an informational report.
+
+    When RHSM is not in use (e.g. Satellite, RHUI, ISO), creates an
+    inhibitor report directing the user to install the affected applications
+    as Flatpaks manually after the upgrade.
+    """
+
+    name = 'check_report_flatpak'
+    consumes = (RpmToFlatpakFacts,)
+    produces = (Report, RpmTransactionTasks)
+    tags = (IPUWorkflowTag, ChecksPhaseTag)
+
+    def process(self):
+        checkreportflatpak.process()

--- a/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/checkreportflatpak/libraries/checkreportflatpak.py
+++ b/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/checkreportflatpak/libraries/checkreportflatpak.py
@@ -1,0 +1,84 @@
+from leapp import reporting
+from leapp.libraries.common.rhsm import skip_rhsm
+from leapp.libraries.stdlib import api
+from leapp.models import RpmToFlatpakFacts, RpmTransactionTasks
+
+_FLATPAK_PKG = 'flatpak'
+_FLATPAK_DOCS_URL = (
+    'https://docs.redhat.com/documentation/red_hat_enterprise_linux/10/html'
+    '/administering_rhel_by_using_the_gnome_desktop_environment/installing-applications-by-using-flatpak'
+)
+
+
+def _report_inhibitor(rpm_names):
+    pkg_list = ', '.join(rpm_names)
+
+    summary = (
+        'The following packages are installed as RPMs but are no longer shipped as RPMs '
+        'on the target system: {packages}. These packages are available as Flatpaks '
+        'on RHEL 10.\n\n'
+        'Automatic RPM-to-Flatpak migration is currently only supported on systems '
+        'using Red Hat Subscription Manager (RHSM). This system is not using RHSM '
+        '(LEAPP_NO_RHSM=1 is set).\n\n'
+        'After the upgrade, install the applications manually as Flatpaks.'
+    ).format(packages=pkg_list)
+
+    reporting.create_report([
+        reporting.Title(
+            'RPM-to-Flatpak migration is not supported without RHSM'
+        ),
+        reporting.Summary(summary),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.DESKTOP]),
+        reporting.Remediation(
+            hint='After the upgrade, install the applications as Flatpaks manually.'
+        ),
+        reporting.ExternalLink(
+            url=_FLATPAK_DOCS_URL,
+            title='Installing applications by using Flatpak'
+        ),
+    ])
+
+
+def _report_migration(rpm_names):
+    pkg_list = ', '.join(rpm_names)
+
+    summary = (
+        'The following packages are installed as RPMs but are no longer shipped as RPMs '
+        'on the target system. They will be migrated to their Flatpak equivalents '
+        'during the upgrade: {packages}.\n\n'
+        'The migration is performed by installing the corresponding '
+        'redhat-flatpak-preinstall-* packages and the flatpak package itself on the '
+        'target system as part of the upgrade transaction, then running '
+        '`flatpak preinstall`.'
+    ).format(packages=pkg_list)
+
+    reporting.create_report([
+        reporting.Title(
+            'RPM packages will be migrated to Flatpak'
+        ),
+        reporting.Summary(summary),
+        reporting.Severity(reporting.Severity.INFO),
+        reporting.Groups([reporting.Groups.DESKTOP]),
+        reporting.ExternalLink(
+            url=_FLATPAK_DOCS_URL,
+            title='Installing applications by using Flatpak'
+        ),
+    ])
+
+
+def process():
+    facts = next(api.consume(RpmToFlatpakFacts), None)
+    if not facts or not facts.packages:
+        return
+
+    rpm_names = sorted(p.rpm_name for p in facts.packages)
+
+    if skip_rhsm():
+        _report_inhibitor(rpm_names)
+        return
+
+    to_install = [_FLATPAK_PKG] + [p.preinstall_pkg for p in facts.packages]
+    api.produce(RpmTransactionTasks(to_install=to_install))
+
+    _report_migration(rpm_names)

--- a/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/checkreportflatpak/tests/test_checkreportflatpak.py
+++ b/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/checkreportflatpak/tests/test_checkreportflatpak.py
@@ -1,0 +1,103 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import checkreportflatpak
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import FlatpakMigrationPackage, RpmToFlatpakFacts, RpmTransactionTasks
+
+
+def _make_facts(*rpm_names):
+    packages = [
+        FlatpakMigrationPackage(
+            rpm_name=name,
+            preinstall_pkg='redhat-flatpak-preinstall-{}'.format(name),
+        )
+        for name in rpm_names
+    ]
+    return RpmToFlatpakFacts(packages=packages)
+
+
+@pytest.mark.parametrize('facts', [None, _make_facts()])
+def test_does_not_report_when_no_packages(monkeypatch, facts):
+    msgs = [facts] if facts is not None else []
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(checkreportflatpak, 'skip_rhsm', lambda: False)
+
+    checkreportflatpak.process()
+
+    assert reporting.create_report.called == 0
+
+
+def test_creates_info_report_and_transaction_tasks_with_rhsm(monkeypatch):
+    facts = _make_facts('firefox', 'thunderbird')
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[facts]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(checkreportflatpak, 'skip_rhsm', lambda: False)
+
+    checkreportflatpak.process()
+
+    assert reporting.create_report.called == 1
+    report = reporting.create_report.reports[0]
+    assert report['title'] == 'RPM packages will be migrated to Flatpak'
+    assert 'firefox' in report['summary']
+    assert 'thunderbird' in report['summary']
+    assert reporting.Groups.INHIBITOR not in report['groups']
+
+    tasks = [m for m in api.produce.model_instances if isinstance(m, RpmTransactionTasks)]
+    assert len(tasks) == 1
+    assert 'flatpak' in tasks[0].to_install
+    assert 'redhat-flatpak-preinstall-firefox' in tasks[0].to_install
+    assert 'redhat-flatpak-preinstall-thunderbird' in tasks[0].to_install
+
+
+def test_creates_inhibitor_report_when_rhsm_not_in_use(monkeypatch):
+    facts = _make_facts('firefox')
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[facts]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(checkreportflatpak, 'skip_rhsm', lambda: True)
+
+    checkreportflatpak.process()
+
+    assert reporting.create_report.called == 1
+    report = reporting.create_report.reports[0]
+    assert reporting.Groups.INHIBITOR in report['groups']
+    assert 'not supported without RHSM' in report['title']
+    assert 'firefox' in report['summary']
+
+    tasks = [m for m in api.produce.model_instances if isinstance(m, RpmTransactionTasks)]
+    assert not tasks
+
+
+def test_inhibitor_report_includes_documentation_link(monkeypatch):
+    facts = _make_facts('firefox')
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[facts]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(checkreportflatpak, 'skip_rhsm', lambda: True)
+
+    checkreportflatpak.process()
+
+    report = reporting.create_report.reports[0]
+    ext_links = [e for e in report.get('detail', {}).get('external', [])
+                 if 'flatpak' in e.get('url', '')]
+    assert ext_links
+
+
+def test_info_report_includes_documentation_link(monkeypatch):
+    facts = _make_facts('firefox')
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[facts]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(checkreportflatpak, 'skip_rhsm', lambda: False)
+
+    checkreportflatpak.process()
+
+    report = reporting.create_report.reports[0]
+    ext_links = [e for e in report.get('detail', {}).get('external', [])
+                 if 'flatpak' in e.get('url', '')]
+    assert ext_links

--- a/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/migraterpmtoflatpak/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/migraterpmtoflatpak/actor.py
@@ -1,0 +1,23 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import migraterpmtoflatpak
+from leapp.models import RpmToFlatpakFacts
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class MigrateRpmToFlatpak(Actor):
+    """
+    Migrate RPM packages to their Flatpak equivalents on the upgraded system.
+
+    Runs ``flatpak preinstall`` to pull in the Flatpak applications from the
+    required remotes as defined in the preinstall configuration. The
+    redhat-flatpak-preinstall-* packages and flatpak itself are already
+    installed at this point via RpmTransactionTasks produced by the scanner.
+    """
+
+    name = 'migrate_rpm_to_flatpak'
+    consumes = (RpmToFlatpakFacts,)
+    produces = ()
+    tags = (IPUWorkflowTag, ApplicationsPhaseTag)
+
+    def process(self):
+        migraterpmtoflatpak.process()

--- a/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/migraterpmtoflatpak/libraries/migraterpmtoflatpak.py
+++ b/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/migraterpmtoflatpak/libraries/migraterpmtoflatpak.py
@@ -1,0 +1,24 @@
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import RpmToFlatpakFacts
+
+
+def _run_flatpak_preinstall():
+    try:
+        run(['flatpak', 'preinstall', '--system', '--noninteractive'])
+    except (CalledProcessError, OSError) as e:
+        api.current_logger().error('Failed to run flatpak preinstall: {}'.format(e))
+        return False
+    return True
+
+
+def process():
+    facts = next(api.consume(RpmToFlatpakFacts), None)
+    if not facts or not facts.packages:
+        return
+
+    rpm_names = sorted(p.rpm_name for p in facts.packages)
+    api.current_logger().info(
+        'Migrating packages from RPM to Flatpak: {}'.format(', '.join(rpm_names))
+    )
+
+    _run_flatpak_preinstall()

--- a/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/migraterpmtoflatpak/tests/test_migraterpmtoflatpak.py
+++ b/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/migraterpmtoflatpak/tests/test_migraterpmtoflatpak.py
@@ -1,0 +1,74 @@
+import pytest
+
+from leapp.libraries.actor import migraterpmtoflatpak
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked
+from leapp.libraries.stdlib import api, CalledProcessError
+from leapp.models import FlatpakMigrationPackage, RpmToFlatpakFacts
+
+
+def _make_facts(*rpm_names):
+    packages = [
+        FlatpakMigrationPackage(
+            rpm_name=name,
+            preinstall_pkg='redhat-flatpak-preinstall-{}'.format(name),
+        )
+        for name in rpm_names
+    ]
+    return RpmToFlatpakFacts(packages=packages)
+
+
+@pytest.mark.parametrize('facts', [None, _make_facts()])
+def test_does_not_run_commands_when_no_packages(monkeypatch, facts):
+    msgs = [facts] if facts is not None else []
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    run_calls = []
+    monkeypatch.setattr(migraterpmtoflatpak, 'run', lambda cmd, **kw: run_calls.append(cmd))
+
+    migraterpmtoflatpak.process()
+
+    assert not run_calls
+
+
+def test_runs_flatpak_preinstall_when_packages_present(monkeypatch):
+    facts = _make_facts('firefox', 'thunderbird')
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[facts]))
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    run_calls = []
+    monkeypatch.setattr(migraterpmtoflatpak, 'run', lambda cmd, **kw: run_calls.append(cmd))
+
+    migraterpmtoflatpak.process()
+
+    assert len(run_calls) == 1
+    assert run_calls[0] == ['flatpak', 'preinstall', '--system', '--noninteractive']
+
+
+def test_run_flatpak_preinstall_uses_correct_command(monkeypatch):
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    run_calls = []
+    monkeypatch.setattr(migraterpmtoflatpak, 'run', lambda cmd, **kw: run_calls.append(cmd))
+
+    result = migraterpmtoflatpak._run_flatpak_preinstall()
+
+    assert result is True
+    assert run_calls == [['flatpak', 'preinstall', '--system', '--noninteractive']]
+
+
+def test_run_flatpak_preinstall_logs_error_on_failure(monkeypatch):
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(migraterpmtoflatpak, 'run', _run_error)
+
+    result = migraterpmtoflatpak._run_flatpak_preinstall()
+
+    assert result is False
+    assert api.current_logger.errmsg
+
+
+def _run_error(cmd, **kwargs):
+    raise CalledProcessError(
+        message='A Leapp Command Error occurred.',
+        command=cmd,
+        result={'exit_code': 1},
+    )

--- a/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/scanrpmtoflatpak/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/scanrpmtoflatpak/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scanrpmtoflatpak
+from leapp.models import DistributionSignedRPM, RpmToFlatpakFacts
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanRpmToFlatpak(Actor):
+    """
+    Scan for RPM packages that will be migrated to Flatpak equivalents after upgrade.
+
+    Detects installed RPM packages (e.g. firefox, thunderbird) that Red Hat ships
+    as Flatpaks on RHEL 10, and produces RpmToFlatpakFacts describing the planned
+    migration so that later actors can report on it and perform the migration.
+    """
+
+    name = 'scan_rpm_to_flatpak'
+    consumes = (DistributionSignedRPM,)
+    produces = (RpmToFlatpakFacts,)
+    tags = (IPUWorkflowTag, FactsPhaseTag)
+
+    def process(self):
+        scanrpmtoflatpak.process()

--- a/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/scanrpmtoflatpak/libraries/scanrpmtoflatpak.py
+++ b/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/scanrpmtoflatpak/libraries/scanrpmtoflatpak.py
@@ -1,0 +1,35 @@
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import DistributionSignedRPM, FlatpakMigrationPackage, RpmToFlatpakFacts
+
+_FLATPAK_PKG = 'flatpak'
+
+# Maps RPM package names to their corresponding flatpak-preinstall package names.
+# The preinstall package is installed on the target system; flatpak preinstall is
+# then called explicitly by migraterpmtoflatpak to pull in the Flatpak from the
+# required remote as defined in the preinstall configuration.
+_RPM_TO_FLATPAK_MAP = {
+    'firefox': 'redhat-flatpak-preinstall-firefox',
+    'thunderbird': 'redhat-flatpak-preinstall-thunderbird',
+}
+
+
+def _get_packages_to_migrate():
+    packages = []
+    for rpm_name, preinstall_pkg in _RPM_TO_FLATPAK_MAP.items():
+        if has_package(DistributionSignedRPM, rpm_name):
+            packages.append(FlatpakMigrationPackage(
+                rpm_name=rpm_name,
+                preinstall_pkg=preinstall_pkg,
+            ))
+            api.current_logger().debug(
+                'Package {} is installed and will be migrated to Flatpak via {}'.format(
+                    rpm_name, preinstall_pkg
+                )
+            )
+    return packages
+
+
+def process():
+    packages = _get_packages_to_migrate()
+    api.produce(RpmToFlatpakFacts(packages=packages))

--- a/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/scanrpmtoflatpak/tests/test_scanrpmtoflatpak.py
+++ b/repos/system_upgrade/el9toel10/actors/rpmtoflatpak/scanrpmtoflatpak/tests/test_scanrpmtoflatpak.py
@@ -1,0 +1,52 @@
+import pytest
+
+from leapp.libraries.actor import scanrpmtoflatpak
+from leapp.libraries.common.testutils import CurrentActorMocked, logger_mocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import DistributionSignedRPM, RPM, RpmToFlatpakFacts
+
+
+def _make_rpm(name):
+    return RPM(name=name, version='1.0', release='1.el9', epoch='0',
+               packager='Red Hat', arch='x86_64', pgpsig='SIG')
+
+
+@pytest.mark.parametrize('installed,expected_pkgs', [
+    ([], []),
+    (['firefox'], [('firefox', 'redhat-flatpak-preinstall-firefox')]),
+    (['thunderbird'], [('thunderbird', 'redhat-flatpak-preinstall-thunderbird')]),
+    (
+        ['firefox', 'thunderbird'],
+        [
+            ('firefox', 'redhat-flatpak-preinstall-firefox'),
+            ('thunderbird', 'redhat-flatpak-preinstall-thunderbird'),
+        ],
+    ),
+    (['vim-enhanced', 'bash'], []),
+])
+def test_produces_migration_facts_for_installed_flatpak_rpms(monkeypatch, installed, expected_pkgs):
+    msgs = [DistributionSignedRPM(items=[_make_rpm(n) for n in installed])]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    scanrpmtoflatpak.process()
+
+    assert api.produce.called == 1
+    facts = api.produce.model_instances[0]
+    assert isinstance(facts, RpmToFlatpakFacts)
+    assert len(facts.packages) == len(expected_pkgs)
+    result_pairs = sorted((p.rpm_name, p.preinstall_pkg) for p in facts.packages)
+    assert result_pairs == sorted(expected_pkgs)
+
+
+def test_logs_debug_for_each_detected_package(monkeypatch):
+    msgs = [DistributionSignedRPM(items=[_make_rpm('firefox')])]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    packages = scanrpmtoflatpak._get_packages_to_migrate()
+
+    assert len(packages) == 1
+    assert packages[0].rpm_name == 'firefox'
+    assert any('firefox' in msg for msg in api.current_logger.dbgmsg)

--- a/repos/system_upgrade/el9toel10/models/rpmtoflatpak.py
+++ b/repos/system_upgrade/el9toel10/models/rpmtoflatpak.py
@@ -1,0 +1,33 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class FlatpakMigrationPackage(Model):
+    """
+    Describes a single RPM-to-Flatpak migration.
+
+    Holds the name of the currently installed RPM and the corresponding
+    preinstall package that must be present on the target system for
+    ``flatpak preinstall`` to pull the Flatpak application.
+    """
+    topic = SystemInfoTopic
+
+    rpm_name = fields.String()
+    """Name of the RPM package installed on the source system."""
+
+    preinstall_pkg = fields.String()
+    """Name of the redhat-flatpak-preinstall-* package to install on the target."""
+
+
+class RpmToFlatpakFacts(Model):
+    """
+    Aggregated facts about RPM packages that will be migrated to Flatpak.
+
+    Produced by the scanner actor and consumed by the checker (to report
+    the planned migration) and the migration actor (to run ``flatpak preinstall``).
+    An empty ``packages`` list means no migration is needed.
+    """
+    topic = SystemInfoTopic
+
+    packages = fields.List(fields.Model(FlatpakMigrationPackage), default=[])
+    """List of RPM packages to be migrated to their Flatpak equivalents."""


### PR DESCRIPTION
Starting with RHEL 10.2, we've switched the default delivery method for Firefox and Thunderbird from RPMs to Flatpaks (see RHEL-139533). To accommodate for that switch for upgrades, we check whether the firefox or thunderbird packages are preinstalled and if so, then we install the packages with flatpak-preinstall configuration files and run flatpak preinstall on it (the same workflow that Anaconda is doing).

We also limit the actor to work on subscribed systems, so we don't have to deal with credentials for the Red Hat Flatpak Registry (see RHEL-85004 for more information).

Developed by Claude Code.

Resolves: RHEL-53806
Resolves: RHEL-67925