### PR TITLE
fix(ceph/luks): Match Ceph/LUKS volumes UUIDs

### DIFF
--- a/repos/system_upgrade/common/actors/cephvolumescan/libraries/cephvolumescan.py
+++ b/repos/system_upgrade/common/actors/cephvolumescan/libraries/cephvolumescan.py
@@ -57,6 +57,16 @@ def get_ceph_lvm_list():
     return json_output
 
 
+def _get_luks_uuid(lv_path):
+    try:
+        output = run(['blkid', '-s', 'UUID', '-o', 'value', lv_path])
+    except CalledProcessError:
+        api.current_logger().warning('Failed to get LUKS UUID for %s', lv_path)
+        return None
+    uuid = output['stdout'].strip()
+    return uuid if uuid else None
+
+
 def encrypted_osds_list():
     result = []
     if os.path.isfile(CEPH_CONF):
@@ -64,7 +74,12 @@ def encrypted_osds_list():
         if output is not None:
             try:
                 for key in output:
-                    result.extend([element['lv_uuid'] for element in output[key] if element['tags']['ceph.encrypted']])
+                    for element in output[key]:
+                        if element['tags']['ceph.encrypted']:
+                            lv_path = '/dev/{}/{}'.format(element['vg_name'], element['lv_name'])
+                            luks_uuid = _get_luks_uuid(lv_path)
+                            if luks_uuid:
+                                result.append(luks_uuid)
             except KeyError:
                 # TODO: possibly raise a report item with a medium risk factor
                 # TODO: possibly create list of problematic osds, extend the cephinfo

--- a/repos/system_upgrade/common/actors/cephvolumescan/tests/test_cephvolumescan.py
+++ b/repos/system_upgrade/common/actors/cephvolumescan/tests/test_cephvolumescan.py
@@ -112,15 +112,32 @@ def test_get_ceph_lvm_list(m_run, m_osd_container, m_has_package):
     assert cephvolumescan.get_ceph_lvm_list() == CEPH_LVM_LIST
 
 
+BLKID_UUIDS = {
+    '/dev/ceph-a696c40d-6b1d-448d-a40e-fadca22b64bc/osd-block-c5215ba7-517b-45c7-88df-37a03eeaa0e9':
+        'aaa11111-1111-1111-1111-111111111111',
+    '/dev/ceph-b78309b3-bd80-4399-87a3-ac647b216b63/osd-db-b04857a0-a2a2-40c3-a490-cbe1f892a76c':
+        'bbb22222-2222-2222-2222-222222222222',
+    '/dev/ceph-e3e0345b-8be1-40a7-955a-378ba967f954/osd-block-477c303f-5eaf-4be8-b5cc-f6073eb345bf':
+        'ccc33333-3333-3333-3333-333333333333',
+}
+
+
+def _mock_run_blkid(cmd):
+    lv_path = cmd[-1]
+    return {'stdout': BLKID_UUIDS[lv_path] + '\n'}
+
+
+@patch('leapp.libraries.actor.cephvolumescan.run')
 @patch('leapp.libraries.actor.cephvolumescan.os.path.isfile')
 @patch('leapp.libraries.actor.cephvolumescan.get_ceph_lvm_list')
-def test_encrypted_osds_list(m_get_ceph_lvm_list, m_isfile):
+def test_encrypted_osds_list(m_get_ceph_lvm_list, m_isfile, m_run):
 
     m_get_ceph_lvm_list.return_value = CEPH_LVM_LIST
     m_isfile.return_value = True
+    m_run.side_effect = _mock_run_blkid
 
     assert cephvolumescan.encrypted_osds_list() == [
-        'Tyc0TH-RDxr-ebAF-9mWF-Kh5R-YnvJ-cEcGVn',
-        'zcvGix-drzz-JwzP-6ktU-Od6W-N5jL-kxRFa3',
-        'Mz1dep-D715-Wxh1-zUuS-0cOA-mKXE-UxaEM3'
+        'aaa11111-1111-1111-1111-111111111111',
+        'bbb22222-2222-2222-2222-222222222222',
+        'ccc33333-3333-3333-3333-333333333333'
     ]

--- a/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
+++ b/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
@@ -153,7 +153,7 @@ def check_invalid_luks_devices():
     ceph_vol = _get_ceph_volumes()
     for luks_dump in luks_dumps.dumps:
         # if the device is managed by ceph, don't inhibit
-        if luks_dump.device_name in ceph_vol:
+        if luks_dump.uuid in ceph_vol:
             api.current_logger().debug('Skipping LUKS CEPH volume: {}'.format(luks_dump.device_name))
             continue
 

--- a/repos/system_upgrade/common/actors/checkluks/tests/test_checkluks.py
+++ b/repos/system_upgrade/common/actors/checkluks/tests/test_checkluks.py
@@ -120,13 +120,14 @@ def test_actor_with_luks2_clevis_tpm_token(monkeypatch, current_actor_context):
 
 def test_actor_with_luks2_ceph(monkeypatch, current_actor_context):
     monkeypatch.setattr(checkluks, 'get_source_major_version', lambda: '8')
-    ceph_volume = ['sda']
+    luks_uuid = '0edb8c11-1a04-4abd-a12d-93433ee7b8d8'
+    ceph_volume = [luks_uuid]
     current_actor_context.feed(CephInfo(encrypted_volumes=ceph_volume))
     luks_dump = LuksDump(
         version=2,
-        uuid='0edb8c11-1a04-4abd-a12d-93433ee7b8d8',
-        device_path='/dev/sda',
-        device_name='sda',
+        uuid=luks_uuid,
+        device_path='/dev/dm-3',
+        device_name='ceph--xxx-osd--block--yyy',
         tokens=[LuksToken(token_id=0, keyslot=1, token_type='clevis')])
     current_actor_context.feed(LuksDumps(dumps=[luks_dump]))
     current_actor_context.run()


### PR DESCRIPTION
The LUKS inhibitor incorrectly compared device names UUIDs against
Ceph LV UUIDs, so encrypted Ceph OSDs were never recognized and always
triggered the upgrade inhibitor. Resolve by querying the actual LUKS UUID
via blkid for each encrypted Ceph OSD and comparing that against the
LUKS dumped UUIDs.

Resolves: rhbz#2264543

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>