### PR TITLE
Increase free space check for / from 100MB to 200MB

### DIFF
--- a/repos/system_upgrade/common/libraries/guards.py
+++ b/repos/system_upgrade/common/libraries/guards.py
@@ -43,7 +43,7 @@ def connection_guard(url='https://example.com'):
     return closure
 
 
-def space_guard(path='/', min_free_mb=100):
+def space_guard(path='/', min_free_mb=200):
     def closure():
         info = os.statvfs(path)
         free_mb = (info.f_bavail * info.f_frsize) >> 20


### PR DESCRIPTION
The space_guard function checks available disk space before proceeding with the upgrade. The previous default of 100MB proved insufficient in some scenarios, leading to failed upgrades due to lack of disk space. Increase the threshold to 200MB to provide a safer margin for the upgrade process.

BZ#2278831