### PR TITLE
mount_unit_generator: Remove pseudo FS mount units from upgrade initramfs

### DIFF
--- a/repos/system_upgrade/common/actors/initramfs/mount_units_generator/libraries/mount_unit_generator.py
+++ b/repos/system_upgrade/common/actors/initramfs/mount_units_generator/libraries/mount_unit_generator.py
@@ -9,6 +9,24 @@ from leapp.models import LiveModeConfig, StorageInfo, TargetUserSpaceInfo, Upgra
 
 BIND_MOUNT_SYSROOT_BOOT_UNIT = 'boot.mount'
 
+PSEUDO_FS_TYPES = frozenset([
+    'hugetlbfs',
+    'tmpfs',
+    'devtmpfs',
+    'devpts',
+    'sysfs',
+    'proc',
+    'cgroup',
+    'cgroup2',
+    'securityfs',
+    'selinuxfs',
+    'debugfs',
+    'mqueue',
+    'pstore',
+    'efivarfs',
+    'bpf',
+])
+
 
 def run_systemd_fstab_generator(output_directory):
     api.current_logger().debug(
@@ -86,6 +104,19 @@ def _prefix_mount_unit_with_sysroot(mount_unit_path, new_unit_destination):
     api.current_logger().debug(
         'Done. Modified mount unit successfully written to {}'.format(new_unit_destination)
     )
+
+
+def _get_mount_unit_fs_type(unit_path):
+    """Return the filesystem type declared in a systemd mount unit, or None."""
+    try:
+        with open(unit_path) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith('Type='):
+                    return line.split('=', 1)[1].strip()
+    except OSError:
+        pass
+    return None
 
 
 def prefix_all_mount_units_with_sysroot(dir_containing_units):
@@ -226,6 +257,7 @@ def fix_symlinks_in_targets(dir_containing_mount_units):
         'remote-fs-pre.target.requires',
         'remote-fs-pre.target.wants',
     ]
+
     for tdir in dir_list:
         _fix_symlinks_in_dir(dir_containing_mount_units, tdir)
 
@@ -278,6 +310,28 @@ def copy_units_into_system_location(upgrade_container_ctx, dir_with_our_mount_un
             copied_files.append(dst_file[prefix_len_to_drop:])
 
     return copied_files
+
+
+def remove_pseudo_fs_mount_units(dir_with_our_mount_units):
+    """
+    Remove mount units for virtual/pseudo filesystems that are not needed during the upgrade.
+
+    Pseudo filesystem entries (hugetlbfs, tmpfs, etc.) from the source system's /etc/fstab
+    become mount units whose target directories may not exist under /sysroot, causing boot
+    failures.  These filesystems serve no purpose during the upgrade initramfs phase, so
+    the simplest and safest approach is to drop them entirely.
+    """
+    for unit_file in os.listdir(dir_with_our_mount_units):
+        if not unit_file.endswith('.mount'):
+            continue
+        unit_path = os.path.join(dir_with_our_mount_units, unit_file)
+        fs_type = _get_mount_unit_fs_type(unit_path)
+        if fs_type in PSEUDO_FS_TYPES:
+            api.current_logger().debug(
+                'Removing pseudo filesystem mount unit {} (type={}) - not needed during upgrade.'
+                .format(unit_file, fs_type)
+            )
+            _delete_file(unit_path)
 
 
 def remove_units_for_targets_that_are_already_mounted_by_dracut(dir_with_our_mount_units):
@@ -365,6 +419,7 @@ def setup_storage_initialization():
     with mounting.NspawnActions(base_dir=userspace_info.path) as upgrade_container_ctx:
         with tempfile.TemporaryDirectory(dir='/var/lib/leapp/', prefix='tmp_systemd_fstab_') as workspace_path:
             run_systemd_fstab_generator(workspace_path)
+            remove_pseudo_fs_mount_units(workspace_path)
             remove_units_for_targets_that_are_already_mounted_by_dracut(workspace_path)
             prefix_all_mount_units_with_sysroot(workspace_path)
             inject_bundled_units(workspace_path)

--- a/repos/system_upgrade/common/actors/initramfs/mount_units_generator/tests/test_mount_unit_generation.py
+++ b/repos/system_upgrade/common/actors/initramfs/mount_units_generator/tests/test_mount_unit_generation.py
@@ -328,6 +328,42 @@ def test_injection_of_sysroot_boot_bindmount_unit(monkeypatch, has_separate_boot
         assert was_copyfile_for_sysroot_boot_called
 
 
+def test_remove_pseudo_fs_mount_units(monkeypatch, tmp_path):
+    """Pseudo FS mount units (hugetlbfs, tmpfs, etc.) should be removed entirely."""
+    hugetlb_unit = tmp_path / 'dev-hugepages2M.mount'
+    hugetlb_unit.write_text('[Unit]\nDescription=Huge Pages\n[Mount]\nWhere=/dev/hugepages2M\nType=hugetlbfs\n')
+
+    xfs_unit = tmp_path / 'home.mount'
+    xfs_unit.write_text('[Unit]\nDescription=Home\n[Mount]\nWhere=/home\nType=xfs\n')
+
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    mount_unit_generator.remove_pseudo_fs_mount_units(str(tmp_path))
+
+    assert not hugetlb_unit.exists()
+    assert xfs_unit.exists()
+
+
+def test_remove_pseudo_fs_mount_units_keeps_regular(monkeypatch, tmp_path):
+    """Regular filesystem mount units should not be removed."""
+    xfs_unit = tmp_path / 'var.mount'
+    xfs_unit.write_text('[Unit]\n[Mount]\nWhere=/var\nType=xfs\n')
+
+    ext4_unit = tmp_path / 'data.mount'
+    ext4_unit.write_text('[Unit]\n[Mount]\nWhere=/data\nType=ext4\n')
+
+    service_file = tmp_path / 'foo.service'
+    service_file.write_text('[Unit]\nDescription=foo\n')
+
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    mount_unit_generator.remove_pseudo_fs_mount_units(str(tmp_path))
+
+    assert xfs_unit.exists()
+    assert ext4_unit.exists()
+    assert service_file.exists()
+
+
 TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files')
 
 


### PR DESCRIPTION
systemd-fstab-generator converts every `/etc/fstab` entry into a systemd mount unit. MountUnitGenerator then prefixes each unit's Where= path with `/sysroot` before bundling them into the upgrade initramfs. For virtual/pseudo filesystem entries such as hugetlbfs (e.g. `/dev/hugepages2M`, `/dev/hugepages1G`) the corresponding directories may not exist under `/sysroot` (`/sysroot/dev/hugepages2M`, `/sysconfig/dev/hugepages1G`).

As the main reasons for having pseudo FS entries in fstab is security hardening, performance tuning, application-specific mounts. Since these pseudo filesystems have no purpose during the in-place upgrade phase, drop their mount units entirely before any further processing.

Resolves: RHEL-180965