### PR TITLE
Drop resume kernel cmdline argument from upgrade boot entry

### DIFF
--- a/repos/system_upgrade/common/actors/checkresumekernelarg/actor.py
+++ b/repos/system_upgrade/common/actors/checkresumekernelarg/actor.py
@@ -1,0 +1,27 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkresumekernelarg
+from leapp.models import KernelCmdline, TargetKernelCmdlineArgTasks, UpgradeKernelCmdlineArgTasks
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckResumeKernelArg(Actor):
+    """
+    Remove the resume argument from the upgrade boot entry.
+
+    The resume argument points to a swap device used for hibernation. During the
+    upgrade the dracut resume module is excluded, so the resume device cannot be
+    resolved and the system can hang during reboot. Therefore, we remove the
+    resume kernel command line argument from the upgrade boot entry to prevent
+    a possible hang during the upgrade reboot.
+
+    The argument is restored on the target kernel so hibernation keeps working
+    after the upgrade.
+    """
+
+    name = 'check_resume_kernel_arg'
+    consumes = (KernelCmdline,)
+    produces = (TargetKernelCmdlineArgTasks, UpgradeKernelCmdlineArgTasks)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        checkresumekernelarg.process()

--- a/repos/system_upgrade/common/actors/checkresumekernelarg/libraries/checkresumekernelarg.py
+++ b/repos/system_upgrade/common/actors/checkresumekernelarg/libraries/checkresumekernelarg.py
@@ -1,0 +1,35 @@
+from leapp.libraries.stdlib import api
+from leapp.models import KernelCmdline, TargetKernelCmdlineArgTasks, UpgradeKernelCmdlineArgTasks
+
+
+def process():
+    """
+    Remove resume from the upgrade boot entry and restore it on the target.
+
+    The upgrade initramfs omits the dracut resume module, so the resume device
+    cannot be resolved during the upgrade boot. This can cause the system to
+    hang waiting for the device. Stripping resume argument from the upgrade kernel
+    command line avoids the hang. The value is added back to the target kernel
+    entry via TargetKernelCmdlineArgTasks so hibernation continues working
+    after the upgrade.
+    """
+    cmdline = next(api.consume(KernelCmdline), None)
+    if not cmdline:
+        api.current_logger().debug('No KernelCmdline message received, nothing to do.')
+        return
+
+    resume_args = [arg for arg in cmdline.parameters if arg.key == 'resume']
+    if not resume_args:
+        api.current_logger().debug('No resume argument found on the kernel command line.')
+        return
+
+    api.current_logger().info(
+        'Requesting removal of resume argument from the upgrade kernel command line: %s',
+        ['{}={}'.format(a.key, a.value or '') for a in resume_args]
+    )
+
+    api.produce(UpgradeKernelCmdlineArgTasks(to_remove=resume_args))
+    # When installing the target kernel RPM, the cmdline is copied from the booted system.
+    # As we remove the resume= args, we would accidentally remove them also from the
+    # target entry. Therefore, we add them back in here.
+    api.produce(TargetKernelCmdlineArgTasks(to_add=resume_args))

--- a/repos/system_upgrade/common/actors/checkresumekernelarg/tests/test_checkresumekernelarg.py
+++ b/repos/system_upgrade/common/actors/checkresumekernelarg/tests/test_checkresumekernelarg.py
@@ -1,0 +1,100 @@
+import pytest
+
+from leapp.libraries.actor import checkresumekernelarg
+from leapp.libraries.common.testutils import CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import KernelCmdline, KernelCmdlineArg, TargetKernelCmdlineArgTasks, UpgradeKernelCmdlineArgTasks
+
+_COMMON_PARAMS = [
+    KernelCmdlineArg(key='ro', value=None),
+    KernelCmdlineArg(key='root', value='/dev/mapper/rhel-root'),
+]
+
+
+@pytest.mark.parametrize('resume_value', [
+    'UUID=010b9c5c-5aca-469b-a852-fdf2fefcf817',
+    '/dev/mapper/rhel-swap',
+    '/dev/md/swap',
+    '/dev/md127',
+    '/dev/dm-1',
+])
+def test_resume_removed_from_upgrade_and_restored_on_target(monkeypatch, resume_value):
+    cmdline = KernelCmdline(parameters=_COMMON_PARAMS + [
+        KernelCmdlineArg(key='resume', value=resume_value),
+    ])
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[cmdline]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkresumekernelarg.process()
+
+    upgrade_msgs = [m for m in api.produce.model_instances if isinstance(m, UpgradeKernelCmdlineArgTasks)]
+    assert len(upgrade_msgs) == 1
+    assert len(upgrade_msgs[0].to_remove) == 1
+    assert upgrade_msgs[0].to_remove[0].key == 'resume'
+    assert upgrade_msgs[0].to_remove[0].value == resume_value
+
+    target_msgs = [m for m in api.produce.model_instances if isinstance(m, TargetKernelCmdlineArgTasks)]
+    assert len(target_msgs) == 1
+    assert len(target_msgs[0].to_add) == 1
+    assert target_msgs[0].to_add[0].key == 'resume'
+    assert target_msgs[0].to_add[0].value == resume_value
+
+
+def test_multiple_resume_args_all_handled(monkeypatch):
+    cmdline = KernelCmdline(parameters=_COMMON_PARAMS + [
+        KernelCmdlineArg(key='resume', value='UUID=aaa-bbb'),
+        KernelCmdlineArg(key='resume', value='/dev/md127'),
+    ])
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[cmdline]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkresumekernelarg.process()
+
+    upgrade_msgs = [m for m in api.produce.model_instances if isinstance(m, UpgradeKernelCmdlineArgTasks)]
+    assert len(upgrade_msgs) == 1
+    removed = {(a.key, a.value) for a in upgrade_msgs[0].to_remove}
+    assert removed == {('resume', 'UUID=aaa-bbb'), ('resume', '/dev/md127')}
+
+    target_msgs = [m for m in api.produce.model_instances if isinstance(m, TargetKernelCmdlineArgTasks)]
+    assert len(target_msgs) == 1
+    added = {(a.key, a.value) for a in target_msgs[0].to_add}
+    assert added == {('resume', 'UUID=aaa-bbb'), ('resume', '/dev/md127')}
+
+
+def test_resume_bare_key_without_value(monkeypatch):
+    cmdline = KernelCmdline(parameters=_COMMON_PARAMS + [
+        KernelCmdlineArg(key='resume', value=None),
+    ])
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[cmdline]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkresumekernelarg.process()
+
+    upgrade_msgs = [m for m in api.produce.model_instances if isinstance(m, UpgradeKernelCmdlineArgTasks)]
+    assert len(upgrade_msgs) == 1
+    assert upgrade_msgs[0].to_remove[0].key == 'resume'
+    assert upgrade_msgs[0].to_remove[0].value is None
+
+    target_msgs = [m for m in api.produce.model_instances if isinstance(m, TargetKernelCmdlineArgTasks)]
+    assert len(target_msgs) == 1
+    assert target_msgs[0].to_add[0].key == 'resume'
+    assert target_msgs[0].to_add[0].value is None
+
+
+def test_no_resume_produces_nothing(monkeypatch):
+    cmdline = KernelCmdline(parameters=_COMMON_PARAMS)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[cmdline]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkresumekernelarg.process()
+
+    assert not api.produce.model_instances
+
+
+def test_no_kernel_cmdline_message_produces_nothing(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    checkresumekernelarg.process()
+
+    assert not api.produce.model_instances


### PR DESCRIPTION
## The reason for the change

The upgrade initramfs excludes the dracut `resume` module (`-o resume`),
but the `resume=` kernel parameter is still copied into the upgrade boot
entry via `grubby --copy-default`. This causes the system to hang during
reboot while waiting for the resume device to appear. The issue is
reproducible when swap is on software RAID but can affect other
configurations as well.

## What has been changed

Added a new `CheckResumeKernelArg` actor (ChecksPhase) that removes the `resume=`
kernel command line parameter from the upgrade boot entry and restores it
on the target kernel entry after the upgrade.

## How it has been changed

The actor consumes `KernelCmdline`, filters for any `resume=` parameters,
and produces:
- `UpgradeKernelCmdlineArgTasks(to_remove=...)` to strip `resume=` from
  the upgrade boot entry
- `TargetKernelCmdlineArgTasks(to_add=...)` to restore `resume=` on the
  target kernel so hibernation keeps working after the upgrade

New files:
- `repos/system_upgrade/common/actors/checkresume/actor.py`
- `repos/system_upgrade/common/actors/checkresume/libraries/checkresume.py`
- `repos/system_upgrade/common/actors/checkresume/tests/test_checkresume.py`

## How to try/test the PR

1. Unit tests: `ACTOR=check_resume_kernel_arg make dev_test_no_lint` (9 tests covering
   UUID, /dev/mapper, /dev/md, bare key, multiple args, no resume, no cmdline)
2. Container tests: `TEST_CONTAINER=el9 make test_container`
3. Manual: On a system with `resume=` on the kernel cmdline, run leapp
   preupgrade and verify the report contains
   "Kernel boot parameter resume= will be removed during the upgrade"

## Reference to a Jira ticket
RHEL-95495