### PR TITLE
Add commit-text and code-review agent skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ Load the relevant skill for the task at hand:
 - **Run tests / lint** → `skills/leapp-test-runner/`
 - **Write or fix unit tests** → `skills/leapp-unit-tests/`
 - **Develop or modify actors** → `skills/leapp-actor-dev/`
+- **Draft commit / PR text** → `skills/leapp-commit-message-assist/`
+- **Review code / PRs** → `skills/leapp-code-review/`
 
 
 ## Definition of Done

--- a/skills/leapp-code-review/SKILL.md
+++ b/skills/leapp-code-review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: leapp-code-review
+description: >-
+  Review leapp-repository code changes and pull requests for upgrade safety,
+  actor design, inhibitors, tests, and project conventions. Use when reviewing
+  a PR, a branch, a diff, or when the user asks for a code review.
+---
+
+# Code review (leapp-repository)
+
+## Scope
+
+Find problems in a change set. Sort by importance.
+
+Do not repeat rules from other skills — cite the skill and explain why the diff breaks the rule. Related skills:
+- Actor structure, phases, placement, Python versions: `skills/leapp-actor-dev/` + `AGENTS.md`
+- Unit tests: `skills/leapp-unit-tests/`
+- Running lint/tests: `skills/leapp-test-runner/`
+- Commit/PR text: `skills/leapp-commit-message-assist/`
+
+Load a linked skill only when a specific finding needs the full rule.
+
+Do not push, merge, or create PRs unless the user asks.
+
+## Workflow
+
+1. Get the full change set: PR URL, `git diff <base>...HEAD`, or files the user points at. Use the full branch diff, not only the latest commit.
+2. Read PR description and commit messages for intent. Flag missing context; point to `leapp-commit-message-assist` for rewording.
+3. Check the diff against the checklist below.
+4. Run unit tests for affected actors (`skills/leapp-test-runner/`) and verify they pass.
+5. Report findings using the output format. Start with blockers.
+6. When uncertain, state confidence: `[Certain]` / `[Likely]` / `[Speculative]`.
+
+## Output format
+
+```markdown
+## Summary
+<1-3 sentences: what the change does and whether it is ready>
+
+## Findings
+
+### Blockers (upgrade will fail or produce wrong result)
+- **[area]** <problem> — <why it matters> — <how to fix> (cite skill if needed)
+
+### Major (wrong pattern, weak tests, unclear reports)
+- ...
+
+### Minor (style, naming — skip if trivial)
+- ...
+
+### Questions
+- ...
+```
+
+Prefer fewer important comments over many small style notes.
+
+## Review checklist
+
+### Upgrade safety (primary focus)
+
+- [ ] Blocking conditions use inhibitors (`reporting.Groups.INHIBITOR`)
+- [ ] Non-blocking issues are reported, not silently ignored
+- [ ] Report text tells the operator what is wrong and how to fix it
+- [ ] Edge cases handled: missing files, empty messages, partial configs, unexpected architectures or versions
+- [ ] External command failures caught (`CalledProcessError`; `OSError` when the binary may be missing)
+- [ ] Environment variables use `LEAPP_` prefix and `get_env`, not bare `os.environ` (bare env does not survive reboots)
+
+### Actor design (cite `leapp-actor-dev` / `AGENTS.md`)
+
+- [ ] Facts collection vs. decision/inhibit/modify are in the correct actors and phases
+- [ ] Consumed/produced models match `api.consume` / `api.produce` usage; producer runs before consumer
+- [ ] No new models or utilities that duplicate what already exists
+- [ ] Change is limited to the stated problem; no unrelated edits
+
+### Commit structure and granularity
+
+- [ ] Each commit is one logical unit, independently revertable without breaking `main`
+- [ ] Fewer well-structured commits preferred over many trivial ones
+- [ ] Fixups are squashed before review (suggest `git commit --fixup` + autosquash rebase if not)
+- [ ] Total commit count reasonable (under ~15)
+- [ ] Multi-actor features grouped logically (e.g. models, then scanner, then checker)
+- [ ] Commit messages have a body, not just a title — point to `leapp-commit-message-assist` for help
+- [ ] Remind the developer to consider adding a Jira/issue reference if none is present
+
+### Test coverage (cite `leapp-unit-tests`)
+
+- [ ] Important behavior is tested (especially inhibitor and report paths), not just "no exception"
+- [ ] Assertions check produced models, report flags, or outcomes
+- [ ] Missing test cases called out as concrete scenarios, not just "add more tests"
+
+## Reference
+
+- [Coding guidelines](https://leapp-repository.readthedocs.io/latest/contributing/coding-guidelines.html)
+- [Phases overview](https://leapp-repository.readthedocs.io/latest/upgrade-architecture-and-workflow/phases-overview.html)

--- a/skills/leapp-commit-message-assist/SKILL.md
+++ b/skills/leapp-commit-message-assist/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: leapp-commit-message-assist
+description: >-
+  Draft and improve commit titles/bodies and PR descriptions for leapp-repository.
+  Use when the user asks for commit message help, PR description text, or wording
+  for a review-ready submission.
+---
+
+# Commit and PR text (advise only)
+
+## Scope and hard rules
+
+This skill **only** helps with wording and structure:
+
+- Commit titles and bodies
+- PR description text
+
+**Do not** (unless the user explicitly requests it):
+
+- Run `git commit`, `git push`, or create a PR (`gh pr create`)
+- Rebase, squash, or rewrite history on the user's behalf
+- Assume a multi-commit series is needed for a small change
+
+Default output: propose the text; let the user apply it.
+
+For code quality review of a diff/PR, use `skills/leapp-code-review/` instead.
+For how to write actors/tests, use `skills/leapp-actor-dev/` and `skills/leapp-unit-tests/`.
+
+## Workflow
+
+1. Identify the specific commit the user wants to (re)write a message for (`git show`, `git log -1`, or the diff they point at).
+2. Infer the problem solved and the approach — prefer *why* over a file list.
+3. Draft the commit message and/or PR description using the formats below.
+4. If the message is weak (title-only, no body), say what to fix and offer rewritten text.
+
+## Commit message format
+
+Every commit ready for review needs a title and a body. WIP/fixup commits that will be squashed before review may omit the body.
+
+### Title
+
+- Imperative mood, concise (≤72 chars)
+- Optional scope prefix for path-specific changes: `el8toel9: actorname: Summary`
+- Series prefix `[N/M]` only when the PR is a deliberate multi-commit progression
+
+### Body
+
+- Explain what problem is solved and how
+- Enough context that readers need not read the full diff
+- If the user provides a Jira/issue reference, place it as the last line using one of the formats below
+
+```
+Jira: RHEL-XXXXX
+```
+
+or
+
+```
+Jira-ref: RHEL-XXXXX
+```
+
+### Examples
+
+Single commit:
+
+```
+Add machine-id validation actors for in-place upgrade
+
+Introduced a scanner/checker actor pair that verifies /etc/machine-id
+exists and contains a valid 32-character hexadecimal identifier.
+The upgrade is inhibited if the file is missing or malformed, as
+a valid machine-id is required by systemd and the target userspace
+container creation.
+
+Jira: RHEL-50161
+```
+
+Series commit:
+
+```
+[3/9] targetcontentresolver: RepositoriesBlacklisted: use it as task
+
+Refactored RepositoriesBlacklisted to operate as a task model consumed
+by the target content resolver instead of being evaluated independently.
+This centralizes message consumption and simplifies dependency tracking.
+
+Jira: RHEL-115867
+```
+
+Scoped commit:
+
+```
+el8toel9: checkkernelarm: Install 64k kernel
+
+On RHEL 8 for ARM, the default kernel is 64k (pagesize) and there is
+no 4k alternative. On RHEL 9 the default kernel is 4k, but for 64k
+the kernel-64k RPMs need to be installed.
+
+JIRA: RHEL-111860
+```
+
+## PR description template
+
+```markdown
+## The reason for the change
+
+<motivation: the problem being solved or requirement being addressed>
+
+## What has been changed
+
+<concise summary of the introduced changes>
+
+## How it has been changed
+
+<implementation approach and key design decisions>
+
+## How to try/test the PR
+
+<steps for reviewers to try/verify — commands, scenarios, or expected output>
+
+## Reference to a Jira ticket
+
+- Jira: RHEL-XXXXX
+```
+
+Fill every section from the diff. Reviewers may decline poorly described PRs.
+
+## Reference
+
+- [PR and commit guidelines](https://leapp-repository.readthedocs.io/latest/contributing/pr-guidelines.html)


### PR DESCRIPTION
## The reason for the change

Agent workflows for leapp-repository need structured guidance for two common tasks: writing good commit/PR text that follows project conventions, and performing code reviews focused on upgrade safety. Dedicated skills ensure the agent produces consistent, high-quality output for each task.

## What has been changed

- Added `skills/leapp-commit-message-assist/` — helps draft commit titles, bodies, and PR descriptions following project conventions (advise-only; does not automate git/GitHub actions unless the user explicitly requests it)
- Added `skills/leapp-code-review/` — provides upgrade-focused code review with severity-ranked findings (Blockers / Major / Minor), citing existing actor-dev and unit-test skills instead of duplicating their rules
- Updated `AGENTS.md` to register both skills in the index

## How it has been changed

- Each skill is a standalone `SKILL.md` with frontmatter, scope definition, workflow steps, output format, and reference links.
- `leapp-code-review` cross-references other skills (`leapp-actor-dev`, `leapp-unit-tests`) for convention details rather than duplicating their rules.
- `leapp-commit-message-assist` includes the canonical commit message format, examples, granularity advice, and the PR description template.
- Both skills are registered in `AGENTS.md` under the Skills section so agents can discover them.

## How to try/test the PR

These skills work with any agent that loads AGENTS.md (Cursor, Claude Code, etc.).
1. Run: `Draft a commit message for this branch`
   - Expect: proposed commit title + body text; no `git commit` executed
2. Run: `Write the PR description for this branch`
   - Expect: proposed PR description following the project template; no PR created
3. Run: `Review this branch`
   - Expect: structured review output (Summary, Findings by severity, Suggested checks); no push/merge
4. Verify `AGENTS.md` lists both skill paths under the Skills section
