### PR TITLE
mount_unit_generator: Treat pseudo FS mount units as nofail

### DIFF
--- a/repos/system_upgrade/common/actors/initramfs/mount_units_generator/libraries/mount_unit_generator.py
+++ b/repos/system_upgrade/common/actors/initramfs/mount_units_generator/libraries/mount_unit_generator.py
@@ -9,6 +9,28 @@ from leapp.models import LiveModeConfig, StorageInfo, TargetUserSpaceInfo, Upgra
 
 BIND_MOUNT_SYSROOT_BOOT_UNIT = 'boot.mount'
 
+# Virtual/pseudo filesystem types that should be treated as nofail during the upgrade initramfs phase.
+# Their mount units are kept but placed only in .wants (not .requires) directories, so systemd
+# will attempt to mount them but continue booting if the mount fails (e.g. mount point does not
+# exist under /sysroot).
+PSEUDO_FS_TYPES = frozenset([
+    'hugetlbfs',
+    'tmpfs',
+    'devtmpfs',
+    'devpts',
+    'sysfs',
+    'proc',
+    'cgroup',
+    'cgroup2',
+    'securityfs',
+    'selinuxfs',
+    'debugfs',
+    'mqueue',
+    'pstore',
+    'efivarfs',
+    'bpf',
+])
+
 
 def run_systemd_fstab_generator(output_directory):
     api.current_logger().debug(
@@ -110,25 +132,33 @@ def prefix_all_mount_units_with_sysroot(dir_containing_units):
         api.current_logger().debug('Original mount unit {} removed.'.format(unit_file_path))
 
 
-def is_unit_marked_with_nofail(unit_path: str) -> bool:
+def parse_unit(unit_path: str) -> dict:
     try:
         with open(unit_path) as in_file:
             lines = [line.strip() for line in in_file.readlines()]
     except OSError:
         api.current_logger().debug(
-            'Could not read the unit {} to determine whether it is nofail.'.format(unit_path)
+            'Could not read the unit {} to parse it contents.'.format(unit_path)
         )
-        return False  # This way, the unit will end up in target's '.requires', so it is a safe choice
+        return {}
+
+    unit_properties = {}
 
     for line in lines:
+        if not line.startswith(('Options', 'Type')):
+            continue
+        line_fragments = line.split('=', 1)
+        if len(line_fragments) <= 1:
+            continue  # Should not happen
+
+        option_value = [opt.strip() for opt in line_fragments[1].split(',')]
+
         if line.startswith('Options'):
-            line_fragments = line.split('=', 1)
-            if len(line_fragments) <= 1:
-                continue  # Should not happen
-            used_options = [opt.strip() for opt in line_fragments[1].split(',')]
-            if 'nofail' in used_options:
-                return True
-    return False
+            unit_properties['Options'] = option_value
+        elif line.startswith('Type'):
+            unit_properties['Type'] = option_value[0]
+
+    return unit_properties
 
 
 def _fix_symlinks_in_dir(dir_containing_mount_units, target_dir):
@@ -164,8 +194,11 @@ def _fix_symlinks_in_dir(dir_containing_mount_units, target_dir):
         if not unit_file.endswith('.mount'):
             continue
 
-        is_nofail = is_unit_marked_with_nofail(os.path.join(dir_containing_mount_units, unit_file))
-        if is_nofail and will_units_be_required:
+        unit_full_path = os.path.join(dir_containing_mount_units, unit_file)
+        unit_properties = parse_unit(unit_full_path)
+        is_nofail = 'nofail' in unit_properties.get('Options', tuple())
+        is_pseudo_fs = unit_properties.get('Type') in PSEUDO_FS_TYPES
+        if (is_nofail or is_pseudo_fs) and will_units_be_required:
             continue
 
         place_fastlink_at = os.path.join(target_dir_path, unit_file)
@@ -226,6 +259,7 @@ def fix_symlinks_in_targets(dir_containing_mount_units):
         'remote-fs-pre.target.requires',
         'remote-fs-pre.target.wants',
     ]
+
     for tdir in dir_list:
         _fix_symlinks_in_dir(dir_containing_mount_units, tdir)
 

--- a/repos/system_upgrade/common/actors/initramfs/mount_units_generator/tests/test_mount_unit_generation.py
+++ b/repos/system_upgrade/common/actors/initramfs/mount_units_generator/tests/test_mount_unit_generation.py
@@ -134,6 +134,50 @@ def test_prefix_all_mount_units_with_sysroot(monkeypatch):
         assert should_be_deleted == was_deleted
 
 
+def test_parse_unit_missing_file(monkeypatch, leapp_tmpdir):
+    """A non-existent unit file results in an empty dict without raising."""
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    unit_path = os.path.join(leapp_tmpdir, 'does-not-exist.mount')
+
+    assert mount_unit_generator.parse_unit(unit_path) == {}
+    assert api.current_logger.dbgmsg
+
+
+def test_parse_unit_parses_options_and_type(leapp_tmpdir):
+    """Options and Type keys are extracted, Options being split into a list."""
+    unit_path = os.path.join(leapp_tmpdir, 'home.mount')
+    with open(unit_path, 'w') as unit_file:
+        unit_file.write(
+            '[Unit]\n'
+            'Description=Mount unit for /home\n'
+            '\n'
+            '[Mount]\n'
+            'What=/dev/sda1\n'
+            'Where=/home\n'
+            'Type=xfs\n'
+            'Options=defaults,nofail,x-systemd.device-timeout=0\n'
+        )
+
+    unit_properties = mount_unit_generator.parse_unit(unit_path)
+
+    assert unit_properties == {
+        'Type': 'xfs',
+        'Options': ['defaults', 'nofail', 'x-systemd.device-timeout=0'],
+    }
+
+
+def test_parse_unit_strips_whitespace_around_options(leapp_tmpdir):
+    """Whitespace surrounding comma-separated Options values is stripped."""
+    unit_path = os.path.join(leapp_tmpdir, 'var.mount')
+    with open(unit_path, 'w') as unit_file:
+        unit_file.write('Options = nofail , x-systemd.device-timeout=0 \n')
+
+    unit_properties = mount_unit_generator.parse_unit(unit_path)
+
+    assert unit_properties == {'Options': ['nofail', 'x-systemd.device-timeout=0']}
+
+
 @pytest.mark.parametrize('dirname', (
     'local-fs.target.requires',
     'local-fs.target.wants',
@@ -328,18 +372,56 @@ def test_injection_of_sysroot_boot_bindmount_unit(monkeypatch, has_separate_boot
         assert was_copyfile_for_sysroot_boot_called
 
 
-TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'files')
+@pytest.mark.parametrize('dirname', (
+    'local-fs.target.requires',
+    'local-fs.target.wants',
+))
+def test_fix_symlinks_in_dir_skips_pseudo_fs_in_requires(monkeypatch, dirname):
+    """Pseudo FS mount units should be excluded from .requires directories."""
 
+    DIR_PATH = os.path.join('/test/dir/', dirname)
 
-@pytest.mark.parametrize(
-    ('unit_filename', 'is_nofail'),
-    [
-        ('unit.mount', False),
-        ('unit-nofail.mount', True),
-        ('non-existing-unit.mount', False),  # This file does not exist in the files/
+    def mock_rmtree(dir_path):
+        assert dir_path == DIR_PATH
+
+    def mock_mkdir(dir_path):
+        assert dir_path == DIR_PATH
+
+    def mock_listdir(dir_path):
+        return ['sysroot-home.mount', 'sysroot-hugepages.mount', 'not-a-mount.service', 'sysroot-nofail.mount']
+
+    def mock_os_path_exist(dir_path):
+        assert dir_path == DIR_PATH
+        return dir_path == DIR_PATH
+
+    def mock_parse_unit(unit_path):
+        return {
+            'Type': 'hugetlbfs' if 'hugepages' in unit_path else 'xfs',
+            'Options': ['nofail'] if 'nofail' in unit_path else ['']
+        }
+
+    expected_calls = [
+        ['ln', '-s', '../sysroot-home.mount', os.path.join(DIR_PATH, 'sysroot-home.mount')],
     ]
-)
-def test_is_unit_marked_with_nofail(unit_filename, is_nofail):
-    unit_path = os.path.join(TEST_DIR, unit_filename)
-    determined_no_fail = mount_unit_generator.is_unit_marked_with_nofail(unit_path)
-    assert determined_no_fail == is_nofail
+    if dirname.endswith('.wants'):
+        expected_calls.extend((
+            ['ln', '-s', '../sysroot-hugepages.mount', os.path.join(DIR_PATH, 'sysroot-hugepages.mount')],
+            ['ln', '-s', '../sysroot-nofail.mount', os.path.join(DIR_PATH, 'sysroot-nofail.mount')]
+        ))
+
+    def mock_run(command):
+        assert command in expected_calls
+        return {
+            "stdout": "",
+            "stderr": "",
+            "exit_code": 0,
+        }
+
+    monkeypatch.setattr('shutil.rmtree', mock_rmtree)
+    monkeypatch.setattr('os.mkdir', mock_mkdir)
+    monkeypatch.setattr('os.listdir', mock_listdir)
+    monkeypatch.setattr('os.path.exists', mock_os_path_exist)
+    monkeypatch.setattr(mount_unit_generator, 'run', mock_run)
+    monkeypatch.setattr(mount_unit_generator, 'parse_unit', mock_parse_unit)
+
+    mount_unit_generator._fix_symlinks_in_dir('/test/dir', dirname)


### PR DESCRIPTION
systemd-fstab-generator converts every /etc/fstab entry into a systemd mount unit. MountUnitGenerator then prefixes each unit's Where= path with /sysroot before bundling them into the upgrade initramfs. For virtual/pseudo filesystem entries such as hugetlbfs (e.g. /dev/hugepages2M, /dev/hugepages1G) the corresponding directories may not exist under /sysroot.

Instead of removing these units entirely, treat them like nofail: keep the mount units but ensure they only end up in .wants directories (not .requires). This way systemd will attempt to mount the pseudo filesystems during the upgrade initramfs boot, but if a mount fails the boot continues. This is appropriate because the main reasons for having pseudo FS entries in fstab (security hardening, performance tuning, application-specific mounts) do not apply during the upgrade phase.

To make this work, fix_symlinks_in_targets now ensures .wants directories exist for each target that has a .requires directory, since systemd-fstab-generator only creates .wants for fstab entries with the nofail option.

Resolves: RHEL-180965, RHEL-16320