### PR TITLE
transitionsystemdservicesstates: Fix reports containing incorrect services

### DIFF
--- a/repos/system_upgrade/common/actors/systemd/transitionsystemdservicesstates/libraries/transitionsystemdservicesstates.py
+++ b/repos/system_upgrade/common/actors/systemd/transitionsystemdservicesstates/libraries/transitionsystemdservicesstates.py
@@ -158,16 +158,16 @@ def _get_required_tasks(services_target, desired_states):
     return tasks
 
 
-def _report_kept_enabled(tasks):
+def _report_kept_enabled(explicitly):
     summary = (
         "Systemd services which were enabled on the system before the upgrade"
         " were kept enabled after the upgrade. "
     )
-    if tasks.to_enable:
+    if explicitly:
         summary += (
             "The following services were originally disabled by preset on the"
             " upgraded system and Leapp attempted to enable them:{}{}"
-        ).format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(sorted(tasks.to_enable)))
+        ).format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(sorted(explicitly)))
         # TODO(mmatuska): When post-upgrade reports are implemented in
         # `setsystemdservicesstates actor, add a note here to check the reports
         # if the enabling failed
@@ -183,6 +183,14 @@ def _report_kept_enabled(tasks):
 
 
 def _get_newly_enabled(services_source, desired_states):
+    """
+    Get services that are newly enabled on the target.
+
+    Newly enabled services are those that were disabled on the source and the
+    preset on target is 'enable'.
+    """
+    # Newly can be enabled either by leapp or just by preset/scriptlet etc.
+    # So just check what the desired state is.
     newly_enabled = []
     for service, state in desired_states.items():
         state_source = services_source[service]
@@ -244,7 +252,16 @@ def process():
     tasks = _get_required_tasks(services_target, desired_states)
 
     api.produce(tasks)
-    _report_kept_enabled(tasks)
+
+    # if a task was produced to enable the service it means it was disabled in
+    # target and the desired state was enabled. If the preset was 'disable' then
+    # it should be explicitly mentioned in the report that leapp tried to enable it.
+    kept_enabled = [
+        service
+        for service in tasks.to_enable
+        if presets_target.get(service) == "disable"
+    ]
+    _report_kept_enabled(explicitly=kept_enabled)
 
     newly_enabled = _get_newly_enabled(services_source, desired_states)
     _report_newly_enabled(newly_enabled)

--- a/repos/system_upgrade/common/actors/systemd/transitionsystemdservicesstates/tests/test_transitionsystemdservicesstates.py
+++ b/repos/system_upgrade/common/actors/systemd/transitionsystemdservicesstates/tests/test_transitionsystemdservicesstates.py
@@ -129,43 +129,47 @@ def test_service_preset_missing_presets(presets):
 
 
 def test_tasks_produced_reports_created(monkeypatch):
+    """
+    Test that reports are created and contain the right services
+    """
     services_source = [
         SystemdServiceFile(name="rsyncd.service", state="enabled"),
-        SystemdServiceFile(name="test.service", state="enabled"),
+        SystemdServiceFile(name="all_enabled.service", state="enabled"),
         SystemdServiceFile(name="newly_enabled.service", state="disabled"),
+        SystemdServiceFile(name="enabled_by_preset.service", state="disabled"),
+        SystemdServiceFile(name="enabled_despite_target_preset_disable.service", state="enabled"),
     ]
-    service_info_source = SystemdServicesInfoSource(service_files=services_source)
-
     presets_source = [
         SystemdServicePreset(service="rsyncd.service", state="enable"),
-        SystemdServicePreset(service="test.service", state="enable"),
+        SystemdServicePreset(service="all_enabled.service", state="enable"),
         SystemdServicePreset(service="newly_enabled.service", state="disable"),
+        SystemdServicePreset(service="enabled_by_preset.service", state="disable"),
+        SystemdServicePreset(service="enabled_despite_target_preset_disable.service", state="enable"),
     ]
-    preset_info_source = SystemdServicesPresetInfoSource(presets=presets_source)
-
     services_target = [
         SystemdServiceFile(name="rsyncd.service", state="disabled"),
-        SystemdServiceFile(name="test.service", state="enabled"),
+        SystemdServiceFile(name="all_enabled.service", state="enabled"),
         SystemdServiceFile(name="newly_enabled.service", state="enabled"),
+        SystemdServiceFile(name="enabled_by_preset.service", state="disabled"),
+        SystemdServiceFile(name="enabled_despite_target_preset_disable.service", state="disabled"),
     ]
-    service_info_target = SystemdServicesInfoTarget(service_files=services_target)
-
     presets_target = [
         SystemdServicePreset(service="rsyncd.service", state="enable"),
-        SystemdServicePreset(service="test.service", state="enable"),
+        SystemdServicePreset(service="all_enabled.service", state="enable"),
         SystemdServicePreset(service="newly_enabled.service", state="enable"),
+        SystemdServicePreset(service="enabled_by_preset.service", state="enable"),
+        SystemdServicePreset(service="enabled_despite_target_preset_disable.service", state="disable"),
     ]
-    preset_info_target = SystemdServicesPresetInfoTarget(presets=presets_target)
 
     monkeypatch.setattr(
         api,
         "current_actor",
         CurrentActorMocked(
             msgs=[
-                service_info_source,
-                service_info_target,
-                preset_info_source,
-                preset_info_target,
+                SystemdServicesInfoSource(service_files=services_source),
+                SystemdServicesInfoTarget(service_files=services_target),
+                SystemdServicesPresetInfoSource(presets=presets_source),
+                SystemdServicesPresetInfoTarget(presets=presets_target),
             ]
         ),
     )
@@ -173,34 +177,46 @@ def test_tasks_produced_reports_created(monkeypatch):
     created_reports = create_report_mocked()
     monkeypatch.setattr(reporting, "create_report", created_reports)
 
-    expected_tasks = SystemdServicesTasks(to_enable=["rsyncd.service"], to_disable=[])
     transitionsystemdservicesstates.process()
 
     assert created_reports.called == 2
+    reports = {r["title"]: r["summary"] for r in created_reports.reports}
+
+    newly_enabled_summary = reports["Some systemd services were newly enabled"]
+    assert "newly_enabled.service" in newly_enabled_summary
+    assert "enabled_by_preset.service" in newly_enabled_summary
+    for s in ["rsyncd.service", "all_enabled.service", "enabled_despite_target_preset_disable.service"]:
+        assert s not in newly_enabled_summary
+
+    kept_enabled_summary = reports["Previously enabled systemd services were kept enabled"]
+    assert "enabled_despite_target_preset_disable.service" in kept_enabled_summary
+    # rsyncd is covered by the generic part of the kept enabled report, not listed explicitly
+    for s in ["rsyncd.service", "all_enabled.service", "newly_enabled.service", "enabled_by_preset.service"]:
+        assert s not in kept_enabled_summary
+
     assert api.produce.called
-    assert api.produce.model_instances[0].to_enable == expected_tasks.to_enable
-    assert api.produce.model_instances[0].to_disable == expected_tasks.to_disable
+    produced_tasks = api.produce.model_instances[0]
+    assert produced_tasks.to_enable == [
+        "rsyncd.service",
+        "enabled_by_preset.service",
+        "enabled_despite_target_preset_disable.service",
+    ]
+    assert produced_tasks.to_disable == []
 
 
 @pytest.mark.parametrize(
-    "tasks, expect_extended_summary",
+    "services, expect_extended_summary",
     (
-        (
-            SystemdServicesTasks(
-                to_enable=["test.service", "other.service"],
-                to_disable=["another.service"],
-            ),
-            True,
-        ),
-        (SystemdServicesTasks(), False),
-        (SystemdServicesTasks(to_enable=[], to_disable=["some.service"]), False),
+        (['explictly-enabled.service', 'explictly-enabled2.service'], True),
+        (['explictly-enabled.service'], True),
+        ([], False),
     ),
 )
-def test_report_kept_enabled(monkeypatch, tasks, expect_extended_summary):
+def test_report_kept_enabled(monkeypatch, services, expect_extended_summary):
     created_reports = create_report_mocked()
     monkeypatch.setattr(reporting, "create_report", created_reports)
 
-    transitionsystemdservicesstates._report_kept_enabled(tasks)
+    transitionsystemdservicesstates._report_kept_enabled(services)
 
     extended_summary_str = (
         "The following services were originally disabled by preset on the"
@@ -210,7 +226,7 @@ def test_report_kept_enabled(monkeypatch, tasks, expect_extended_summary):
     assert created_reports.called == 1
     if expect_extended_summary:
         assert extended_summary_str in created_reports.report_fields["summary"]
-        all(s in created_reports.report_fields['summary'] for s in tasks.to_enable)
+        assert all(s in created_reports.report_fields['summary'] for s in services)
     else:
         assert extended_summary_str not in created_reports.report_fields["summary"]
 


### PR DESCRIPTION
### keeping this as draft until we decide if it can go into the release

There is a bug in how 'newly enabled' and 'kept enabled' services are
reported in the transition_systemd_services_states actor which causes
services with particular states and presets on source and target to be
incorrectly included in both reports.

For example, the following service is 'newly enabled' - it was not
enabled on source system, it is not enabled on the target system, but a
preset from the target system is 'enable', therefore leapp will try to
enable the service via
SystemdServicesTasks(to_enable='systemd-sysext.service) task:

    [root@localhost ~]# leapp-inspector messages | grep -i -C 2 -e sysext.service -e 'Type: SystemdServices'
    Actor: scan_systemd_source
    Phase: FactsCollection
    Type: SystemdServicesInfoSource
    Message_data:
    {
    --
            },
            {
                "name": "systemd-sysext.service",
                "state": "disabled"
            },
    --
    Actor: scan_systemd_source
    Phase: FactsCollection
    Type: SystemdServicesPresetInfoSource
    Message_data:
    {
    --
            },
            {
                "service": "systemd-sysext.service",
                "state": "disable"
            },
    --
    Actor: scan_systemd_target
    Phase: Applications
    Type: SystemdServicesInfoTarget
    Message_data:
    {
    --
            },
            {
                "name": "systemd-sysext.service",
                "state": "disabled"
            },
    --
    Actor: scan_systemd_target
    Phase: Applications
    Type: SystemdServicesPresetInfoTarget
    Message_data:
    {
    --
            },
            {
                "service": "systemd-sysext.service",
                "state": "enable"
            },
    --
    Actor: transition_systemd_services_states
    Phase: Applications
    Type: SystemdServicesTasks
    Message_data:
    {
    --
        "to_enable": [
            "rpmdb-rebuild.service",
            "systemd-sysext.service"
        ]
    }
    --

however, it is also included in the 'kept enabled' report
(rpmdb-rebuild.service is the same case):

    ----------------------------------------
    Risk Factor: info
    Title: Previously enabled systemd services were kept enabled
    Summary: Systemd services which were enabled on the system before the upgrade were kept enabled after the upgrade. The following services were originally disabled by preset on the upgraded system and Leapp attempted to enable them:
        - rpmdb-rebuild.service
        - systemd-sysext.service
    Key: 8b6e3847f69e1d18f05a56eb6243a7c5f6d9cebf
    ----------------------------------------
    Risk Factor: info
    Title: Some systemd services were newly enabled
    Summary: The following services were disabled before the upgrade and were set to enabled by a systemd preset after the upgrade:
        - rpmdb-rebuild.service
        - systemd-sysext.service
    Key: 13935017e49d814d7d40c4de87321d1726e5e16b

This patch fixes how 'kept enabled' services are determined so that they
don't include service which were in fact 'newly enabled':

    ----------------------------------------
    Risk Factor: info
    Title: Previously enabled systemd services were kept enabled
    Summary: Systemd services which were enabled on the system before the upgrade were kept enabled after the upgrade.
    Key: 8b6e3847f69e1d18f05a56eb6243a7c5f6d9cebf
    ----------------------------------------
    Risk Factor: info
    Title: Some systemd services were newly enabled
    Summary: The following services were disabled before the upgrade and were set to enabled by a systemd preset after the upgrade:
        - rpmdb-rebuild.service
        - systemd-sysext.service
    Key: 13935017e49d814d7d40c4de87321d1726e5e16b

Also updated a test to ensure the services are contained in the right
report.