### PR TITLE
Add Vim /etc/virc migration actor for el8toel9 upgrade

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/vircmodifier/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/vircmodifier/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import vircmodifier
+from leapp.models import VircConfig
+from leapp.tags import ApplicationsPhaseTag, IPUWorkflowTag
+
+
+class VircModifier(Actor):
+    """
+    Remove obsolete lines from /etc/virc during RHEL 8 to 9 upgrade.
+
+    Consumes VircConfig produced by VircScanner and removes the flagged lines.
+    """
+
+    name = 'virc_modifier'
+    consumes = (VircConfig,)
+    produces = ()
+    tags = (IPUWorkflowTag, ApplicationsPhaseTag,)
+
+    def process(self):
+        vircmodifier.process(self.consume(VircConfig))

--- a/repos/system_upgrade/el8toel9/actors/vircmodifier/libraries/vircmodifier.py
+++ b/repos/system_upgrade/el8toel9/actors/vircmodifier/libraries/vircmodifier.py
@@ -1,0 +1,29 @@
+from leapp.libraries.stdlib import api
+
+
+def process(virc_messages):
+    """
+    Remove lines flagged by VircScanner from /etc/virc.
+    """
+    config = next(virc_messages, None)
+    if list(virc_messages):
+        api.current_logger().warning('Unexpectedly received more than one VircConfig message.')
+    if not config or not config.lines_to_remove:
+        return
+
+    to_remove = set(config.lines_to_remove)
+
+    try:
+        with open(config.path, 'r') as f:
+            lines = f.readlines()
+    except (OSError, IOError) as error:
+        api.current_logger().warning('Could not read {}: {}'.format(config.path, error))
+        return
+
+    filtered = [line for line in lines if line not in to_remove]
+
+    try:
+        with open(config.path, 'w') as f:
+            f.writelines(filtered)
+    except (OSError, IOError) as error:
+        api.current_logger().warning('Could not write {}: {}'.format(config.path, error))

--- a/repos/system_upgrade/el8toel9/actors/vircmodifier/tests/test_vircmodifier.py
+++ b/repos/system_upgrade/el8toel9/actors/vircmodifier/tests/test_vircmodifier.py
@@ -1,0 +1,115 @@
+import pytest
+
+from leapp.libraries.actor import vircmodifier
+from leapp.libraries.common.testutils import CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import VircConfig
+
+VIRC_CONTENT = (
+    'set nocompatible\n'
+    'set history=50\n'
+    'filetype plugin on\n'
+    'let skip_defaults_vim=1\n'
+    'set ruler\n'
+)
+
+VIRC_EXPECTED = (
+    'set nocompatible\n'
+    'set history=50\n'
+    'set ruler\n'
+)
+
+VIRC_ONLY_FILETYPE = (
+    'set nocompatible\n'
+    'set history=50\n'
+    'filetype plugin on\n'
+    'set ruler\n'
+)
+
+VIRC_WHITESPACE_CONTENT = (
+    'set nocompatible\n'
+    'set history=50\n'
+    '  filetype  plugin on  \n'
+    '\tlet skip_defaults_vim=1\t\n'
+    'set ruler\n'
+)
+
+
+class MockFile:
+    def __init__(self, content=''):
+        self.content = content
+
+    def readlines(self):
+        return self.content.splitlines(True)
+
+    def writelines(self, lines):
+        self.content = ''.join(lines)
+
+    def mock_open(self, path, mode='r'):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+def test_both_lines_removed(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    mock_file = MockFile(VIRC_CONTENT)
+    monkeypatch.setattr(vircmodifier, 'open', mock_file.mock_open, raising=False)
+    config = VircConfig(path='/etc/virc', lines_to_remove=['filetype plugin on\n', 'let skip_defaults_vim=1\n'])
+    vircmodifier.process(iter([config]))
+    assert mock_file.content == VIRC_EXPECTED
+
+
+def test_whitespace_lines_removed(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    mock_file = MockFile(VIRC_WHITESPACE_CONTENT)
+    monkeypatch.setattr(vircmodifier, 'open', mock_file.mock_open, raising=False)
+    config = VircConfig(
+        path='/etc/virc',
+        lines_to_remove=['  filetype  plugin on  \n', '\tlet skip_defaults_vim=1\t\n']
+    )
+    vircmodifier.process(iter([config]))
+    assert mock_file.content == VIRC_EXPECTED
+
+
+def test_single_line_removed(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    mock_file = MockFile(VIRC_ONLY_FILETYPE)
+    monkeypatch.setattr(vircmodifier, 'open', mock_file.mock_open, raising=False)
+    config = VircConfig(path='/etc/virc', lines_to_remove=['filetype plugin on\n'])
+    vircmodifier.process(iter([config]))
+    assert mock_file.content == VIRC_EXPECTED
+
+
+def test_empty_lines_to_remove(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    mock_file = MockFile(VIRC_EXPECTED)
+    monkeypatch.setattr(vircmodifier, 'open', mock_file.mock_open, raising=False)
+    config = VircConfig(path='/etc/virc', lines_to_remove=[])
+    vircmodifier.process(iter([config]))
+    assert mock_file.content == VIRC_EXPECTED
+
+
+def test_no_virc_config_message(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    mock_file = MockFile('')
+    monkeypatch.setattr(vircmodifier, 'open', mock_file.mock_open, raising=False)
+    vircmodifier.process(iter([]))
+    assert mock_file.content == ''
+
+
+def test_read_error(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    mock_file = MockFile(VIRC_CONTENT)
+
+    def _mock_open_error(path, mode='r'):
+        raise OSError('Permission denied')
+
+    monkeypatch.setattr(vircmodifier, 'open', _mock_open_error, raising=False)
+    config = VircConfig(path='/etc/virc', lines_to_remove=['filetype plugin on\n'])
+    vircmodifier.process(iter([config]))
+    assert mock_file.content == VIRC_CONTENT

--- a/repos/system_upgrade/el8toel9/actors/vircscanner/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/vircscanner/actor.py
@@ -1,0 +1,21 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import vircscanner
+from leapp.models import DistributionSignedRPM, VircConfig
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class VircScanner(Actor):
+    """
+    Scan /etc/virc for lines that need to be removed during RHEL 8 to 9 upgrade.
+
+    Detects 'filetype plugin on' and 'let skip_defaults_vim=1' lines
+    and produces a VircConfig message for the modifier actor.
+    """
+
+    name = 'virc_scanner'
+    consumes = (DistributionSignedRPM,)
+    produces = (VircConfig,)
+    tags = (FactsPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        vircscanner.process(self)

--- a/repos/system_upgrade/el8toel9/actors/vircscanner/libraries/vircscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/vircscanner/libraries/vircscanner.py
@@ -1,0 +1,59 @@
+import os
+
+from leapp import reporting
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import DistributionSignedRPM, VircConfig
+
+VIRC_CONFIG = '/etc/virc'
+
+OPTIONS_TO_REMOVE = (
+    'filetype',
+    'let',
+)
+
+
+def _scan_virc(path):
+    """
+    Read virc and return the original (unstripped) lines whose stripped content
+    matches any entry in OPTIONS_TO_REMOVE.
+    """
+    try:
+        with open(path, 'r') as f:
+            lines = f.readlines()
+    except (OSError, IOError):
+        api.current_logger().warning('Could not read {}.'.format(path))
+        return []
+
+    return [line for line in lines if any(line.strip().startswith(option) for option in OPTIONS_TO_REMOVE)]
+
+
+def process(actor):
+    if not has_package(DistributionSignedRPM, 'vim-minimal'):
+        api.current_logger().debug('vim-minimal is not installed, skipping virc scan.')
+        return
+
+    if not os.path.isfile(VIRC_CONFIG):
+        api.current_logger().debug('{} does not exist, skipping virc scan.'.format(VIRC_CONFIG))
+        return
+
+    found = _scan_virc(VIRC_CONFIG)
+    if not found:
+        api.current_logger().debug('No lines to remove found in {}.'.format(VIRC_CONFIG))
+        return
+
+    actor.produce(VircConfig(path=VIRC_CONFIG, lines_to_remove=found))
+
+    reporting.create_report([
+        reporting.Title('Vim /etc/virc will be updated during upgrade'),
+        reporting.Summary(
+            'The following lines will be removed from {path} during the upgrade: {lines}'.format(
+                path=VIRC_CONFIG,
+                lines=', '.join('"{}"'.format(l) for l in found),
+            )
+        ),
+        reporting.Severity(reporting.Severity.INFO),
+        reporting.Groups([reporting.Groups.SERVICES]),
+        reporting.RelatedResource('package', 'vim-minimal'),
+        reporting.RelatedResource('file', VIRC_CONFIG),
+    ])

--- a/repos/system_upgrade/el8toel9/actors/vircscanner/tests/test_vircscanner.py
+++ b/repos/system_upgrade/el8toel9/actors/vircscanner/tests/test_vircscanner.py
@@ -1,0 +1,153 @@
+import os
+from io import StringIO
+
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import vircscanner
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import VircConfig
+
+VIRC_BOTH_LINES = (
+    'set nocompatible\n'
+    'set history=50\n'
+    'filetype plugin on\n'
+    'let skip_defaults_vim=1\n'
+    'let smth=1\n'
+)
+
+VIRC_ONLY_FILETYPE = (
+    'set nocompatible\n'
+    'filetype plugin on\n'
+    'set history=50\n'
+)
+
+VIRC_ONLY_SKIP = (
+    'set nocompatible\n'
+    'let skip_defaults_vim=1\n'
+)
+
+VIRC_NEITHER = (
+    'set nocompatible\n'
+    'set history=50\n'
+)
+
+VIRC_WHITESPACE = (
+    '  filetype plugin on  \n'
+    '\tlet skip_defaults_vim=1\t\n'
+    'filetype   plugin  on\n'
+    '  filetype plugin on\n'
+)
+
+
+class MockActor:
+    def __init__(self):
+        self.produced = []
+
+    def produce(self, msg):
+        self.produced.append(msg)
+
+
+def _mock_has_package(installed):
+    def _has_package(_model, pkg_name):
+        return pkg_name in installed
+    return _has_package
+
+
+def _mock_isfile(existing_files):
+    def _isfile(path):
+        return path in existing_files
+    return _isfile
+
+
+def _mock_open(content):
+    def _open(path, mode='r'):
+        return StringIO(content)
+    return _open
+
+
+def test_no_vim_minimal(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(vircscanner, 'has_package', _mock_has_package([]))
+    actor = MockActor()
+    vircscanner.process(actor)
+    assert not actor.produced
+
+
+def test_virc_not_exists(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(vircscanner, 'has_package', _mock_has_package(['vim-minimal']))
+    monkeypatch.setattr(os.path, 'isfile', _mock_isfile([]))
+    actor = MockActor()
+    vircscanner.process(actor)
+    assert not actor.produced
+
+
+def test_both_lines_present(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(vircscanner, 'has_package', _mock_has_package(['vim-minimal']))
+    monkeypatch.setattr(os.path, 'isfile', _mock_isfile(['/etc/virc']))
+    monkeypatch.setattr(vircscanner, 'open', _mock_open(VIRC_BOTH_LINES), raising=False)
+    actor = MockActor()
+    vircscanner.process(actor)
+    assert len(actor.produced) == 1
+    msg = actor.produced[0]
+    assert isinstance(msg, VircConfig)
+    assert len(msg.lines_to_remove) == 3
+    assert 'filetype plugin on\n' in msg.lines_to_remove
+    assert 'let skip_defaults_vim=1\n' in msg.lines_to_remove
+    assert 'let smth=1\n' in msg.lines_to_remove
+
+
+def test_only_filetype(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(vircscanner, 'has_package', _mock_has_package(['vim-minimal']))
+    monkeypatch.setattr(os.path, 'isfile', _mock_isfile(['/etc/virc']))
+    monkeypatch.setattr(vircscanner, 'open', _mock_open(VIRC_ONLY_FILETYPE), raising=False)
+    actor = MockActor()
+    vircscanner.process(actor)
+    assert len(actor.produced) == 1
+    assert len(actor.produced[0].lines_to_remove) == 1
+    assert 'filetype plugin on\n' in actor.produced[0].lines_to_remove
+
+
+def test_only_skip_defaults(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(vircscanner, 'has_package', _mock_has_package(['vim-minimal']))
+    monkeypatch.setattr(os.path, 'isfile', _mock_isfile(['/etc/virc']))
+    monkeypatch.setattr(vircscanner, 'open', _mock_open(VIRC_ONLY_SKIP), raising=False)
+    actor = MockActor()
+    vircscanner.process(actor)
+    assert len(actor.produced) == 1
+    assert len(actor.produced[0].lines_to_remove) == 1
+    assert 'let skip_defaults_vim=1\n' in actor.produced[0].lines_to_remove
+
+
+def test_neither_line_present(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(vircscanner, 'has_package', _mock_has_package(['vim-minimal']))
+    monkeypatch.setattr(os.path, 'isfile', _mock_isfile(['/etc/virc']))
+    monkeypatch.setattr(vircscanner, 'open', _mock_open(VIRC_NEITHER), raising=False)
+    actor = MockActor()
+    vircscanner.process(actor)
+    assert not actor.produced
+
+
+def test_lines_with_whitespace(monkeypatch):
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(vircscanner, 'has_package', _mock_has_package(['vim-minimal']))
+    monkeypatch.setattr(os.path, 'isfile', _mock_isfile(['/etc/virc']))
+    monkeypatch.setattr(vircscanner, 'open', _mock_open(VIRC_WHITESPACE), raising=False)
+    actor = MockActor()
+    vircscanner.process(actor)
+    assert len(actor.produced) == 1
+    assert len(actor.produced[0].lines_to_remove) == 4
+    assert 'filetype   plugin  on\n' in actor.produced[0].lines_to_remove
+    assert '  filetype plugin on\n' in actor.produced[0].lines_to_remove
+    assert '  filetype plugin on  \n' in actor.produced[0].lines_to_remove
+    assert '\tlet skip_defaults_vim=1\t\n' in actor.produced[0].lines_to_remove

--- a/repos/system_upgrade/el8toel9/models/vircconfig.py
+++ b/repos/system_upgrade/el8toel9/models/vircconfig.py
@@ -1,0 +1,14 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class VircConfig(Model):
+    """
+    Information about /etc/virc lines that need to be removed during upgrade.
+    """
+    topic = SystemInfoTopic
+
+    path = fields.String()
+    """ Path to the virc configuration file. """
+    lines_to_remove = fields.List(fields.String(), default=[])
+    """ Lines found in virc that should be removed during upgrade. """


### PR DESCRIPTION
Remove 'filetype plugin on' and 'let skip_defaults_vim=1' from /etc/virc during RHEL 8 to 9 in-place upgrade. Uses scanner/modifier pattern: vircscanner detects lines in FactsPhase, vircmodifier removes them in ApplicationsPhase.

Jira: RHEL-194363
Assisted-by: Claude Code