### PR TITLE
fix(targetcontentresolver): correctly form error details

### DIFF
--- a/repos/system_upgrade/common/actors/targetcontentresolver/libraries/targetcontentresolver.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/libraries/targetcontentresolver.py
@@ -40,7 +40,7 @@ class InputData():
                  message='Cannot calculate target content requirements',
                  details={
                      'details': 'Some of required leapp messages are missing.',
-                     'missing': [i.__name__ for i in self._missing_messages]
+                     'missing': ', '.join(i.__name__ for i in self._missing_messages)
                  }
             )
 


### PR DESCRIPTION
The `details` dict passed to `StopActorExecutionError` contained a list under the `missing` key, but the framework's `print_error` expects all detail values to be strings. This caused an `AttributeError` when upstream actors failed (e.g. due to misconfigured proxy), masking the real error with a traceback.

Jira: RHEL-193717