### PR TITLE
fix(arm_boot_workaround): run after transaction dry run

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/addarmbootloaderworkaround/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/addarmbootloaderworkaround/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor import addupgradebootloader
 from leapp.libraries.common.config import architecture
 from leapp.libraries.common.config.version import matches_target_version
-from leapp.models import ArmWorkaroundEFIBootloaderInfo, TargetUserSpaceInfo
+from leapp.models import ArmWorkaroundEFIBootloaderInfo, TargetUserSpaceInfo, TransactionDryRun
 from leapp.tags import InterimPreparationPhaseTag, IPUWorkflowTag
 
 
@@ -45,7 +45,7 @@ class AddArmBootloaderWorkaround(Actor):
     """
 
     name = 'add_arm_bootloader_workaround'
-    consumes = (TargetUserSpaceInfo,)
+    consumes = (TargetUserSpaceInfo, TransactionDryRun,)
     produces = (ArmWorkaroundEFIBootloaderInfo,)
     tags = (IPUWorkflowTag, InterimPreparationPhaseTag)
 


### PR DESCRIPTION
Previously, the only message consumed by the add_arm_bootloader_workaround actor was TargetUserSpaceInfo, meaning that the actor could be executed at any time in the InterimPreparationPhase. This is problematic in case that the dnf_dry_run actor finds that the transaction cannot be performed, e.g., because of an insufficient disk space as we would incorrectly modify the EFI boot order.

Jira-ref: RHEL-213986