### PR TITLE
Add symlink for automatic custom repository discovery

### DIFF
--- a/docs/source/tutorials/custom-content.md
+++ b/docs/source/tutorials/custom-content.md
@@ -72,18 +72,24 @@ git repo and register related leapp repositories using `snactor` manually. See
    only there.
    ```
 
-5. Create a symlink in `/etc/leapp/repos.d/` to register your repository for leapp:
+5. If you do not find an `/etc/leapp/repos.d/custom-repositories` symlink on
+   the system, create it manually:
    ```shell
-   ln -s /usr/share/leapp-repository/custom-repositories/<repository_name> /etc/leapp/repos.d/
+   ln -s /usr/share/leapp-repository/custom-repositories /etc/leapp/repos.d/custom-repositories
    ```
+
+   This symlink ensures that any leapp repository created under
+   `/usr/share/leapp-repository/custom-repositories/` is discovered by leapp
+   without any additional steps.
 
    ```{note}
-   This step is required to be done just on the system where the custom repository
-   is installed so leapp will discover the repository.
+   The symlink is nowadays part of upstream development packages and will be
+   part of `leapp-upgrade-*` RPM packages of v0.26.0 and newer.
    ```
 
-Note that such a created leapp repository can be installed to other systems as it is,
-just the symlink needs to be always created as well (step `5`).
+Note that such a created leapp repository can be installed to other systems as it is.
+Ensure the target system has the symlink (step 5) and the repository is placed under
+`/usr/share/leapp-repository/custom-repositories/`.
 
 ## Create custom actor
 

--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -299,6 +299,11 @@ do
     ln -s  %{repositorydir}/$REPOSITORY  %{buildroot}%{_sysconfdir}/leapp/repos.d/$REPOSITORY
 done;
 
+# Enable custom repository discovery - any leapp repository created under
+# custom-repositories/ will be automatically discovered by leapp without
+# requiring manual symlink creation.
+ln -s  %{custom_repositorydir}  %{buildroot}%{_sysconfdir}/leapp/repos.d/custom-repositories
+
 # __python2 could be problematic on systems with Python3 only, but we have
 # no choice as __python became error on F33+:
 #   https://fedoraproject.org/wiki/Changes/PythonMacroError


### PR DESCRIPTION
## The reason for the change
When customers create custom leapp repositories under
`/usr/share/leapp-repository/custom-repositories/`, they must manually
create a symlink in `/etc/leapp/repos.d/` for leapp to discover them
(step 5 in the custom content tutorial). This is error-prone and
frequently missed, leading to custom actors silently not being loaded
during in-place upgrades.


## What has been changed
- The RPM spec now creates a symlink from
 `/etc/leapp/repos.d/custom-repositories` to
 `/usr/share/leapp-repository/custom-repositories/` at install time,
 matching the existing pattern used for shipped repositories.
- The custom content tutorial (`docs/source/tutorials/custom-content.md`)
 is updated: step 5 now instructs users to verify the directory-level
  symlink exists and create it manually on systems where the RPM does not
  yet ship it (pre-v0.26.0). 

## How it has been changed
A single `ln -s` command was added to the `%install` section of
`packaging/leapp-repository.spec`, after the existing loop that creates
symlinks for shipped repositories. The symlink is picked up by the
existing `%{_sysconfdir}/leapp/repos.d/*` glob in `%files`, so no
additional packaging changes are needed.
The framework's `find_and_scan_repositories()` already handles this
correctly:
- `find -L` follows symlinks recursively, discovering `.leapp/` metadata
 under nested directories (same as the existing `system_upgrade` container).
- `RepositoryManager.add_repo()` keys by `repo_id` (UUID), so if a customer
 has both an old manual per-repo symlink and the new blanket symlink, the
 same repository is simply overwritten in the dict -- no duplicates or errors.

## How to try/test the PR
#### Step 1: Build the RPM:
`BUILD_CONTAINER=el9 make build_container`

#### Step 2: Install package on a test system and verify the symlink exists:
`ls -la /etc/leapp/repos.d/custom-repositories`

_Expected output:_ 
`custom-repositories -> /usr/share/leapp-repository/custom-repositories/`

#### Step 3: Create a custom repository and confirm automatic discovery

- Create a custom repo with proper links:
   ```
   cd /usr/share/leapp-repository/custom-repositories/
   snactor repo new my_test_repo
   cd my_test_repo
   snactor repo link --path /usr/share/leapp-repository/repositories/system_upgrade/common
   snactor repo link --path /usr/share/leapp-repository/repositories/common
   ```
- Verify the framework discovers it without any manual symlink:
   `find -L /etc/leapp/repos.d -name .leapp | grep my_test_repo`
   
   _Expected output:_ 
   `/etc/leapp/repos.d/custom-repositories/my_test_repo/.leapp`

- Verify leapp initializes the repository:
   `leapp preupgrade --debug 2>&1 | grep -i "my_test_repo"`

   _Expected:_ 
   Repository is initialized and loaded without any manual symlink.

#### Step 4: Verify backward compatibility with existing manual symlinks:
This verifies that a user who followed the old documentation (manually created a per-repo symlink) 
does not encounter errors after upgrading to the RPM that ships the blanket symlink.

- Simulate the pre-existing state by adding a manual per-repo symlink(as old documentation instructed)
   `ln -s /usr/share/leapp-repository/custom-repositories/my_test_repo /etc/leapp/repos.d/`

- Confirm both paths now exist:
   `ls -la /etc/leapp/repos.d/ | grep -E "my_test_repo|custom-repositories"`

   Expected output: 
   ```
   custom-repositories -> /usr/share/leapp-repository/custom-repositories/ 
   my_test_repo -> /usr/share/leapp-repository/custom-repositories/my_test_repo
   ```

- Verify the repo is reachable via both paths:
   `find -L /etc/leapp/repos.d -name .leapp | grep my_test_repo`

   _Expected output:_
   ```
   /etc/leapp/repos.d/my_test_repo/.leapp 
   /etc/leapp/repos.d/custom-repositories/my_test_repo/.leapp
   ```

- Verify leapp handles the duplicate gracefully:
   `leapp preupgrade --debug 2>&1 | grep -i "my_test_repo"`

   _Expected:_ 
   The repository appears as initialized exactly once. No errors about duplicate 
   repositories or actors. The framework deduplicates by repo_id (UUID from .leapp/info), 
   so the second scan silently overwrites the first.

## Reference to a Jira ticket
RHEL-95839