### PR TITLE
Add KCS article link to dynamic linker configuration report

### DIFF
--- a/repos/system_upgrade/common/actors/checkdynamiclinkerconfiguration/libraries/checkdynamiclinkerconfiguration.py
+++ b/repos/system_upgrade/common/actors/checkdynamiclinkerconfiguration/libraries/checkdynamiclinkerconfiguration.py
@@ -19,6 +19,11 @@ def _report_custom_dynamic_linker_configuration(summary):
         reporting.Remediation(hint=('Remove or revert the custom dynamic linker configurations and apply the changes '
                                     'using the ldconfig command. In case of possible active software collections we '
                                     'suggest disabling them persistently.')),
+        reporting.ExternalLink(
+            url='https://access.redhat.com/solutions/7130046',
+            title='Leapp upgrade command returns Error: No handle specified'
+                  ' with Message: Unable to install RHEL X userspace packages.'
+        ),
         reporting.RelatedResource('file', '/etc/ld.so.conf'),
         reporting.RelatedResource('directory', '/etc/ld.so.conf.d'),
         reporting.Severity(reporting.Severity.HIGH),

--- a/repos/system_upgrade/common/actors/checkdynamiclinkerconfiguration/tests/test_checkdynamiclinkerconfiguration.py
+++ b/repos/system_upgrade/common/actors/checkdynamiclinkerconfiguration/tests/test_checkdynamiclinkerconfiguration.py
@@ -47,6 +47,10 @@ def test_check_ld_so_configuration(monkeypatch, included_configs_modifications, 
 
     assert reporting.create_report.called == 1
     assert 'configuration for dynamic linker' in reporting.create_report.reports[0]['title']
+    external_links = reporting.create_report.reports[0].get('detail', {}).get('external', [])
+    assert any(
+        'https://access.redhat.com/solutions/7130046' in link.get('url', '') for link in external_links
+    )
     summary = reporting.create_report.reports[0]['summary']
 
     if any(included_configs_modifications):


### PR DESCRIPTION
## The reason for the change
Users experiencing a custom dynamic linker configuration hit a confusing
"Error: No handle specified" / "Unable to install RHEL X userspace packages"
failure during upgrade, with no guidance pointing them to the documented
resolution. The existing report ("Detected customized configuration for
dynamic linker") lacks a reference to the relevant KCS article.

## What has been changed
Added an external link to KCS article 7130046 in the dynamic linker
configuration report, and a corresponding test assertion.

## How it has been changed
- Added `reporting.ExternalLink(url=..., title=...)` to the report
  entries in `_report_custom_dynamic_linker_configuration()`.
- Added a test assertion verifying the KCS URL is present in the
  report's external links when a report is generated.

## Reference to a Jira ticket
RHEL-119943