### PR TITLE
Handle inaccessible EFI runtime variables gracefully

### DIFF
--- a/repos/system_upgrade/common/actors/convert/securebootinhibit/actor.py
+++ b/repos/system_upgrade/common/actors/convert/securebootinhibit/actor.py
@@ -1,4 +1,6 @@
 from leapp.actors import Actor
+from leapp.dialogs import Dialog
+from leapp.dialogs.components import BooleanComponent
 from leapp.libraries.actor import securebootinhibit
 from leapp.models import FirmwareFacts
 from leapp.reporting import Report
@@ -8,12 +10,45 @@ from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 class SecureBootInhibit(Actor):
     """
     Inhibit the conversion if SecureBoot is enabled.
+
+    When EFI runtime variables are inaccessible and the Secure Boot state
+    cannot be determined automatically, the user is asked to confirm the
+    state via a dialog.
     """
 
     name = 'secure_boot_inhibit'
     consumes = (FirmwareFacts,)
     produces = (Report,)
     tags = (IPUWorkflowTag, ChecksPhaseTag)
+    dialogs = (
+        Dialog(
+            scope='secure_boot_inhibit',
+            reason='Confirmation',
+            components=(
+                BooleanComponent(
+                    key='confirm_secureboot_enabled',
+                    label='Is Secure Boot enabled on this system?',
+                    description=(
+                        'Set to True if Secure Boot is enabled, False if disabled.'
+                        ' If unsure, check your UEFI firmware settings.'
+                    ),
+                    reason=(
+                        'EFI runtime variables are not accessible, so the Secure Boot'
+                        ' state cannot be determined automatically.'
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    _asked_answer = False
+    _sb_answer = None
+
+    def get_sb_answer(self):
+        if not self._asked_answer:
+            self._asked_answer = True
+            self._sb_answer = self.get_answers(self.dialogs[0]).get('confirm_secureboot_enabled')
+        return self._sb_answer
 
     def process(self):
         securebootinhibit.process()

--- a/repos/system_upgrade/common/actors/convert/securebootinhibit/actor.py
+++ b/repos/system_upgrade/common/actors/convert/securebootinhibit/actor.py
@@ -33,8 +33,8 @@ class SecureBootInhibit(Actor):
                         ' If unsure, check your UEFI firmware settings.'
                     ),
                     reason=(
-                        'EFI runtime variables are not accessible, so the Secure Boot'
-                        ' state cannot be determined automatically.'
+                        'The Secure Boot state cannot be determined automatically'
+                        ' because UEFI runtime variables are not accessible.'
                     ),
                 ),
             ),

--- a/repos/system_upgrade/common/actors/convert/securebootinhibit/libraries/securebootinhibit.py
+++ b/repos/system_upgrade/common/actors/convert/securebootinhibit/libraries/securebootinhibit.py
@@ -5,6 +5,33 @@ from leapp.libraries.stdlib import api
 from leapp.models import FirmwareFacts
 
 
+def _report_secureboot_enabled(extra_hint=''):
+    hint = (
+        "Disable Secure Boot to be able to convert the system to"
+        " a different Linux distribution. Then re-enable Secure Boot"
+        " again after the conversion process is finished successfully."
+        " Check instructions for your current OS, or hypervisor in"
+        " case of virtual machines, for more information how to"
+        " disable Secure Boot."
+    )
+    if extra_hint:
+        hint += ' ' + extra_hint
+    reporting.create_report([
+        reporting.Title(
+            "Detected enabled Secure Boot when trying to convert the system"
+        ),
+        reporting.Summary(
+            "Conversion to a different Linux distribution is not possible"
+            " when the Secure Boot is enabled. Artifacts of the target"
+            " Linux distribution are signed by keys that are not accepted"
+            " by the source Linux distribution."
+        ),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.BOOT]),
+        reporting.Remediation(hint=hint),
+    ])
+
+
 def process():
     if not is_conversion():
         return
@@ -16,27 +43,61 @@ def process():
             details={"details": "Actor did not receive FirmwareFacts message."},
         )
 
-    if ff.firmware == "efi" and ff.secureboot_enabled:
-        report = [
-            reporting.Title(
-                "Detected enabled Secure Boot when trying to convert the system"
-            ),
-            reporting.Summary(
-                "Conversion to a different Linux distribution is not possible"
-                " when the Secure Boot is enabled. Artifacts of the target"
-                " Linux distribution are signed by keys that are not accepted"
-                " by the source Linux distribution."
-            ),
-            reporting.Severity(reporting.Severity.HIGH),
-            reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.BOOT]),
-            # TODO some link
-            reporting.Remediation(
-                hint="Disable Secure Boot to be able to convert the system to"
-                " a different Linux distribution. Then re-enable Secure Boot"
-                " again after the upgrade process is finished successfully."
-                " Check instructions for your current OS, or hypervisor in"
-                " case of virtual machines, for more information how to"
-                " disable Secure Boot."
-            ),
-        ]
-        reporting.create_report(report)
+    if ff.firmware != 'efi':
+        return
+
+    secureboot_enabled = ff.secureboot_enabled
+
+    # Hardware does not support Secure Boot (EFI vars readable, state is None).
+    if secureboot_enabled is None and ff.efi_vars_accessible is True:
+        api.current_logger().info(
+            "EFI variables are accessible but Secure Boot is not supported"
+            " by the hardware; proceeding."
+        )
+        return
+
+    # EFI runtime variables inaccessible -> the user's answer is our only source.
+    answered_by_user = False
+    if secureboot_enabled is None:
+        secureboot_enabled = api.current_actor().get_sb_answer()
+        answered_by_user = True
+
+    if secureboot_enabled is True:
+        _report_secureboot_enabled(
+            extra_hint=(
+                "If Secure Boot is already disabled and the answer was"
+                " incorrect, change the value of 'confirm_secureboot_enabled'"
+                " from True to False in the answer file and re-run."
+            ) if answered_by_user else '',
+        )
+        return
+
+    if secureboot_enabled is False:
+        if answered_by_user:
+            api.current_logger().info(
+                "User confirmed Secure Boot is disabled; proceeding despite"
+                " inaccessible EFI variables."
+            )
+        return
+
+    # Still None -> user did not answer; state genuinely undeterminable.
+    reporting.create_report([
+        reporting.Title("Cannot determine the Secure Boot status"),
+        reporting.Summary(
+            "The system is booted in UEFI mode but the Secure Boot state"
+            " cannot be determined automatically because EFI runtime"
+            " variables are not accessible. The Secure Boot status is"
+            " important for the conversion process as converting with"
+            " Secure Boot enabled could lead to a system that fails"
+            " to boot."
+        ),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.BOOT]),
+        reporting.Remediation(
+            hint="Verify the Secure Boot status in your UEFI firmware"
+            " settings. If Secure Boot is enabled, disable it before"
+            " proceeding with the conversion. Then provide the Secure Boot"
+            " status by setting the value of 'confirm_secureboot_enabled'"
+            " to True or False in the answer file and re-run."
+        ),
+    ])

--- a/repos/system_upgrade/common/actors/convert/securebootinhibit/libraries/securebootinhibit.py
+++ b/repos/system_upgrade/common/actors/convert/securebootinhibit/libraries/securebootinhibit.py
@@ -5,17 +5,26 @@ from leapp.libraries.stdlib import api
 from leapp.models import FirmwareFacts
 
 
-def _report_secureboot_enabled(extra_hint=''):
+def _report_secureboot_enabled(answered_by_user):
+    answerfile_hint = ""
+    if answered_by_user:
+        # extra space in the beginning due to pasting inside the hint str
+        answerfile_hint = (
+            " "
+            "Then update your answer about the secure boot in the answerfile"
+            " to reflect the new state (for key: 'confirm_secureboot_enabled')."
+        )
+
     hint = (
-        "Disable Secure Boot to be able to convert the system to"
-        " a different Linux distribution. Then re-enable Secure Boot"
-        " again after the conversion process is finished successfully."
+        "To be able to convert the system to a different Linux distribution,"
+        " disable Secure Boot.{} Then re-enable Secure Boot"
+        " again after the upgrade process with conversion is finished successfully."
         " Check instructions for your current OS, or hypervisor in"
         " case of virtual machines, for more information how to"
         " disable Secure Boot."
+        .format(answerfile_hint)
     )
-    if extra_hint:
-        hint += ' ' + extra_hint
+
     reporting.create_report([
         reporting.Title(
             "Detected enabled Secure Boot when trying to convert the system"
@@ -43,33 +52,23 @@ def process():
             details={"details": "Actor did not receive FirmwareFacts message."},
         )
 
-    if ff.firmware != 'efi':
+    if ff.firmware != 'efi' or ff.secureboot_enabled is False:
         return
 
     secureboot_enabled = ff.secureboot_enabled
-
-    # Hardware does not support Secure Boot (EFI vars readable, state is None).
     if secureboot_enabled is None and ff.efi_vars_accessible is True:
-        api.current_logger().info(
-            "EFI variables are accessible but Secure Boot is not supported"
-            " by the hardware; proceeding."
-        )
+        # HW does not support Secure Boot (EFI vars readable, SB state is None).
+        api.current_logger().info("Secure Boot is not supported by the HW. Skipping.")
         return
 
-    # EFI runtime variables inaccessible -> the user's answer is our only source.
     answered_by_user = False
     if secureboot_enabled is None:
+        # Cannot determine the SB state (no EFI vars) -> get answer from user
         secureboot_enabled = api.current_actor().get_sb_answer()
         answered_by_user = True
 
     if secureboot_enabled is True:
-        _report_secureboot_enabled(
-            extra_hint=(
-                "If Secure Boot is already disabled and the answer was"
-                " incorrect, change the value of 'confirm_secureboot_enabled'"
-                " from True to False in the answer file and re-run."
-            ) if answered_by_user else '',
-        )
+        _report_secureboot_enabled(answered_by_user)
         return
 
     if secureboot_enabled is False:
@@ -87,9 +86,8 @@ def process():
             "The system is booted in UEFI mode but the Secure Boot state"
             " cannot be determined automatically because EFI runtime"
             " variables are not accessible. The Secure Boot status is"
-            " important for the conversion process as converting with"
-            " Secure Boot enabled could lead to a system that fails"
-            " to boot."
+            " important to be able to determine next steps for the in-place"
+            " upgrade process with the conversion."
         ),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.BOOT]),

--- a/repos/system_upgrade/common/actors/convert/securebootinhibit/libraries/securebootinhibit.py
+++ b/repos/system_upgrade/common/actors/convert/securebootinhibit/libraries/securebootinhibit.py
@@ -6,38 +6,61 @@ from leapp.models import FirmwareFacts
 
 
 def _report_secureboot_enabled(answered_by_user):
-    answerfile_hint = ""
+    answerfile_hint = ''
     if answered_by_user:
         # extra space in the beginning due to pasting inside the hint str
         answerfile_hint = (
-            " "
-            "Then update your answer about the secure boot in the answerfile"
-            " to reflect the new state (for key: 'confirm_secureboot_enabled')."
+            ' '
+            'Then update your answer about the secure boot state in the answerfile'
+            ' to reflect the new state (for key: "confirm_secureboot_enabled").'
         )
 
     hint = (
-        "To be able to convert the system to a different Linux distribution,"
-        " disable Secure Boot.{} Then re-enable Secure Boot"
-        " again after the upgrade process with conversion is finished successfully."
-        " Check instructions for your current OS, or hypervisor in"
-        " case of virtual machines, for more information how to"
-        " disable Secure Boot."
+        'To be able to convert the system to a different Linux distribution,'
+        ' disable Secure Boot.{} Then re-enable Secure Boot'
+        ' again after the upgrade and conversion process is finished successfully.'
+        ' Check instructions for your current OS, or hypervisor in'
+        ' case of virtual machines, for more information how to'
+        ' disable Secure Boot.'
         .format(answerfile_hint)
     )
 
     reporting.create_report([
         reporting.Title(
-            "Detected enabled Secure Boot when trying to convert the system"
+            'Detected enabled Secure Boot when trying to convert the system'
         ),
         reporting.Summary(
-            "Conversion to a different Linux distribution is not possible"
-            " when the Secure Boot is enabled. Artifacts of the target"
-            " Linux distribution are signed by keys that are not accepted"
-            " by the source Linux distribution."
+            'Conversion to a different Linux distribution is not possible'
+            ' when the Secure Boot is enabled. Artifacts of the target'
+            ' Linux distribution are signed by keys that are not accepted'
+            ' by the source Linux distribution.'
         ),
         reporting.Severity(reporting.Severity.HIGH),
         reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.BOOT]),
         reporting.Remediation(hint=hint),
+    ])
+
+
+def _report_missing_answer():
+    reporting.create_report([
+        reporting.Title('Cannot determine the Secure Boot state'),
+        reporting.Summary(
+            'The system is booted in UEFI mode but the Secure Boot state'
+            ' cannot be determined automatically because EFI runtime'
+            ' variables are not accessible. The information Secure Boot state'
+            ' is required to determine the next steps for the in-place upgrade'
+            ' and conversion process.'
+        ),
+
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.BOOT]),
+        reporting.Remediation(
+            hint='Verify the Secure Boot state in your UEFI firmware'
+            ' settings. If Secure Boot is enabled, disable it before'
+            ' proceeding with the upgrade and conversion. Then provide the Secure Boot'
+            ' state by setting the value of "confirm_secureboot_enabled"'
+            ' to True or False in the answer file and re-run.'
+        ),
     ])
 
 
@@ -48,8 +71,8 @@ def process():
     ff = next(api.consume(FirmwareFacts), None)
     if not ff:
         raise StopActorExecutionError(
-            "Could not identify system firmware",
-            details={"details": "Actor did not receive FirmwareFacts message."},
+            'Could not identify system firmware',
+            details={'details': 'Actor did not receive FirmwareFacts message.'},
         )
 
     if ff.firmware != 'efi' or ff.secureboot_enabled is False:
@@ -58,44 +81,22 @@ def process():
     secureboot_enabled = ff.secureboot_enabled
     if secureboot_enabled is None and ff.efi_vars_accessible is True:
         # HW does not support Secure Boot (EFI vars readable, SB state is None).
-        api.current_logger().info("Secure Boot is not supported by the HW. Skipping.")
+        api.current_logger().info('Secure Boot is not supported by the HW. Skipping.')
         return
 
     answered_by_user = False
     if secureboot_enabled is None:
         # Cannot determine the SB state (no EFI vars) -> get answer from user
         secureboot_enabled = api.current_actor().get_sb_answer()
+        if secureboot_enabled is None:
+            _report_missing_answer()
+            return
         answered_by_user = True
 
     if secureboot_enabled is True:
         _report_secureboot_enabled(answered_by_user)
-        return
-
-    if secureboot_enabled is False:
-        if answered_by_user:
-            api.current_logger().info(
-                "User confirmed Secure Boot is disabled; proceeding despite"
-                " inaccessible EFI variables."
-            )
-        return
-
-    # Still None -> user did not answer; state genuinely undeterminable.
-    reporting.create_report([
-        reporting.Title("Cannot determine the Secure Boot status"),
-        reporting.Summary(
-            "The system is booted in UEFI mode but the Secure Boot state"
-            " cannot be determined automatically because EFI runtime"
-            " variables are not accessible. The Secure Boot status is"
-            " important to be able to determine next steps for the in-place"
-            " upgrade process with the conversion."
-        ),
-        reporting.Severity(reporting.Severity.HIGH),
-        reporting.Groups([reporting.Groups.INHIBITOR, reporting.Groups.BOOT]),
-        reporting.Remediation(
-            hint="Verify the Secure Boot status in your UEFI firmware"
-            " settings. If Secure Boot is enabled, disable it before"
-            " proceeding with the conversion. Then provide the Secure Boot"
-            " status by setting the value of 'confirm_secureboot_enabled'"
-            " to True or False in the answer file and re-run."
-        ),
-    ])
+    else:
+        api.current_logger().info(
+            'User confirmed Secure Boot is disabled; proceeding despite'
+            ' inaccessible EFI variables.'
+        )

--- a/repos/system_upgrade/common/actors/convert/securebootinhibit/tests/test_securebootinhibit.py
+++ b/repos/system_upgrade/common/actors/convert/securebootinhibit/tests/test_securebootinhibit.py
@@ -52,7 +52,7 @@ def test_process_definitive_sb_state(monkeypatch, ff, is_conversion, should_inhi
         assert reporting.create_report.called == 1
         assert reporting.Groups.INHIBITOR in reporting.create_report.report_fields['groups']
         assert reporting.create_report.report_fields['title'] == (
-            "Detected enabled Secure Boot when trying to convert the system"
+            'Detected enabled Secure Boot when trying to convert the system'
         )
     else:
         assert not reporting.create_report.called
@@ -73,9 +73,9 @@ def test_sb_none_efi_vars_accessible(monkeypatch):
 @pytest.mark.parametrize(
     'sb_answer,should_inhibit,expected_title,efi_vars_accessible', [
         (False, False, None, False),
-        (True, True, "Detected enabled Secure Boot when trying to convert the system", False),
-        (None, True, "Cannot determine the Secure Boot status", False),
-        (None, True, "Cannot determine the Secure Boot status", None),
+        (True, True, 'Detected enabled Secure Boot when trying to convert the system', False),
+        (None, True, 'Cannot determine the Secure Boot state', False),
+        (None, True, 'Cannot determine the Secure Boot state', None),
     ]
 )
 def test_sb_none_efi_vars_inaccessible_dialog(monkeypatch, sb_answer, should_inhibit, expected_title,

--- a/repos/system_upgrade/common/actors/convert/securebootinhibit/tests/test_securebootinhibit.py
+++ b/repos/system_upgrade/common/actors/convert/securebootinhibit/tests/test_securebootinhibit.py
@@ -7,52 +7,93 @@ from leapp.libraries.stdlib import api
 from leapp.models import FirmwareFacts
 
 
+def _ff(firmware='efi', secureboot_enabled=None, efi_vars_accessible=None):
+    return FirmwareFacts(
+        firmware=firmware,
+        ppc64le_opal=None,
+        secureboot_enabled=secureboot_enabled,
+        efi_vars_accessible=efi_vars_accessible,
+    )
+
+
+class _CurrentActorWithDialog(CurrentActorMocked):
+    def __init__(self, *args, **kwargs):
+        self._sb_answer = kwargs.pop('sb_answer', None)
+        super().__init__(*args, **kwargs)
+
+    def get_sb_answer(self):
+        return self._sb_answer
+
+
 @pytest.mark.parametrize(
     'ff,is_conversion,should_inhibit', [
-        # conversion, secureboot enabled = inhibit
-        (
-            FirmwareFacts(firmware='efi', ppc64le_opal=None, secureboot_enabled=True),
-            True,
-            True
-        ),
-        (
-            FirmwareFacts(firmware='efi', ppc64le_opal=None, secureboot_enabled=True),
-            False,
-            False
-        ),
-        # bios is ok
-        (
-            FirmwareFacts(firmware='bios', ppc64le_opal=None, secureboot_enabled=False),
-            False,
-            False
-        ),
-        # bios is ok during conversion too
-        (
-            FirmwareFacts(firmware='bios', ppc64le_opal=None, secureboot_enabled=False),
-            True,
-            False
-        ),
-        (
-            FirmwareFacts(firmware='efi', ppc64le_opal=None, secureboot_enabled=False),
-            True,
-            False
-        ),
-        (
-            FirmwareFacts(firmware='efi', ppc64le_opal=None, secureboot_enabled=False),
-            False,
-            False
-        ),
+        # SB enabled + conversion = inhibit
+        (_ff(secureboot_enabled=True, efi_vars_accessible=True), True, True),
+        # SB enabled + no conversion = no report
+        (_ff(secureboot_enabled=True, efi_vars_accessible=True), False, False),
+        # SB disabled + conversion = no report
+        (_ff(secureboot_enabled=False, efi_vars_accessible=True), True, False),
+        # SB disabled + no conversion = no report
+        (_ff(secureboot_enabled=False, efi_vars_accessible=True), False, False),
+        # BIOS + conversion = no report
+        (_ff(firmware='bios', secureboot_enabled=False), True, False),
+        # BIOS + no conversion = no report
+        (_ff(firmware='bios', secureboot_enabled=False), False, False),
     ]
 )
-def test_process(monkeypatch, ff, is_conversion, should_inhibit):
+def test_process_definitive_sb_state(monkeypatch, ff, is_conversion, should_inhibit):
     monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[ff]))
-    monkeypatch.setattr(reporting, "create_report", create_report_mocked())
-    monkeypatch.setattr(securebootinhibit, "is_conversion", lambda: is_conversion)
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(securebootinhibit, 'is_conversion', lambda: is_conversion)
 
     securebootinhibit.process()
 
     if should_inhibit:
         assert reporting.create_report.called == 1
         assert reporting.Groups.INHIBITOR in reporting.create_report.report_fields['groups']
+        assert reporting.create_report.report_fields['title'] == (
+            "Detected enabled Secure Boot when trying to convert the system"
+        )
+    else:
+        assert not reporting.create_report.called
+
+
+def test_sb_none_efi_vars_accessible(monkeypatch):
+    """HW does not support Secure Boot -- efi_vars work, sb is None."""
+    ff = _ff(secureboot_enabled=None, efi_vars_accessible=True)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[ff]))
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(securebootinhibit, 'is_conversion', lambda: True)
+
+    securebootinhibit.process()
+
+    assert not reporting.create_report.called
+
+
+@pytest.mark.parametrize(
+    'sb_answer,should_inhibit,expected_title,efi_vars_accessible', [
+        (False, False, None, False),
+        (True, True, "Detected enabled Secure Boot when trying to convert the system", False),
+        (None, True, "Cannot determine the Secure Boot status", False),
+        (None, True, "Cannot determine the Secure Boot status", None),
+    ]
+)
+def test_sb_none_efi_vars_inaccessible_dialog(monkeypatch, sb_answer, should_inhibit, expected_title,
+                                              efi_vars_accessible):
+    """EFI vars inaccessible or None -- dialog determines outcome."""
+    ff = _ff(secureboot_enabled=None, efi_vars_accessible=efi_vars_accessible)
+    monkeypatch.setattr(
+        api, 'current_actor',
+        _CurrentActorWithDialog(sb_answer=sb_answer, msgs=[ff]),
+    )
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(securebootinhibit, 'is_conversion', lambda: True)
+
+    securebootinhibit.process()
+
+    if should_inhibit:
+        assert reporting.create_report.called == 1
+        assert reporting.Groups.INHIBITOR in reporting.create_report.report_fields['groups']
+        assert reporting.create_report.report_fields['title'] == expected_title
     else:
         assert not reporting.create_report.called

--- a/repos/system_upgrade/common/actors/systemfacts/libraries/systemfacts.py
+++ b/repos/system_upgrade/common/actors/systemfacts/libraries/systemfacts.py
@@ -315,20 +315,40 @@ def get_firewalls_status():
 
 
 def _get_secure_boot_state():
+    """Determine the Secure Boot state using mokutil.
+
+    :returns: A tuple of (secureboot_enabled, efi_vars_accessible) where:
+
+        - *secureboot_enabled*:
+          - ``True`` -- Secure Boot is enabled.
+          - ``False`` -- mokutil is not available (OSError); Secure Boot state is unknown.
+          - ``None`` -- the system does not support Secure Boot, or EFI variables are inaccessible.
+        - *efi_vars_accessible*:
+          - ``True`` -- EFI variables are accessible (mokutil ran successfully or reported
+            unsupported Secure Boot).
+          - ``False`` -- EFI variables are not accessible.
+          - ``None`` -- mokutil is not available; EFI variable accessibility is unknown.
+    :rtype: tuple(bool or None, bool or None)
+    :raises StopActorExecutionError: When mokutil fails for an unexpected reason.
+    """
     try:
         stdout = run(['mokutil', '--sb-state'])['stdout']
-        return 'enabled' in stdout
+        return ('enabled' in stdout, True)
     except CalledProcessError as e:
         if "doesn't support Secure Boot" in e.stderr:
-            return None
+            return (None, True)
+        if "EFI variables are not supported" in e.stderr:
+            api.current_logger().warning(
+                'EFI variables are not accessible: %s', e.stderr
+            )
+            return (None, False)
 
         raise StopActorExecutionError('Failed to determine SecureBoot state: {}'.format(e))
     except OSError as e:
-        # shim depends on mokutil, if it's not installed assume SecureBoot is disabled
         api.current_logger().debug(
             'Failed to execute mokutil, assuming SecureBoot is disabled: {}'.format(e)
         )
-        return False
+        return (False, None)
 
 
 def get_firmware():
@@ -339,10 +359,16 @@ def get_firmware():
         ppc64le_opal = os.path.isdir('/sys/firmware/opal/')
 
     is_secureboot = None
+    efi_vars_accessible = None
     if firmware == 'efi':
-        is_secureboot = _get_secure_boot_state()
+        is_secureboot, efi_vars_accessible = _get_secure_boot_state()
 
-    return FirmwareFacts(firmware=firmware, ppc64le_opal=ppc64le_opal, secureboot_enabled=is_secureboot)
+    return FirmwareFacts(
+        firmware=firmware,
+        ppc64le_opal=ppc64le_opal,
+        secureboot_enabled=is_secureboot,
+        efi_vars_accessible=efi_vars_accessible,
+    )
 
 
 @aslist

--- a/repos/system_upgrade/common/actors/systemfacts/tests/test_systemfacts.py
+++ b/repos/system_upgrade/common/actors/systemfacts/tests/test_systemfacts.py
@@ -156,7 +156,7 @@ def test_get_secure_boot_state_ok(mocked_run: mock.MagicMock, is_enabled):
 
     out = _get_secure_boot_state()
 
-    assert out == is_enabled
+    assert out == (is_enabled, True)
     mocked_run.assert_called_once_with(['mokutil', '--sb-state'])
 
 
@@ -166,7 +166,7 @@ def test_get_secure_boot_state_no_mokutil(mocked_run: mock.MagicMock):
 
     out = _get_secure_boot_state()
 
-    assert out is False
+    assert out == (False, None)
     mocked_run.assert_called_once_with(['mokutil', '--sb-state'])
 
 
@@ -185,7 +185,26 @@ def test_get_secure_boot_state_not_supported(mocked_run: mock.MagicMock):
 
     out = _get_secure_boot_state()
 
-    assert out is None
+    assert out == (None, True)
+    mocked_run.assert_called_once_with(cmd)
+
+
+@mock.patch('leapp.libraries.actor.systemfacts.run')
+def test_get_secure_boot_state_efi_vars_unavailable(mocked_run: mock.MagicMock):
+    cmd = ['mokutil', '--sb-state']
+    result = {
+        'stderr': 'EFI variables are not supported on this system',
+        'exit_code': 1,
+    }
+    mocked_run.side_effect = CalledProcessError(
+        "Command mokutil --sb-state failed with exit code 1.",
+        cmd,
+        result
+    )
+
+    out = _get_secure_boot_state()
+
+    assert out == (None, False)
     mocked_run.assert_called_once_with(cmd)
 
 
@@ -193,7 +212,7 @@ def test_get_secure_boot_state_not_supported(mocked_run: mock.MagicMock):
 def test_get_secure_boot_state_failed(mocked_run: mock.MagicMock):
     cmd = ['mokutil', '--sb-state']
     result = {
-        'stderr': 'EFI variables are not supported on this system',
+        'stderr': 'Unexpected mokutil error',
         'exit_code': 1,
     }
     mocked_run.side_effect = CalledProcessError(
@@ -211,11 +230,12 @@ def test_get_secure_boot_state_failed(mocked_run: mock.MagicMock):
     mocked_run.assert_called_once_with(cmd)
 
 
-def _ff(firmware, ppc64le_opal, is_secureboot):
+def _ff(firmware, ppc64le_opal, is_secureboot, efi_vars_accessible=None):
     return FirmwareFacts(
         firmware=firmware,
         ppc64le_opal=ppc64le_opal,
-        secureboot_enabled=is_secureboot
+        secureboot_enabled=is_secureboot,
+        efi_vars_accessible=efi_vars_accessible,
     )
 
 
@@ -223,17 +243,19 @@ def _ff(firmware, ppc64le_opal, is_secureboot):
     "has_sys_efi, has_sys_opal, is_ppc, secboot_state, expect",
     [
         # 1. Standard BIOS on x86
-        (False, False, False, None, _ff("bios", None, None)),
+        (False, False, False, None,           _ff("bios", None,  None,  None)),
         # 2. EFI on x86 with Secure Boot Enabled
-        (True,  False, False, True,  _ff("efi",  None, True)),
+        (True,  False, False, (True,  True),  _ff("efi",  None,  True,  True)),
         # 3. EFI on x86 with Secure Boot Disabled
-        (True,  False, False, False, _ff("efi",  None, False)),
+        (True,  False, False, (False, True),  _ff("efi",  None,  False, True)),
         # 4. PPC64LE with OPAL (No EFI)
-        (False, True,  True,  None,  _ff("bios", True, None)),
+        (False, True,  True,  None,           _ff("bios", True,  None,  None)),
         # 5. PPC64LE without OPAL (No EFI)
-        (False, False, True,  None,  _ff("bios", False, None)),
+        (False, False, True,  None,           _ff("bios", False, None,  None)),
         # 6. EFI on PPC64LE with OPAL
-        (True,  True,  True,  True,  _ff("efi",  True, True)),
+        (True,  True,  True,  (True,  True),  _ff("efi",  True,  True,  True)),
+        # 7. EFI on x86 with EFI vars unavailable
+        (True,  False, False, (None,  False), _ff("efi",  None,  None,  False)),
     ]
 )
 def test_get_firmware_logic(

--- a/repos/system_upgrade/common/models/firmwarefacts.py
+++ b/repos/system_upgrade/common/models/firmwarefacts.py
@@ -13,8 +13,22 @@ class FirmwareFacts(Model):
 
     secureboot_enabled = fields.Nullable(fields.Boolean())
     """
-    Check whether SecureBoot is enabled, always False on BIOS systems
+    Check whether SecureBoot is enabled.
 
-    Note that some machines do not support SecureBoot at all - even for systems booted with UEFI.
-    For systems booted with UEFI that does not support SecureBoot set None.
+    The value can be None in these cases:
+        * on BIOS systems (mokutil is never called)
+        * on systems that do not support SecureBoot (even when booted with UEFI)
+        * on systems with disabled EFI variables (usually on Real Time systems due to effect on latency)
+    """
+
+    efi_vars_accessible = fields.Nullable(fields.Boolean())
+    """
+    True if EFI runtime variables are accessible via mokutil.
+
+    Checking this value is useful on systems booted with UEFI when the information about
+    the Secure Boot settings is not determined (`secureboot_enabled` is None).
+    Other values:
+
+        * False if mokutil fails with "EFI variables are not supported".
+        * None for BIOS systems or when mokutil is not installed.
     """


### PR DESCRIPTION
## The reason for the change

On UEFI systems where EFI runtime variables are inaccessible (e.g. certain hypervisors, RT kernels, or firmware configurations), `mokutil --sb-state` exits with "EFI variables are not supported". This error was not handled by the `system_facts` actor, causing it to crash with a `StopActorExecutionError` and blocking the process entirely.

During conversions (CentOS to RHEL), this also prevented the `securebootinhibit` actor from distinguishing between "Secure Boot unsupported" and "EFI vars inaccessible", making it impossible to safely determine whether conversion could proceed.

## What has been changed

- **FirmwareFacts model**: added `efi_vars_accessible` field  (`Nullable(Boolean)`) to distinguish between inaccessible EFI vars and hardware that simply lacks Secure Boot support.
- **system_facts actor library**: `_get_secure_boot_state()` now returns a `(secureboot_enabled, efi_vars_accessible)` tuple and gracefully handles the "EFI variables are not supported" error instead of crashing.  `get_firmware()` unpacks the tuple accordingly.
- **securebootinhibit actor** (conversion-only, ChecksPhase): extended to consume the new `efi_vars_accessible` field.  When EFI vars are inaccessible, presents a Leapp Dialog asking the user whether Secure Boot is enabled. Uses fail-safe logic and produces an inhibitor report when the state cannot be confirmed as safe.
- **Tests**: updated existing `test_systemfacts.py` for tuple returns and added a new `test_get_secure_boot_state_efi_vars_unavailable` case.  Updated `test_securebootinhibit.py` with parametrized test cases covering the dialog paths (answer True, False, and None) and the "EFI vars accessible but no SB support" path.

## How it has been changed

1. **Separating EFI variable accessibility from Secure Boot support status.**
  Previously both "no SB support" and "EFI vars inaccessible" mapped to `secureboot_enabled=None`, making them indistinguishable.  The new `efi_vars_accessible` field resolves this ambiguity.
3. **Fail-safe dialog design (conversion path only).**
   The dialog asks "Is Secure Boot enabled?" (`confirm_secureboot_enabled`).  A blind True or no answer keeps the conversion inhibited (safe default).
   Only a deliberate False (user explicitly confirms SB is disabled) removes the inhibitor.  This protects copy-paste users who confirm without verifying.
4. **Inhibitor behavior.**
   Two outcomes when EFI vars are inaccessible:
   - User answers False (SB disabled): no inhibitor, conversion proceeds.
   - User answers True or does not answer: inhibitor titled "EFI runtime variables are not accessible" with a hint to verify the Secure Boot status in UEFI firmware settings.

## How to try/test the PR

### Crash fix (upgrades and conversions)
1. On a UEFI system with inaccessible EFI vars (e.g. RT kernel), run `leapp preupgrade` and verify `system_facts` no longer crashes. `FirmwareFacts` should have `efi_vars_accessible=False` and `secureboot_enabled=None`.

### Dialog logic (conversions only)
2. During a conversion (`leapp convert`), verify the inhibitor "EFI runtime variables are not accessible" is produced.
4. Answer False (confirm SB is disabled):
   `leapp answer --section secure_boot_inhibit.confirm_secureboot_enabled=False`
   Re-run and verify the inhibitor is not produced.
5. Answer True (confirm SB is enabled):
   `leapp answer --section secure_boot_inhibit.confirm_secureboot_enabled=True`
   Re-run and verify the inhibitor is still produced.
6. On a BIOS system, verify no inhibitor from `secure_boot_inhibit`.

## Reference to a Jira ticket

Jira: RHEL-160096

## Test results

see https://github.com/oamg/leapp-repository/pull/1579#issuecomment-5327515929