### PR TITLE
opensslproviders: Add Report to the produces tuple

### DIFF
--- a/repos/system_upgrade/el8toel9/actors/opensslproviders/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslproviders/actor.py
@@ -34,7 +34,7 @@ class OpenSslProviders(Actor):
 
     name = 'open_ssl_providers'
     consumes = (OpenSslConfig,)
-    produces = ()
+    produces = (Report,)
     tags = (IPUWorkflowTag, ApplicationsPhaseTag,)
 
     def process(self):

--- a/repos/system_upgrade/el8toel9/actors/opensslproviders/libraries/add_provider.py
+++ b/repos/system_upgrade/el8toel9/actors/opensslproviders/libraries/add_provider.py
@@ -132,10 +132,9 @@ def process(openssl_messages):
             reporting.Groups([
                     reporting.Groups.SECURITY,
                     reporting.Groups.NETWORK,
-                    reporting.Groups.SERVICES
-            ]),
-            reporting.Groups([
-                reporting.Groups.POST
+                    reporting.Groups.SERVICES,
+                    reporting.Groups.POST,
+                    reporting.Groups.FAILURE,
             ]),
             reporting.RelatedResource('package', 'openssl'),
             reporting.RelatedResource('file', '/etc/pki/tls/openssl.cnf')


### PR DESCRIPTION
The actor tries to generate a report when it fails, but the `Report` message was not in the `produces` tuple so it was ignored in case of failure.

Relates to Jira: RHEL-235172