### PR TITLE
Replace custom FMT_LIST_SEPARATOR formatting with stdlib format_list

### DIFF
--- a/repos/system_upgrade/common/actors/checkcustommodifications/libraries/checkcustommodifications.py
+++ b/repos/system_upgrade/common/actors/checkcustommodifications/libraries/checkcustommodifications.py
@@ -1,25 +1,17 @@
 from leapp import reporting
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import CustomModifications
-
-FMT_LIST_SEPARATOR = "\n    - "
 
 
 def _pretty_files(messages):
     """
     Return formatted string of discovered files from obtained CustomModifications messages.
     """
-    flist = []
+    items = []
     for msg in messages:
         actor = ' (Actor: {})'.format(msg.actor_name) if msg.actor_name else ''
-        flist.append(
-            '{sep}{filename}{actor}'.format(
-                sep=FMT_LIST_SEPARATOR,
-                filename=msg.filename,
-                actor=actor
-            )
-        )
-    return ''.join(flist)
+        items.append('{}{}'.format(msg.filename, actor))
+    return format_list(items)
 
 
 def _is_modified_config(msg):

--- a/repos/system_upgrade/common/actors/checkdetecteddevicesanddrivers/libraries/checkdddd.py
+++ b/repos/system_upgrade/common/actors/checkdetecteddevicesanddrivers/libraries/checkdddd.py
@@ -4,7 +4,7 @@ from enum import IntEnum
 from leapp import reporting
 from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import DetectedDeviceOrDriver
 
 
@@ -29,10 +29,9 @@ def create_inhibitors(inhibiting_entries):
             reporting.Summary(
                 (
                     'Support for the following {source_distro} {source_version} device drivers has'
-                    ' been removed in {target_distro} {target_version}:\n'
-                    '     - {drivers}\n'
+                    ' been removed in {target_distro} {target_version}:{drivers}'
                 ).format(
-                    drivers='\n     - '.join([entry.driver_name for entry in drivers]),
+                    drivers=format_list([entry.driver_name for entry in drivers]),
                     target_version=get_target_major_version(),
                     source_version=get_source_major_version(),
                     **DISTRO_REPORT_NAMES
@@ -68,11 +67,10 @@ def create_inhibitors(inhibiting_entries):
             ),
             reporting.Summary(
                 (
-                    'Support for the following devices has been removed in {target_distro} {version}:\n'
-                    '     - {devices}\n'
+                    'Support for the following devices has been removed in {target_distro} {version}:{devices}'
                 ).format(
-                    devices='\n     - '.join(['{name} ({pci})'.format(name=entry.device_name,
-                                             pci=entry.device_id) for entry in devices]),
+                    devices=format_list(['{name} ({pci})'.format(name=entry.device_name,
+                                         pci=entry.device_id) for entry in devices]),
                     version=get_target_major_version(),
                     **DISTRO_REPORT_NAMES
                 )
@@ -93,10 +91,9 @@ def create_inhibitors(inhibiting_entries):
             ),
             reporting.Summary(
                 (
-                    'Support for the following processors has been removed in {target_distro} {version}:\n'
-                    '     - {processors}\n'
+                    'Support for the following processors has been removed in {target_distro} {version}:{processors}'
                 ).format(
-                    processors='\n     - '.join([entry.device_name for entry in cpus]),
+                    processors=format_list([entry.device_name for entry in cpus]),
                     version=get_target_major_version(),
                     **DISTRO_REPORT_NAMES
                 )
@@ -122,10 +119,9 @@ def create_warnings(unmaintained_entries):
             reporting.Summary(
                 (
                     'The following {source_distro} {source_version} device drivers are no longer'
-                    ' maintained {target_distro} {target_version}:\n'
-                    '     - {drivers}\n'
+                    ' maintained {target_distro} {target_version}:{drivers}'
                 ).format(
-                    drivers='\n     - '.join([entry.driver_name for entry in drivers]),
+                    drivers=format_list([entry.driver_name for entry in drivers]),
                     target_version=get_target_major_version(),
                     source_version=get_source_major_version(),
                     **DISTRO_REPORT_NAMES
@@ -146,10 +142,10 @@ def create_warnings(unmaintained_entries):
             reporting.Summary(
                 (
                     'The support for the following devices has been removed in {target_distro} {version} and '
-                    'are no longer maintained:\n     - {devices}\n'
+                    'are no longer maintained:{devices}'
                 ).format(
-                    devices='\n     - '.join(['{name} ({pci})'.format(name=entry.device_name,
-                                             pci=entry.device_id) for entry in devices]),
+                    devices=format_list(['{name} ({pci})'.format(name=entry.device_name,
+                                         pci=entry.device_id) for entry in devices]),
                     version=get_target_major_version(),
                     **DISTRO_REPORT_NAMES
                 )
@@ -168,10 +164,9 @@ def create_warnings(unmaintained_entries):
             ),
             reporting.Summary(
                 (
-                    'The following processors are no longer maintained in {target_distro} {version}:\n'
-                    '     - {processors}\n'
+                    'The following processors are no longer maintained in {target_distro} {version}:{processors}'
                 ).format(
-                    processors='\n     - '.join([entry.device_name for entry in cpus]),
+                    processors=format_list([entry.device_name for entry in cpus]),
                     version=get_target_major_version(),
                     **DISTRO_REPORT_NAMES
                 )

--- a/repos/system_upgrade/common/actors/checkdynamiclinkerconfiguration/libraries/checkdynamiclinkerconfiguration.py
+++ b/repos/system_upgrade/common/actors/checkdynamiclinkerconfiguration/libraries/checkdynamiclinkerconfiguration.py
@@ -1,13 +1,11 @@
 from leapp import reporting
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import DynamicLinkerConfiguration
 
 LD_SO_CONF_DIR = '/etc/ld.so.conf.d'
 LD_SO_CONF_MAIN = '/etc/ld.so.conf'
 LD_LIBRARY_PATH_VAR = 'LD_LIBRARY_PATH'
 LD_PRELOAD_VAR = 'LD_PRELOAD'
-FMT_LIST_SEPARATOR_1 = '\n- '
-FMT_LIST_SEPARATOR_2 = '\n    - '
 
 
 def _report_custom_dynamic_linker_configuration(summary):
@@ -39,9 +37,9 @@ def check_dynamic_linker_configuration():
     custom_configurations = ''
     if configuration.main_config.modified:
         custom_configurations += (
-            '{}The {} file has unexpected contents:{}{}'
-            .format(FMT_LIST_SEPARATOR_1, LD_SO_CONF_MAIN,
-                    FMT_LIST_SEPARATOR_2, FMT_LIST_SEPARATOR_2.join(configuration.main_config.modified_lines))
+            '\n- The {} file has unexpected contents:{}'
+            .format(LD_SO_CONF_MAIN,
+                    format_list(configuration.main_config.modified_lines, callback_sort=None))
         )
 
     custom_configs = []
@@ -51,15 +49,14 @@ def check_dynamic_linker_configuration():
 
     if custom_configs:
         custom_configurations += (
-            '{}The following drop in config files were marked as custom:{}{}'
-            .format(FMT_LIST_SEPARATOR_1, FMT_LIST_SEPARATOR_2, FMT_LIST_SEPARATOR_2.join(custom_configs))
+            '\n- The following drop in config files were marked as custom:{}'
+            .format(format_list(custom_configs))
         )
 
     if configuration.used_variables:
         custom_configurations += (
-            '{}The following variables contain unexpected dynamic linker configuration:{}{}'
-            .format(FMT_LIST_SEPARATOR_1, FMT_LIST_SEPARATOR_2,
-                    FMT_LIST_SEPARATOR_2.join(configuration.used_variables))
+            '\n- The following variables contain unexpected dynamic linker configuration:{}'
+            .format(format_list(configuration.used_variables))
         )
 
     if custom_configurations:

--- a/repos/system_upgrade/common/actors/checkfstabmountorder/libraries/checkfstabmountorder.py
+++ b/repos/system_upgrade/common/actors/checkfstabmountorder/libraries/checkfstabmountorder.py
@@ -1,10 +1,8 @@
 import os
 
 from leapp import reporting
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import StorageInfo
-
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def _get_common_path(path1, path2):
@@ -78,8 +76,8 @@ def check_fstab_mount_order():
         summary += '\nDetected order of overshadowing mount points: {}'.format(', '.join(overshadowing_in_order))
         hint += (
             ' Reorder the detected overshadowing entries. Possible order of all mount '
-            'points without overshadowing:{}{}'
-        ).format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(overshadowing_fixed))
+            'points without overshadowing:{}'
+        ).format(format_list(overshadowing_fixed, callback_sort=None))
 
     reporting.create_report([
         reporting.Title(

--- a/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
+++ b/repos/system_upgrade/common/actors/checkluks/libraries/checkluks.py
@@ -1,7 +1,7 @@
 from leapp import reporting
 from leapp.libraries.common.config.version import get_source_major_version
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import (
     CephInfo,
     CopyFile,
@@ -21,12 +21,6 @@ from leapp.reporting import create_report
 # https://red.ht/convert-to-luks2-rhel9
 CLEVIS_DOC_URL_FMT = 'https://red.ht/clevis-tpm2-luks-auto-unlock-rhel{}'
 LUKS2_CONVERT_DOC_URL_FMT = 'https://red.ht/convert-to-luks2-rhel{}'
-
-FMT_LIST_SEPARATOR = '\n    - '
-
-
-def _formatted_list_output(input_list, sep=FMT_LIST_SEPARATOR):
-    return ['{}{}'.format(sep, item) for item in input_list]
 
 
 def _at_least_one_tpm_token(luks_dump):
@@ -59,7 +53,7 @@ def report_inhibitor(luks1_partitions, no_tpm2_partitions):
             ' it has some limitations in comparison to LUKS2.'
             ' Only the LUKS2 format is supported for upgrades.'
             ' The following LUKS1 partitions have been discovered on your system:{partitions}'
-            .format(**DISTRO_REPORT_NAMES, partitions=''.join(_formatted_list_output(luks1_partitions)))
+            .format(**DISTRO_REPORT_NAMES, partitions=format_list(luks1_partitions))
         )
         report_hints.append(reporting.Remediation(
             hint=(
@@ -80,9 +74,9 @@ def report_inhibitor(luks1_partitions, no_tpm2_partitions):
             ' encrypted devices during the upgrade process.'
             ' Currently we support automatic unlocking during the upgrade only'
             ' for volumes bound to Clevis TPM2 token.'
-            ' The following LUKS2 devices without Clevis TPM2 token '
-            ' have been discovered on your system: {}'
-            .format(''.join(_formatted_list_output(no_tpm2_partitions)))
+            ' The following LUKS2 devices without Clevis TPM2 token'
+            ' have been discovered on your system:{}'
+            .format(format_list(no_tpm2_partitions))
         )
 
         report_hints.append(reporting.Remediation(

--- a/repos/system_upgrade/common/actors/checknvme/libraries/checknvme.py
+++ b/repos/system_upgrade/common/actors/checknvme/libraries/checknvme.py
@@ -5,7 +5,7 @@ from typing import List
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.config.version import get_source_major_version
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import (
     CopyFile,
     DracutModule,
@@ -22,7 +22,6 @@ from leapp.models import (
     UpgradeKernelCmdlineArgTasks
 )
 
-FMT_LIST_SEPARATOR = '\n    - '
 FABRICS_TRANSPORT_TYPES = ['fc', 'tcp', 'rdma']
 BROKEN_TRANSPORT_TYPES = ['tcp', 'rdma']
 SAFE_TRANSPORT_TYPES = ['pcie', 'fc']
@@ -74,20 +73,6 @@ class NVMEDeviceCollection:
             fabrics_devices.extend(self.device_by_transport[transport])
 
         return fabrics_devices
-
-
-def _format_list(data, sep=FMT_LIST_SEPARATOR, callback_sort=sorted, limit=0):
-    # NOTE(pstodulk): Teaser O:-> https://issues.redhat.com/browse/RHEL-126447
-
-    def identity(values):
-        return values
-
-    if callback_sort is None:
-        callback_sort = identity
-    res = ['{}{}'.format(sep, item) for item in callback_sort(data)]
-    if limit:
-        return ''.join(res[:limit])
-    return ''.join(res)
 
 
 def is_livemode_enabled() -> bool:
@@ -326,8 +311,8 @@ def check_unhandled_devices_present_in_fstab(nvme_device_collection: NVMEDeviceC
     if required_unhandled_dev_nodes:
         summary = (
             'The system has NVMe devices with a transport type that is currently '
-            'not handled during the upgrade process present in fstab. Problematic devices: {0}'
-        ).format(_format_list(required_unhandled_dev_nodes))
+            'not handled during the upgrade process present in fstab. Problematic devices:{0}'
+        ).format(format_list(required_unhandled_dev_nodes))
 
         reporting.create_report([
             reporting.Title('NVMe devices with unhandled transport type present in fstab'),

--- a/repos/system_upgrade/common/actors/checkosrelease/libraries/checkosrelease.py
+++ b/repos/system_upgrade/common/actors/checkosrelease/libraries/checkosrelease.py
@@ -3,9 +3,9 @@ import os
 from leapp import reporting
 from leapp.libraries.common.config import version
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
+from leapp.libraries.stdlib import format_list
 
 COMMON_REPORT_TAGS = [reporting.Groups.SANITY]
-FMT_LIST_SEPARATOR = '\n    - '
 
 related = [reporting.RelatedResource('file', '/etc/os-release')]
 
@@ -41,9 +41,9 @@ def check_os_version():
             ),
             reporting.Summary(
                 'The supported OS releases for the upgrade process:'
-                '{}{}\n\nThe detected OS release is: {}'.format(FMT_LIST_SEPARATOR,
-                                                                FMT_LIST_SEPARATOR.join(supported_releases),
-                                                                current_release)
+                '{}\n\nThe detected OS release is: {}'.format(
+                    format_list(supported_releases, callback_sort=None),
+                    current_release)
             ),
             reporting.Severity(reporting.Severity.HIGH),
             reporting.Groups(COMMON_REPORT_TAGS),

--- a/repos/system_upgrade/common/actors/checksaphana/libraries/checksaphana.py
+++ b/repos/system_upgrade/common/actors/checksaphana/libraries/checksaphana.py
@@ -1,6 +1,6 @@
 from leapp import reporting
 from leapp.libraries.common.config import architecture, version
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import SapHanaInfo
 
 # SAP HANA Compatibility
@@ -82,9 +82,7 @@ def _create_detected_instances_list(details):
                                                 instances=', '.join(meta['numbers']),
                                                 admin=meta['admin'],
                                                 path=meta['path']))
-    if result:
-        return '- {}'.format('\n- '.join(result))
-    return ''
+    return format_list(result, callback_sort=None)
 
 
 def _min_ver_string():

--- a/repos/system_upgrade/common/actors/checktargetversion/libraries/checktargetversion.py
+++ b/repos/system_upgrade/common/actors/checktargetversion/libraries/checktargetversion.py
@@ -1,8 +1,6 @@
 from leapp import reporting
 from leapp.libraries.common.config import get_env, version
-from leapp.libraries.stdlib import api
-
-FMT_LIST_SEPARATOR = '\n    - '
+from leapp.libraries.stdlib import api, format_list
 
 
 def get_supported_target_versions():
@@ -62,10 +60,9 @@ def process():
             ' is not supported from the current system version. Follow the official'
             ' documentation for up to date information about supported upgrade'
             ' paths and future plans (see the attached link).'
-            ' The in-place upgrade is enabled to the following versions of the target system:{sep}{ver_list}'
+            ' The in-place upgrade is enabled to the following versions of the target system:{ver_list}'
             .format(
-                sep=FMT_LIST_SEPARATOR,
-                ver_list=FMT_LIST_SEPARATOR.join(supported_target_versions),
+                ver_list=format_list(supported_target_versions, callback_sort=None),
                 tgt_ver=target_version
             )
         ),

--- a/repos/system_upgrade/common/actors/checkthirdpartytargetpythonmodules/libraries/checkthirdpartytargetpythonmodules.py
+++ b/repos/system_upgrade/common/actors/checkthirdpartytargetpythonmodules/libraries/checkthirdpartytargetpythonmodules.py
@@ -1,23 +1,19 @@
 from leapp import reporting
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, FMT_LIST_SEPARATOR, format_list
 from leapp.models import ThirdPartyTargetPythonModules
 
-FMT_LIST_SEPARATOR = '\n    - '
 MAX_REPORTED_ITEMS = 30
 
 
-def _formatted_list_output_with_max_items(input_list, sep=FMT_LIST_SEPARATOR, max_items=MAX_REPORTED_ITEMS):
+def _formatted_list_output_with_max_items(input_list, max_items=MAX_REPORTED_ITEMS):
     if not input_list:
         return ''
 
-    total_count = len(input_list)
-    items_to_show = input_list[:max_items]
-    formatted = ['{}{}'.format(sep, item) for item in items_to_show]
+    result = format_list(input_list, limit=max_items, callback_sort=None)
+    if len(input_list) > max_items:
+        result += '{}... and {} more'.format(FMT_LIST_SEPARATOR, len(input_list) - max_items)
 
-    if total_count > max_items:
-        formatted.append('{}... and {} more'.format(sep, total_count - max_items))
-
-    return ''.join(formatted)
+    return result
 
 
 def check_third_party_target_python_modules(third_party_target_python_modules):

--- a/repos/system_upgrade/common/actors/checkyumpluginsenabled/libraries/checkyumpluginsenabled.py
+++ b/repos/system_upgrade/common/actors/checkyumpluginsenabled/libraries/checkyumpluginsenabled.py
@@ -2,11 +2,11 @@ import os
 
 from leapp import reporting
 from leapp.libraries.common.rhsm import skip_rhsm
+from leapp.libraries.stdlib import format_list
 
 # If LEAPP_NO_RHSM is set, subscription-manager and product-id will not be
 # considered as required when checking whether the required plugins are enabled.
 REQUIRED_DNF_PLUGINS = {'subscription-manager', 'product-id'}
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def check_required_dnf_plugins_enabled(pkg_manager_info):
@@ -24,9 +24,7 @@ def check_required_dnf_plugins_enabled(pkg_manager_info):
         missing_required_plugins -= {'subscription-manager', 'product-id'}
 
     if missing_required_plugins:
-        missing_required_plugins_text = ''
-        for missing_plugin in missing_required_plugins:
-            missing_required_plugins_text += '{0}{1}'.format(FMT_LIST_SEPARATOR, missing_plugin)
+        missing_required_plugins_text = format_list(missing_required_plugins)
 
         # dnf_conf_path - enable/disable plugins globally
         # rhsm_plugin_conf, product_id_plugin_conf - plugins can be disabled individually
@@ -44,7 +42,7 @@ def check_required_dnf_plugins_enabled(pkg_manager_info):
         reporting.create_report([
             reporting.Title('Required DNF plugins are not being loaded.'),
             reporting.Summary(
-                'The following DNF plugins are not being loaded: {}'.format(missing_required_plugins_text)
+                'The following DNF plugins are not being loaded:{}'.format(missing_required_plugins_text)
             ),
             reporting.Remediation(
                 hint=(

--- a/repos/system_upgrade/common/actors/distributionsignedrpmcheck/libraries/distributionsignedrpmcheck.py
+++ b/repos/system_upgrade/common/actors/distributionsignedrpmcheck/libraries/distributionsignedrpmcheck.py
@@ -1,9 +1,7 @@
 from leapp import reporting
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.libraries.stdlib.config import is_verbose
 from leapp.models import ThirdPartyRPM
-
-FMT_LIST_SEPARATOR = "\n    - "
 
 
 def _generate_report(packages):
@@ -24,8 +22,8 @@ def _generate_report(packages):
         " cannot be satisfied and hence such packages cannot be installed on"
         " the target system.\n\n"
         "The following packages have not been signed by the vendor of the"
-        " distribution:{}{}"
-    ).format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(packages))
+        " distribution:{}"
+    ).format(format_list(packages))
     hint = (
         "The most simple solution that does not require additional knowledge"
         " about the upgrade process is the uninstallation of such packages"
@@ -71,7 +69,6 @@ def get_third_party_pkgs():
         )
 
     third_party_pkgs = list(set(pkg.name for pkg in data.items))
-    third_party_pkgs.sort()
     return third_party_pkgs
 
 

--- a/repos/system_upgrade/common/actors/gpgpubkeycheck/libraries/gpgpubkeycheck.py
+++ b/repos/system_upgrade/common/actors/gpgpubkeycheck/libraries/gpgpubkeycheck.py
@@ -1,10 +1,8 @@
 from leapp import reporting
 from leapp.libraries.common.gpg import is_nogpgcheck_set
 from leapp.libraries.common.rpms import get_installed_rpms
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import TrustedGpgKeys
-
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def _get_installed_fps_tuple():
@@ -40,10 +38,9 @@ def _report_cannot_check_keys(installed_fps):
         ' in the start of the upgrade process on the original system.'
         ' Unexpected unexpected installed GPG keys could be e.g. a mark of'
         ' a malicious attempt to hijack the upgrade process.'
-        ' The list of all GPG keys in RPM DB:{sep}{key_list}'
+        ' The list of all GPG keys in RPM DB:{key_list}'
         .format(
-            sep=FMT_LIST_SEPARATOR,
-            key_list=FMT_LIST_SEPARATOR.join(installed_fps)
+            key_list=format_list(installed_fps, callback_sort=None)
         )
     )
     hint = (
@@ -68,11 +65,9 @@ def _report_unexpected_keys(unexpected_fps):
         'The system contains unexpected GPG keys after upgrade.'
         ' This can be caused e.g. by a manual intervention'
         ' or by malicious attempt to hijack the upgrade process.'
-        ' The unexpected keys are the following:'
-        ' {sep}{key_list}'
+        ' The unexpected keys are the following:{key_list}'
         .format(
-            sep=FMT_LIST_SEPARATOR,
-            key_list=FMT_LIST_SEPARATOR.join(unexpected_fps)
+            key_list=format_list(unexpected_fps, callback_sort=None)
         )
     )
     hint = (

--- a/repos/system_upgrade/common/actors/initramfs/checkinitramfstasks/libraries/checkinitramfstasks.py
+++ b/repos/system_upgrade/common/actors/initramfs/checkinitramfstasks/libraries/checkinitramfstasks.py
@@ -2,7 +2,7 @@ import os
 from collections import defaultdict
 
 from leapp import reporting
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import TargetInitramfsTasks, UpgradeInitramfsTasks
 
 DRACUT_MOD_DIR = '/usr/lib/dracut/modules.d/'
@@ -15,11 +15,8 @@ SUMMARY_FMT = (
 
 
 def _printable_modules(conflicts):
-    list_separator_fmt = '\n    - '
-    for name, paths in conflicts.items():
-        paths = sorted([str(i) for i in paths])
-        output = ['{}{}: {}'.format(list_separator_fmt, name, paths)]
-    return ''.join(output)
+    items = ['{}: {}'.format(name, sorted([str(i) for i in paths])) for name, paths in conflicts.items()]
+    return format_list(items)
 
 
 def _treat_path_dracut(dmodule):

--- a/repos/system_upgrade/common/actors/missinggpgkeysinhibitor/libraries/missinggpgkey.py
+++ b/repos/system_upgrade/common/actors/missinggpgkeysinhibitor/libraries/missinggpgkey.py
@@ -10,7 +10,7 @@ from leapp import reporting
 from leapp.exceptions import StopActorExecution, StopActorExecutionError
 from leapp.libraries.common.config.version import get_target_major_version
 from leapp.libraries.common.gpg import get_gpg_fp_from_file, get_path_to_gpg_certs, is_nogpgcheck_set
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import (
     DNFWorkaround,
     TargetUserSpaceInfo,
@@ -19,8 +19,6 @@ from leapp.models import (
     UsedTargetRepositories
 )
 from leapp.utils.deprecation import suppress_deprecation
-
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def _expand_vars(path):
@@ -143,11 +141,10 @@ def _report(title, summary, keys, inhibitor=False):
         ' review is required, so any spurious keys are not imported in the system'
         ' during the in-place upgrade.'
         ' The following additional gpg keys are required to be imported during'
-        ' the upgrade:{sep}{key_list}'
+        ' the upgrade:{key_list}'
         .format(
             summary=summary,
-            sep=FMT_LIST_SEPARATOR,
-            key_list=FMT_LIST_SEPARATOR.join(keys)
+            key_list=format_list(keys, callback_sort=None)
         )
     )
     hint = (
@@ -224,11 +221,9 @@ def _report_repos_missing_keys(repos):
         ' Leapp is not able to guarantee validity of such gpg keys and manual'
         ' review is required, so any spurious keys are not imported in the system'
         ' during the in-place upgrade.'
-        ' The following repositories require some attention before the upgrade:'
-        ' {sep}{key_list}'
+        ' The following repositories require some attention before the upgrade:{key_list}'
         .format(
-            sep=FMT_LIST_SEPARATOR,
-            key_list=FMT_LIST_SEPARATOR.join(repos)
+            key_list=format_list(repos, callback_sort=None)
         )
     )
     hint = (

--- a/repos/system_upgrade/common/actors/reportleftoverpackages/libraries/reportleftoverpackages.py
+++ b/repos/system_upgrade/common/actors/reportleftoverpackages/libraries/reportleftoverpackages.py
@@ -1,9 +1,7 @@
 from leapp import reporting
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import LeftoverPackages, RemovedPackages
-
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def process():
@@ -15,12 +13,11 @@ def process():
         title = 'Leftover packages from the original OS have been removed'
         removed = ['-'.join([pkg.name, pkg.version, pkg.release]) for pkg in removed_packages.items]
         summary = (
-            'Following {source_distro} packages have been removed:{sep}{list}\n'
+            'Following {source_distro} packages have been removed:{list}\n'
             'Dependent packages may have been removed as well, please check that you are not missing '
             'any packages.'
             .format(
-                sep=FMT_LIST_SEPARATOR,
-                list=FMT_LIST_SEPARATOR.join(removed),
+                list=format_list(removed),
                 **DISTRO_REPORT_NAMES
             )
         )
@@ -35,11 +32,10 @@ def process():
 
     if leftover_packages and leftover_packages.items:
         summary = (
-            'Following {source_distro} packages have not been upgraded:{sep}{list}\n'
+            'Following {source_distro} packages have not been upgraded:{list}\n'
             'Please remove these packages to keep your system in supported state.'
             .format(
-                sep=FMT_LIST_SEPARATOR,
-                list=FMT_LIST_SEPARATOR.join(leftover_pkgs_to_remove),
+                list=format_list(leftover_pkgs_to_remove),
                 **DISTRO_REPORT_NAMES
             )
         )

--- a/repos/system_upgrade/common/actors/rpmtransactionconfigtaskscollector/libraries/rpmtransactionconfigtaskscollector.py
+++ b/repos/system_upgrade/common/actors/rpmtransactionconfigtaskscollector/libraries/rpmtransactionconfigtaskscollector.py
@@ -1,6 +1,6 @@
 import os.path
 
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import DistributionSignedRPM, RpmTransactionTasks
 
 
@@ -29,8 +29,8 @@ def load_tasks(base_dir, logger):
     filtered = set(to_install) - set(to_install_filtered)
     if filtered:
         api.current_logger().debug(
-            'The following packages from "to_install" file will be ignored as they are already installed:\n- %s',
-            '\n- '.join(filtered)
+            'The following packages from "to_install" file will be ignored as they are already installed:%s',
+            format_list(filtered)
         )
 
     return RpmTransactionTasks(

--- a/repos/system_upgrade/common/actors/scanthirdpartytargetpythonmodules/libraries/scanthirdpartytargetpythonmodules.py
+++ b/repos/system_upgrade/common/actors/scanthirdpartytargetpythonmodules/libraries/scanthirdpartytargetpythonmodules.py
@@ -7,15 +7,10 @@ import rpm
 
 from leapp.libraries.common.config.version import get_target_major_version
 from leapp.libraries.common.rpms import has_package
-from leapp.libraries.stdlib import api, run
+from leapp.libraries.stdlib import api, format_list, run
 from leapp.models import DistributionSignedRPM, ThirdPartyTargetPythonModules
 
 PYTHON_EXTENSIONS = (".py", ".so", ".pyc")
-FMT_LIST_SEPARATOR = '\n  - '
-
-
-def _formatted_list_output(input_list, sep=FMT_LIST_SEPARATOR):
-    return ['{}{}'.format(sep, item) for item in input_list]
 
 
 def get_python_sys_paths(python_interpreter):
@@ -175,14 +170,14 @@ def process():
         if third_party_rpms:
             api.current_logger().info(
                 'Complete list of third-party RPM packages:{}'.format(
-                    ''.join(_formatted_list_output(third_party_rpms))
+                    format_list(third_party_rpms)
                 )
             )
 
         if all_third_party_files:
             api.current_logger().info(
                 'Complete list of third-party Python modules:{}'.format(
-                    ''.join(_formatted_list_output(all_third_party_files))
+                    format_list(all_third_party_files)
                 )
             )
 

--- a/repos/system_upgrade/common/actors/systemd/checksystemdbrokensymlinks/libraries/checksystemdbrokensymlinks.py
+++ b/repos/system_upgrade/common/actors/systemd/checksystemdbrokensymlinks/libraries/checksystemdbrokensymlinks.py
@@ -2,10 +2,8 @@ import os
 
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import SystemdBrokenSymlinksSource, SystemdServicesInfoSource
-
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def _report_broken_symlinks(symlinks):
@@ -17,8 +15,8 @@ def _report_broken_symlinks(symlinks):
         ' has not been properly modified.'
         ' These symlinks will not be handled during the in-place upgrade'
         ' as they are already broken.'
-        ' The list of detected broken systemd symlinks:{}{}'
-        .format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(sorted(symlinks)))
+        ' The list of detected broken systemd symlinks:{}'
+        .format(format_list(symlinks))
     )
 
     command = ['/usr/bin/rm'] + symlinks
@@ -44,8 +42,8 @@ def _report_enabled_services_broken_symlinks(symlinks):
         ' to existing systemd units, but on different paths. This could lead'
         ' in future to unexpected behaviour. Also, these symlinks will not be'
         ' handled during the in-place upgrade as they are already broken.'
-        ' The list of detected broken symlinks:{}{}'
-        .format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(sorted(symlinks)))
+        ' The list of detected broken symlinks:{}'
+        .format(format_list(symlinks))
     )
 
     hint = (

--- a/repos/system_upgrade/common/actors/systemd/checksystemdservicetasks/libraries/checksystemdservicetasks.py
+++ b/repos/system_upgrade/common/actors/systemd/checksystemdservicetasks/libraries/checksystemdservicetasks.py
@@ -1,16 +1,14 @@
 from leapp import reporting
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import SystemdServicesTasks
-
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def _inhibit_upgrade_with_conflicts(conflicts):
     summary = (
         'The requested states for systemd services on the target system are in conflict.'
         ' The following systemd services were requested to be both enabled and'
-        ' disabled on the target system:{}{}'
-        .format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(sorted(conflicts)))
+        ' disabled on the target system:{}'
+        .format(format_list(conflicts))
     )
     report = [
         reporting.Title('Conflicting requirements of systemd service states'),

--- a/repos/system_upgrade/common/actors/systemd/transitionsystemdservicesstates/libraries/transitionsystemdservicesstates.py
+++ b/repos/system_upgrade/common/actors/systemd/transitionsystemdservicesstates/libraries/transitionsystemdservicesstates.py
@@ -1,7 +1,7 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.config import version
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import (
     SystemdServicesInfoSource,
     SystemdServicesInfoTarget,
@@ -9,8 +9,6 @@ from leapp.models import (
     SystemdServicesPresetInfoTarget,
     SystemdServicesTasks
 )
-
-FMT_LIST_SEPARATOR = "\n    - "
 
 
 def _get_desired_service_state(state_source, preset_source, preset_target):
@@ -166,8 +164,8 @@ def _report_kept_enabled(tasks):
     if tasks.to_enable:
         summary += (
             "The following services were originally disabled by preset on the"
-            " upgraded system and Leapp attempted to enable them:{}{}"
-        ).format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(sorted(tasks.to_enable)))
+            " upgraded system and Leapp attempted to enable them:{}"
+        ).format(format_list(tasks.to_enable))
         # TODO(mmatuska): When post-upgrade reports are implemented in
         # `setsystemdservicesstates actor, add a note here to check the reports
         # if the enabling failed
@@ -198,8 +196,8 @@ def _report_newly_enabled(newly_enabled):
 
     summary = (
         "The following services were disabled before the upgrade and were set"
-        " to enabled by a systemd preset after the upgrade:{}{}".format(
-            FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(sorted(newly_enabled))
+        " to enabled by a systemd preset after the upgrade:{}".format(
+            format_list(newly_enabled)
         )
     )
 

--- a/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repositoriesblocklist.py
+++ b/repos/system_upgrade/common/actors/targetcontentresolver/libraries/repositoriesblocklist.py
@@ -1,7 +1,7 @@
 from leapp import reporting
 from leapp.libraries.common.config import get_target_distro_id
 from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import RepositoriesBlocklisted
 
 
@@ -15,7 +15,7 @@ def _report_excluded_repos(repos):
         reporting.Summary(
             'The following repositories are not supported by '
             'Red Hat and are excluded from the list of repositories '
-            'used during the upgrade.\n- {}'.format('\n- '.join(repos))
+            'used during the upgrade.{}'.format(format_list(repos))
         ),
         reporting.Severity(reporting.Severity.INFO),
         reporting.Groups([reporting.Groups.REPOSITORY]),

--- a/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
+++ b/repos/system_upgrade/common/actors/targetuserspacecreator/libraries/userspacegen.py
@@ -21,7 +21,7 @@ from leapp.libraries.common.config.version import (
 )
 from leapp.libraries.common.dnflibs import dnfplugin
 from leapp.libraries.common.gpg import get_path_to_gpg_certs, is_nogpgcheck_set
-from leapp.libraries.stdlib import api, CalledProcessError, config, run
+from leapp.libraries.stdlib import api, CalledProcessError, config, format_list, run
 from leapp.models import RequiredTargetUserspacePackages  # deprecated
 from leapp.models import TMPTargetRepositoriesFacts  # deprecated all the time
 from leapp.models import (
@@ -69,7 +69,6 @@ from leapp.utils.deprecation import suppress_deprecation
 PROD_CERTS_FOLDER = 'prod-certs'
 PERSISTENT_PACKAGE_CACHE_DIR = '/var/lib/leapp/persistent_package_cache'
 DEDICATED_LEAPP_PART_URL = 'https://access.redhat.com/solutions/7011704'
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def _check_deprecated_rhsm_skip():
@@ -786,18 +785,17 @@ def _inhibit_on_duplicate_repos(repofiles):
 
     if not duplicates:
         return
-    list_separator_fmt = '\n    - '
     api.current_logger().warning(
-        'The following repoids are defined multiple times:{0}{1}'
-        .format(list_separator_fmt, list_separator_fmt.join(sorted(duplicates)))
+        'The following repoids are defined multiple times:{}'
+        .format(format_list(duplicates))
     )
 
     reporting.create_report([
         reporting.Title('A YUM/DNF repository defined multiple times'),
         reporting.Summary(
             'The following repositories are defined multiple times inside the'
-            ' "upgrade" container:{0}{1}'
-            .format(list_separator_fmt, list_separator_fmt.join(sorted(duplicates)))
+            ' "upgrade" container:{}'
+            .format(format_list(duplicates))
         ),
         reporting.Severity(reporting.Severity.MEDIUM),
         reporting.Groups([reporting.Groups.REPOSITORY]),
@@ -1027,10 +1025,9 @@ def gather_target_repositories(context, indata):
     distro_repoids = _get_distro_available_repoids(context, indata)
     if distro_repoids:
         api.current_logger().info(
-            "The following repoids are considered as provided by the '{}' distribution:{}{}".format(
+            "The following repoids are considered as provided by the '{}' distribution:{}".format(
                 get_target_distro_id(),
-                FMT_LIST_SEPARATOR,
-                FMT_LIST_SEPARATOR.join(sorted(distro_repoids)),
+                format_list(distro_repoids),
             )
         )
     else:
@@ -1110,8 +1107,8 @@ def gather_target_repositories(context, indata):
                 'This can happen when a repository ID was entered incorrectly either'
                 ' while using the --enablerepo option of leapp, or in a third party actor that produces a'
                 ' CustomTargetRepositoryMessage.\n'
-                'The following repositories IDs could not be found in the target configuration:\n'
-                '- {}\n'.format('\n- '.join(sorted(missing_custom_repoids)))
+                'The following repositories IDs could not be found in the target configuration:{}'
+                .format(format_list(missing_custom_repoids))
             ),
             reporting.Groups([reporting.Groups.REPOSITORY]),
             reporting.Groups([reporting.Groups.INHIBITOR]),

--- a/repos/system_upgrade/common/actors/unsupportedupgradecheck/actor.py
+++ b/repos/system_upgrade/common/actors/unsupportedupgradecheck/actor.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.actors import Actor
+from leapp.libraries.stdlib import format_list
 from leapp.models import Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
 
@@ -46,7 +47,7 @@ class UnsupportedUpgradeCheck(Actor):
                         'guaranteed and the upgrade is unsupported.\n'
                         'You can bypass this error by setting the LEAPP_UNSUPPORTED variable but by doing so, '
                         'you continue at your own risk.\n'
-                        'Found development variables:\n- {}\n'.format('\n- '.join([v.name for v in devel_vars]))
+                        'Found development variables:{}'.format(format_list([v.name for v in devel_vars]))
                     ),
                     reporting.Severity(reporting.Severity.HIGH),
                     reporting.Groups([reporting.Groups.INHIBITOR]),

--- a/repos/system_upgrade/common/libraries/rhsm.py
+++ b/repos/system_upgrade/common/libraries/rhsm.py
@@ -8,7 +8,7 @@ from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common import repofileutils
 from leapp.libraries.common.config import get_env, get_target_distro_id
-from leapp.libraries.stdlib import api, CalledProcessError
+from leapp.libraries.stdlib import api, CalledProcessError, format_list
 from leapp.models import RHSMInfo
 
 _RE_REPO_UID = re.compile(r'Repo ID:\s*([^\s]+)')
@@ -195,10 +195,9 @@ def get_available_repo_ids(context):
             rhsm_repos.sort()
             break
 
-    list_separator_fmt = '\n    - '
     if rhsm_repos:
-        api.current_logger().info('The following repoids are available through RHSM:{0}{1}'
-                                  .format(list_separator_fmt, list_separator_fmt.join(rhsm_repos)))
+        api.current_logger().info('The following repoids are available through RHSM:{}'
+                                  .format(format_list(rhsm_repos)))
     else:
         api.current_logger().info('There are no repos available through RHSM.')
     return rhsm_repos
@@ -215,17 +214,16 @@ def _inhibit_on_duplicate_repos(repofiles):
 
     if not duplicates:
         return
-    list_separator_fmt = '\n    - '
     api.current_logger().warning(
-        'The following repoids are defined multiple times:{0}{1}'
-        .format(list_separator_fmt, list_separator_fmt.join(duplicates))
+        'The following repoids are defined multiple times:{}'
+        .format(format_list(duplicates))
     )
 
     reporting.create_report([
         reporting.Title('A YUM/DNF repository defined multiple times'),
         reporting.Summary(
-            'The following repositories are defined multiple times:{0}{1}'
-            .format(list_separator_fmt, list_separator_fmt.join(duplicates))
+            'The following repositories are defined multiple times:{}'
+            .format(format_list(duplicates))
         ),
         reporting.Severity(reporting.Severity.MEDIUM),
         reporting.Groups([reporting.Groups.REPOSITORY]),

--- a/repos/system_upgrade/el8toel9/actors/checkdeprecatedrpmsignature/libraries/checkdeprecatedrpmsignature.py
+++ b/repos/system_upgrade/el8toel9/actors/checkdeprecatedrpmsignature/libraries/checkdeprecatedrpmsignature.py
@@ -1,9 +1,7 @@
 from leapp import reporting
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import CryptoPolicyInfo, InstalledRPM
-
-FMT_LIST_SEPARATOR = '\n    - '
 
 # FIXME(pstodulk): Adding the links to the summary as information inside has
 # serious impact. This will create a duplication of links for Satellite and
@@ -62,10 +60,9 @@ def process():
     bad_rpms = _get_rpms_with_sha1_sig()
     cpi = next(api.consume(CryptoPolicyInfo), None)
     if bad_rpms:
-        bad_rpms_str = ''.join([
-            '{prefix}{pkgname} ({sig})'.format(prefix=FMT_LIST_SEPARATOR, pkgname=pkg.name, sig=pkg.pgpsig)
-            for pkg in bad_rpms
-        ])
+        bad_rpms_str = format_list(
+            ['{} ({})'.format(pkg.name, pkg.pgpsig) for pkg in bad_rpms]
+        )
         report = [
             reporting.Title('Detected RPMs with RSA/SHA1 signature'),
             reporting.Summary(SUMMARY_FMT.format(

--- a/repos/system_upgrade/el8toel9/actors/checkifcfg/libraries/checkifcfg_ifcfg.py
+++ b/repos/system_upgrade/el8toel9/actors/checkifcfg/libraries/checkifcfg_ifcfg.py
@@ -3,16 +3,8 @@ import os
 from leapp import reporting
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import IfCfg, InstalledRPM, RpmTransactionTasks
-
-FMT_LIST_SEPARATOR = '\n    - '
-
-
-def _format_files_list(files):
-    return "".join(
-        ["{}{}".format(FMT_LIST_SEPARATOR, f) for f in files]
-    )
 
 
 def process():
@@ -87,7 +79,7 @@ def process():
             " NetworkManager. Files for device types that are not"
             " supported by NetworkManager are present in the system."
             " Files with the problematic configuration:{bad_files}".format(
-                bad_files=_format_files_list(bad_type_files),
+                bad_files=format_list(bad_type_files),
                 **DISTRO_REPORT_NAMES,
             )
         )
@@ -121,7 +113,7 @@ def process():
             ' prohibit NetworkManager from loading it.'
             ' Files with the problematic configuration:{bad_files}'
         ).format(
-            bad_files=_format_files_list(not_controlled_files),
+            bad_files=format_list(not_controlled_files),
             **DISTRO_REPORT_NAMES,
         )
         remediation = ('Ensure the ifcfg files comply with format described in'

--- a/repos/system_upgrade/el8toel9/actors/networkdeprecations/libraries/networkdeprecations.py
+++ b/repos/system_upgrade/el8toel9/actors/networkdeprecations/libraries/networkdeprecations.py
@@ -1,8 +1,6 @@
 from leapp import reporting
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import IfCfg, NetworkManagerConnection, SystemdServicesInfoSource
-
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def process():
@@ -59,7 +57,7 @@ def process():
                    ' that use the phased out WEP algorithm is present in the system'
                    ' and will not work after the upgrade.'
                    ' Files with the problematic configuration:{}').format(
-            ''.join(['{}{}'.format(FMT_LIST_SEPARATOR, bfile) for bfile in wep_files])
+            format_list(wep_files)
         )
         remediation = ('Remove configuration for networks that use WEP or'
                        ' upgrade the networks to use more secure encryption'
@@ -87,7 +85,7 @@ def process():
             ' connections will not be active unless NetworkManager is enabled.'
             ' Files with the problematic configuration:{}'
         ).format(
-            ''.join(['{}{}'.format(FMT_LIST_SEPARATOR, f) for f in nm_controlled_files])
+            format_list(nm_controlled_files)
         )
         remediation = (
             'Either enable the NetworkManager service before upgrading, or add'

--- a/repos/system_upgrade/el8toel9/actors/rocecheck/libraries/rocecheck.py
+++ b/repos/system_upgrade/el8toel9/actors/rocecheck/libraries/rocecheck.py
@@ -2,10 +2,9 @@ from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.config import architecture, get_target_distro_id
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import KernelCmdline, RoceDetected
 
-FMT_LIST_SEPARATOR = '\n    - {}'
 DOC_URL = 'https://red.ht/predictable-network-interface-device-names-on-the-system-z-platform'
 
 
@@ -34,10 +33,6 @@ def is_kernel_arg_set():
     return False
 
 
-def _fmt_list(items):
-    return ''.join([FMT_LIST_SEPARATOR.format(i) for i in items])
-
-
 def _report_wrong_setup(roce):
     roce_nics = roce.roce_nics_connected + roce.roce_nics_connecting
 
@@ -50,7 +45,7 @@ def _report_wrong_setup(roce):
         ' For more information, see: {url}'
         '\n\nRoCE detected on the following NICs:{nics}'
     ).format(
-        nics=_fmt_list(roce_nics),
+        nics=format_list(roce_nics),
         url=DOC_URL,
         **DISTRO_REPORT_NAMES,
     )

--- a/repos/system_upgrade/el8toel9/actors/xorgdrvcheck/actor.py
+++ b/repos/system_upgrade/el8toel9/actors/xorgdrvcheck/actor.py
@@ -1,5 +1,6 @@
 from leapp import reporting
 from leapp.actors import Actor
+from leapp.libraries.stdlib import format_list
 from leapp.models import XorgDrvFacts
 from leapp.reporting import create_report, Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
@@ -8,7 +9,7 @@ SUMMARY_XORG_DEPRECATE_DRIVERS_FMT = (
     'Leapp has detected the use of some deprecated Xorg drivers. '
     'Using these drivers could lead to a broken graphical session after the upgrade. '
     'Any custom configuration related to these drivers will be ignored. '
-    'The list of used deprecated drivers: {}')
+    'The list of used deprecated drivers:{}')
 
 SUMMARY_XORG_DEPRECATE_DRIVERS_HINT = (
     'Please uninstall the Xorg driver and remove the corresponding driver '
@@ -16,17 +17,17 @@ SUMMARY_XORG_DEPRECATE_DRIVERS_HINT = (
     'such as `/etc/X11/xorg.conf` and `/etc/X11/xorg.conf.d/` and reboot before '
     'upgrading to make sure you have a graphical session after upgrading.'
 )
-FMT_LIST_SEPARATOR = '\n    - {}'
 
 
 def _printable_drv(facts):
-    output = ''
+    items = []
     for fact in facts:
         for driver in fact.xorg_drivers:
-            output += FMT_LIST_SEPARATOR.format(driver.driver)
+            item = driver.driver
             if driver.has_options:
-                output += ' (with custom driver options)'
-    return output
+                item += ' (with custom driver options)'
+            items.append(item)
+    return format_list(items, callback_sort=None)
 
 
 class XorgDrvCheck8to9(Actor):

--- a/repos/system_upgrade/el9toel10/actors/checkoldxfs/libraries/checkoldxfs.py
+++ b/repos/system_upgrade/el9toel10/actors/checkoldxfs/libraries/checkoldxfs.py
@@ -1,14 +1,8 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import XFSInfoFacts
-
-FMT_LIST_SEPARATOR = '\n    - '
-
-
-def _formatted_list_output(input_list, sep=FMT_LIST_SEPARATOR):
-    return ['{}{}'.format(sep, item) for item in input_list]
 
 
 def process():
@@ -78,7 +72,7 @@ def _report_bigtime(invalid_bigtime):
         ' failures.'
         ' Following XFS file systems have not enabled the "bigtime" feature:{fs_list}'.format(
             distro=DISTRO_REPORT_NAMES.target,
-            fs_list=''.join(_formatted_list_output(invalid_bigtime))
+            fs_list=format_list(invalid_bigtime)
         )
     )
 
@@ -116,7 +110,7 @@ def _inhibit_crc(invalid_crc):
         ' the target kernel. Such filesystems cannot be mounted by target'
         ' system kernel and so the upgrade cannot proceed successfully.'
         ' Following XFS filesystems have v4 format:{}'
-        .format(''.join(_formatted_list_output(invalid_crc)))
+        .format(format_list(invalid_crc))
     )
     remediation_hint = (
         'Migrate XFS v4 filesystems to new XFS v5 format.'

--- a/repos/system_upgrade/el9toel10/actors/krb5conf/checkkrb5conf/libraries/checkkrb5conf.py
+++ b/repos/system_upgrade/el9toel10/actors/krb5conf/checkkrb5conf/libraries/checkkrb5conf.py
@@ -1,16 +1,8 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import OutdatedKrb5conf
-
-FMT_LIST_SEPARATOR = "\n    - "
-
-
-def __human_readable_list(unmanaged_files):
-    if unmanaged_files:
-        return FMT_LIST_SEPARATOR + FMT_LIST_SEPARATOR.join(unmanaged_files)
-    return ''
 
 
 def process():
@@ -27,7 +19,7 @@ def process():
                 'the location of the reference X.509 CA bundle '
                 'file was modified. The following unmanaged MIT krb5 '
                 'configuration files have to be updated to point to the new '
-                'bundle file:' + __human_readable_list(msg.unmanaged_files)),
+                'bundle file:' + format_list(msg.unmanaged_files)),
             reporting.Severity(reporting.Severity.INFO),
             reporting.Groups([reporting.Groups.SECURITY, reporting.Groups.AUTHENTICATION])
         ])
@@ -46,7 +38,7 @@ def process():
                 'RPMs were updated to reflect this change, or you may be '
                 'unable to complete Kerberos PKINIT pre-authentication (e.g. '
                 'using user certificates, or smartcards). The following files '
-                'are affected:' + __human_readable_list(file_paths_from_rpm)),
+                'are affected:' + format_list(file_paths_from_rpm)),
             reporting.Severity(reporting.Severity.MEDIUM),
             reporting.Groups([reporting.Groups.SECURITY, reporting.Groups.AUTHENTICATION])
         ])

--- a/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
+++ b/repos/system_upgrade/el9toel10/actors/mysql/checkmysql/libraries/checkmysql.py
@@ -3,21 +3,15 @@ from typing import TYPE_CHECKING
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 
 if TYPE_CHECKING:
     from repos.system_upgrade.el9toel10.models.mysql import MySQLConfiguration
 else:
     from leapp.models import MySQLConfiguration
 
-FMT_LIST_SEPARATOR = '\n    - '
-
 # Link URL for mysql-server report
 REPORT_SERVER_INST_LINK_URL = 'https://access.redhat.com/articles/7099234'
-
-
-def _formatted_list_output(input_list, sep=FMT_LIST_SEPARATOR):
-    return ['{}{}'.format(sep, item) for item in input_list]
 
 
 def _generate_mysql_present_report() -> None:
@@ -73,7 +67,7 @@ def _generate_deprecated_config_report(found_options: list,
         summary_list.append(
             'Following incompatible configuration options have been detected:{}'
             '\nDefault configuration file is present at `/etc/my.cnf`'
-            .format(''.join(_formatted_list_output(found_options)))
+            .format(format_list(found_options, callback_sort=None))
         )
         remedy_list.append('Drop all deprecated configuration options before the upgrade.')
 
@@ -83,7 +77,7 @@ def _generate_deprecated_config_report(found_options: list,
             'will not work with the new MySQL after upgrading:{}\n'
             'Default service override file is present at '
             '`/etc/systemd/system/mysqld.service.d/override.conf`'
-            .format(''.join(_formatted_list_output(found_arguments)))
+            .format(format_list(found_arguments, callback_sort=None))
         )
         remedy_list.append(
             'Drop all detected problematic startup arguments from '
@@ -108,7 +102,7 @@ def _generate_deprecated_config_report(found_options: list,
         reporting.RelatedResource('file', '/etc/systemd/system/mysqld.service.d/override.conf'),
         reporting.Remediation(hint=(
             'To ensure smooth upgrade process it is strongly recommended to:{}'
-            .format(''.join(_formatted_list_output(remedy_list)))
+            .format(format_list(remedy_list, callback_sort=None))
         )),
         ])
 

--- a/repos/system_upgrade/el9toel10/actors/networkdeprecations/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/networkdeprecations/actor.py
@@ -3,14 +3,9 @@ import os
 from leapp import reporting
 from leapp.actors import Actor
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
+from leapp.libraries.stdlib import format_list
 from leapp.models import IfCfg, NetworkManagerConfig, Report
 from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
-
-FMT_LIST_SEPARATOR = '\n    - '
-
-
-def _formatted_list_output(input_list, sep=FMT_LIST_SEPARATOR):
-    return ['{}{}'.format(sep, item) for item in sorted(input_list)]
 
 
 class CheckNetworkDeprecations9to10(Actor):
@@ -63,7 +58,7 @@ class CheckNetworkDeprecations9to10(Actor):
                 ' natively and therefore can not be migrated automatically.'
                 ' The following configuration files were found:{files}'
                 .format(
-                    files=''.join(_formatted_list_output(conn.values())),
+                    files=format_list(conn.values()),
                     target_distro=DISTRO_REPORT_NAMES.target
                 )
             ),
@@ -97,7 +92,7 @@ class CheckNetworkDeprecations9to10(Actor):
                 'Files that used to accompany legacy network configuration in "ifcfg"'
                 ' format are present, even though the configuration itself is not'
                 ' longer there. These files will be ignored:{}'
-                .format(''.join(_formatted_list_output(conn.values())))
+                .format(format_list(conn.values()))
             ),
             reporting.Remediation(hint='Verify that the files were not left behind by incomplete'
                                        ' migration, fix up configuration if necessary, and remove'
@@ -119,7 +114,7 @@ class CheckNetworkDeprecations9to10(Actor):
                 'In {target_distro} 10, support for these files is no longer'
                 ' enabled and the configuration will be ignored. The following files'
                 ' were found:{conns}'.format(
-                    conns=''.join(_formatted_list_output(conn.values())),
+                    conns=format_list(conn.values()),
                     target_distro=DISTRO_REPORT_NAMES.target,
                 )
             ),

--- a/repos/system_upgrade/el9toel10/actors/opensslenginescheck/libraries/opensslenginescheck.py
+++ b/repos/system_upgrade/el9toel10/actors/opensslenginescheck/libraries/opensslenginescheck.py
@@ -1,16 +1,11 @@
 from leapp import reporting
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 
-FMT_LIST_SEPARATOR = '\n    - '
 RESOURCES = [
     reporting.RelatedResource('package', 'openssl'),
     reporting.RelatedResource('file', '/etc/pki/tls/openssl.cnf')
 ]
-
-
-def _formatted_list_output(input_list, sep=FMT_LIST_SEPARATOR):
-    return ['{}{}'.format(sep, item) for item in input_list]
 
 
 # NOTE: This is taken from the el8toel9 library in
@@ -117,7 +112,7 @@ def check_openssl_engines(config):
                 ' The following OpenSSL engines are configured inside the'
                 ' /etc/pki/tls/openssl.cnf file:{engines}'.format(
                     target=DISTRO_REPORT_NAMES.target,
-                    engines=''.join(_formatted_list_output(enabled_engines)),
+                    engines=format_list(enabled_engines),
                 )
             ),
             reporting.Remediation(hint=(

--- a/repos/system_upgrade/el9toel10/actors/pamuserdb/checkpamuserdb/libraries/checkpamuserdb.py
+++ b/repos/system_upgrade/el9toel10/actors/pamuserdb/checkpamuserdb/libraries/checkpamuserdb.py
@@ -1,10 +1,8 @@
 from leapp import reporting
 from leapp.exceptions import StopActorExecutionError
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import PamUserDbLocation
-
-FMT_LIST_SEPARATOR = "\n    - "
 
 
 def process():
@@ -19,9 +17,8 @@ def process():
                 'On {target_distro} 10, GDMB is used by pam_userdb as it\'s backend database,'
                 ' replacing BerkeleyDB. Existing pam_userdb databases will be'
                 ' converted to GDBM. The following databases will be converted:'
-                '{sep}{locations}'.format(
-                    sep=FMT_LIST_SEPARATOR,
-                    locations=FMT_LIST_SEPARATOR.join(msg.locations),
+                '{locations}'.format(
+                    locations=format_list(msg.locations),
                     target_distro=DISTRO_REPORT_NAMES.target,
                 )
             ),

--- a/repos/system_upgrade/el9toel10/actors/pulseaudiocheck/checkpulseaudio/libraries/checkpulseaudio.py
+++ b/repos/system_upgrade/el9toel10/actors/pulseaudiocheck/checkpulseaudio/libraries/checkpulseaudio.py
@@ -1,10 +1,8 @@
 from leapp import reporting
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
-from leapp.libraries.stdlib import api
+from leapp.libraries.stdlib import api, format_list
 from leapp.models import DistributionSignedRPM, PulseAudioConfiguration
-
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def _report_custom_pulseaudio_config(modified_defaults, dropin_dirs, user_config_dirs):
@@ -21,24 +19,21 @@ def _report_custom_pulseaudio_config(modified_defaults, dropin_dirs, user_config
     details = []
     if modified_defaults:
         details.append(
-            'The following default PulseAudio configuration files have been modified:{sep}{files}'.format(
-                sep=FMT_LIST_SEPARATOR,
-                files=FMT_LIST_SEPARATOR.join(modified_defaults),
+            'The following default PulseAudio configuration files have been modified:{}'.format(
+                format_list(modified_defaults),
             )
         )
     if dropin_dirs:
         details.append(
             'The following PulseAudio drop-in configuration directories contain custom '
-            'fragments:{sep}{dirs}'.format(
-                sep=FMT_LIST_SEPARATOR,
-                dirs=FMT_LIST_SEPARATOR.join(dropin_dirs),
+            'fragments:{}'.format(
+                format_list(dropin_dirs),
             )
         )
     if user_config_dirs:
         details.append(
-            'Per-user PulseAudio configuration was found in:{sep}{dirs}'.format(
-                sep=FMT_LIST_SEPARATOR,
-                dirs=FMT_LIST_SEPARATOR.join(user_config_dirs),
+            'Per-user PulseAudio configuration was found in:{}'.format(
+                format_list(user_config_dirs),
             )
         )
 

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/libraries/sssdchecks.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/libraries/sssdchecks.py
@@ -1,6 +1,5 @@
 from leapp import reporting
-
-FMT_LIST_SEPARATOR = '\n    - '
+from leapp.libraries.stdlib import format_list
 
 
 def check_config(model):
@@ -17,9 +16,8 @@ def check_config(model):
         'to reflect this by updating every mention of sss_ssh_knownhostsproxy by '
         'the corresponding mention of sss_ssh_knownhosts, even those commented out. '
         'SSSD\'s ssh service will be enabled if not already done.\n\n'
-        'The following files will be updated:{}{}'.format(
-            FMT_LIST_SEPARATOR,
-            FMT_LIST_SEPARATOR.join(model.sssd_config_files + model.ssh_config_files)
+        'The following files will be updated:{}'.format(
+            format_list(model.sssd_config_files + model.ssh_config_files, callback_sort=None)
         )
     )
 

--- a/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/tests/component_test_sssdchecks.py
+++ b/repos/system_upgrade/el9toel10/actors/sssd/sssdchecks/tests/component_test_sssdchecks.py
@@ -1,3 +1,4 @@
+from leapp.libraries.stdlib import format_list
 from leapp.models import KnownHostsProxyConfig, Report
 
 
@@ -25,5 +26,4 @@ def test_sssdchecks__files(current_actor_context):
     assert report['title'] == 'The sss_ssh_knownhostsproxy will be replaced by sss_ssh_knownhosts'
     assert 'sss_ssh_knownhosts tool.' in report['summary']
 
-    FMT_LIST_SEPARATOR = '\n    - '
-    assert "{}{}".format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(all_files)) in report['summary']
+    assert format_list(all_files, callback_sort=None) in report['summary']

--- a/repos/system_upgrade/el9toel10/actors/xorgcheck/libraries/xorgcheck.py
+++ b/repos/system_upgrade/el9toel10/actors/xorgcheck/libraries/xorgcheck.py
@@ -1,6 +1,7 @@
 from leapp import reporting
 from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
 from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import format_list
 from leapp.models import DistributionSignedRPM
 
 # List of Xorg server packages to check
@@ -13,9 +14,6 @@ _XORG_PACKAGES = [
     'xorg-x11-server-utils',
     'xorg-x11-utils',
 ]
-
-# Separator for list formatting in reports
-FMT_LIST_SEPARATOR = '\n    - '
 
 
 def _report_xorg_installed(packages):
@@ -33,11 +31,10 @@ def _report_xorg_installed(packages):
         "Xorg server packages have been detected on your system. The Xorg server is no longer available "
         "in {distro} 10. Applications and services that depend on Xorg server packages will "
         "not work after the upgrade. Migrate to Wayland or maintain the Xorg packages through alternative means. "
-        "The following Xorg server packages have been detected and are not available in {distro} 10:{sep}{list}"
+        "The following Xorg server packages have been detected and are not available in {distro} 10:{list}"
     ).format(
         distro=DISTRO_REPORT_NAMES.target,
-        sep=FMT_LIST_SEPARATOR,
-        list=FMT_LIST_SEPARATOR.join(packages),
+        list=format_list(packages),
     )
 
     reporting.create_report([


### PR DESCRIPTION
## What has been changed
Replaced all custom FMT_LIST_SEPARATOR-based list formatting (and local helper functions like` _format_list`, `_formatted_list_output`, `__human_readable_list`, etc.) with the framework-provided format_list() function from leapp.libraries.stdlib. Modified files span across common/, el8toel9/, and el9toel10/ repositories, covering both actor libraries and shared libraries.

## How it has been changed
- Removed local `FMT_LIST_SEPARATOR` constant definitions and local
 formatting helper functions from each actor library and actor module.
- Added `from leapp.libraries.stdlib import format_list` imports.
- Replaced `.join()`-based and loop-based formatting calls with
 `format_list(items)` (or `format_list(items, callback_sort=None)`
 where ordering must be preserved).
- Used `FMT_LIST_SEPARATOR` from stdlib for the truncation suffix 
  in `checkthirdpartytargetpythonmodules` to stay in sync with format_list.
- Updated one test assertion in `component_test_sssdchecks.py` to match
 the new `format_list` output.

## Reason for the change
- **Standardization**: RHEL-126447 introduced `format_list` in the
 framework to provide a single, consistent way to format lists in
 reports, logs, and error messages. Each actor was previously
 reinventing this with its own `FMT_LIST_SEPARATOR` constant.
- **Sorted output**: `format_list` sorts by default, improving report
 readability for users. Previously most lists were unsorted.
- **Maintainability**: Reduces ~124 lines of duplicated formatting
 boilerplate across the codebase.