### PR TITLE
Warn when Postfix still uses Berkeley DB hash/btree maps

### DIFF
--- a/repos/system_upgrade/el9toel10/actors/postfix/checkpostfixbdb/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/postfix/checkpostfixbdb/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import checkpostfixbdb
+from leapp.models import PostfixBdbConfiguration, Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckPostfixBdb(Actor):
+    """
+    Warn when Postfix still uses Berkeley DB hash/btree maps.
+
+    Those map types are not available on RHEL 10. The administrator must
+    convert them to lmdb; Leapp does not rewrite Postfix configuration
+    automatically because the layouts can be complex.
+    """
+
+    name = 'check_postfix_bdb'
+    consumes = (PostfixBdbConfiguration,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        checkpostfixbdb.process()

--- a/repos/system_upgrade/el9toel10/actors/postfix/checkpostfixbdb/libraries/checkpostfixbdb.py
+++ b/repos/system_upgrade/el9toel10/actors/postfix/checkpostfixbdb/libraries/checkpostfixbdb.py
@@ -1,0 +1,58 @@
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.common.distro import DISTRO_REPORT_NAMES
+from leapp.libraries.stdlib import api, format_list
+from leapp.models import PostfixBdbConfiguration
+
+REPORT_KCS_URL = 'https://access.redhat.com/solutions/7131247'
+
+
+def process():
+    msg = next(api.consume(PostfixBdbConfiguration), None)
+    if not msg:
+        raise StopActorExecutionError('Expected PostfixBdbConfiguration, but got None')
+
+    if not msg.postfix_present:
+        api.current_logger().debug('postfix package not found, no report generated')
+        return
+
+    if not msg.bdb_occurrences:
+        api.current_logger().debug(
+            'Postfix is installed but no hash:/btree: maps were found; no report generated'
+        )
+        return
+
+    summary = (
+        'RHEL 10 no longer provides Berkeley DB, so Postfix cannot use the '
+        'hash: or btree: lookup table types after the upgrade. Postfix will '
+        'fail to start or to rebuild aliases (unsupported dictionary type: hash) '
+        'until the maps are converted to lmdb. '
+        'The following configuration entries still use a Berkeley DB map type:'
+        '{occurrences}'
+    ).format(
+        occurrences=format_list(msg.bdb_occurrences, callback_sort=None),
+    )
+
+    hint = (
+        'Do not rely on Leapp to rewrite Postfix configuration. Before or after '
+        'the upgrade, replace hash: and btree: with lmdb: in /etc/postfix/main.cf '
+        '(and related files), set default_database_type = lmdb, and rebuild maps '
+        'with postmap/postalias. See the linked article for the full procedure. '
+        'Target system: {target_distro} 10.'
+    ).format_map(DISTRO_REPORT_NAMES)
+
+    reporting.create_report([
+        reporting.Title(
+            'Postfix Berkeley DB (hash/btree) maps are not available after the upgrade'
+        ),
+        reporting.Summary(summary),
+        reporting.Severity(reporting.Severity.HIGH),
+        reporting.Groups([reporting.Groups.SERVICES]),
+        reporting.ExternalLink(
+            title='Postfix fails with unsupported dictionary type: hash after upgrading to RHEL 10',
+            url=REPORT_KCS_URL,
+        ),
+        reporting.RelatedResource('package', 'postfix'),
+        reporting.RelatedResource('file', '/etc/postfix/main.cf'),
+        reporting.Remediation(hint=hint),
+    ])

--- a/repos/system_upgrade/el9toel10/actors/postfix/checkpostfixbdb/tests/test_checkpostfixbdb.py
+++ b/repos/system_upgrade/el9toel10/actors/postfix/checkpostfixbdb/tests/test_checkpostfixbdb.py
@@ -1,0 +1,67 @@
+import pytest
+
+from leapp import reporting
+from leapp.exceptions import StopActorExecutionError
+from leapp.libraries.actor import checkpostfixbdb
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, logger_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import PostfixBdbConfiguration
+
+
+def test_process_no_msg(monkeypatch):
+    def consume_mocked(*args, **kwargs):
+        yield None
+
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+
+    with pytest.raises(StopActorExecutionError):
+        checkpostfixbdb.process()
+
+
+def test_process_postfix_absent(monkeypatch):
+    def consume_mocked(*args, **kwargs):
+        yield PostfixBdbConfiguration(postfix_present=False, bdb_occurrences=[])
+
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+
+    checkpostfixbdb.process()
+    assert 'postfix package not found' in ''.join(api.current_logger.dbgmsg)
+    assert reporting.create_report.called == 0
+
+
+def test_process_already_lmdb(monkeypatch):
+    def consume_mocked(*args, **kwargs):
+        yield PostfixBdbConfiguration(postfix_present=True, bdb_occurrences=[])
+
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+
+    checkpostfixbdb.process()
+    assert 'no hash:/btree:' in ''.join(api.current_logger.dbgmsg)
+    assert reporting.create_report.called == 0
+
+
+def test_process_hash_maps_reported(monkeypatch):
+    findings = [
+        '/etc/postfix/main.cf: alias_maps = hash:/etc/aliases',
+        '/etc/postfix/main.cf: default_database_type = hash',
+    ]
+
+    def consume_mocked(*args, **kwargs):
+        yield PostfixBdbConfiguration(postfix_present=True, bdb_occurrences=findings)
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+
+    checkpostfixbdb.process()
+    assert reporting.create_report.called == 1
+    report = reporting.create_report.reports[0]
+    assert 'Berkeley DB' in report['title']
+    summary = report['summary']
+    assert 'alias_maps = hash:/etc/aliases' in summary
+    assert 'default_database_type = hash' in summary
+    assert checkpostfixbdb.REPORT_KCS_URL in str(report)

--- a/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/actor.py
+++ b/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/actor.py
@@ -1,0 +1,22 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scanpostfixbdb
+from leapp.models import DistributionSignedRPM, PostfixBdbConfiguration
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanPostfixBdb(Actor):
+    """
+    Detect Postfix Berkeley DB (hash/btree) lookup tables.
+
+    RHEL 10 removed Berkeley DB, so hash: and btree: maps used on RHEL 9 will
+    not work after the upgrade. Collect the relevant configuration lines so a
+    later check actor can warn the administrator.
+    """
+
+    name = 'scan_postfix_bdb'
+    consumes = (DistributionSignedRPM,)
+    produces = (PostfixBdbConfiguration,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        self.produce(scanpostfixbdb.scan_postfix_configuration())

--- a/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/libraries/scanpostfixbdb.py
+++ b/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/libraries/scanpostfixbdb.py
@@ -1,0 +1,71 @@
+import os
+import re
+
+from leapp.libraries.common.rpms import has_package
+from leapp.libraries.stdlib import api
+from leapp.models import DistributionSignedRPM, PostfixBdbConfiguration
+
+DEFAULT_POSTFIX_PATHS = ['/etc/postfix']
+
+# Map type used as a prefix: hash:/etc/aliases, proxy:hash:/path, ...
+BDB_MAP_RE = re.compile(r'(?:^|[\s,=:])(hash|btree):', re.IGNORECASE)
+# Compiled default on RHEL 9 is hash; an explicit setting of hash/btree is also BDB.
+DEFAULT_DB_RE = re.compile(r'^\s*default_database_type\s*=\s*(hash|btree)\b', re.IGNORECASE)
+
+
+def _iter_config_files(paths):
+    """Yield Postfix *.cf files from the given files or directories."""
+    for path in paths:
+        if os.path.isdir(path):
+            try:
+                names = os.listdir(path)
+            except OSError as err:
+                api.current_logger().warning(
+                    'Could not list Postfix configuration directory {}: {}'.format(path, err)
+                )
+                continue
+            for name in sorted(names):
+                if name.endswith('.cf'):
+                    yield os.path.join(path, name)
+        elif os.path.isfile(path):
+            yield path
+
+
+def _scan_file(path):
+    """Return list of 'path: line' strings for Berkeley DB map settings."""
+    occurrences = []
+    try:
+        with open(path) as conf_file:
+            for line in conf_file:
+                stripped = line.strip()
+                if not stripped or stripped.startswith('#'):
+                    continue
+                if BDB_MAP_RE.search(stripped) or DEFAULT_DB_RE.search(stripped):
+                    occurrences.append('{}: {}'.format(path, stripped))
+    except OSError as err:
+        api.current_logger().warning(
+            'Could not read Postfix configuration file {}: {}'.format(path, err)
+        )
+    return occurrences
+
+
+def scan_postfix_configuration(conf_paths=None, _context=api):
+    """
+    Scan Postfix configuration for Berkeley DB (hash/btree) lookup tables.
+
+    :param conf_paths: Files or directories to scan. Defaults to /etc/postfix.
+    :return: PostfixBdbConfiguration
+    """
+    postfix_present = has_package(DistributionSignedRPM, 'postfix', context=_context)
+    if not postfix_present:
+        return PostfixBdbConfiguration(postfix_present=False, bdb_occurrences=[])
+
+    paths = DEFAULT_POSTFIX_PATHS if conf_paths is None else conf_paths
+    occurrences = []
+    for conf_file in _iter_config_files(paths):
+        occurrences.extend(_scan_file(conf_file))
+
+    return PostfixBdbConfiguration(
+        postfix_present=True,
+        bdb_occurrences=occurrences,
+    )

--- a/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/tests/files/main.cf.hash
+++ b/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/tests/files/main.cf.hash
@@ -1,0 +1,5 @@
+alias_maps = hash:/etc/aliases
+alias_database = hash:/etc/aliases
+default_database_type = hash
+# commented hash:/etc/aliases should be ignored
+smtp_tls_CAfile = /etc/pki/tls/certs/ca-bundle.crt

--- a/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/tests/files/main.cf.lmdb
+++ b/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/tests/files/main.cf.lmdb
@@ -1,0 +1,4 @@
+default_database_type = lmdb
+alias_maps = lmdb:/etc/aliases
+alias_database = lmdb:/etc/aliases
+# leftover comment: hash:/etc/aliases

--- a/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/tests/files/main.cf.proxyhash
+++ b/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/tests/files/main.cf.proxyhash
@@ -1,0 +1,2 @@
+smtp_sasl_password_maps = proxy:hash:/etc/postfix/sasl_passwd
+virtual_alias_maps = btree:/etc/postfix/virtual

--- a/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/tests/test_scanpostfixbdb.py
+++ b/repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/tests/test_scanpostfixbdb.py
@@ -1,0 +1,82 @@
+import os
+
+import pytest
+
+from leapp.libraries.actor import scanpostfixbdb
+from leapp.libraries.common.testutils import CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import DistributionSignedRPM, RPM
+
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+FILES_DIR = os.path.join(CUR_DIR, 'files')
+
+
+def _rpm(name):
+    return RPM(name=name,
+               version='0.1',
+               release='1.sm01',
+               epoch='1',
+               pgpsig='RSA/SHA256, Mon 01 Jan 1970 00:00:00 AM -03, Key ID 199e2f91fd431d51',
+               packager='Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>',
+               arch='noarch')
+
+
+def _mock_packages(monkeypatch, names):
+    rpms = [_rpm(name) for name in names]
+    monkeypatch.setattr(
+        api,
+        'current_actor',
+        CurrentActorMocked(msgs=[DistributionSignedRPM(items=rpms)]),
+    )
+
+
+def test_scan_postfix_not_installed(monkeypatch):
+    _mock_packages(monkeypatch, ['sed'])
+    result = scanpostfixbdb.scan_postfix_configuration(
+        conf_paths=[os.path.join(FILES_DIR, 'main.cf.hash')]
+    )
+    assert result.postfix_present is False
+    assert result.bdb_occurrences == []
+
+
+def test_scan_hash_maps(monkeypatch):
+    _mock_packages(monkeypatch, ['postfix'])
+    conf = os.path.join(FILES_DIR, 'main.cf.hash')
+    result = scanpostfixbdb.scan_postfix_configuration(conf_paths=[conf])
+    assert result.postfix_present is True
+    assert len(result.bdb_occurrences) == 3
+    joined = '\n'.join(result.bdb_occurrences)
+    assert 'alias_maps = hash:/etc/aliases' in joined
+    assert 'alias_database = hash:/etc/aliases' in joined
+    assert 'default_database_type = hash' in joined
+    assert 'commented' not in joined
+
+
+def test_scan_lmdb_maps_ignored(monkeypatch):
+    _mock_packages(monkeypatch, ['postfix'])
+    conf = os.path.join(FILES_DIR, 'main.cf.lmdb')
+    result = scanpostfixbdb.scan_postfix_configuration(conf_paths=[conf])
+    assert result.postfix_present is True
+    assert result.bdb_occurrences == []
+
+
+def test_scan_proxy_hash_and_btree(monkeypatch):
+    _mock_packages(monkeypatch, ['postfix'])
+    conf = os.path.join(FILES_DIR, 'main.cf.proxyhash')
+    result = scanpostfixbdb.scan_postfix_configuration(conf_paths=[conf])
+    assert result.postfix_present is True
+    assert len(result.bdb_occurrences) == 2
+    joined = '\n'.join(result.bdb_occurrences)
+    assert 'proxy:hash:/etc/postfix/sasl_passwd' in joined
+    assert 'btree:/etc/postfix/virtual' in joined
+
+
+@pytest.mark.parametrize('missing', [
+    os.path.join(FILES_DIR, 'does-not-exist.cf'),
+    os.path.join(FILES_DIR, 'missing-dir'),
+])
+def test_scan_missing_path(monkeypatch, missing):
+    _mock_packages(monkeypatch, ['postfix'])
+    result = scanpostfixbdb.scan_postfix_configuration(conf_paths=[missing])
+    assert result.postfix_present is True
+    assert result.bdb_occurrences == []

--- a/repos/system_upgrade/el9toel10/models/postfixbdb.py
+++ b/repos/system_upgrade/el9toel10/models/postfixbdb.py
@@ -1,0 +1,23 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class PostfixBdbConfiguration(Model):
+    """
+    Presence of Postfix lookup tables that use Berkeley DB (hash/btree).
+
+    RHEL 10 Postfix no longer supports the Berkeley DB backends. Existing
+    hash: and btree: maps must be converted to lmdb: before or immediately
+    after the upgrade, otherwise Postfix fails to start.
+    """
+
+    topic = SystemInfoTopic
+
+    postfix_present = fields.Boolean(default=False)
+    """True when the postfix package is installed."""
+
+    bdb_occurrences = fields.List(fields.String(), default=[])
+    """
+    Human-readable findings such as
+    '/etc/postfix/main.cf: alias_maps = hash:/etc/aliases'.
+    """


### PR DESCRIPTION
## Summary
- RHEL 10 removed Berkeley DB, so Postfix `hash:` / `btree:` lookup tables fail after a 9→10 in-place upgrade (`unsupported dictionary type: hash`).
- Add a Facts-phase scanner and a Checks-phase reporter that warn when `/etc/postfix/*.cf` still uses those map types. Systems already converted to `lmdb:` are left alone.
- Configuration is **not** rewritten automatically (Postfix layouts are too varied). The report points at [KCS 7131247](https://access.redhat.com/solutions/7131247).

Jira: [RHEL-114756](https://redhat.atlassian.net/browse/RHEL-114756)

## Test plan
- [ ] `pytest repos/system_upgrade/el9toel10/actors/postfix/scanpostfixbdb/tests repos/system_upgrade/el9toel10/actors/postfix/checkpostfixbdb/tests` (10 unit tests)
- [ ] On a RHEL 9 system with default Postfix (`alias_maps = hash:/etc/aliases`), `leapp preupgrade` shows a high-risk report with the KCS link
- [ ] After converting maps to `lmdb:`, the report is not produced


Made with [Cursor](https://cursor.com)

[RHEL-114756]: https://redhat.atlassian.net/browse/RHEL-114756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ