### PR TITLE
mount_units_generator: Preserve parent units for nested dracut mounts

### DIFF
--- a/repos/system_upgrade/common/actors/initramfs/mount_units_generator/libraries/mount_unit_generator.py
+++ b/repos/system_upgrade/common/actors/initramfs/mount_units_generator/libraries/mount_unit_generator.py
@@ -314,6 +314,20 @@ def copy_units_into_system_location(upgrade_container_ctx, dir_with_our_mount_un
     return copied_files
 
 
+def _has_child_mount_units(dir_path, parent_unit_name):
+    """
+    Check if any mount unit file in dir_path is a child of parent_unit_name.
+
+    Uses systemd unit name convention: /usr/local -> usr-local.mount is a child
+    of /usr -> usr.mount because the name starts with 'usr-'.
+    """
+    parent_prefix = parent_unit_name[:-len('.mount')] + '-'
+    for filename in os.listdir(dir_path):
+        if filename.endswith('.mount') and filename.startswith(parent_prefix):
+            return True
+    return False
+
+
 def remove_units_for_targets_that_are_already_mounted_by_dracut(dir_with_our_mount_units):
     """
     Remove mount units for mount targets that are already mounted by dracut.
@@ -321,6 +335,11 @@ def remove_units_for_targets_that_are_already_mounted_by_dracut(dir_with_our_mou
     Namely, remove mount units:
         '-.mount'   (mounts /)
         'usr.mount' (mounts /usr)
+
+    A mount unit is preserved when child mount units that depend on it exist
+    in the workspace (e.g. usr.mount is kept when usr-local.mount is present),
+    so that systemd's implicit path-based ordering ensures the parent is
+    mounted before its children in the upgrade initramfs.
     """
 
     # NOTE: remount-fs.service creates dependency cycles that are nondeterministically broken
@@ -340,6 +359,13 @@ def remove_units_for_targets_that_are_already_mounted_by_dracut(dir_with_our_mou
 
         if not os.path.exists(unit_location):
             api.current_logger().debug('The {} unit does not exists, no need to remove it.'.format(unit))
+            continue
+
+        if (unit == 'usr.mount' and _has_child_mount_units(dir_with_our_mount_units, unit)):
+            api.current_logger().info(
+                'Keeping the mount unit {} as child mount units exist that depend on it.'
+                .format(unit)
+            )
             continue
 
         _delete_file(unit_location)

--- a/repos/system_upgrade/common/actors/initramfs/mount_units_generator/tests/test_mount_unit_generation.py
+++ b/repos/system_upgrade/common/actors/initramfs/mount_units_generator/tests/test_mount_unit_generation.py
@@ -425,3 +425,55 @@ def test_fix_symlinks_in_dir_skips_pseudo_fs_in_requires(monkeypatch, dirname):
     monkeypatch.setattr(mount_unit_generator, 'parse_unit', mock_parse_unit)
 
     mount_unit_generator._fix_symlinks_in_dir('/test/dir', dirname)
+
+
+@pytest.mark.parametrize('dir_contents,parent_unit,expected', (
+    (['usr-local.mount', 'usr-sap.mount', 'home.mount'], 'usr.mount', True),
+    (['usr-local.mount', 'home.mount'], 'usr.mount', True),
+    (['var.mount', 'home.mount'], 'usr.mount', False),
+    ([], 'usr.mount', False),
+    (['home.mount', 'var.mount', 'usr.mount'], 'usr.mount', False),
+    (['var-log.mount', 'var.mount'], 'var.mount', True),
+    (['home.mount', 'var.mount', 'usr.mount'], '-.mount', False),
+))
+def test_has_child_mount_units(monkeypatch, dir_contents, parent_unit, expected):
+    """Detect whether a parent mount unit has child mount units in the directory."""
+    monkeypatch.setattr('os.listdir', lambda _path: dir_contents)
+    assert mount_unit_generator._has_child_mount_units('/test/dir', parent_unit) is expected
+
+
+def _touch(path):
+    with open(path, 'w'):
+        pass
+
+
+def test_remove_units_preserves_parent_with_child_mount(monkeypatch, leapp_tmpdir):
+    """Parent mount unit is preserved when a child mount unit exists."""
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    for unit in ('-.mount', 'usr.mount', 'usr-local.mount'):
+        _touch(os.path.join(leapp_tmpdir, unit))
+
+    mount_unit_generator.remove_units_for_targets_that_are_already_mounted_by_dracut(leapp_tmpdir)
+
+    assert not os.path.exists(os.path.join(leapp_tmpdir, '-.mount'))
+    assert os.path.exists(os.path.join(leapp_tmpdir, 'usr.mount'))
+    assert os.path.exists(os.path.join(leapp_tmpdir, 'usr-local.mount'))
+
+
+def test_remove_units_removes_parent_without_children(monkeypatch, leapp_tmpdir):
+    """Mount unit is removed when no child mount units exist."""
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    for unit in ('-.mount', 'usr.mount'):
+        _touch(os.path.join(leapp_tmpdir, unit))
+    os.makedirs(os.path.join(leapp_tmpdir, 'local-fs.target.wants'))
+    _touch(os.path.join(leapp_tmpdir, 'local-fs.target.wants', 'systemd-remount-fs.service'))
+
+    mount_unit_generator.remove_units_for_targets_that_are_already_mounted_by_dracut(leapp_tmpdir)
+
+    assert not os.path.exists(os.path.join(leapp_tmpdir, '-.mount'))
+    assert not os.path.exists(os.path.join(leapp_tmpdir, 'usr.mount'))
+    assert not os.path.exists(
+        os.path.join(leapp_tmpdir, 'local-fs.target.wants', 'systemd-remount-fs.service')
+    )


### PR DESCRIPTION
## The reason for the change

Systems with nested mounts under paths already mounted by dracut (e.g.
/usr/local or /usr/sap under /usr) need parent mount units present in
the upgrade initramfs so systemd can order parent-before-child mounts.
The mount unit generator previously removed parent units such as
usr.mount unconditionally, which breaks that ordering for nested mounts.

## What has been changed

- `remove_units_for_targets_that_are_already_mounted_by_dracut()` now
  skips removal of a parent mount unit when child mount units exist in
  the workspace.
- New helper `_has_child_mount_units()` detects child units using
  systemd unit naming (e.g. `usr-local.mount` is a child of `usr.mount`).
- Unit tests for the helper and for preserve/remove integration behavior.

## How it has been changed

Before deleting units that dracut already mounts (`-.mount`, `usr.mount`),
the generator scans the workspace for child mount unit files whose names
start with the parent prefix (e.g. `usr-` for `usr.mount`). If any exist,
the parent unit is kept and an info log is emitted; otherwise behavior is
unchanged. Child detection relies on systemd's path-to-unit-name 
convention rather than parsing Requires= dependencies.

## Jira
RHEL-192249