### PR TITLE
feat(convert): clean up boot loader entries

### DIFF
--- a/repos/system_upgrade/common/actors/convert/cleanupbootloaderentries/actor.py
+++ b/repos/system_upgrade/common/actors/convert/cleanupbootloaderentries/actor.py
@@ -1,0 +1,32 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import cleanupbootloaderentries
+from leapp.models import MachineIdInfo, TransactionCompleted
+from leapp.reporting import Report
+from leapp.tags import IPUWorkflowTag, RPMUpgradePhaseTag
+
+
+class CleanupBootloaderEntries(Actor):
+    """
+    Remove boot loader entries that don't match the current machine ID during conversion.
+
+    Boot Loader Specification entry files are named
+    ``/boot/loader/entries/<entry-token>-<kernel-version>.conf``, where the
+    entry token defaults to ``/etc/machine-id``. When the current machine ID
+    differs from the one used when the original OS kernels were installed,
+    ``kernel-install remove`` (run from the kernel package scriptlets during the
+    upgrade transaction) derives the entry path from the current machine ID and
+    fails to remove the original entries, leaving them orphaned. The newly
+    installed target kernel entry uses the current machine ID.
+
+    This actor removes the entries whose file name doesn't contain the
+    current machine ID. The target kernel is set as the default boot entry later
+    by the force_default_boot_to_target_kernel_version actor.
+    """
+
+    name = 'cleanup_bootloader_entries'
+    consumes = (MachineIdInfo, TransactionCompleted)
+    produces = (Report,)
+    tags = (RPMUpgradePhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        cleanupbootloaderentries.process()

--- a/repos/system_upgrade/common/actors/convert/cleanupbootloaderentries/libraries/cleanupbootloaderentries.py
+++ b/repos/system_upgrade/common/actors/convert/cleanupbootloaderentries/libraries/cleanupbootloaderentries.py
@@ -1,0 +1,75 @@
+import glob
+import os
+from typing import List, Optional
+
+from leapp import reporting
+from leapp.libraries.common.config import is_conversion
+from leapp.libraries.stdlib import api, format_list
+from leapp.models import MachineIdInfo
+
+MACHINE_ID_PATH = '/etc/machine-id'
+BOOT_ENTRIES_PATH = '/boot/loader/entries'
+
+
+def _read_machine_id() -> Optional[str]:
+    try:
+        with open(MACHINE_ID_PATH, 'r') as f:
+            return f.read().strip()
+    except OSError as e:
+        api.current_logger().warning('Failed to read {}: {}'.format(MACHINE_ID_PATH, e))
+        return None
+
+
+def _remove_stale_entries(machine_id: str) -> List[str]:
+    """
+    Remove boot loader entries whose file name doesn't contain the machine ID.
+
+    Return the list of removed entry paths.
+    """
+    removed = []
+    for entry in glob.glob(os.path.join(BOOT_ENTRIES_PATH, '*.conf')):
+        if machine_id in os.path.basename(entry):
+            continue
+        try:
+            os.remove(entry)
+            removed.append(entry)
+            api.current_logger().info('Removed stale boot loader entry {}'.format(entry))
+        except OSError as e:
+            api.current_logger().warning('Failed to remove boot loader entry {}: {}'.format(entry, e))
+    return removed
+
+
+def process() -> None:
+    if not is_conversion():
+        return
+
+    machine_id = _read_machine_id()
+    if not machine_id:
+        api.current_logger().warning(
+            'Could not determine the current machine ID, skipping boot loader entry cleanup.'
+        )
+        return
+
+    original = next(api.consume(MachineIdInfo), None)
+    if original and original.machine_id and original.machine_id != machine_id:
+        api.current_logger().info(
+            'The machine ID changed during the upgrade (before: {}, after: {}).'.format(
+                original.machine_id, machine_id
+            )
+        )
+
+    removed = _remove_stale_entries(machine_id)
+    if not removed:
+        return
+
+    reporting.create_report([
+        reporting.Title('Removed obsolete boot loader entries'),
+        reporting.Summary(
+            'The following boot loader entries in {} did not match'
+            ' the current machine ID ({}) and have been removed:{}'.format(
+                BOOT_ENTRIES_PATH, machine_id, format_list(removed)
+            )
+        ),
+        reporting.Severity(reporting.Severity.INFO),
+        reporting.Groups([reporting.Groups.BOOT, reporting.Groups.POST]),
+    ])

--- a/repos/system_upgrade/common/actors/convert/cleanupbootloaderentries/tests/test_cleanupbootloaderentries.py
+++ b/repos/system_upgrade/common/actors/convert/cleanupbootloaderentries/tests/test_cleanupbootloaderentries.py
@@ -1,0 +1,149 @@
+import pytest
+
+from leapp.libraries.actor import cleanupbootloaderentries
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked, logger_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import MachineIdInfo
+
+_MACHINE_ID = '1485ef58ae5a41f1a109b2ae85e22374'
+_OLD_MACHINE_ID = 'ff1165e69b5a4fa18d2bb47c8a8a51e6'
+
+# Stale entries named after the old machine ID; expected to be removed.
+_OLD_ENTRIES = [
+    '/boot/loader/entries/{}-0-rescue.conf'.format(_OLD_MACHINE_ID),
+    '/boot/loader/entries/{}-5.14.0-687.el9_8.x86_64.conf'.format(_OLD_MACHINE_ID),
+]
+
+# Entries named after the current machine ID; expected to be kept.
+_NEW_ENTRIES = [
+    '/boot/loader/entries/{}-5.14.0-999.el9.x86_64.conf'.format(_MACHINE_ID),
+]
+
+_ENTRIES = _OLD_ENTRIES + _NEW_ENTRIES
+
+
+class _FakeFile:
+    def __init__(self, content):
+        self._content = content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return self._content
+
+
+def _setup(monkeypatch, entries, machine_id=_MACHINE_ID, original_machine_id=None,
+           src_distro='ol', dst_distro='rhel'):
+    """
+    Mock the actor context for cleanupbootloaderentries.process().
+
+    :param entries: boot loader entry paths returned by the mocked glob.glob
+    :param machine_id: value returned by the mocked _read_machine_id (None to simulate a read failure)
+    :param original_machine_id: machine ID from the consumed MachineIdInfo (None means no such message)
+    :param src_distro: source distro ID (differs from dst_distro to simulate a conversion)
+    :param dst_distro: target distro ID
+    :returns: (report_mock, removed, logger) where removed collects paths passed to os.remove
+    """
+    msgs = [] if original_machine_id is None else [MachineIdInfo(machine_id=original_machine_id)]
+    monkeypatch.setattr(api, 'current_actor',
+                        CurrentActorMocked(src_distro=src_distro, dst_distro=dst_distro, msgs=msgs))
+    logger = logger_mocked()
+    monkeypatch.setattr(api, 'current_logger', logger)
+    report_mock = create_report_mocked()
+    monkeypatch.setattr(cleanupbootloaderentries.reporting, 'create_report', report_mock)
+
+    removed = []
+    monkeypatch.setattr(cleanupbootloaderentries.glob, 'glob', lambda pattern: list(entries))
+    monkeypatch.setattr(cleanupbootloaderentries.os, 'remove', removed.append)
+    monkeypatch.setattr(cleanupbootloaderentries, '_read_machine_id', lambda: machine_id)
+    return report_mock, removed, logger
+
+
+def test_removes_only_non_matching_entries(monkeypatch):
+    report_mock, removed, _ = _setup(monkeypatch, _ENTRIES)
+
+    cleanupbootloaderentries.process()
+
+    assert removed == _OLD_ENTRIES
+    assert report_mock.called == 1
+    summary = report_mock.report_fields['summary']
+    assert _MACHINE_ID in summary
+    assert all(entry in summary for entry in _OLD_ENTRIES)
+    assert all(entry not in summary for entry in _NEW_ENTRIES)
+
+
+@pytest.mark.parametrize('original_machine_id,expect_logged', [
+    (_OLD_MACHINE_ID, True),   # machine ID changed during the upgrade
+    (_MACHINE_ID, False),      # machine ID unchanged
+    (None, False),             # no MachineIdInfo message consumed
+], ids=['changed', 'unchanged', 'no_machineidinfo'])
+def test_machine_id_change_logging(monkeypatch, original_machine_id, expect_logged):
+    _, _, logger = _setup(monkeypatch, _ENTRIES, original_machine_id=original_machine_id)
+
+    cleanupbootloaderentries.process()
+
+    logged = any('machine ID changed' in msg for msg in logger.infomsg)
+    assert logged == expect_logged
+    if expect_logged:
+        assert any(_MACHINE_ID in msg and _OLD_MACHINE_ID in msg for msg in logger.infomsg)
+
+
+@pytest.mark.parametrize('setup_kwargs', [
+    {'entries': _ENTRIES, 'src_distro': 'rhel', 'dst_distro': 'rhel'},  # not a conversion
+    {'entries': _NEW_ENTRIES},                                          # all entries match current machine ID
+    {'entries': _ENTRIES, 'machine_id': None},                          # machine ID unreadable
+    {'entries': _ENTRIES, 'machine_id': ''},                            # machine ID empty
+], ids=['no_stale_entries', 'not_converting', 'machine_id_unreadable', 'machine_id_empty'])
+def test_no_entries_removed(monkeypatch, setup_kwargs):
+    report_mock, removed, _ = _setup(monkeypatch, **setup_kwargs)
+
+    cleanupbootloaderentries.process()
+
+    assert not removed
+    assert report_mock.called == 0
+
+
+def test_continues_when_removal_fails(monkeypatch):
+    report_mock, removed, _ = _setup(monkeypatch, _ENTRIES)
+
+    def fake_remove(path):
+        if path == _OLD_ENTRIES[0]:
+            raise OSError('permission denied')
+        removed.append(path)
+
+    monkeypatch.setattr(cleanupbootloaderentries.os, 'remove', fake_remove)
+
+    cleanupbootloaderentries.process()
+
+    # _OLD_ENTRIES[0] failed to be removed, _OLD_ENTRIES[1] still removed
+    assert removed == [_OLD_ENTRIES[1]]
+    assert report_mock.called == 1
+    assert _OLD_ENTRIES[1] in report_mock.report_fields['summary']
+    assert _OLD_ENTRIES[0] not in report_mock.report_fields['summary']
+
+
+@pytest.mark.parametrize('content,expected', [
+    ('{}\n'.format(_MACHINE_ID), _MACHINE_ID),
+    (_MACHINE_ID, _MACHINE_ID),
+    ('', ''),
+    ('\n', ''),
+])
+def test_read_machine_id(monkeypatch, content, expected):
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+    monkeypatch.setattr(cleanupbootloaderentries, 'open',
+                        lambda *a, **k: _FakeFile(content), raising=False)
+    assert cleanupbootloaderentries._read_machine_id() == expected
+
+
+def test_read_machine_id_unreadable(monkeypatch):
+    monkeypatch.setattr(api, 'current_logger', logger_mocked())
+
+    def _raise(*a, **k):
+        raise OSError('no such file')
+
+    monkeypatch.setattr(cleanupbootloaderentries, 'open', _raise, raising=False)
+    assert cleanupbootloaderentries._read_machine_id() is None


### PR DESCRIPTION
During a conversion the machine ID can differ from the one used when the original kernels were installed. Boot Loader Specification entries are named after the machine ID, so when the old kernels are removed, kernel-install derives the entry path from the current machine ID and leaves the original entries orphaned in /boot/loader/entries/.

Add the `cleanup_bootloader_entries` actor, which runs in the `RPMUpgradePhase` after the upgrade transaction and removes any boot loader entry whose file name does not contain the current machine ID. The target kernel is set as the default boot entry separately by the `force_default_boot_to_target_kernel_version` actor.

Jira: RHEL-188166


### Testing
I could not reproduce a machine ID change on its own, so I tested OL 9 -> RHEL 10 conversion+upgrade (using the #1585). The VM had UEK and normal kernel installed while the normal kernel was the default. I regenerated the machine ID during the upgrade just before the reboot, which triggered the actor resulting in the following output.

Relevant part of the `leapp-upgrade.log`:
```text
2026-08-29 14:54:37.456 INFO     PID: 43400 leapp.workflow.RPMUpgrade.cleanup_bootloader_entries: The machine ID changed during the upgrade (before: 1485ef58ae5a41f1a109b2ae85e22374, after: 4185093146c34318abe2f44020eaecea).
2026-08-29 14:54:37.487 INFO     PID: 43400 leapp.workflow.RPMUpgrade.cleanup_bootloader_entries: Removed stale boot loader entry /boot/loader/entries/1485ef58ae5a41f1a109b2ae85e22374-5.14.0-687.41.1.el9_8.x86_64.conf
2026-08-29 14:54:37.513 INFO     PID: 43400 leapp.workflow.RPMUpgrade.cleanup_bootloader_entries: Removed stale boot loader entry /boot/loader/entries/1485ef58ae5a41f1a109b2ae85e22374-0-rescue.conf
2026-08-29 14:54:37.540 INFO     PID: 43400 leapp.workflow.RPMUpgrade.cleanup_bootloader_entries: Removed stale boot loader entry /boot/loader/entries/1485ef58ae5a41f1a109b2ae85e22374-6.12.0-205.92.4.2.el9uek.x86_64.conf
```
Relevant part of the `leapp-report.txt` after the upgrade:
```text
----------------------------------------
Risk Factor: info
Title: Removed obsolete boot loader entries
Summary: The following boot loader entries in /boot/loader/entries did not match the current machine ID (4185093146c34318abe2f44020eaecea) and have been removed:
    - /boot/loader/entries/1485ef58ae5a41f1a109b2ae85e22374-0-rescue.conf
    - /boot/loader/entries/1485ef58ae5a41f1a109b2ae85e22374-5.14.0-687.41.1.el9_8.x86_64.conf
    - /boot/loader/entries/1485ef58ae5a41f1a109b2ae85e22374-6.12.0-205.92.4.2.el9uek.x86_64.conf
Key: 9f9547c7eacf0c417d1738675345bb350dbdb440
----------------------------------------
```

Contents of `/boot/loader/entries/` after upgrade:
```bash
[root@oracle9 vagrant]# ls -l /boot/loader/entries/
total 8
-rw-r--r--. 1 root root 648 Aug 29 14:53 4185093146c34318abe2f44020eaecea-0-rescue.conf
-rw-r--r--. 1 root root 624 Aug 29 14:56 4185093146c34318abe2f44020eaecea-6.12.0-211.7.1.el10_2.x86_64.conf
```