### PR TITLE
fix(add_upgrade_boot_entry): drop inherited rd.lvm.lv args from the upgrade entry

### DIFF
--- a/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/libraries/addupgradebootentry.py
@@ -48,7 +48,19 @@ def collect_undesired_args(livemode_enabled):
     args = {}
     if livemode_enabled:
         args = dict(zip(('ro', 'rhgb', 'quiet'), itertools.repeat(None)))
-        args['rd.lvm.lv'] = _get_rdlvm_arg_values()
+
+    # rd.lvm.lv=<vg>/<lv> args inherited from the default boot entry via
+    # `grubby --copy-default` make dracut's lvm_scan activate *only* the listed
+    # LVs (typically root and swap) and skip the `vgchange -ay` of whole VGs.
+    # On a regular boot the remaining LVs are activated later by the booted
+    # system, but the upgrade initramfs never switches root - it mounts all
+    # fstab entries under /sysroot inside the initramfs. LVs backing e.g. /var,
+    # /home or /srv would stay inactive, the sysroot-*.mount units time out and
+    # the system drops into the emergency shell. Drop the args so that lvm_scan
+    # activates all volume groups (same as already done for the live mode).
+    rd_lvm_values = _get_rdlvm_arg_values(required=livemode_enabled)
+    if rd_lvm_values:
+        args['rd.lvm.lv'] = rd_lvm_values
 
     undesired = set(args.items())
     undesired |= collect_set_of_kernel_args_from_msgs(UpgradeKernelCmdlineArgTasks, 'to_remove')
@@ -310,16 +322,20 @@ def _get_device_uuid(mount_point):
     return None
 
 
-def _get_rdlvm_arg_values():
+def _get_rdlvm_arg_values(required=True):
     # should we not check args returned by grubby instead?
     cmdline_msg = next(api.consume(KernelCmdline), None)
 
     if not cmdline_msg:
-        raise StopActorExecutionError('Did not receive any KernelCmdline arguments.')
+        if required:
+            raise StopActorExecutionError('Did not receive any KernelCmdline arguments.')
+        api.current_logger().debug('No KernelCmdline message received; no rd.lvm.lv args to drop.')
+        return tuple()
 
     rd_lvm_values = sorted(arg.value for arg in cmdline_msg.parameters if arg.key == 'rd.lvm.lv')
-    api.current_logger().debug('Collected the following rd.lvm.lv args that are undesired for the squashfs: %s',
-                               rd_lvm_values)
+    api.current_logger().debug(
+        'Collected the following rd.lvm.lv args that are undesired for the upgrade boot entry: %s', rd_lvm_values
+    )
 
     return tuple(rd_lvm_values)
 

--- a/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
+++ b/repos/system_upgrade/common/actors/addupgradebootentry/tests/unit_test_addupgradebootentry.py
@@ -400,6 +400,7 @@ def test_modify_grubenv_to_have_separate_blsdir(monkeypatch, has_separate_boot):
 
 def test_collect_undesired_args_includes_upgrade_to_remove(monkeypatch):
     msgs = [
+        KernelCmdline(parameters=[]),
         UpgradeKernelCmdlineArgTasks(to_remove=[
             KernelCmdlineArg(key='rd.luks.uuid', value='luks-aaa'),
             KernelCmdlineArg(key='rd.luks.uuid', value='luks-bbb'),
@@ -414,8 +415,26 @@ def test_collect_undesired_args_includes_upgrade_to_remove(monkeypatch):
 
 
 def test_collect_undesired_args_no_upgrade_to_remove(monkeypatch):
-    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[]))
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[KernelCmdline(parameters=[])]))
 
     undesired = addupgradebootentry.collect_undesired_args(livemode_enabled=False)
 
     assert undesired == set()
+
+
+def test_collect_undesired_args_drops_rd_lvm_lv(monkeypatch):
+    """rd.lvm.lv args from the booted cmdline are removed from the upgrade entry even outside live mode."""
+    msgs = [
+        KernelCmdline(parameters=[
+            KernelCmdlineArg(key='rd.lvm.lv', value='vg00/lv_root'),
+            KernelCmdlineArg(key='rd.md.uuid', value='aaaa:bbbb'),
+            KernelCmdlineArg(key='rd.lvm.lv', value='vg00/lv_swap'),
+        ]),
+    ]
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=msgs))
+
+    undesired = addupgradebootentry.collect_undesired_args(livemode_enabled=False)
+
+    assert undesired == {('rd.lvm.lv', ('vg00/lv_root', 'vg00/lv_swap'))}
+    assert 'rd.lvm.lv=vg00/lv_root rd.lvm.lv=vg00/lv_swap' == \
+        addupgradebootentry.format_grubby_args_from_args_set(undesired)


### PR DESCRIPTION
The upgrade boot entry is created with `grubby --copy-default`, so it inherits the `rd.lvm.lv=<vg>/<lv>` arguments (typically root and swap) of the default entry. With `rd.lvm.lv` present dracut's `lvm_scan` activates only the listed LVs and skips the `vgchange -ay` of whole volume groups. On a regular boot the remaining LVs are activated later by the booted system, but the upgrade initramfs never switches root - it mounts all fstab entries under `/sysroot` inside the initramfs. LVs backing e.g. `/var`, `/home` or `/srv` stay inactive, the `sysroot-*.mount` units time out and the system drops into the emergency shell:
```
  Timed out waiting for device dev-mapper-vg00raid1\x2dlv_var.device
  Dependency failed for sysroot-var.mount - /sysroot/var.
```
Remove the `rd.lvm.lv` args from the upgrade boot entry in the regular mode as well, as it is already done for the live mode, so that `lvm_scan` activates all volume groups. Reproduced and verified on a RHEL 9.8 to 10 upgrade with LVs for `/`, `swap`, `/var`, `/home` and `/data`.

Resolves: https://github.com/oamg/leapp-repository/issues/1590