### PR TITLE
livemode: report mem requirements only for network boot

### DIFF
--- a/repos/system_upgrade/common/actors/livemode/livemodereporter/libraries/report_livemode.py
+++ b/repos/system_upgrade/common/actors/livemode/livemodereporter/libraries/report_livemode.py
@@ -8,13 +8,20 @@ def report_live_mode_if_enabled():
     if not livemode or not livemode.is_enabled:
         return
 
-    summary = (
+    storage_part = (
         'The Live Upgrade Mode requires at least 2 GB of additional space '
         'in the partition that hosts /var/lib/leapp in order to create '
-        'the squashfs image. During the "reboot phase", the image will '
-        'need more space into memory, in particular for booting over the '
-        'network. The recommended memory for this mode is at least 4 GB.'
+        'the squashfs image.'
     )
+    memory_part = (
+        'During the "reboot phase", the squashfs image will be pulled over '
+        'the network into memory. The recommended memory for this mode is '
+        'at least 4 GB.'
+    )
+
+    summary = storage_part
+    if livemode.url_to_load_squashfs_from:
+        summary = '{storage} {memory}'.format(storage=storage_part, memory=memory_part)
     reporting.create_report([
         reporting.Title('Live Upgrade Mode enabled'),
         reporting.Summary(summary),


### PR DESCRIPTION
As per findings documented in RHEL-56041, LiveMode consumes on average about 200mb less than the current implementation. This is because during standard upgrade path, upgrade is launched from an initramfs, without ever reaching switch-root. Therefore, the entire initramfs resides decompressed in memory when the upgrade runs. When booting from squashfs (LiveMode), switch-root is performed, our initramfs is deallocated. Pages of / from the squashfs are decompressed and (de)allocated on demand. Root is mounted using this mechanism as read-only on top of which there is a write layer, whose contents reside in system memory, which is small during upgrades. This patch drops informing user about additional memory requirements unless the image is pulled in over the network (in which case, the entire image is stored in memory).

Jira-ref: RHEL-56041